### PR TITLE
new function stub hostswithclass (commercial extension)

### DIFF
--- a/docs/reference/functions/hostswithclass_example.texinfo
+++ b/docs/reference/functions/hostswithclass_example.texinfo
@@ -1,0 +1,22 @@
+@verbatim
+body common control
+{
+bundlesequence => { "test" };
+inputs => { "cfengine_stdlib.cf" };
+}
+
+
+bundle agent test
+{
+vars:
+
+am_policy_hub::
+ "host_list" slist => hostswithclass( "debian", "name" );
+
+files:
+am_policy_hub::
+  "/tmp/master_config.cfg"
+         edit_line => insert_lines("host=$(host_list)"),
+            create => "true";
+}
+@end verbatim

--- a/docs/reference/functions/hostswithclass_notes.texinfo
+++ b/docs/reference/functions/hostswithclass_notes.texinfo
@@ -1,0 +1,16 @@
+
+On CFEngine Nova hubs, this function can be used to return a list of
+hostnames or ip-addresses of hosts that has the class given as
+argument 1.  Argument 2 may be @samp{address} or @samp{name}, to
+return ip address or hostname form.
+
+Note that this function only works locally on the hub, but allows the
+hub to construct custom configuration files for (classes of) hosts.
+
+@i{History}: Was introduced in 3.3.0, Nova 2.2.0 (2012)
+
+Availability: Enterprise editions of CFEngine only. 
+
+@verbatim
+
+@end verbatim

--- a/examples/hostswithclass.cf
+++ b/examples/hostswithclass.cf
@@ -1,0 +1,20 @@
+body common control
+{
+bundlesequence => { "test" };
+inputs => { "cfengine_stdlib.cf" };
+}
+
+
+bundle agent test
+{
+vars:
+
+am_policy_hub::
+ "host_list" slist => hostswithclass( "debian", "name" );
+
+files:
+am_policy_hub::
+  "/tmp/master_config.cfg"
+         edit_line => insert_lines("host=$(host_list)"),
+            create => "true";
+}

--- a/src/enterprise_stubs.c
+++ b/src/enterprise_stubs.c
@@ -538,4 +538,13 @@ void VerifyWindowsService(Attributes a, Promise *pp)
     CfOut(cf_error, "", "!! Windows service management is only supported in CFEngine Nova");
 }
 
+/*****************************************************************************/
+
+bool CFDB_HostsWithClass(Rlist *return_list, char *class_name, char *return_format)
+{
+    CfOut(cf_error, "", "!! Host class counting is only available in CFEngine Nova");
+    
+    return false;
+}
+
 #endif

--- a/src/evalfunction.c
+++ b/src/evalfunction.c
@@ -276,6 +276,26 @@ static FnCallResult FnCallHostsSeen(FnCall *fp, Rlist *finalargs)
 
 /*********************************************************************/
 
+static FnCallResult FnCallHostsWithClass(FnCall *fp, Rlist *finalargs)
+{
+    Rlist *returnlist = NULL;
+
+    char *class_name = ScalarValue(finalargs);
+    char *return_format = ScalarValue(finalargs->next);
+    
+    if(!CFDB_HostsWithClass(&returnlist, class_name, return_format))
+    {
+        return (FnCallResult){ FNCALL_FAILURE };
+    }
+    
+    return (FnCallResult)
+    {
+        FNCALL_SUCCESS, { returnlist, CF_LIST } 
+    };
+}
+
+/*********************************************************************/
+
 static FnCallResult FnCallRandomInt(FnCall *fp, Rlist *finalargs)
 {
     char buffer[CF_BUFSIZE];
@@ -4484,6 +4504,13 @@ FnCallArg HOSTSSEEN_ARGS[] =
     {NULL, cf_notype, NULL}
 };
 
+FnCallArg HOSTSWITHCLASS_ARGS[] =
+{
+    {"[a-zA-Z0-9_]+", cf_str, "Class name to look for"},
+    {"name,address", cf_opts, "Type of return value desired"},
+    {NULL, cf_notype, NULL}
+};
+
 FnCallArg IPRANGE_ARGS[] =
 {
     {CF_ANYSTRING, cf_str, "IP address range syntax"},
@@ -4931,6 +4958,8 @@ const FnCallType CF_FNCALL_TYPES[] =
      "True if the current host lies in the range of enumerated hostnames specified"},
     {"hostsseen", cf_slist, HOSTSSEEN_ARGS, &FnCallHostsSeen,
      "Extract the list of hosts last seen/not seen within the last arg1 hours"},
+    {"hostswithclass", cf_slist, HOSTSWITHCLASS_ARGS, &FnCallHostsWithClass,
+     "Extract the list of hosts with the given class set from the hub database (commercial extension)"},
     {"hubknowledge", cf_str, HUB_KNOWLEDGE_ARGS, &FnCallHubKnowledge,
      "Read global knowledge from the hub host by id (commercial extension)"},
     {"iprange", cf_class, IPRANGE_ARGS, &FnCallIPRange,

--- a/src/prototypes3.h
+++ b/src/prototypes3.h
@@ -315,6 +315,7 @@ void NewPromiser(Promise *pp);
 void AnalyzePromiseConflicts(void);
 void AddGoalsToDB(char *goal_patterns, char *goal_categories);
 void VerifyWindowsService(Attributes a, Promise *pp);
+bool CFDB_HostsWithClass(Rlist **return_list, char *class_name, char *return_format);
 
 void SetSyslogHost(const char *host);
 void SetSyslogPort(uint16_t port);


### PR DESCRIPTION
This is a stub for the community edition only.
It allows to find hosts by class in the policy, it has been requested by several users/customers.

Please note the associated pull request for Nova.

The main question is the name - hostswithclass or hostsinclass, hostshavingclass, etc?

Please note that this also needs backport to 3.3.x to go into the next Nova release.
