### PR TITLE
Move embedded database file out of the way if it is corrupted

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,7 +52,7 @@ libpromises_la_SOURCES = \
         conversion.c \
         crypto.c \
         csv_writer.c csv_writer.h \
-        dbm_api.c dbm_api.h dbm_priv.h \
+        dbm_api.c dbm_api.h dbm_lib.h dbm_lib.c dbm_priv.h \
         dbm_quick.c \
         dbm_tokyocab.c \
         dir.c dir.h dir_priv.h \

--- a/src/dbm_api.c
+++ b/src/dbm_api.c
@@ -36,6 +36,7 @@
 
 #include "dbm_api.h"
 #include "dbm_priv.h"
+#include "dbm_lib.h"
 
 /******************************************************************************/
 
@@ -138,7 +139,13 @@ bool OpenDB(DBHandle **dbp, dbid id)
 
     if (handle->refcount == 0)
     {
-        handle->priv = DBPrivOpenDB(handle->filename);
+        int lock_fd = DBPathLock(handle->filename);
+
+        if(lock_fd != -1)
+        {
+            handle->priv = DBPrivOpenDB(handle->filename);
+            DBPathUnLock(lock_fd);
+        }
     }
 
     if (handle->priv)

--- a/src/dbm_lib.c
+++ b/src/dbm_lib.c
@@ -1,0 +1,93 @@
+/*
+
+   Copyright (C) Cfengine AS
+
+   This file is part of Cfengine 3 - written and maintained by Cfengine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of Cfengine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+/*****************************************************************************/
+/*                                                                           */
+/* File: dbm_lib.c                                                           */
+/*                                                                           */
+/*****************************************************************************/
+
+#include "cf3.defs.h"
+#include "cf3.extern.h"
+#include "dbm_lib.h"
+#include <sys/file.h>
+
+int DBPathLock(const char *filename)
+{
+    char *filename_lock;
+    if (xasprintf(&filename_lock, "%s.lock", filename) == -1)
+    {
+        FatalError("Unable to construct lock database filename for file %s",
+                   filename);
+    }
+
+    int fd = open(filename_lock, O_CREAT, 0666);
+
+    free(filename_lock);
+
+    if(fd == -1)
+    {
+        CfOut(cf_error, "flock", "!! Could not open db lock-file");
+        return -1;
+    }
+
+    if(flock(fd, LOCK_EX|LOCK_NB) == -1)
+    {
+        close(fd);
+        CfOut(cf_error, "flock", "!! Could not lock db lock-file");
+        return -1;
+    }
+
+    return fd;
+}
+
+void DBPathUnLock(int fd)
+{
+    if(flock(fd, LOCK_UN) == -1)
+    {
+        CfOut(cf_error, "flock", "!! Could not unlock db lock-file");
+    }
+
+    if(close(fd) != 0)
+    {
+        CfOut(cf_error, "close", "!! Could not close db lock-file");
+    }
+}
+
+void DBPathMoveBroken(const char *filename)
+{
+    char *filename_broken;
+    if (xasprintf(&filename_broken, "%s.broken", filename) == -1)
+    {
+        FatalError("Unable to construct broken database filename for file %s", filename);
+    }
+
+    if(cf_rename(filename, filename_broken) != 0)
+    {
+        CfOut(cf_error, "", "!! Failed moving broken db out of the way");
+    }
+
+    free(filename_broken);
+}

--- a/src/dbm_lib.h
+++ b/src/dbm_lib.h
@@ -1,0 +1,33 @@
+/*
+   Copyright (C) Cfengine AS
+
+   This file is part of Cfengine 3 - written and maintained by Cfengine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of Cfengine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#ifndef CFENGINE_DBM_LIB_H
+#define CFENGINE_DBM_LIB_H
+
+int DBPathLock(const char *filename);
+void DBPathUnLock(int fd);
+void DBPathMoveBroken(const char *filename);
+
+
+#endif  /* NOT CFENGINE_DBM_LIB_H */

--- a/src/dbm_quick.c
+++ b/src/dbm_quick.c
@@ -32,6 +32,7 @@
 
 #include "dbm_api.h"
 #include "dbm_priv.h"
+#include "dbm_lib.h"
 
 #ifdef QDB
 # include <depot.h>
@@ -128,6 +129,11 @@ DBPriv *DBPrivOpenDB(const char *filename)
         if (dprepair(filename))
         {
             CfOut(cf_log, "", "Successfully repaired database \"%s\"", filename);
+        }
+        else
+        {
+            CfOut(cf_error, "", "!! Failed to repair database %s, recreating...", filename);
+            DBPathMoveBroken(filename);
         }
 
         db->depot = dpopen(filename, DP_OWRITER | DP_OCREAT, -1);

--- a/src/dbm_tokyocab.c
+++ b/src/dbm_tokyocab.c
@@ -30,6 +30,7 @@
 #include "cf3.defs.h"
 #include "cf3.extern.h"
 #include "dbm_priv.h"
+#include "dbm_lib.h"
 
 #ifdef TCDB
 
@@ -120,7 +121,23 @@ DBPriv *DBPrivOpenDB(const char *dbpath)
     {
         CfOut(cf_error, "", "!! Could not open database %s: %s",
               dbpath, ErrorMessage(db->hdb));
-        goto err;
+
+        int errcode = tchdbecode(db->hdb);
+
+        if(errcode != TCEMETA && errcode != TCEREAD)
+        {
+            goto err;
+        }
+
+        CfOut(cf_error, "", "!! Database \"%s\" is broken, recreating...", dbpath);
+        DBPathMoveBroken(dbpath);
+
+        if(!tchdbopen(db->hdb, dbpath, HDBOWRITER | HDBOCREAT))
+        {
+            CfOut(cf_error, "", "!! Could not open database %s after recreate: %s",
+                  dbpath, ErrorMessage(db->hdb));
+            goto err;
+        }
     }
 
     return db;

--- a/tests/load/Makefile.am
+++ b/tests/load/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST = run_db_load
 
 check_PROGRAMS = db_load
 
-db_load_SOURCES = db_load.c $(srcdir)/../../src/dbm_tokyocab.c $(srcdir)/../../src/dbm_api.c $(srcdir)/../../src/dbm_quick.c $(srcdir)/../../src/alloc.c
+db_load_SOURCES = db_load.c $(srcdir)/../../src/dbm_tokyocab.c $(srcdir)/../../src/dbm_api.c $(srcdir)/../../src/dbm_quick.c $(srcdir)/../../src/dbm_lib.c  $(srcdir)/../../src/alloc.c
 db_load_LDADD = ../../pub/libcfpub.la
 
 TESTS = run_db_load

--- a/tests/load/db_load.c
+++ b/tests/load/db_load.c
@@ -351,5 +351,10 @@ char *MapNameCopy(const char *s)
     return xstrdup(s);
 }
 
+int cf_rename(const char *oldpath, const char *newpath)
+{
+    return rename(oldpath, newpath);
+}
+
 pthread_mutex_t *cft_dbhandle;
 #endif


### PR DESCRIPTION
This ensures self-healing and avoids logs being flooded with errors.
