### PR TITLE
Fix countclassesmatching when regex starts with alphanum

### DIFF
--- a/src/evalfunction.c
+++ b/src/evalfunction.c
@@ -625,7 +625,7 @@ static FnCallResult FnCallCountClassesMatching(FnCall *fp, Rlist *finalargs)
             }
         }
 
-        for (ip = VHEAP.list[i]; ip != NULL; ip = ip->next)
+        for (ip = VADDCLASSES.list[i]; ip != NULL; ip = ip->next)
         {
             if (FullTextMatch(string, ip->name))
             {


### PR DESCRIPTION
For the case when the match string starts with an alphanumeric
character, the code was looking twice through VHEAP instead of
looking through both VHEAP and VADDCLASSES.
