### PR TITLE
package_method does not take a quoted string. 

### DIFF
--- a/docs/reference/bodyparts/package_policy_example.texinfo
+++ b/docs/reference/bodyparts/package_policy_example.texinfo
@@ -5,6 +5,6 @@ packages:
   "$(match_package)"
 
      package_policy => "add",
-     package_method => "xyz";
+     package_method => xyz;
 
 @end verbatim


### PR DESCRIPTION
fixes https://cfengine.com/bugtracker/view.php?id=1097
