### PR TITLE
Introduce ReportContext for core reporting.h

### DIFF
--- a/src/agentdiagnostic.c
+++ b/src/agentdiagnostic.c
@@ -25,23 +25,28 @@
 
 #include "cf3.defs.h"
 
+#include "reporting.h"
+
 void AgentDiagnostic(void)
 {
+    ReportContext *report_context = ReportContextNew();
     if (VERBOSE || DEBUG)
     {
-        FREPORT_TXT = stdout;
-        FREPORT_HTML = fopen(NULLFILE, "w");
+        ReportContextAddWriter(report_context, REPORT_OUTPUT_TYPE_TEXT, FileWriter(stdout));
+        ReportContextAddWriter(report_context, REPORT_OUTPUT_TYPE_HTML, FileWriter(fopen(NULLFILE, "w")));
     }
     else
     {
-        FREPORT_TXT = fopen(NULLFILE, "w");
-        FREPORT_HTML = fopen(NULLFILE, "w");
+        ReportContextAddWriter(report_context, REPORT_OUTPUT_TYPE_TEXT, FileWriter(fopen(NULLFILE, "w")));
+        ReportContextAddWriter(report_context, REPORT_OUTPUT_TYPE_HTML, FileWriter(fopen(NULLFILE, "w")));
     }
 
     printf("----------------------------------------------------------\n");
     printf("Cfengine 3 - Performing level 2 self-diagnostic (dialogue)\n");
     printf("----------------------------------------------------------\n\n");
     TestVariableScan();
-    TestExpandPromise();
-    TestExpandVariables();
+    TestExpandPromise(report_context);
+    TestExpandVariables(report_context);
+
+    ReportContextDestroy(report_context);
 }

--- a/src/cf-agent.c
+++ b/src/cf-agent.c
@@ -94,14 +94,14 @@ char *TYPESEQUENCE[] =
 static void ThisAgentInit(void);
 static GenericAgentConfig CheckOpts(int argc, char **argv);
 static void CheckAgentAccess(Rlist *list);
-static void KeepAgentPromise(Promise *pp);
+static void KeepAgentPromise(Promise *pp, const ReportContext *report_context);
 static int NewTypeContext(enum typesequence type);
-static void DeleteTypeContext(Policy *policy, enum typesequence type);
+static void DeleteTypeContext(Policy *policy, enum typesequence type, const ReportContext *report_context);
 static void ClassBanner(enum typesequence type);
-static void ParallelFindAndVerifyFilesPromises(Promise *pp);
+static void ParallelFindAndVerifyFilesPromises(Promise *pp, const ReportContext *report_context);
 static bool VerifyBootstrap(void);
-static void KeepPromiseBundles(Policy *policy, Rlist *bundlesequence);
-static void KeepPromises(Policy *policy, GenericAgentConfig config);
+static void KeepPromiseBundles(Policy *policy, Rlist *bundlesequence, const ReportContext *report_context);
+static void KeepPromises(Policy *policy, GenericAgentConfig config, const ReportContext *report_context);
 static int NoteBundleCompliance(const Bundle *bundle, int save_pr_kept, int save_pr_repaired, int save_pr_notkept);
 
 /*******************************************************************/
@@ -157,9 +157,11 @@ int main(int argc, char *argv[])
 
     GenericAgentConfig config = CheckOpts(argc, argv);
 
-    Policy *policy = GenericInitialize("agent", config);
+    ReportContext *report_context = OpenReports("agent");
+    Policy *policy = GenericInitialize("agent", config, report_context);
     ThisAgentInit();
-    KeepPromises(policy, config);
+    KeepPromises(policy, config, report_context);
+    CloseReports("agent", report_context);
     NoteClassUsage(VHEAP, true);
 #ifdef HAVE_NOVA
     Nova_NoteVarUsageDB();
@@ -370,13 +372,13 @@ static void ThisAgentInit(void)
 
 /*******************************************************************/
 
-static void KeepPromises(Policy *policy, GenericAgentConfig config)
+static void KeepPromises(Policy *policy, GenericAgentConfig config, const ReportContext *report_context)
 {
  double efficiency, model;
 
     BeginAudit();
     KeepControlPromises(policy);
-    KeepPromiseBundles(policy, config.bundlesequence);
+    KeepPromiseBundles(policy, config.bundlesequence, report_context);
     EndAudit();
 
 // TOPICS counts the number of currently defined promises
@@ -773,7 +775,7 @@ void KeepControlPromises(Policy *policy)
 
 /*********************************************************************/
 
-static void KeepPromiseBundles(Policy *policy, Rlist *bundlesequence)
+static void KeepPromiseBundles(Policy *policy, Rlist *bundlesequence, const ReportContext *report_context)
 {
     Bundle *bp;
     Rlist *rp, *params;
@@ -880,7 +882,7 @@ static void KeepPromiseBundles(Policy *policy, Rlist *bundlesequence)
             BannerBundle(bp, params);
             THIS_BUNDLE = bp->name;
             DeletePrivateClassContext();        // Each time we change bundle
-            ScheduleAgentOperations(bp);
+            ScheduleAgentOperations(bp, report_context);
             ResetBundleOutputs(bp->name);
         }
     }
@@ -890,7 +892,7 @@ static void KeepPromiseBundles(Policy *policy, Rlist *bundlesequence)
 /* Level 3                                                           */
 /*********************************************************************/
 
-int ScheduleAgentOperations(Bundle *bp)
+int ScheduleAgentOperations(Bundle *bp, const ReportContext *report_context)
 // NB - this function can be called recursively through "methods"
 {
     SubType *sp;
@@ -935,18 +937,18 @@ int ScheduleAgentOperations(Bundle *bp)
                     CF_TOPICS++;
                 }
 
-                ExpandPromise(cf_agent, bp->name, pp, KeepAgentPromise);
+                ExpandPromise(cf_agent, bp->name, pp, KeepAgentPromise, report_context);
 
                 if (Abort())
                 {
                     NoteClassUsage(VADDCLASSES, false);
-                    DeleteTypeContext(bp->parent_policy, type);
+                    DeleteTypeContext(bp->parent_policy, type, report_context);
                     NoteBundleCompliance(bp, save_pr_kept, save_pr_repaired, save_pr_notkept);
                     return false;
                 }
             }
 
-            DeleteTypeContext(bp->parent_policy, type);
+            DeleteTypeContext(bp->parent_policy, type, report_context);
         }
     }
 
@@ -1019,7 +1021,7 @@ static void CheckAgentAccess(Rlist *list)
 
 /*********************************************************************/
 
-static void KeepAgentPromise(Promise *pp)
+static void KeepAgentPromise(Promise *pp, const ReportContext *report_context)
 {
     char *sp = NULL;
     struct timespec start = BeginMeasure();
@@ -1100,7 +1102,7 @@ static void KeepAgentPromise(Promise *pp)
 
     if (strcmp("storage", pp->agentsubtype) == 0)
     {
-        FindAndVerifyStoragePromises(pp);
+        FindAndVerifyStoragePromises(pp, report_context);
         EndMeasurePromise(start, pp);
         return;
     }
@@ -1116,11 +1118,11 @@ static void KeepAgentPromise(Promise *pp)
     {
         if (GetBooleanConstraint("background", pp))
         {
-            ParallelFindAndVerifyFilesPromises(pp);
+            ParallelFindAndVerifyFilesPromises(pp, report_context);
         }
         else
         {
-            FindAndVerifyFilesPromises(pp);
+            FindAndVerifyFilesPromises(pp, report_context);
         }
 
         EndMeasurePromise(start, pp);
@@ -1143,14 +1145,14 @@ static void KeepAgentPromise(Promise *pp)
 
     if (strcmp("methods", pp->agentsubtype) == 0)
     {
-        VerifyMethodsPromise(pp);
+        VerifyMethodsPromise(pp, report_context);
         EndMeasurePromise(start, pp);
         return;
     }
 
     if (strcmp("services", pp->agentsubtype) == 0)
     {
-        VerifyServicesPromise(pp);
+        VerifyServicesPromise(pp, report_context);
         EndMeasurePromise(start, pp);
         return;
     }
@@ -1219,14 +1221,14 @@ static int NewTypeContext(enum typesequence type)
 
 /*********************************************************************/
 
-static void DeleteTypeContext(Policy *policy, enum typesequence type)
+static void DeleteTypeContext(Policy *policy, enum typesequence type, const ReportContext *report_context)
 {
     Attributes a = { {0} };
 
     switch (type)
     {
     case kp_classes:
-        HashVariables(policy, THIS_BUNDLE);
+        HashVariables(policy, THIS_BUNDLE, report_context);
         break;
 
     case kp_environments:
@@ -1249,7 +1251,7 @@ static void DeleteTypeContext(Policy *policy, enum typesequence type)
         {
             if (FSTABLIST)
             {
-                SaveItemListAsFile(FSTABLIST, VFSTAB[VSYSTEMHARDCLASS], a, NULL);
+                SaveItemListAsFile(FSTABLIST, VFSTAB[VSYSTEMHARDCLASS], a, NULL, report_context);
                 DeleteItemList(FSTABLIST);
                 FSTABLIST = NULL;
             }
@@ -1326,7 +1328,7 @@ static void ClassBanner(enum typesequence type)
 /* Thread context                                             */
 /**************************************************************/
 
-static void ParallelFindAndVerifyFilesPromises(Promise *pp)
+static void ParallelFindAndVerifyFilesPromises(Promise *pp, const ReportContext *report_context)
 {
     pid_t child = 1;
     int background = GetBooleanConstraint("background", pp);
@@ -1366,7 +1368,7 @@ static void ParallelFindAndVerifyFilesPromises(Promise *pp)
 
     if (child == 0 || !background)
     {
-        FindAndVerifyFilesPromises(pp);
+        FindAndVerifyFilesPromises(pp, report_context);
     }
 
 #endif /* NOT MINGW */

--- a/src/cf-key.c
+++ b/src/cf-key.c
@@ -28,6 +28,7 @@
 #include "dbm_api.h"
 #include "lastseen.h"
 #include "dir.h"
+#include "reporting.h"
 
 int SHOWHOSTS = false;
 bool REMOVEKEYS = false;
@@ -77,7 +78,8 @@ int main(int argc, char *argv[])
 
     THIS_AGENT_TYPE = cf_keygen;
 
-    GenericInitialize("keygenerator", config);
+    ReportContext *report_context = OpenReports("keygenerator");
+    GenericInitialize("keygenerator", config, report_context);
 
     if (SHOWHOSTS)
     {
@@ -91,6 +93,8 @@ int main(int argc, char *argv[])
     }
 
     KeepKeyPromises();
+
+    ReportContextDestroy(report_context);
     return 0;
 }
 

--- a/src/cf-know.c
+++ b/src/cf-know.c
@@ -62,7 +62,7 @@ static void AddOccurrence(Occurrence **list, char *reference, Rlist *represents,
 static Topic *TopicExists(char *topic_name, char *topic_type);
 static TopicAssociation *AssociationExists(TopicAssociation *list, char *fwd, char *bwd);
 static Occurrence *OccurrenceExists(Occurrence *list, char *locator, enum representations repy_type, char *s);
-static void KeepPromiseBundles(Policy *policy);
+static void KeepPromiseBundles(Policy *policy, const ReportContext *report_context);
 int GetTopicPid(char *classified_topic);
 
 /*******************************************************************/
@@ -178,7 +178,8 @@ int main(int argc, char *argv[])
 {
     GenericAgentConfig config = CheckOpts(argc, argv);
 
-    Policy *policy = GenericInitialize("knowledge", config);
+    ReportContext *report_context = OpenReports("knowledge");
+    Policy *policy = GenericInitialize("knowledge", config, report_context);
     ThisAgentInit();
 
     KeepKnowControlPromises(policy);
@@ -244,7 +245,7 @@ int main(int argc, char *argv[])
         int complete;
         double percent;
 
-        KeepPromiseBundles(policy);
+        KeepPromiseBundles(policy, report_context);
         WriteKMDB();
         GenerateManual();
         ShowWords();
@@ -258,6 +259,7 @@ int main(int argc, char *argv[])
         CfOut(cf_inform, "", " -> Hit probability (efficiency) yields %d/%d = %.4lf%%\n", CF_OCCUR, CF_TOPICS, percent);
     }
 
+    ReportContextDestroy(report_context);
     return 0;
 }
 
@@ -555,7 +557,7 @@ static void KeepKnowControlPromises(Policy *policy)
 
 /*****************************************************************************/
 
-static void KeepPromiseBundles(Policy *policy)
+static void KeepPromiseBundles(Policy *policy, const ReportContext *report_context)
 {
     Bundle *bp;
     SubType *sp;
@@ -644,7 +646,7 @@ static void KeepPromiseBundles(Policy *policy)
 
             for (pp = sp->promiselist; pp != NULL; pp = pp->next)
             {
-                ExpandPromise(cf_know, bp->name, pp, KeepKnowledgePromise);
+                ExpandPromise(cf_know, bp->name, pp, KeepKnowledgePromise, report_context);
             }
         }
     }

--- a/src/cf-monitord.c
+++ b/src/cf-monitord.c
@@ -28,6 +28,7 @@
 #include "env_context.h"
 #include "constraints.h"
 #include "conversion.h"
+#include "reporting.h"
 
 /*****************************************************************************/
 
@@ -93,11 +94,14 @@ int main(int argc, char *argv[])
 {
     GenericAgentConfig config = CheckOpts(argc, argv);
 
-    Policy *policy = GenericInitialize("monitor", config);
+    ReportContext *report_context = OpenReports("monitor");
+    Policy *policy = GenericInitialize("monitor", config, report_context);
     ThisAgentInit();
     KeepPromises(policy);
 
-    MonitorStartServer(policy);
+    MonitorStartServer(policy, report_context);
+
+    ReportContextDestroy(report_context);
     return 0;
 }
 

--- a/src/cf-promises.c
+++ b/src/cf-promises.c
@@ -27,6 +27,7 @@
 
 #include "env_context.h"
 #include "conversion.h"
+#include "reporting.h"
 
 /*******************************************************************/
 
@@ -89,10 +90,13 @@ int main(int argc, char *argv[])
 {
     GenericAgentConfig config = CheckOpts(argc, argv);
 
-    GenericInitialize("common", config);
+    ReportContext *report_context = OpenReports("common");
+    GenericInitialize("common", config, report_context);
     ThisAgentInit();
     AnalyzePromiseConflicts();
     GenericDeInitialize();
+
+    ReportContextDestroy(report_context);
 
     if (ERRORCOUNT > 0)
     {

--- a/src/cf-runagent.c
+++ b/src/cf-runagent.c
@@ -33,6 +33,7 @@
 #include "promises.h"
 #include "constraints.h"
 #include "conversion.h"
+#include "reporting.h"
 
 static void ThisAgentInit(void);
 static GenericAgentConfig CheckOpts(int argc, char **argv);
@@ -127,8 +128,9 @@ int main(int argc, char *argv[])
     int pid;
 
     GenericAgentConfig config = CheckOpts(argc, argv);
+    ReportContext *report_context = OpenReports("runagent");
 
-    Policy *policy = GenericInitialize("runagent", config);
+    Policy *policy = GenericInitialize("runagent", config, report_context);
     ThisAgentInit();
     KeepControlPromises(policy);      // Set RUNATTR using copy
 
@@ -201,6 +203,7 @@ int main(int argc, char *argv[])
 #endif
 
     DeletePromise(pp);
+    ReportContextDestroy(report_context);
 
     return 0;
 }

--- a/src/cf-serverd.c
+++ b/src/cf-serverd.c
@@ -36,6 +36,7 @@
 #include "promises.h"
 #include "item_lib.h"
 #include "conversion.h"
+#include "reporting.h"
 
 #define QUEUESIZE 50
 #define CF_BUFEXT 128
@@ -55,7 +56,7 @@ static GenericAgentConfig CheckOpts(int argc, char **argv);
 static int OpenReceiverChannel(void);
 static void PurgeOldConnections(Item **list, time_t now);
 static void SpawnConnection(int sd_reply, char *ipaddr);
-static void CheckFileChanges(Policy **policy, GenericAgentConfig config);
+static void CheckFileChanges(Policy **policy, GenericAgentConfig config, const ReportContext *report_context);
 static void *HandleConnection(ServerConnectionState *conn);
 static int BusyWithConnection(ServerConnectionState *conn);
 static int MatchClasses(ServerConnectionState *conn);
@@ -96,7 +97,7 @@ static int OptionFound(char *args, char *pos, char *word);
 static in_addr_t GetInetAddr(char *host);
 #endif
 
-static void StartServer(Policy *policy, GenericAgentConfig config);
+static void StartServer(Policy *policy, GenericAgentConfig config, const ReportContext *report_context);
 
 char CFRUNCOMMAND[CF_BUFSIZE];
 
@@ -212,12 +213,15 @@ int main(int argc, char *argv[])
 {
     GenericAgentConfig config = CheckOpts(argc, argv);
 
-    Policy *policy = GenericInitialize("server", config);
+    ReportContext *report_context = OpenReports("server");
+    Policy *policy = GenericInitialize("server", config, report_context);
     ThisAgentInit();
-    KeepPromises(policy);
+    KeepPromises(policy, report_context);
     Summarize();
 
-    StartServer(policy, config);
+    StartServer(policy, config, report_context);
+
+    ReportContextDestroy(report_context);
     return 0;
 }
 
@@ -325,7 +329,7 @@ static void ThisAgentInit(void)
 
 /*******************************************************************/
 
-static void StartServer(Policy *policy, GenericAgentConfig config)
+static void StartServer(Policy *policy, GenericAgentConfig config, const ReportContext *report_context)
 {
     char ipaddr[CF_MAXVARSIZE], intime[64];
     int sd, sd_reply;
@@ -415,7 +419,7 @@ static void StartServer(Policy *policy, GenericAgentConfig config)
         {
             if (ACTIVE_THREADS == 0)
             {
-                CheckFileChanges(&policy, config);
+                CheckFileChanges(&policy, config, report_context);
             }
             ThreadUnlock(cft_server_children);
         }
@@ -754,7 +758,7 @@ static void SpawnConnection(int sd_reply, char *ipaddr)
 
 /**************************************************************/
 
-static void CheckFileChanges(Policy **policy, GenericAgentConfig config)
+static void CheckFileChanges(Policy **policy, GenericAgentConfig config, const ReportContext *report_context)
 {
     if (EnterpriseExpiry())
     {
@@ -767,7 +771,7 @@ static void CheckFileChanges(Policy **policy, GenericAgentConfig config)
     {
         CfOut(cf_verbose, "", " -> New promises detected...\n");
 
-        if (CheckPromises(cf_server))
+        if (CheckPromises(cf_server, report_context))
         {
             CfOut(cf_inform, "", "Rereading config files %s..\n", VINPUTFILE);
 
@@ -839,8 +843,8 @@ static void CheckFileChanges(Policy **policy, GenericAgentConfig config)
             NewClass(CF_AGENTTYPES[THIS_AGENT_TYPE]);
 
             SetReferenceTime(true);
-            *policy = ReadPromises(cf_server, CF_SERVERC, config);
-            KeepPromises(*policy);
+            *policy = ReadPromises(cf_server, CF_SERVERC, config, report_context);
+            KeepPromises(*policy, report_context);
             Summarize();
 
         }

--- a/src/cf3.defs.h
+++ b/src/cf3.defs.h
@@ -1087,6 +1087,24 @@ enum knowledgecertainty
 
 /*************************************************************************/
 
+typedef enum
+{
+    REPORT_OUTPUT_TYPE_TEXT,
+    REPORT_OUTPUT_TYPE_HTML,
+
+    REPORT_OUTPUT_TYPE_MAX
+} ReportOutputType;
+
+typedef struct Writer_ Writer;
+
+typedef struct
+{
+    Writer *report_writers[REPORT_OUTPUT_TYPE_MAX];
+} ReportContext;
+
+
+/*************************************************************************/
+
 typedef struct
 {
     const char *lval;

--- a/src/cf3.extern.h
+++ b/src/cf3.extern.h
@@ -164,8 +164,6 @@ extern int CF_PERSISTENCE;
 extern int LOOKUP;
 extern int BOOTSTRAP;
 extern int XML;
-extern FILE *FREPORT_HTML;
-extern FILE *FREPORT_TXT;
 extern FILE *FKNOW;
 extern int CSV;
 

--- a/src/cf3.server.h
+++ b/src/cf3.server.h
@@ -87,6 +87,6 @@ int Constellation_ReturnRelayQueryData(ServerConnectionState *conn, char *query,
 void Constellation_RunQueries(Item *queries, Item **results_p);
 #endif
 
-void KeepPromises(Policy *policy);
+void KeepPromises(Policy *policy, const ReportContext *report_context);
 
 #endif

--- a/src/cf3globals.c
+++ b/src/cf3globals.c
@@ -51,8 +51,6 @@ bool ALLCLASSESREPORT = false;
 
 struct utsname VSYSNAME;
 
-FILE *FREPORT_HTML = NULL;
-FILE *FREPORT_TXT = NULL;
 FILE *FKNOW = NULL;
 int XML = false;
 

--- a/src/env_monitor.c
+++ b/src/env_monitor.c
@@ -81,10 +81,10 @@ int NO_FORK = false;
 
 static void GetDatabaseAge(void);
 static void LoadHistogram(void);
-static void GetQ(const Policy *policy);
+static void GetQ(const Policy *policy, const ReportContext *report_context);
 static Averages EvalAvQ(char *timekey);
 static void ArmClasses(Averages newvals, char *timekey);
-static void GatherPromisedMeasures(const Policy *policy);
+static void GatherPromisedMeasures(const Policy *policy, const ReportContext *report_context);
 
 static void LeapDetection(void);
 static Averages *GetCurrentAverages(char *timekey);
@@ -235,7 +235,7 @@ static void LoadHistogram(void)
 
 /*********************************************************************/
 
-void MonitorStartServer(const Policy *policy)
+void MonitorStartServer(const Policy *policy, const ReportContext *report_context)
 {
     char timekey[CF_SMALLBUF];
     Averages averages;
@@ -282,7 +282,7 @@ void MonitorStartServer(const Policy *policy)
 
     while (true)
     {
-        GetQ(policy);
+        GetQ(policy, report_context);
         snprintf(timekey, sizeof(timekey), "%s", GenTimeKey(time(NULL)));
         averages = EvalAvQ(timekey);
         LeapDetection();
@@ -298,7 +298,7 @@ void MonitorStartServer(const Policy *policy)
 
 /*********************************************************************/
 
-static void GetQ(const Policy *policy)
+static void GetQ(const Policy *policy, const ReportContext *report_context)
 {
     CfDebug("========================= GET Q ==============================\n");
 
@@ -316,7 +316,7 @@ static void GetQ(const Policy *policy)
     MonTempGatherData(CF_THIS);
 #endif /* NOT MINGW */
     MonOtherGatherData(CF_THIS);
-    GatherPromisedMeasures(policy);
+    GatherPromisedMeasures(policy, report_context);
 }
 
 /*********************************************************************/
@@ -1074,7 +1074,7 @@ static double RejectAnomaly(double new, double average, double variance, double 
 /* Level 5                                                     */
 /***************************************************************/
 
-static void GatherPromisedMeasures(const Policy *policy)
+static void GatherPromisedMeasures(const Policy *policy, const ReportContext *report_context)
 {
     SubType *sp;
     Promise *pp;
@@ -1091,7 +1091,7 @@ static void GatherPromisedMeasures(const Policy *policy)
             {
                 for (pp = sp->promiselist; pp != NULL; pp = pp->next)
                 {
-                    ExpandPromise(cf_monitor, scope, pp, KeepMonitorPromise);
+                    ExpandPromise(cf_monitor, scope, pp, KeepMonitorPromise, report_context);
                 }
             }
         }

--- a/src/env_monitor.h
+++ b/src/env_monitor.h
@@ -26,6 +26,6 @@
 #define CFENGINE_ENV_MONITOR_H
 
 void MonitorInitialize(void);
-void MonitorStartServer(const Policy *policy);
+void MonitorStartServer(const Policy *policy, const ReportContext *report_context);
 
 #endif

--- a/src/expand.c
+++ b/src/expand.c
@@ -106,7 +106,8 @@ since these cannot be mapped into "this" without some magic.
    
 **********************************************************************/
 
-void ExpandPromise(enum cfagenttype agent, const char *scopeid, Promise *pp, void *fnptr)
+void ExpandPromise(enum cfagenttype agent, const char *scopeid, Promise *pp, void *fnptr,
+                   const ReportContext *report_context)
 {
     Rlist *listvars = NULL, *scalarvars = NULL;
     Constraint *cp;
@@ -143,7 +144,7 @@ void ExpandPromise(enum cfagenttype agent, const char *scopeid, Promise *pp, voi
     CopyLocalizedIteratorsToThisScope(scopeid, listvars);
 
     PushThisScope();
-    ExpandPromiseAndDo(agent, scopeid, pcopy, scalarvars, listvars, fnptr);
+    ExpandPromiseAndDo(agent, scopeid, pcopy, scalarvars, listvars, fnptr, report_context);
     PopThisScope();
 
     DeletePromise(pcopy);
@@ -629,7 +630,7 @@ int ExpandPrivateScalar(const char *scopeid, const char *string, char buffer[CF_
 /*********************************************************************/
 
 void ExpandPromiseAndDo(enum cfagenttype agent, const char *scopeid, Promise *pp, Rlist *scalarvars, Rlist *listvars,
-                        void (*fnptr) ())
+                        void (*fnptr) (), const ReportContext *report_context)
 {
     Rlist *lol = NULL;
     Promise *pexp;
@@ -717,8 +718,8 @@ void ExpandPromiseAndDo(enum cfagenttype agent, const char *scopeid, Promise *pp
         switch (agent)
         {
         case cf_common:
-            ShowPromise(REPORT_OUTPUT_TYPE_TEXT, pexp, 6);
-            ShowPromise(REPORT_OUTPUT_TYPE_HTML, pexp, 6);
+            ShowPromise(report_context, REPORT_OUTPUT_TYPE_TEXT, pexp, 6);
+            ShowPromise(report_context, REPORT_OUTPUT_TYPE_HTML, pexp, 6);
             ReCheckAllConstraints(pexp);
             break;
 

--- a/src/expand.h
+++ b/src/expand.h
@@ -28,9 +28,11 @@
 
 #include "cf3.defs.h"
 
-void ExpandPromise(enum cfagenttype ag, const char *scopeid, Promise *pp, void *fnptr);
+#include "reporting.h"
+
+void ExpandPromise(enum cfagenttype ag, const char *scopeid, Promise *pp, void *fnptr, const ReportContext *report_context);
 void ExpandPromiseAndDo(enum cfagenttype ag, const char *scope, Promise *p, Rlist *scalarvars, Rlist *listvars,
-                        void (*fnptr) ());
+                        void (*fnptr) (), const ReportContext *report_context);
 Rval ExpandDanglers(const char *scope, Rval rval, const Promise *pp);
 void MapIteratorsFromRval(const char *scope, Rlist **los, Rlist **lol, Rval rval, const Promise *pp);
 

--- a/src/files_copy.c
+++ b/src/files_copy.c
@@ -29,7 +29,7 @@
 
 /*****************************************************************************/
 
-void *CopyFileSources(char *destination, Attributes attr, Promise *pp)
+void *CopyFileSources(char *destination, Attributes attr, Promise *pp, const ReportContext *report_context)
 {
     char *source = attr.copy.source;
     char *server = pp->this_server;
@@ -62,7 +62,7 @@ void *CopyFileSources(char *destination, Attributes attr, Promise *pp)
         strcat(vbuff, ".");
     }
 
-    if (!MakeParentDirectory(vbuff, attr.move_obstructions))
+    if (!MakeParentDirectory(vbuff, attr.move_obstructions, report_context))
     {
         cfPS(cf_inform, CF_FAIL, "", pp, attr, "Can't make directories for %s in files.copyfrom promise\n", vbuff);
         return NULL;
@@ -77,19 +77,19 @@ void *CopyFileSources(char *destination, Attributes attr, Promise *pp)
 
         CfOut(cf_verbose, "", " ->>  Entering %s\n", source);
         SetSearchDevice(&ssb, pp);
-        SourceSearchAndCopy(source, destination, attr.recursion.depth, attr, pp);
+        SourceSearchAndCopy(source, destination, attr.recursion.depth, attr, pp, report_context);
 
         if (cfstat(destination, &dsb) != -1)
         {
             if (attr.copy.check_root)
             {
-                VerifyCopiedFileAttributes(destination, &dsb, &ssb, attr, pp);
+                VerifyCopiedFileAttributes(destination, &dsb, &ssb, attr, pp, report_context);
             }
         }
     }
     else
     {
-        VerifyCopy(source, destination, attr, pp);
+        VerifyCopy(source, destination, attr, pp, report_context);
     }
 
     snprintf(eventname, CF_BUFSIZE - 1, "Copy(%s:%s > %s)", server, source, destination);

--- a/src/files_edit.c
+++ b/src/files_edit.c
@@ -65,7 +65,7 @@ EditContext *NewEditContext(char *filename, Attributes a, Promise *pp)
 
 /*****************************************************************************/
 
-void FinishEditContext(EditContext *ec, Attributes a, Promise *pp)
+void FinishEditContext(EditContext *ec, Attributes a, Promise *pp, const ReportContext *report_context)
 {
     Item *ip;
 
@@ -90,7 +90,7 @@ void FinishEditContext(EditContext *ec, Attributes a, Promise *pp)
         }
         else
         {
-            SaveItemListAsFile(ec->file_start, ec->filename, a, pp);
+            SaveItemListAsFile(ec->file_start, ec->filename, a, pp, report_context);
         }
     }
     else
@@ -192,7 +192,8 @@ int LoadFileAsItemList(Item **liststart, const char *file, Attributes a, Promise
 
 /*********************************************************************/
 
-int SaveItemListAsFile(Item *liststart, const char *file, Attributes a, Promise *pp)
+int SaveItemListAsFile(Item *liststart, const char *file, Attributes a, Promise *pp,
+                       const ReportContext *report_context)
 {
     Item *ip;
     struct stat statbuf;
@@ -271,7 +272,7 @@ int SaveItemListAsFile(Item *liststart, const char *file, Attributes a, Promise 
 
     if (a.edits.backup != cfa_nobackup)
     {
-        if (ArchiveToRepository(backup, a, pp))
+        if (ArchiveToRepository(backup, a, pp, report_context))
         {
             unlink(backup);
         }

--- a/src/files_editline.c
+++ b/src/files_editline.c
@@ -98,7 +98,8 @@ static int InsertFileAtLocation(Item **start, Item *begin_ptr, Item *end_ptr, It
 /* Level                                                                     */
 /*****************************************************************************/
 
-int ScheduleEditLineOperations(char *filename, Bundle *bp, Attributes a, Promise *parentp)
+int ScheduleEditLineOperations(char *filename, Bundle *bp, Attributes a, Promise *parentp,
+                               const ReportContext *report_context)
 {
     enum editlinetypesequence type;
     SubType *sp;
@@ -155,7 +156,7 @@ int ScheduleEditLineOperations(char *filename, Bundle *bp, Attributes a, Promise
                 pp->this_server = filename;
                 pp->donep = &(pp->done);
 
-                ExpandPromise(cf_agent, bp->name, pp, KeepEditLinePromise);
+                ExpandPromise(cf_agent, bp->name, pp, KeepEditLinePromise, report_context);
 
                 if (Abort())
                 {

--- a/src/files_links.c
+++ b/src/files_links.c
@@ -35,7 +35,8 @@ static char *AbsLinkPath(char *from, char *relto);
 
 /*****************************************************************************/
 
-char VerifyLink(char *destination, char *source, Attributes attr, Promise *pp)
+char VerifyLink(char *destination, char *source, Attributes attr, Promise *pp,
+                const ReportContext *report_context)
 #ifdef MINGW
 {
     CfOut(cf_verbose, "", "Windows does not support symbolic links (at VerifyLink())");
@@ -105,14 +106,14 @@ if (MatchRlistItem(attr.link.copy_patterns,lastnode))
 
     if (readlink(destination, linkbuf, CF_BUFSIZE - 1) == -1)
     {
-        if (!MakeParentDirectory(destination, attr.move_obstructions))  /* link doesn't exist */
+        if (!MakeParentDirectory(destination, attr.move_obstructions, report_context))  /* link doesn't exist */
         {
             cfPS(cf_verbose, CF_FAIL, "", pp, attr, " !! Unable to create link %s -> %s", destination, to);
             return CF_FAIL;
         }
         else
         {
-            if (!MoveObstruction(destination, attr, pp))
+            if (!MoveObstruction(destination, attr, pp, report_context))
             {
                 cfPS(cf_verbose, CF_FAIL, "", pp, attr, " !! Unable to create link %s -> %s", destination, to);
                 return CF_FAIL;
@@ -175,7 +176,8 @@ if (MatchRlistItem(attr.link.copy_patterns,lastnode))
 
 /*****************************************************************************/
 
-char VerifyAbsoluteLink(char *destination, char *source, Attributes attr, Promise *pp)
+char VerifyAbsoluteLink(char *destination, char *source, Attributes attr, Promise *pp,
+                        const ReportContext *report_context)
 {
     char absto[CF_BUFSIZE];
     char expand[CF_BUFSIZE];
@@ -219,12 +221,13 @@ char VerifyAbsoluteLink(char *destination, char *source, Attributes attr, Promis
 
     CompressPath(linkto, expand);
 
-    return VerifyLink(destination, linkto, attr, pp);
+    return VerifyLink(destination, linkto, attr, pp, report_context);
 }
 
 /*****************************************************************************/
 
-char VerifyRelativeLink(char *destination, char *source, Attributes attr, Promise *pp)
+char VerifyRelativeLink(char *destination, char *source, Attributes attr, Promise *pp,
+                        const ReportContext *report_context)
 {
     char *sp, *commonto, *commonfrom;
     char buff[CF_BUFSIZE], linkto[CF_BUFSIZE], add[CF_BUFSIZE];
@@ -234,7 +237,7 @@ char VerifyRelativeLink(char *destination, char *source, Attributes attr, Promis
 
     if (*source == '.')
     {
-        return VerifyLink(destination, source, attr, pp);
+        return VerifyLink(destination, source, attr, pp, report_context);
     }
 
     if (!CompressPath(linkto, source))
@@ -295,12 +298,13 @@ char VerifyRelativeLink(char *destination, char *source, Attributes attr, Promis
         return CF_FAIL;
     }
 
-    return VerifyLink(destination, buff, attr, pp);
+    return VerifyLink(destination, buff, attr, pp, report_context);
 }
 
 /*****************************************************************************/
 
-char VerifyHardLink(char *destination, char *source, Attributes attr, Promise *pp)
+char VerifyHardLink(char *destination, char *source, Attributes attr, Promise *pp,
+                    const ReportContext *report_context)
 {
     char to[CF_BUFSIZE], absto[CF_BUFSIZE];
     struct stat ssb, dsb;
@@ -372,7 +376,7 @@ char VerifyHardLink(char *destination, char *source, Attributes attr, Promise *p
 
     CfOut(cf_inform, "", " !! %s does not appear to be a hard link to %s\n", destination, to);
 
-    if (!MoveObstruction(destination, attr, pp))
+    if (!MoveObstruction(destination, attr, pp, report_context))
     {
         return CF_FAIL;
     }

--- a/src/files_names.c
+++ b/src/files_names.c
@@ -33,7 +33,8 @@
 
 /*****************************************************************************/
 
-void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *path, Promise *ptr))
+void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *path, Promise *ptr, const ReportContext *report_context),
+                             const ReportContext *report_context)
 {
     Item *path, *ip, *remainder = NULL;
     char pbuffer[CF_BUFSIZE];
@@ -50,7 +51,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
     if (!IsPathRegex(wildpath) || (pathtype && (strcmp(pathtype, "literal") == 0)))
     {
         CfOut(cf_verbose, "", " -> Using literal pathtype for %s\n", wildpath);
-        (*fnptr) (wildpath, pp);
+        (*fnptr) (wildpath, pp, report_context);
         return;
     }
     else
@@ -120,7 +121,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
         {
             // Could be a dummy directory to be created so this is not an error.
             CfOut(cf_verbose, "", " -> Using best-effort expanded (but non-existent) file base path %s\n", wildpath);
-            (*fnptr) (wildpath, pp);
+            (*fnptr) (wildpath, pp, report_context);
             DeleteItemList(path);
             return;
         }
@@ -166,7 +167,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
 
                 if (!lastnode && (strcmp(nextbuffer, wildpath) != 0))
                 {
-                    LocateFilePromiserGroup(nextbuffer, pp, fnptr);
+                    LocateFilePromiserGroup(nextbuffer, pp, fnptr, report_context);
                 }
                 else
                 {
@@ -187,7 +188,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
                     /* If there were back references there could still be match.x vars to expand */
 
                     pcopy = ExpandDeRefPromise(CONTEXTID, pp);
-                    (*fnptr) (nextbufferOrig, pcopy);
+                    (*fnptr) (nextbufferOrig, pcopy, report_context);
                     DeletePromise(pcopy);
                 }
             }
@@ -198,7 +199,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
     else
     {
         CfOut(cf_verbose, "", " -> Using file base path %s\n", pbuffer);
-        (*fnptr) (pbuffer, pp);
+        (*fnptr) (pbuffer, pp, report_context);
     }
 
     if (count == 0)
@@ -207,7 +208,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
 
         if (create)
         {
-            VerifyFilePromise(pp->promiser, pp);
+            VerifyFilePromise(pp->promiser, pp, report_context);
         }
     }
 

--- a/src/files_operators.c
+++ b/src/files_operators.c
@@ -44,9 +44,9 @@ static void TruncateFile(char *name);
 static int VerifyFinderType(char *file, struct stat *statbuf, Attributes a, Promise *pp);
 #endif
 static int TransformFile(char *file, Attributes attr, Promise *pp);
-static void VerifyName(char *path, struct stat *sb, Attributes attr, Promise *pp);
+static void VerifyName(char *path, struct stat *sb, Attributes attr, Promise *pp, const ReportContext *report_context);
 static void VerifyDelete(char *path, struct stat *sb, Attributes attr, Promise *pp);
-static void DeleteDirectoryTree(char *path, Promise *pp);
+static void DeleteDirectoryTree(char *path, Promise *pp, const ReportContext *report_context);
 
 #ifndef MINGW
 static void VerifySetUidGid(char *file, struct stat *dstat, mode_t newperm, Promise *pp, Attributes attr);
@@ -54,7 +54,8 @@ static void VerifySetUidGid(char *file, struct stat *dstat, mode_t newperm, Prom
 
 /*****************************************************************************/
 
-int VerifyFileLeaf(char *path, struct stat *sb, Attributes attr, Promise *pp)
+int VerifyFileLeaf(char *path, struct stat *sb, Attributes attr, Promise *pp,
+                   const ReportContext *report_context)
 {
 /* Here we can assume that we are in the parent directory of the leaf */
 
@@ -82,7 +83,7 @@ int VerifyFileLeaf(char *path, struct stat *sb, Attributes attr, Promise *pp)
     {
         if (attr.haverename)
         {
-            VerifyName(path, sb, attr, pp);
+            VerifyName(path, sb, attr, pp, report_context);
         }
 
         if (attr.havedelete)
@@ -105,7 +106,7 @@ int VerifyFileLeaf(char *path, struct stat *sb, Attributes attr, Promise *pp)
         }
         else
         {
-            VerifyFileAttributes(path, sb, attr, pp);
+            VerifyFileAttributes(path, sb, attr, pp, report_context);
         }
     }
 
@@ -142,7 +143,8 @@ FILE *CreateEmptyStream()
 
 /*****************************************************************************/
 
-int CfCreateFile(char *file, Promise *pp, Attributes attr)
+int CfCreateFile(char *file, Promise *pp, Attributes attr,
+                 const ReportContext *report_context)
 {
     int fd;
 
@@ -163,7 +165,7 @@ int CfCreateFile(char *file, Promise *pp, Attributes attr)
 
         if (!DONTDO && attr.transaction.action != cfa_warn)
         {
-            if (!MakeParentDirectory(file, attr.move_obstructions))
+            if (!MakeParentDirectory(file, attr.move_obstructions, report_context))
             {
                 cfPS(cf_inform, CF_FAIL, "creat", pp, attr, " !! Error creating directories for %s\n", file);
                 return false;
@@ -195,7 +197,7 @@ int CfCreateFile(char *file, Promise *pp, Attributes attr)
                 filemode = attr.perms.plus & ~(attr.perms.minus);
             }
 
-            MakeParentDirectory(file, attr.move_obstructions);
+            MakeParentDirectory(file, attr.move_obstructions, report_context);
 
             if ((fd = creat(file, filemode)) == -1)
             {
@@ -222,7 +224,8 @@ int CfCreateFile(char *file, Promise *pp, Attributes attr)
 
 /*****************************************************************************/
 
-int ScheduleCopyOperation(char *destination, Attributes attr, Promise *pp)
+int ScheduleCopyOperation(char *destination, Attributes attr, Promise *pp,
+                          const ReportContext *report_context)
 {
     AgentConnection *conn = NULL;
 
@@ -254,7 +257,7 @@ int ScheduleCopyOperation(char *destination, Attributes attr, Promise *pp)
     pp->conn = conn;            /* for ease of access */
     pp->cache = NULL;
 
-    CopyFileSources(destination, attr, pp);
+    CopyFileSources(destination, attr, pp, report_context);
 
     if (attr.transaction.background)
     {
@@ -270,7 +273,8 @@ int ScheduleCopyOperation(char *destination, Attributes attr, Promise *pp)
 
 /*****************************************************************************/
 
-int ScheduleLinkChildrenOperation(char *destination, char *source, int recurse, Attributes attr, Promise *pp)
+int ScheduleLinkChildrenOperation(char *destination, char *source, int recurse, Attributes attr, Promise *pp,
+                                  const ReportContext *report_context)
 {
     Dir *dirh;
     const struct dirent *dirp;
@@ -294,7 +298,7 @@ int ScheduleLinkChildrenOperation(char *destination, char *source, int recurse, 
 
     snprintf(promiserpath, CF_BUFSIZE, "%s/.", destination);
 
-    if ((ret == -1 || !S_ISDIR(lsb.st_mode)) && !CfCreateFile(promiserpath, pp, attr))
+    if ((ret == -1 || !S_ISDIR(lsb.st_mode)) && !CfCreateFile(promiserpath, pp, attr, report_context))
     {
         CfOut(cf_error, "", "Cannot promise to link multiple files to children of %s as it is not a directory!",
               destination);
@@ -351,11 +355,11 @@ int ScheduleLinkChildrenOperation(char *destination, char *source, int recurse, 
 
         if ((attr.recursion.depth > recurse) && (lstat(sourcepath, &lsb) != -1) && S_ISDIR(lsb.st_mode))
         {
-            ScheduleLinkChildrenOperation(promiserpath, sourcepath, recurse + 1, attr, pp);
+            ScheduleLinkChildrenOperation(promiserpath, sourcepath, recurse + 1, attr, pp, report_context);
         }
         else
         {
-            ScheduleLinkOperation(promiserpath, sourcepath, attr, pp);
+            ScheduleLinkOperation(promiserpath, sourcepath, attr, pp, report_context);
         }
     }
 
@@ -365,7 +369,8 @@ int ScheduleLinkChildrenOperation(char *destination, char *source, int recurse, 
 
 /*****************************************************************************/
 
-int ScheduleLinkOperation(char *destination, char *source, Attributes attr, Promise *pp)
+int ScheduleLinkOperation(char *destination, char *source, Attributes attr, Promise *pp,
+                          const ReportContext *report_context)
 {
     const char *lastnode;
 
@@ -374,23 +379,23 @@ int ScheduleLinkOperation(char *destination, char *source, Attributes attr, Prom
     if (MatchRlistItem(attr.link.copy_patterns, lastnode))
     {
         CfOut(cf_verbose, "", " -> Link %s matches copy_patterns\n", destination);
-        VerifyCopy(attr.link.source, destination, attr, pp);
+        VerifyCopy(attr.link.source, destination, attr, pp, report_context);
         return true;
     }
 
     switch (attr.link.link_type)
     {
     case cfa_symlink:
-        VerifyLink(destination, source, attr, pp);
+        VerifyLink(destination, source, attr, pp, report_context);
         break;
     case cfa_hardlink:
-        VerifyHardLink(destination, source, attr, pp);
+        VerifyHardLink(destination, source, attr, pp, report_context);
         break;
     case cfa_relative:
-        VerifyRelativeLink(destination, source, attr, pp);
+        VerifyRelativeLink(destination, source, attr, pp, report_context);
         break;
     case cfa_absolute:
-        VerifyAbsoluteLink(destination, source, attr, pp);
+        VerifyAbsoluteLink(destination, source, attr, pp, report_context);
         break;
     default:
         CfOut(cf_error, "", "Unknown link type - should not happen.\n");
@@ -402,7 +407,7 @@ int ScheduleLinkOperation(char *destination, char *source, Attributes attr, Prom
 
 /*****************************************************************************/
 
-int ScheduleEditOperation(char *filename, Attributes a, Promise *pp)
+int ScheduleEditOperation(char *filename, Attributes a, Promise *pp, const ReportContext *report_context)
 {
     Bundle *bp;
     void *vp;
@@ -425,7 +430,7 @@ int ScheduleEditOperation(char *filename, Attributes a, Promise *pp)
     if (pp->edcontext == NULL)
     {
         cfPS(cf_error, CF_FAIL, "", pp, a, "File %s was marked for editing but could not be opened\n", filename);
-        FinishEditContext(pp->edcontext, a, pp);
+        FinishEditContext(pp->edcontext, a, pp, report_context);
         YieldCurrentLock(thislock);
         return false;
     }
@@ -456,7 +461,7 @@ int ScheduleEditOperation(char *filename, Attributes a, Promise *pp)
         }
         else
         {
-            FinishEditContext(pp->edcontext, a, pp);
+            FinishEditContext(pp->edcontext, a, pp, report_context);
             YieldCurrentLock(thislock);
             return false;
         }
@@ -471,11 +476,11 @@ int ScheduleEditOperation(char *filename, Attributes a, Promise *pp)
 
             DeleteScope(bp->name);
             NewScope(bp->name);
-            HashVariables(policy, bp->name);
+            HashVariables(policy, bp->name, report_context);
 
             AugmentScope(bp->name, bp->args, params);
             PushPrivateClassContext(a.edits.inherit);
-            retval = ScheduleEditLineOperations(filename, bp, a, pp);
+            retval = ScheduleEditLineOperations(filename, bp, a, pp, report_context);
             PopPrivateClassContext();
             DeleteScope(bp->name);
         }
@@ -489,17 +494,17 @@ int ScheduleEditOperation(char *filename, Attributes a, Promise *pp)
 
             DeleteScope(bp->name);
             NewScope(bp->name);
-            HashVariables(policy, bp->name);
+            HashVariables(policy, bp->name, report_context);
 
             PushPrivateClassContext(a.edits.inherit);
-            retval = ScheduleEditLineOperations(filename,bp,a,pp);
+            retval = ScheduleEditLineOperations(filename, bp, a, pp, report_context);
             PopPrivateClassContext();
             DeleteScope(bp->name);
         }
         // FIXME: why it crashes? DeleteBundles(bp);
     }
 
-    FinishEditContext(pp->edcontext, a, pp);
+    FinishEditContext(pp->edcontext, a, pp, report_context);
     YieldCurrentLock(thislock);
     return retval;
 }
@@ -512,7 +517,7 @@ int ScheduleEditOperation(char *filename, Attributes a, Promise *pp)
 /* Level                                                                     */
 /*****************************************************************************/
 
-int MoveObstruction(char *from, Attributes attr, Promise *pp)
+int MoveObstruction(char *from, Attributes attr, Promise *pp, const ReportContext *report_context)
 {
     struct stat sb;
     char stamp[CF_BUFSIZE], saved[CF_BUFSIZE];
@@ -552,7 +557,7 @@ int MoveObstruction(char *from, Attributes attr, Promise *pp)
                 return false;
             }
 
-            if (ArchiveToRepository(saved, attr, pp))
+            if (ArchiveToRepository(saved, attr, pp, report_context))
             {
                 unlink(saved);
             }
@@ -708,7 +713,8 @@ static int VerifyFinderType(char *file, struct stat *statbuf, Attributes a, Prom
 /* Level                                                             */
 /*********************************************************************/
 
-static void VerifyName(char *path, struct stat *sb, Attributes attr, Promise *pp)
+static void VerifyName(char *path, struct stat *sb, Attributes attr, Promise *pp,
+                       const ReportContext *report_context)
 {
     mode_t newperm;
     struct stat dsb;
@@ -864,7 +870,7 @@ static void VerifyName(char *path, struct stat *sb, Attributes attr, Promise *pp
                          newname, (uintmax_t)newperm);
                 }
 
-                if (ArchiveToRepository(newname, attr, pp))
+                if (ArchiveToRepository(newname, attr, pp, report_context))
                 {
                     unlink(newname);
                 }
@@ -1021,7 +1027,7 @@ void TouchFile(char *path, struct stat *sb, Attributes attr, Promise *pp)
 
 /*********************************************************************/
 
-void VerifyFileIntegrity(char *file, Attributes attr, Promise *pp)
+void VerifyFileIntegrity(char *file, Attributes attr, Promise *pp, const ReportContext *report_context)
 {
     unsigned char digest1[EVP_MAX_MD_SIZE + 1];
     unsigned char digest2[EVP_MAX_MD_SIZE + 1];
@@ -1072,7 +1078,7 @@ void VerifyFileIntegrity(char *file, Attributes attr, Promise *pp)
 
     if (attr.change.report_diffs)
     {
-        LogFileChange(file, changed, attr, pp);
+        LogFileChange(file, changed, attr, pp, report_context);
     }
 }
 
@@ -1296,7 +1302,7 @@ static int TransformFile(char *file, Attributes attr, Promise *pp)
 
 /*******************************************************************/
 
-int MakeParentDirectory(char *parentandchild, int force)
+int MakeParentDirectory(char *parentandchild, int force, const ReportContext *report_context)
 {
     char *spc, *sp;
     char currentpath[CF_BUFSIZE];
@@ -1379,7 +1385,7 @@ int MakeParentDirectory(char *parentandchild, int force)
                 {
                     if (S_ISDIR(sbuf.st_mode))
                     {
-                        DeleteDirectoryTree(currentpath, NULL);
+                        DeleteDirectoryTree(currentpath, NULL, report_context);
                     }
                     else
                     {
@@ -1657,7 +1663,7 @@ void RotateFiles(char *name, int number)
 /* Level                                                           */
 /*******************************************************************/
 
-static void DeleteDirectoryTree(char *path, Promise *pp)
+static void DeleteDirectoryTree(char *path, Promise *pp, const ReportContext *report_context)
 {
     Promise promise = { 0 };
     char s[CF_MAXVARSIZE];
@@ -1704,7 +1710,7 @@ static void DeleteDirectoryTree(char *path, Promise *pp)
     ConstraintAppendToPromise(&promise, "file_select", (Rval) {"true", CF_SCALAR}, "any", false);
     ConstraintAppendToPromise(&promise, "mtime", (Rval) {s, CF_SCALAR}, "any", false);
     ConstraintAppendToPromise(&promise, "file_result", (Rval) {"mtime", CF_SCALAR}, "any", false);
-    VerifyFilePromise(promise.promiser, &promise);
+    VerifyFilePromise(promise.promiser, &promise, report_context);
     rmdir(path);
 }
 
@@ -2121,7 +2127,8 @@ GidList *MakeGidList(char *gidnames)
 
 /*****************************************************************************/
 
-void VerifyFileAttributes(char *file, struct stat *dstat, Attributes attr, Promise *pp)
+void VerifyFileAttributes(char *file, struct stat *dstat, Attributes attr, Promise *pp,
+                          const ReportContext *report_context)
 {
     mode_t newperm = dstat->st_mode, maskvalue;
 
@@ -2186,7 +2193,7 @@ void VerifyFileAttributes(char *file, struct stat *dstat, Attributes attr, Promi
 
     if (attr.havechange && S_ISREG(dstat->st_mode))
     {
-        VerifyFileIntegrity(file, attr, pp);
+        VerifyFileIntegrity(file, attr, pp, report_context);
     }
 
     if (attr.havechange)
@@ -2313,7 +2320,7 @@ void VerifyFileAttributes(char *file, struct stat *dstat, Attributes attr, Promi
 /*****************************************************************************/
 
 void VerifyCopiedFileAttributes(char *file, struct stat *dstat, struct stat *sstat, Attributes attr,
-                                            Promise *pp)
+                                Promise *pp, const ReportContext *report_context)
 {
     mode_t newplus, newminus;
     uid_t save_uid;
@@ -2347,7 +2354,7 @@ void VerifyCopiedFileAttributes(char *file, struct stat *dstat, struct stat *sst
         newminus = ~newplus & 07777;
         attr.perms.plus = newplus;
         attr.perms.minus = newminus;
-        VerifyFileAttributes(file, dstat, attr, pp);
+        VerifyFileAttributes(file, dstat, attr, pp, report_context);
     }
     else
     {
@@ -2367,7 +2374,7 @@ void VerifyCopiedFileAttributes(char *file, struct stat *dstat, struct stat *sst
             newminus = ~(newplus & ~(attr.perms.minus)) & 07777;
             attr.perms.plus = newplus;
             attr.perms.minus = newminus;
-            VerifyFileAttributes(file, dstat, attr, pp);
+            VerifyFileAttributes(file, dstat, attr, pp, report_context);
         }
     }
 

--- a/src/files_repository.c
+++ b/src/files_repository.c
@@ -87,7 +87,7 @@ bool GetRepositoryPath(const char *file, Attributes attr, char *destination)
 
 /*********************************************************************/
 
-int ArchiveToRepository(char *file, Attributes attr, Promise *pp)
+int ArchiveToRepository(char *file, Attributes attr, Promise *pp, const ReportContext *report_context)
  /* Returns true if the file was backup up and false if not */
 {
     char destination[CF_BUFSIZE];
@@ -119,7 +119,7 @@ int ArchiveToRepository(char *file, Attributes attr, Promise *pp)
     
     JoinPath(destination, CanonifyName(file));
 
-    if (!MakeParentDirectory(destination, attr.move_obstructions))
+    if (!MakeParentDirectory(destination, attr.move_obstructions, report_context))
     {
     }
 

--- a/src/files_repository.h
+++ b/src/files_repository.h
@@ -28,7 +28,7 @@
 void SetRepositoryLocation(const char *path);
 void SetRepositoryChar(char c);
 
-int ArchiveToRepository(char *file, Attributes attr, Promise *pp);
+int ArchiveToRepository(char *file, Attributes attr, Promise *pp, const ReportContext *report_context);
 bool FileInRepository(const char *filename);
 
 /* Returns false if backing up files to repository is not set up */

--- a/src/generic_agent.h
+++ b/src/generic_agent.h
@@ -35,17 +35,17 @@ typedef struct
     bool verify_promises;
 } GenericAgentConfig;
 
-Policy *GenericInitialize(char *agents, GenericAgentConfig config);
+Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportContext *report_context);
 void GenericDeInitialize(void);
-void InitializeGA(void);
+void InitializeGA(const ReportContext *report_context);
 void Syntax(const char *comp, const struct option options[], const char *hints[], const char *id);
 void ManPage(const char *component, const struct option options[], const char *hints[], const char *id);
 void PrintVersionBanner(const char *component);
-int CheckPromises(enum cfagenttype ag);
-Policy *ReadPromises(enum cfagenttype ag, char *agents, GenericAgentConfig config);
+int CheckPromises(enum cfagenttype ag, const ReportContext *report_context);
+Policy *ReadPromises(enum cfagenttype ag, char *agents, GenericAgentConfig config, const ReportContext *report_context);
 int NewPromiseProposals(void);
 void CompilationReport(Policy *policy, char *fname);
-void HashVariables(Policy *policy, const char *name);
+void HashVariables(Policy *policy, const char *name, const ReportContext *report_context);
 void HashControls(const Policy *policy);
 void CloseLog(void);
 Constraint *ControlBodyConstraints(const Policy *policy, enum cfagenttype agent);
@@ -57,10 +57,13 @@ void PromiseBanner(Promise *pp);
 void BannerBundle(Bundle *bp, Rlist *args);
 void BannerSubBundle(Bundle *bp, Rlist *args);
 void WritePID(char *filename);
-void OpenCompilationReportFiles(const char *fname);
+ReportContext *OpenCompilationReportFiles(const char *fname);
 GenericAgentConfig GenericAgentDefaultConfig(enum cfagenttype agent_type);
 void CheckLicenses(void);
 void ReloadPromises(enum cfagenttype ag);
 void SetInputFile(const char *filename);
+
+ReportContext *OpenReports(const char *agents);
+void CloseReports(const char *agents, ReportContext *report_context);
 
 #endif

--- a/src/html.c
+++ b/src/html.c
@@ -25,14 +25,14 @@
 
 #include "cf3.defs.h"
 
-void CfHtmlHeader(FILE *fp, char *title, char *css, char *webdriver, char *header)
+void CfHtmlHeader(Writer *writer, char *title, char *css, char *webdriver, char *header)
 {
     if (title == NULL)
     {
         title = "Cfengine Knowledge";
     }
 
-    fprintf(fp, "<html>\n"
+    WriterWriteF(writer, "<html>\n"
             "  <head>\n"
             "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=iso-8859-1\" />\n"
             "    <meta http-equiv=\"refresh\" CONTENT=\"150\">\n"
@@ -45,27 +45,27 @@ void CfHtmlHeader(FILE *fp, char *title, char *css, char *webdriver, char *heade
     {
         if (strlen(LICENSE_COMPANY) > 0)
         {
-            fprintf(fp, "<div id=\"company\">%s</div>\n%s\n", LICENSE_COMPANY, header);
+            WriterWriteF(writer, "<div id=\"company\">%s</div>\n%s\n", LICENSE_COMPANY, header);
         }
         else
         {
-            fprintf(fp, "%s\n", header);
+            WriterWriteF(writer, "%s\n", header);
         }
     }
 
-    fprintf(fp, "<div id=\"primary\">\n");
+    WriterWriteF(writer, "<div id=\"primary\">\n");
 }
 
 /*****************************************************************************/
 
-void CfHtmlFooter(FILE *fp, char *footer)
+void CfHtmlFooter(Writer *writer, char *footer)
 {
     if (strlen(footer) > 0)
     {
-        fprintf(fp, "%s", footer);
+        WriterWriteF(writer, "%s", footer);
     }
 
-    fprintf(fp, "</div></body></html>\n");
+    WriterWriteF(writer, "</div></body></html>\n");
 }
 
 /*****************************************************************************/

--- a/src/logging.c
+++ b/src/logging.c
@@ -349,7 +349,9 @@ void ClassAuditLog(const Promise *pp, Attributes attr, char *str, char status, c
 
     if (DEBUG)
     {
-        AuditStatusMessage(stdout, status);
+        Writer *writer = FileWriter(stdout);
+        AuditStatusMessage(writer, status);
+        FileWriterDetach(writer);
     }
 
     if (ap != NULL)
@@ -511,44 +513,44 @@ void FatalError(char *s, ...)
 
 /*****************************************************************************/
 
-void AuditStatusMessage(FILE *fp, char status)
+void AuditStatusMessage(Writer *writer, char status)
 {
     switch (status)             /* Reminder */
     {
     case CF_CHG:
-        fprintf(fp, "made a system correction");
+        WriterWriteF(writer, "made a system correction");
         break;
 
     case CF_WARN:
-        fprintf(fp, "promise not kept, no action taken");
+        WriterWriteF(writer, "promise not kept, no action taken");
         break;
 
     case CF_TIMEX:
-        fprintf(fp, "timed out");
+        WriterWriteF(writer, "timed out");
         break;
 
     case CF_FAIL:
-        fprintf(fp, "failed to make a correction");
+        WriterWriteF(writer, "failed to make a correction");
         break;
 
     case CF_DENIED:
-        fprintf(fp, "was denied access to an essential resource");
+        WriterWriteF(writer, "was denied access to an essential resource");
         break;
 
     case CF_INTERPT:
-        fprintf(fp, "was interrupted\n");
+        WriterWriteF(writer, "was interrupted\n");
         break;
 
     case CF_NOP:
-        fprintf(fp, "was applied but performed no required actions");
+        WriterWriteF(writer, "was applied but performed no required actions");
         break;
 
     case CF_UNKNOWN:
-        fprintf(fp, "was applied but status unknown");
+        WriterWriteF(writer, "was applied but status unknown");
         break;
 
     case CF_REPORT:
-        fprintf(fp, "report");
+        WriterWriteF(writer, "report");
         break;
     }
 

--- a/src/prototypes3.h
+++ b/src/prototypes3.h
@@ -47,7 +47,7 @@ int yyparse(void);
 
 /* agent.c */
 
-int ScheduleAgentOperations(Bundle *bp);
+int ScheduleAgentOperations(Bundle *bp, const ReportContext *report_context);
 
 /* agentdiagnostic.c */
 
@@ -197,12 +197,12 @@ void VerifyMeasurement(double *this, Attributes a, Promise *pp);
 void SetMeasurementPromises(Item **classlist);
 void LongHaul(time_t current);
 void VerifyACL(char *file, Attributes a, Promise *pp);
-void LogFileChange(char *file, int change, Attributes a, Promise *pp);
+void LogFileChange(char *file, int change, Attributes a, Promise *pp, const ReportContext *report_context);
 void RemoteSysLog(int log_priority, const char *log_string);
 void ReportPatches(PackageManager *list);
 void SummarizeSoftware(int xml, int html, int csv, int embed, char *stylesheet, char *head, char *foot, char *web);
 void SummarizeUpdates(int xml, int html, int csv, int embed, char *stylesheet, char *head, char *foot, char *web);
-void VerifyServices(Attributes a, Promise *pp);
+void VerifyServices(Attributes a, Promise *pp, const ReportContext *report_context);
 void LoadSlowlyVaryingObservations(void);
 void MonOtherInit(void);
 void MonOtherGatherData(double *cf_this);
@@ -262,7 +262,7 @@ void ArgFree(char **args);
 
 /* files_copy.c */
 
-void *CopyFileSources(char *destination, Attributes attr, Promise *pp);
+void *CopyFileSources(char *destination, Attributes attr, Promise *pp, const ReportContext *report_context);
 int CopyRegularFileDisk(char *source, char *new, Attributes attr, Promise *pp);
 void CheckForFileHoles(struct stat *sstat, Promise *pp);
 int FSWrite(char *new, int dd, char *buf, int towrite, int *last_write_made_hole, int n_read, Attributes attr,
@@ -271,22 +271,22 @@ int FSWrite(char *new, int dd, char *buf, int towrite, int *last_write_made_hole
 /* files_edit.c */
 
 EditContext *NewEditContext(char *filename, Attributes a, Promise *pp);
-void FinishEditContext(EditContext *ec, Attributes a, Promise *pp);
+void FinishEditContext(EditContext *ec, Attributes a, Promise *pp, const ReportContext *report_context);
 int LoadFileAsItemList(Item **liststart, const char *file, Attributes a, Promise *pp);
-int SaveItemListAsFile(Item *liststart, const char *file, Attributes a, Promise *pp);
+int SaveItemListAsFile(Item *liststart, const char *file, Attributes a, Promise *pp, const ReportContext *report_context);
 int AppendIfNoSuchLine(char *filename, char *line);
 
 /* files_editline.c */
 
-int ScheduleEditLineOperations(char *filename, Bundle *bp, Attributes a, Promise *pp);
+int ScheduleEditLineOperations(char *filename, Bundle *bp, Attributes a, Promise *pp, const ReportContext *report_context);
 Bundle *MakeTemporaryBundleFromTemplate(Attributes a,Promise *pp);
 
 /* files_links.c */
 
-char VerifyLink(char *destination, char *source, Attributes attr, Promise *pp);
-char VerifyAbsoluteLink(char *destination, char *source, Attributes attr, Promise *pp);
-char VerifyRelativeLink(char *destination, char *source, Attributes attr, Promise *pp);
-char VerifyHardLink(char *destination, char *source, Attributes attr, Promise *pp);
+char VerifyLink(char *destination, char *source, Attributes attr, Promise *pp, const ReportContext *report_context);
+char VerifyAbsoluteLink(char *destination, char *source, Attributes attr, Promise *pp, const ReportContext *report_context);
+char VerifyRelativeLink(char *destination, char *source, Attributes attr, Promise *pp, const ReportContext *report_context);
+char VerifyHardLink(char *destination, char *source, Attributes attr, Promise *pp, const ReportContext *report_context);
 int KillGhostLink(char *name, Attributes attr, Promise *pp);
 int MakeHardLink(char *from, char *to, Attributes attr, Promise *pp);
 int ExpandLinks(char *dest, char *from, int level);
@@ -311,33 +311,33 @@ void HashPubKey(RSA *key, unsigned char digest[EVP_MAX_MD_SIZE + 1], enum cfhash
 
 /* files_interfaces.c */
 
-void SourceSearchAndCopy(char *from, char *to, int maxrecurse, Attributes attr, Promise *pp);
-void VerifyCopy(char *source, char *destination, Attributes attr, Promise *pp);
-void LinkCopy(char *sourcefile, char *destfile, struct stat *sb, Attributes attr, Promise *pp);
+void SourceSearchAndCopy(char *from, char *to, int maxrecurse, Attributes attr, Promise *pp, const ReportContext *report_context);
+void VerifyCopy(char *source, char *destination, Attributes attr, Promise *pp, const ReportContext *report_context);
+void LinkCopy(char *sourcefile, char *destfile, struct stat *sb, Attributes attr, Promise *pp, const ReportContext *report_context);
 int cfstat(const char *path, struct stat *buf);
 int cf_stat(char *file, struct stat *buf, Attributes attr, Promise *pp);
 int cf_lstat(char *file, struct stat *buf, Attributes attr, Promise *pp);
-int CopyRegularFile(char *source, char *dest, struct stat sstat, struct stat dstat, Attributes attr, Promise *pp);
+int CopyRegularFile(char *source, char *dest, struct stat sstat, struct stat dstat, Attributes attr, Promise *pp, const ReportContext *report_context);
 int CfReadLine(char *buff, int size, FILE *fp);
 int cf_readlink(char *sourcefile, char *linkbuf, int buffsize, Attributes attr, Promise *pp);
 
 /* files_operators.c */
 
-int VerifyFileLeaf(char *path, struct stat *sb, Attributes attr, Promise *pp);
-int CfCreateFile(char *file, Promise *pp, Attributes attr);
+int VerifyFileLeaf(char *path, struct stat *sb, Attributes attr, Promise *pp, const ReportContext *report_context);
+int CfCreateFile(char *file, Promise *pp, Attributes attr, const ReportContext *report_context);
 FILE *CreateEmptyStream(void);
-int ScheduleCopyOperation(char *destination, Attributes attr, Promise *pp);
-int ScheduleLinkChildrenOperation(char *destination, char *source, int rec, Attributes attr, Promise *pp);
-int ScheduleLinkOperation(char *destination, char *source, Attributes attr, Promise *pp);
-int ScheduleEditOperation(char *filename, Attributes attr, Promise *pp);
+int ScheduleCopyOperation(char *destination, Attributes attr, Promise *pp, const ReportContext *report_context);
+int ScheduleLinkChildrenOperation(char *destination, char *source, int rec, Attributes attr, Promise *pp, const ReportContext *report_context);
+int ScheduleLinkOperation(char *destination, char *source, Attributes attr, Promise *pp, const ReportContext *report_context);
+int ScheduleEditOperation(char *filename, Attributes attr, Promise *pp, const ReportContext *report_context);
 FileCopy *NewFileCopy(Promise *pp);
-void VerifyFileAttributes(char *file, struct stat *dstat, Attributes attr, Promise *pp);
-void VerifyFileIntegrity(char *file, Attributes attr, Promise *pp);
+void VerifyFileAttributes(char *file, struct stat *dstat, Attributes attr, Promise *pp, const ReportContext *report_context);
+void VerifyFileIntegrity(char *file, Attributes attr, Promise *pp, const ReportContext *report_context);
 int VerifyOwner(char *file, Promise *pp, Attributes attr, struct stat *statbuf);
-void VerifyCopiedFileAttributes(char *file, struct stat *dstat, struct stat *sstat, Attributes attr, Promise *pp);
-int MoveObstruction(char *from, Attributes attr, Promise *pp);
+void VerifyCopiedFileAttributes(char *file, struct stat *dstat, struct stat *sstat, Attributes attr, Promise *pp, const ReportContext *report_context);
+int MoveObstruction(char *from, Attributes attr, Promise *pp, const ReportContext *report_context);
 void TouchFile(char *path, struct stat *sb, Attributes attr, Promise *pp);
-int MakeParentDirectory(char *parentandchild, int force);
+int MakeParentDirectory(char *parentandchild, int force, const ReportContext *report_context);
 void RotateFiles(char *name, int number);
 void CreateEmptyFile(char *name);
 void VerifyFileChanges(char *file, struct stat *sb, Attributes attr, Promise *pp);
@@ -424,8 +424,8 @@ CfAssoc *HashIteratorNext(HashIterator *iterator);
 
 /* html.c */
 
-void CfHtmlHeader(FILE *fp, char *title, char *css, char *webdriver, char *banner);
-void CfHtmlFooter(FILE *fp, char *footer);
+void CfHtmlHeader(Writer *writer, char *title, char *css, char *webdriver, char *banner);
+void CfHtmlFooter(Writer *writer, char *footer);
 void CfHtmlTitle(FILE *fp, char *title);
 int IsHtmlHeader(char *s);
 
@@ -469,7 +469,7 @@ void ClassAuditLog(const Promise *pp, Attributes attr, char *str, char status, c
 void PromiseLog(char *s);
 void FatalError(char *s, ...) FUNC_ATTR_NORETURN FUNC_ATTR_FORMAT(printf, 1, 2);
 
-void AuditStatusMessage(FILE *fp, char status);
+void AuditStatusMessage(Writer *writer, char status);
 
 /* manual.c */
 
@@ -566,7 +566,7 @@ bool IsProcessNameRunning(char *procNameRegex);
 
 /* recursion.c */
 
-int DepthSearch(char *name, struct stat *sb, int rlevel, Attributes attr, Promise *pp);
+int DepthSearch(char *name, struct stat *sb, int rlevel, Attributes attr, Promise *pp, const ReportContext *report_context);
 int SkipDirLinks(char *path, const char *lastnode, Recursion r);
 
 /* rlist.c */
@@ -597,8 +597,8 @@ void ShowScope(char *);
 
 void SelfDiagnostic(void);
 void TestVariableScan(void);
-void TestExpandPromise(void);
-void TestExpandVariables(void);
+void TestExpandPromise(const ReportContext *report_context);
+void TestExpandVariables(const ReportContext *report_context);
 
 /* server_transform.c */
 
@@ -693,10 +693,11 @@ void VerifyExecPromise(Promise *pp);
 
 /* verify_files.c */
 
-void VerifyFilePromise(char *path, Promise *pp);
+void VerifyFilePromise(char *path, Promise *pp, const ReportContext *report_context);
 
-void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *path, Promise *ptr));
-void *FindAndVerifyFilesPromises(Promise *pp);
+void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *path, Promise *ptr, const ReportContext *report_context),
+                             const ReportContext *report_context);
+void *FindAndVerifyFilesPromises(Promise *pp, const ReportContext *report_context);
 int FileSanityChecks(char *path, Attributes a, Promise *pp);
 
 /* verify_interfaces.c */
@@ -710,8 +711,8 @@ void VerifyMeasurementPromise(double *this, Promise *pp);
 
 /* verify_methods.c */
 
-void VerifyMethodsPromise(Promise *pp);
-int VerifyMethod(char *attrname, Attributes a, Promise *pp);
+void VerifyMethodsPromise(Promise *pp, const ReportContext *report_context);
+int VerifyMethod(char *attrname, Attributes a, Promise *pp, const ReportContext *report_context);
 
 /* verify_packages.c */
 
@@ -730,12 +731,12 @@ void GetProcessColumnNames(char *proc, char **names, int *start, int *end);
 
 /* verify_services.c */
 
-void VerifyServicesPromise(Promise *pp);
+void VerifyServicesPromise(Promise *pp, const ReportContext *report_context);
 
 /* verify_storage.c */
 
-void *FindAndVerifyStoragePromises(Promise *pp);
-void VerifyStoragePromise(char *path, Promise *pp);
+void *FindAndVerifyStoragePromises(Promise *pp, const ReportContext *report_context);
+void VerifyStoragePromise(char *path, Promise *pp, const ReportContext *report_context);
 
 /* verify_reports.c */
 

--- a/src/recursion.c
+++ b/src/recursion.c
@@ -38,7 +38,8 @@ static void CheckLinkSecurity(struct stat *sb, char *name);
 /* Depth searches                                                    */
 /*********************************************************************/
 
-int DepthSearch(char *name, struct stat *sb, int rlevel, Attributes attr, Promise *pp)
+int DepthSearch(char *name, struct stat *sb, int rlevel, Attributes attr, Promise *pp,
+                const ReportContext *report_context)
 {
     Dir *dirh;
     int goback;
@@ -54,7 +55,7 @@ int DepthSearch(char *name, struct stat *sb, int rlevel, Attributes attr, Promis
         snprintf(basedir, sizeof(basedir), "%s", name);
         ChopLastNode(basedir);
         chdir(basedir);
-        return VerifyFileLeaf(name, sb, attr, pp);
+        return VerifyFileLeaf(name, sb, attr, pp, report_context);
     }
 
     if (rlevel > CF_RECURSION_LIMIT)
@@ -110,7 +111,7 @@ int DepthSearch(char *name, struct stat *sb, int rlevel, Attributes attr, Promis
         {
             if (!KillGhostLink(path, attr, pp))
             {
-                VerifyFileLeaf(path, &lsb, attr, pp);
+                VerifyFileLeaf(path, &lsb, attr, pp, report_context);
             }
             else
             {
@@ -154,18 +155,18 @@ int DepthSearch(char *name, struct stat *sb, int rlevel, Attributes attr, Promis
             if (attr.recursion.depth > 1 && rlevel <= attr.recursion.depth)
             {
                 CfOut(cf_verbose, "", " ->>  Entering %s (%d)\n", path, rlevel);
-                goback = DepthSearch(path, &lsb, rlevel + 1, attr, pp);
+                goback = DepthSearch(path, &lsb, rlevel + 1, attr, pp, report_context);
                 PopDirState(goback, name, sb, attr.recursion);
-                VerifyFileLeaf(path, &lsb, attr, pp);
+                VerifyFileLeaf(path, &lsb, attr, pp, report_context);
             }
             else
             {
-                VerifyFileLeaf(path, &lsb, attr, pp);
+                VerifyFileLeaf(path, &lsb, attr, pp, report_context);
             }
         }
         else
         {
-            VerifyFileLeaf(path, &lsb, attr, pp);
+            VerifyFileLeaf(path, &lsb, attr, pp, report_context);
         }
     }
 

--- a/src/reporting.h
+++ b/src/reporting.h
@@ -27,22 +27,22 @@
 
 #include "cf3.defs.h"
 
-typedef enum
-{
-    REPORT_OUTPUT_TYPE_TEXT,
-    REPORT_OUTPUT_TYPE_HTML
-} ReportOutputType;
+#include "writer.h"
 
-void ShowPromises(ReportOutputType type, const Bundle *bundles, const Body *bodies);
-void ShowPromise(ReportOutputType type, const Promise *pp, int indent);
-void ShowScopedVariables(ReportOutputType type);
-void ShowPromiseInReport(ReportOutputType type, const char *version, const Promise *pp, int indent);
-void ShowPromisesInReport(ReportOutputType type, const Bundle *bundles, const Body *bodies);
+ReportContext *ReportContextNew(void);
+bool ReportContextAddWriter(ReportContext *context, ReportOutputType type, Writer *writer);
+void ReportContextDestroy(ReportContext *context);
+
+void ShowPromises(const ReportContext *context, ReportOutputType type, const Bundle *bundles, const Body *bodies);
+void ShowPromise(const ReportContext *context, ReportOutputType type, const Promise *pp, int indent);
+void ShowScopedVariables(const ReportContext *context, ReportOutputType type);
+void ShowPromiseInReport(const ReportContext *context, ReportOutputType type, const char *version, const Promise *pp, int indent);
+void ShowPromisesInReport(const ReportContext *context, ReportOutputType type, const Bundle *bundles, const Body *bodies);
+void ShowContext(const ReportContext *report_context);
 
 // stdout only
 void SyntaxTree(void);
 void ReportError(char *s);
-void ShowContext(void);
 void BannerSubType(const char *bundlename, const char *type, int p);
 void BannerSubSubType(const char *bundlename, const char *type);
 void Banner(const char *s);

--- a/src/rlist.c
+++ b/src/rlist.c
@@ -1157,7 +1157,7 @@ Rlist *RlistAt(Rlist *start, size_t index)
 
 /*******************************************************************/
 
-static void RlistPrint(Writer *writer, const Rlist *list)
+void RlistPrint(Writer *writer, const Rlist *list)
 {
     WriterWrite(writer, " {");
 

--- a/src/rlist.h
+++ b/src/rlist.h
@@ -93,6 +93,7 @@ void ShowRlist(FILE *fp, const Rlist *list);
 void ShowRval(FILE *fp, Rval rval);
 
 void RvalPrint(Writer *writer, Rval rval);
+void RlistPrint(Writer *writer, const Rlist *list);
 
 Rlist *RlistAt(Rlist *start, size_t index);
 

--- a/src/selfdiagnostic.c
+++ b/src/selfdiagnostic.c
@@ -45,15 +45,16 @@ void SelfDiagnostic()
     int i, j;
     char *names, *numbers, *pattern;
 
+    ReportContext *report_context = ReportContextNew();
     if (VERBOSE || DEBUG)
     {
-        FREPORT_TXT = stdout;
-        FREPORT_HTML = fopen(NULLFILE, "w");
+        ReportContextAddWriter(report_context, REPORT_OUTPUT_TYPE_TEXT, FileWriter(stdout));
+        ReportContextAddWriter(report_context, REPORT_OUTPUT_TYPE_TEXT, FileWriter(fopen(NULLFILE, "w")));
     }
     else
     {
-        FREPORT_TXT = fopen(NULLFILE, "w");
-        FREPORT_HTML = fopen(NULLFILE, "w");
+        ReportContextAddWriter(report_context, REPORT_OUTPUT_TYPE_TEXT, FileWriter(fopen(NULLFILE, "w")));
+        ReportContextAddWriter(report_context, REPORT_OUTPUT_TYPE_HTML, FileWriter(fopen(NULLFILE, "w")));
     }
 
     printf("----------------------------------------------------------\n");
@@ -66,8 +67,8 @@ void SelfDiagnostic()
     printf("Cfengine - Level 2 self-diagnostic \n");
     printf("----------------------------------------------------------\n\n");
     TestVariableScan();
-    TestExpandPromise();
-    TestExpandVariables();
+    TestExpandPromise(report_context);
+    TestExpandVariables(report_context);
     TestRegularExpressions();
     TestAgentPromises();
 
@@ -105,6 +106,8 @@ void SelfDiagnostic()
 
     TestHashEntropy(pattern, "pattern 2");
 //#endif
+
+    ReportContextDestroy(report_context);
 }
 
 /*****************************************************************************/
@@ -158,7 +161,7 @@ void TestVariableScan()
 
 /*****************************************************************************/
 
-void TestExpandPromise()
+void TestExpandPromise(const ReportContext *report_context)
 {
     Promise pp = { 0 }, *pcopy;
 
@@ -194,18 +197,18 @@ void TestExpandPromise()
     {
         printf("-----------------------------------------------------------\n");
         printf("Raw test promises\n\n");
-        ShowPromise(REPORT_OUTPUT_TYPE_TEXT, &pp, 4);
-        ShowPromise(REPORT_OUTPUT_TYPE_HTML, &pp, 4);
+        ShowPromise(report_context, REPORT_OUTPUT_TYPE_TEXT, &pp, 4);
+        ShowPromise(report_context, REPORT_OUTPUT_TYPE_HTML, &pp, 4);
 
-        ShowPromise(REPORT_OUTPUT_TYPE_TEXT, pcopy, 6);
-        ShowPromise(REPORT_OUTPUT_TYPE_HTML, pcopy, 6);
+        ShowPromise(report_context, REPORT_OUTPUT_TYPE_TEXT, pcopy, 6);
+        ShowPromise(report_context, REPORT_OUTPUT_TYPE_HTML, pcopy, 6);
     }
     DeletePromise(pcopy);
 }
 
 /*****************************************************************************/
 
-void TestExpandVariables()
+void TestExpandVariables(const ReportContext *report_context)
 {
     Promise pp = { 0 }, *pcopy;
     Rlist *args, *listvars = NULL, *scalarvars = NULL;
@@ -262,7 +265,7 @@ void TestExpandVariables()
         MapIteratorsFromRval("diagnostic", &scalarvars, &listvars, cp->rval, NULL);
     }
 
-    ExpandPromiseAndDo(cf_common, "diagnostic", pcopy, scalarvars, listvars, NULL);
+    ExpandPromiseAndDo(cf_common, "diagnostic", pcopy, scalarvars, listvars, NULL, report_context);
 /* No cleanup */
 }
 

--- a/src/server_transform.c
+++ b/src/server_transform.c
@@ -35,11 +35,11 @@
 #include "reporting.h"
 #include "expand.h"
 
-static void KeepContextBundles(Policy *policy);
+static void KeepContextBundles(Policy *policy, const ReportContext *report_context);
 static void KeepServerPromise(Promise *pp);
 static void InstallServerAuthPath(char *path, Auth **list, Auth **listtop);
 static void KeepServerRolePromise(Promise *pp);
-static void KeepPromiseBundles(Policy *policy);
+static void KeepPromiseBundles(Policy *policy, const ReportContext *report_context);
 
 extern const BodySyntax CFS_CONTROLBODY[];
 extern const BodySyntax CF_REMROLE_BODIES[];
@@ -70,11 +70,11 @@ void KeepQueryAccessPromise(Promise *pp, char *type);
 /* Level                                                           */
 /*******************************************************************/
 
-void KeepPromises(Policy *policy)
+void KeepPromises(Policy *policy, const ReportContext *report_context)
 {
-    KeepContextBundles(policy);
+    KeepContextBundles(policy, report_context);
     KeepControlPromises(policy);
-    KeepPromiseBundles(policy);
+    KeepPromiseBundles(policy, report_context);
 }
 
 /*******************************************************************/
@@ -440,7 +440,7 @@ void KeepControlPromises(Policy *policy)
 
 /*********************************************************************/
 
-static void KeepContextBundles(Policy *policy)
+static void KeepContextBundles(Policy *policy, const ReportContext *report_context)
 {
     SubType *sp;
     Promise *pp;
@@ -473,7 +473,7 @@ static void KeepContextBundles(Policy *policy)
 
                 for (pp = sp->promiselist; pp != NULL; pp = pp->next)
                 {
-                    ExpandPromise(cf_server, scope, pp, KeepServerPromise);
+                    ExpandPromise(cf_server, scope, pp, KeepServerPromise, report_context);
                 }
             }
         }
@@ -482,7 +482,7 @@ static void KeepContextBundles(Policy *policy)
 
 /*********************************************************************/
 
-static void KeepPromiseBundles(Policy *policy)
+static void KeepPromiseBundles(Policy *policy, const ReportContext *report_context)
 {
     SubType *sp;
     Promise *pp;
@@ -515,7 +515,7 @@ static void KeepPromiseBundles(Policy *policy)
 
                 for (pp = sp->promiselist; pp != NULL; pp = pp->next)
                 {
-                    ExpandPromise(cf_server, scope, pp, KeepServerPromise);
+                    ExpandPromise(cf_server, scope, pp, KeepServerPromise, report_context);
                 }
             }
         }

--- a/src/verify_files.c
+++ b/src/verify_files.c
@@ -29,14 +29,14 @@
 #include "promises.h"
 #include "vars.h"
 
-static void FindFilePromiserObjects(Promise *pp);
+static void FindFilePromiserObjects(Promise *pp, const ReportContext *report_context);
 
 /*****************************************************************************/
 
-void *FindAndVerifyFilesPromises(Promise *pp)
+void *FindAndVerifyFilesPromises(Promise *pp, const ReportContext *report_context)
 {
     PromiseBanner(pp);
-    FindFilePromiserObjects(pp);
+    FindFilePromiserObjects(pp, report_context);
 
     if (AM_BACKGROUND_PROCESS && !pp->done)
     {
@@ -50,7 +50,7 @@ void *FindAndVerifyFilesPromises(Promise *pp)
 
 /*****************************************************************************/
 
-static void FindFilePromiserObjects(Promise *pp)
+static void FindFilePromiserObjects(Promise *pp, const ReportContext *report_context)
 {
     char *val = GetConstraintValue("pathtype", pp, CF_SCALAR);
     int literal = GetBooleanConstraint("copy_from", pp) || ((val != NULL) && (strcmp(val, "literal") == 0));
@@ -61,10 +61,10 @@ static void FindFilePromiserObjects(Promise *pp)
     {
         // Prime the promiser temporarily, may override later
         NewScalar("this", "promiser", pp->promiser, cf_str);
-        VerifyFilePromise(pp->promiser, pp);
+        VerifyFilePromise(pp->promiser, pp, report_context);
     }
     else                        // Default is to expand regex paths
     {
-        LocateFilePromiserGroup(pp->promiser, pp, VerifyFilePromise);
+        LocateFilePromiserGroup(pp->promiser, pp, VerifyFilePromise, report_context);
     }
 }

--- a/src/verify_methods.c
+++ b/src/verify_methods.c
@@ -32,19 +32,19 @@
 
 /*****************************************************************************/
 
-void VerifyMethodsPromise(Promise *pp)
+void VerifyMethodsPromise(Promise *pp, const ReportContext *report_context)
 {
     Attributes a = { {0} };
 
     a = GetMethodAttributes(pp);
 
-    VerifyMethod("usebundle", a, pp);
+    VerifyMethod("usebundle", a, pp, report_context);
     DeleteScalar("this", "promiser");
 }
 
 /*****************************************************************************/
 
-int VerifyMethod(char *attrname, Attributes a, Promise *pp)
+int VerifyMethod(char *attrname, Attributes a, Promise *pp, const ReportContext *report_context)
 {
     Bundle *bp;
     void *vp;
@@ -102,14 +102,14 @@ int VerifyMethod(char *attrname, Attributes a, Promise *pp)
 
         DeleteScope(bp->name);
         NewScope(bp->name);
-        HashVariables(PolicyFromPromise(pp), bp->name);
+        HashVariables(PolicyFromPromise(pp), bp->name, report_context);
 
         AugmentScope(bp->name, bp->args, params);
 
         THIS_BUNDLE = bp->name;
         PushPrivateClassContext(a.inherit);
 
-        retval = ScheduleAgentOperations(bp);
+        retval = ScheduleAgentOperations(bp, report_context);
 
         PopPrivateClassContext();
         THIS_BUNDLE = bp_stack;

--- a/src/verify_services.c
+++ b/src/verify_services.c
@@ -30,11 +30,11 @@
 
 static int ServicesSanityChecks(Attributes a, Promise *pp);
 static void SetServiceDefaults(Attributes *a);
-static void DoVerifyServices(Attributes a, Promise *pp);
+static void DoVerifyServices(Attributes a, Promise *pp, const ReportContext *report_context);
 
 /*****************************************************************************/
 
-void VerifyServicesPromise(Promise *pp)
+void VerifyServicesPromise(Promise *pp, const ReportContext *report_context)
 {
     Attributes a = { {0} };
 
@@ -44,7 +44,7 @@ void VerifyServicesPromise(Promise *pp)
 
     if (ServicesSanityChecks(a, pp))
     {
-        VerifyServices(a, pp);
+        VerifyServices(a, pp, report_context);
     }
 }
 
@@ -141,7 +141,7 @@ static void SetServiceDefaults(Attributes *a)
 /* Level                                                                     */
 /*****************************************************************************/
 
-void VerifyServices(Attributes a, Promise *pp)
+void VerifyServices(Attributes a, Promise *pp, const ReportContext *report_context)
 {
     CfLock thislock;
 
@@ -171,7 +171,7 @@ void VerifyServices(Attributes a, Promise *pp)
     }
     else
     {
-        DoVerifyServices(a, pp);
+        DoVerifyServices(a, pp, report_context);
     }
 
     DeleteScalar("this", "promiser");
@@ -182,7 +182,7 @@ void VerifyServices(Attributes a, Promise *pp)
 /* Level                                                                     */
 /*****************************************************************************/
 
-static void DoVerifyServices(Attributes a, Promise *pp)
+static void DoVerifyServices(Attributes a, Promise *pp, const ReportContext *report_context)
 {
     FnCall *default_bundle = NULL;
     Rlist *args = NULL;
@@ -235,6 +235,6 @@ static void DoVerifyServices(Attributes a, Promise *pp)
 
     if (!DONTDO)
     {
-        VerifyMethod("service_bundle", a, pp);  // Send list of classes to set privately?
+        VerifyMethod("service_bundle", a, pp, report_context);  // Send list of classes to set privately?
     }
 }

--- a/src/verify_storage.c
+++ b/src/verify_storage.c
@@ -28,7 +28,7 @@
 #include "dir.h"
 #include "conversion.h"
 
-static void FindStoragePromiserObjects(Promise *pp);
+static void FindStoragePromiserObjects(Promise *pp, const ReportContext *report_context);
 static int VerifyFileSystem(char *name, Attributes a, Promise *pp);
 static int VerifyFreeSpace(char *file, Attributes a, Promise *pp);
 static void VolumeScanArrivals(char *file, Attributes a, Promise *pp);
@@ -36,31 +36,31 @@ static int FileSystemMountedCorrectly(Rlist *list, char *name, char *options, At
 static int IsForeignFileSystem(struct stat *childstat, char *dir);
 
 #ifndef MINGW
-static int VerifyMountPromise(char *file, Attributes a, Promise *pp);
+static int VerifyMountPromise(char *file, Attributes a, Promise *pp, const ReportContext *report_context);
 #endif /* NOT MINGW */
 
 /*****************************************************************************/
 
-void *FindAndVerifyStoragePromises(Promise *pp)
+void *FindAndVerifyStoragePromises(Promise *pp, const ReportContext *report_context)
 {
     PromiseBanner(pp);
-    FindStoragePromiserObjects(pp);
+    FindStoragePromiserObjects(pp, report_context);
 
     return (void *) NULL;
 }
 
 /*****************************************************************************/
 
-static void FindStoragePromiserObjects(Promise *pp)
+static void FindStoragePromiserObjects(Promise *pp, const ReportContext *report_context)
 {
 /* Check if we are searching over a regular expression */
 
-    LocateFilePromiserGroup(pp->promiser, pp, VerifyStoragePromise);
+    LocateFilePromiserGroup(pp->promiser, pp, VerifyStoragePromise, report_context);
 }
 
 /*****************************************************************************/
 
-void VerifyStoragePromise(char *path, Promise *pp)
+void VerifyStoragePromise(char *path, Promise *pp, const ReportContext *report_context)
 {
     Attributes a = { {0} };
     CfLock thislock;
@@ -113,7 +113,7 @@ void VerifyStoragePromise(char *path, Promise *pp)
 
     if (a.havemount)
     {
-        VerifyMountPromise(path, a, pp);
+        VerifyMountPromise(path, a, pp, report_context);
     }
 #endif /* NOT MINGW */
 
@@ -411,7 +411,7 @@ static int IsForeignFileSystem(struct stat *childstat, char *dir)
 
 #ifndef MINGW
 
-static int VerifyMountPromise(char *name, Attributes a, Promise *pp)
+static int VerifyMountPromise(char *name, Attributes a, Promise *pp, const ReportContext *report_context)
 {
     char *options;
     char dir[CF_BUFSIZE];
@@ -433,7 +433,7 @@ static int VerifyMountPromise(char *name, Attributes a, Promise *pp)
     {
         if (!a.mount.unmount)
         {
-            if (!MakeParentDirectory(dir, a.move_obstructions))
+            if (!MakeParentDirectory(dir, a.move_obstructions, report_context))
             {
             }
 


### PR DESCRIPTION
This is a high impact code change, but there should be no changes to the behavior of the programs.

(Read commit msg). One notable change is that report files are no longer opened and closed in ReadPromises. Rather, a ReportContext is created at the very top level and passed to GenericAgentInitialize and KeepPromises. This is because there are code-paths from KeepPromises that need a ReportContext. Presumably they are not exercised because of global switches (SHOWREPORTS?). It also means that daemons calling InitializeGA and/or GenericAgentInitialize will have their reporting files open for their entire lifecycle.
