### PR TITLE
Fix for bug that ignored last block in multiline package listings

### DIFF
--- a/src/verify_packages.c
+++ b/src/verify_packages.c
@@ -405,6 +405,11 @@ static int VerifyInstalledPackages(PackageManager **all_mgrs, Attributes a, Prom
                 }
             }
 
+            if (a.packages.package_multiline_start)
+            {
+                PrependMultiLinePackageItem(&(manager->pack_list), vbuff, reset, a, pp);
+            }
+
             cf_pclose(prp);
         }
     }


### PR DESCRIPTION
This bug was discovered some time ago while visiting LinkedIn with Eystein.
When processing multiline package listing records, the last record was being
discarded, which resulted in an incomplete package list. The patch adds the
last-processed block, if any, to the list.
