### PR TITLE
Fix some typos that cause confusion between list and array in the reference manual

### DIFF
--- a/src/evalfunction.c
+++ b/src/evalfunction.c
@@ -4426,7 +4426,7 @@ FnCallArg GETUID_ARGS[] =
 FnCallArg GREP_ARGS[] =
 {
     {CF_ANYSTRING, cf_str, "Regular expression"},
-    {CF_IDRANGE, cf_str, "Cfengine array identifier"},
+    {CF_IDRANGE, cf_str, "CFEngine list identifier"},
     {NULL, cf_notype, NULL}
 };
 
@@ -4527,7 +4527,7 @@ FnCallArg ISVARIABLE_ARGS[] =
 FnCallArg JOIN_ARGS[] =
 {
     {CF_ANYSTRING, cf_str, "Join glue-string"},
-    {CF_IDRANGE, cf_str, "Cfengine array identifier"},
+    {CF_IDRANGE, cf_str, "CFEngine list identifier"},
     {NULL, cf_notype, NULL}
 };
 


### PR DESCRIPTION
Two special functions are describes as expecting an array when they actually expect a list. This causes confusion every time I see this, and for newcomers especially. This small patch fixes that.

Should I also open a bug on bug.cfengine.com, or is this sufficient?
