### PR TITLE
New options for `cf-key` to manage client keys

### DIFF
--- a/docs/guides/cf_Quickref3.texinfo
+++ b/docs/guides/cf_Quickref3.texinfo
@@ -535,6 +535,8 @@ Debug levels: 1=parsing, 2=running, 3=summary, 4
 (-r @var{value}) - Remove keys for specified hostname/IP from lastseen database 
 @item --print-digest
 (-p @var{pubkeyfile}) - Print digest of the specified public key file
+@item --trust-key
+(-t @var{pubkeyfile}) - Make cf-serverd/cf-agent trust the specified public key
 @end table
 
 


### PR DESCRIPTION
These two commits add options to `cf-key` to:
- print the digest of a `.pub` public key file
- copy a public key file to its trusted location

Both options are meant to be used in fully-automated installs,
where there is some trusted path to extract the key file from a
client and place it on the server, without the need to add a
`trustkeysfrom` line and restart the server.

The patches are in the `master` branch, but they apply cleanly 
to `3.3.x` as well.
