### PR TITLE
Documentation fix

### DIFF
--- a/docs/guides/cf_Quickref3.texinfo
+++ b/docs/guides/cf_Quickref3.texinfo
@@ -194,8 +194,8 @@ Debug levels: 1=parsing, 2=running, 3=summary, 4=expression eval
 
 The server daemon provides two services: it acts as a
 file server for remote file copying and it allows an
-authorized cf-runagent to start start a cf-agent process
-and set certain additional classes with role-based access
+authorized cf-runagent to start a cf-agent process and
+set certain additional classes with role-based access
 control.
 
 

--- a/src/cf-serverd.c
+++ b/src/cf-serverd.c
@@ -120,8 +120,8 @@ static const char *PROTOCOL[] =
 
 static const char *ID = "The server daemon provides two services: it acts as a\n"
     "file server for remote file copying and it allows an\n"
-    "authorized cf-runagent to start start a cf-agent process\n"
-    "and set certain additional classes with role-based access\n" "control.\n";
+    "authorized cf-runagent to start a cf-agent process and\n"
+    "set certain additional classes with role-based access control.\n";
 
 static const struct option OPTIONS[15] =
 {


### PR DESCRIPTION
Replaced "start start" by "start"
