### PR TITLE
Make standard_services bundle available in 3.3.x releases

### DIFF
--- a/masterfiles/cfengine_stdlib.cf
+++ b/masterfiles/cfengine_stdlib.cf
@@ -1523,7 +1523,7 @@ package_name_convention => "$(name).$(arch)";
 # set it to "0" to avoid caching of list during upgrade
 package_list_update_ifelapsed => "240";
 
-package_patch_installed_regex => "^\s.*";
+package_patch_installed_regex => "^[^*]\s.*";
 package_patch_name_regex    => "([^.]+).*";
 package_patch_version_regex => "[^\s]\s+([^\s]+).*";
 package_patch_arch_regex    => "[^.]+\.([^\s]+).*";


### PR DESCRIPTION
Subset of changes made to standard library in copbl repo.
