### PR TITLE
When hostname returns FQDN sys.domain is set to an empty string.

### DIFF
--- a/src/sysinfo.c
+++ b/src/sysinfo.c
@@ -172,13 +172,14 @@ void CalculateDomainName(const char *nodename, const char *dnsname, char *fqname
         if (p != NULL)
         {
             strlcpy(uqname, nodename, MIN(CF_BUFSIZE, p - nodename + 1));
+            strcpy(domain, p + 1);
         }
         else
         {
             strcpy(uqname, nodename);
+            strcpy(domain, "");
         }
 
-        strcpy(domain, "");
     }
 }
 


### PR DESCRIPTION
My hostname are set fully qualified, eg:
- gb-r2n1.irc.sara.nl

With this setting the sys.domain is set to an empty string. This patch set the sys.domain to irc.sara.nl
