### PR TITLE
Fix typo in variable name in cfengine-code-style.el

### DIFF
--- a/contrib/cfengine-code-style.el
+++ b/contrib/cfengine-code-style.el
@@ -51,7 +51,7 @@
 (defun cfengine-c-mode-hook ()
   (if (eq c-file-style "CFEngine")
       (progn
-        (setq indent-tab-mode nil)
+        (setq indent-tabs-mode nil)
         (setq c-tab-always-indent t)
         (subword-mode 1))))
 


### PR DESCRIPTION
Thanks for Eystein for catching it.
