### PR TITLE
Define sys.flavo{,u}r on Gentoo and Arch Linux reflecting their classes.

### DIFF
--- a/src/sysinfo.c
+++ b/src/sysinfo.c
@@ -768,12 +768,16 @@ void OSClasses()
     {
         CfOut(cf_verbose, "", "This appears to be a gentoo system.\n");
         NewClass("gentoo");
+        NewScalar("sys", "flavour", "gentoo", cf_str);
+        NewScalar("sys", "flavor", "gentoo", cf_str);
     }
 
     if (cfstat("/etc/arch-release", &statbuf) != -1)
     {
         CfOut(cf_verbose, "", "This appears to be an Arch Linux system.\n");
         NewClass("archlinux");
+        NewScalar("sys", "flavour", "archlinux", cf_str);
+        NewScalar("sys", "flavor", "archlinux", cf_str);
     }
 
     if (cfstat("/proc/vmware/version", &statbuf) != -1 || cfstat("/etc/vmware-release", &statbuf) != -1)


### PR DESCRIPTION
Those systems don't have a version, but it is desirable to have sys.flavo{,u}r defined on them too.

When I made a pull request last time adding archlinux class I didn't know that sys.flavo{,u}r wasn't automatically set from class names (and honestly I didn't really care back then), now it bites me when I want to use it and it's undefined..
