### PR TITLE
correct and clean up dry-run modes

### DIFF
--- a/src/files_edit.c
+++ b/src/files_edit.c
@@ -28,6 +28,7 @@
 #include "env_context.h"
 #include "files_names.h"
 #include "item_lib.h"
+#include "transaction.h"
 
 /*****************************************************************************/
 
@@ -71,7 +72,7 @@ void FinishEditContext(EditContext *ec, Attributes a, Promise *pp, const ReportC
 
     EDIT_MODEL = false;
 
-    if (DONTDO || a.transaction.action == cfa_warn)
+    if (!EnforcePromise(a.transaction.action))
     {
         if (ec && !CompareToFile(ec->file_start, ec->filename, a, pp) && ec->num_edits > 0)
         {

--- a/src/files_editline.c
+++ b/src/files_editline.c
@@ -35,6 +35,7 @@
 #include "conversion.h"
 #include "reporting.h"
 #include "expand.h"
+#include "transaction.h"
 
 /*****************************************************************************/
 
@@ -878,7 +879,7 @@ static int DeletePromisedLinesMatching(Item **start, Item *begin, Item *end, Att
         {
             CfOut(cf_verbose, "", " -> Delete chunk of %d lines\n", matches);
 
-            if (a.transaction.action == cfa_warn)
+            if (!EnforcePromise(a.transaction.action))
             {
                 cfPS(cf_error, CF_WARN, "", pp, a,
                      " -> Need to delete line \"%s\" from %s - but only a warning was promised", ip->name,
@@ -1027,7 +1028,7 @@ static int ReplacePatterns(Item *file_start, Item *file_end, Attributes a, Promi
             break;
         }
 
-        if (a.transaction.action == cfa_warn)
+        if (!EnforcePromise(a.transaction.action))
         {
             cfPS(cf_verbose, CF_WARN, "", pp, a,
                  " -> Need to replace line \"%s\" in %s - but only a warning was promised", pp->promiser,
@@ -1403,7 +1404,7 @@ static int InsertLineAtLocation(char *newline, Item **start, Item *location, Ite
         {
             if (*start == NULL)
             {
-                if (a.transaction.action == cfa_warn)
+                if (!EnforcePromise(a.transaction.action))
                 {
                     cfPS(cf_error, CF_WARN, "", pp, a,
                          " -> Need to insert the promised line \"%s\" in %s - but only a warning was promised", newline,
@@ -1422,7 +1423,7 @@ static int InsertLineAtLocation(char *newline, Item **start, Item *location, Ite
 
             if (strcmp((*start)->name, newline) != 0)
             {
-                if (a.transaction.action == cfa_warn)
+                if (!EnforcePromise(a.transaction.action))
                 {
                     cfPS(cf_error, CF_WARN, "", pp, a,
                          " -> Need to prepend the promised line \"%s\" to %s - but only a warning was promised",
@@ -1457,7 +1458,7 @@ static int InsertLineAtLocation(char *newline, Item **start, Item *location, Ite
         }
         else
         {
-            if (a.transaction.action == cfa_warn)
+            if (!EnforcePromise(a.transaction.action))
             {
                 cfPS(cf_error, CF_WARN, "", pp, a,
                      " -> Need to insert line \"%s\" into %s but only a warning was promised", newline,
@@ -1485,7 +1486,7 @@ static int InsertLineAtLocation(char *newline, Item **start, Item *location, Ite
         }
         else
         {
-            if (a.transaction.action == cfa_warn)
+            if (!EnforcePromise(a.transaction.action))
             {
                 cfPS(cf_error, CF_WARN, "", pp, a,
                      " -> Need to insert line \"%s\" in %s but only a warning was promised", newline, pp->this_server);
@@ -1570,7 +1571,7 @@ static int EditLineByColumn(Rlist **columns, Attributes a, Promise *pp)
 
         if (retval)
         {
-            if (a.transaction.action == cfa_warn)
+            if (!EnforcePromise(a.transaction.action))
             {
                 cfPS(cf_error, CF_WARN, "", pp, a, " -> Need to edit field in %s but only warning promised",
                      pp->this_server);
@@ -1600,7 +1601,7 @@ static int EditLineByColumn(Rlist **columns, Attributes a, Promise *pp)
 
         if (a.column.column_operation && strcmp(a.column.column_operation, "delete") == 0)
         {
-            if (a.transaction.action == cfa_warn)
+            if (!EnforcePromise(a.transaction.action))
             {
                 cfPS(cf_error, CF_WARN, "", pp, a,
                      " -> Need to delete field field value %s in %s but only a warning was promised", ScalarValue(rp),
@@ -1619,7 +1620,7 @@ static int EditLineByColumn(Rlist **columns, Attributes a, Promise *pp)
         }
         else
         {
-            if (a.transaction.action == cfa_warn)
+            if (!EnforcePromise(a.transaction.action))
             {
                 cfPS(cf_error, CF_WARN, "", pp, a,
                      " -> Need to set column field value %s to %s in %s but only a warning was promised",

--- a/src/files_interfaces.c
+++ b/src/files_interfaces.c
@@ -31,6 +31,7 @@
 #include "files_names.h"
 #include "item_lib.h"
 #include "vars.h"
+#include "transaction.h"
 
 static void PurgeLocalFiles(Item *filelist, char *directory, Attributes attr, Promise *pp, const ReportContext *report_context);
 static void CfCopyFile(char *sourcefile, char *destfile, struct stat sourcestatbuf, Attributes attr, Promise *pp, const ReportContext *report_context);
@@ -74,7 +75,7 @@ void SourceSearchAndCopy(char *from, char *to, int maxrecurse, Attributes attr, 
     AddSlash(newto);
     strcat(newto, "dummy");
 
-    if (attr.transaction.action != cfa_warn)
+    if (EnforcePromise(attr.transaction.action))
     {
         struct stat tostat;
 
@@ -848,7 +849,7 @@ static void CfCopyFile(char *sourcefile, char *destfile, struct stat ssb, Attrib
 
     if (found == -1)
     {
-        if (attr.transaction.action == cfa_warn)
+        if (!EnforcePromise(attr.transaction.action))
         {
             cfPS(cf_error, CF_WARN, "", pp, attr, " !! Image file \"%s\" is non-existent and should be a copy of %s\n",
                  destfile, sourcefile);
@@ -1004,7 +1005,7 @@ static void CfCopyFile(char *sourcefile, char *destfile, struct stat ssb, Attrib
             }
         }
 
-        if (ok_to_copy && (attr.transaction.action == cfa_warn))
+        if (ok_to_copy && !EnforcePromise(attr.transaction.action))
         {
             cfPS(cf_error, CF_WARN, "", pp, attr, " !! Image file \"%s\" exists but is not up to date wrt %s\n",
                  destfile, sourcefile);
@@ -2022,7 +2023,7 @@ static void RegisterAHardLink(int i, char *value, Attributes attr, Promise *pp)
         }
         else
         {
-            if (attr.transaction.action == cfa_warn)
+            if (!EnforcePromise(attr.transaction.action))
             {
                 CfOut(cf_verbose, "", " !! Need to remove old hard link %s to preserve structure..\n", value);
             }

--- a/src/files_links.c
+++ b/src/files_links.c
@@ -461,7 +461,7 @@ static int MakeLink(char *from, char *to, Attributes attr, Promise *pp)
 }
 #else                           /* NOT MINGW */
 {
-    if (DONTDO || attr.transaction.action == cfa_warn)
+    if (!EnforcePromise(attr.transaction.action))
     {
         CfOut(cf_error, "", " !! Need to link files %s -> %s\n", from, to);
         return false;

--- a/src/verify_databases.c
+++ b/src/verify_databases.c
@@ -28,6 +28,7 @@
 #include "promises.h"
 #include "files_names.h"
 #include "conversion.h"
+#include "transaction.h"
 
 static int CheckDatabaseSanity(Attributes a, Promise *pp);
 static void VerifySQLPromise(Attributes a, Promise *pp);
@@ -287,7 +288,7 @@ static int VerifyDatabasePromise(CfdbConn *cfdb, char *database, Attributes a, P
 
     if (a.database.operation && strcmp(a.database.operation, "drop") == 0)
     {
-        if (a.transaction.action != cfa_warn && !DONTDO)
+        if (EnforcePromise(a.transaction.action))
         {
             CfOut(cf_verbose, "", " -> Attempting to delete the database %s", database);
             snprintf(query, CF_MAXVARSIZE - 1, "drop database %s", database);
@@ -303,7 +304,7 @@ static int VerifyDatabasePromise(CfdbConn *cfdb, char *database, Attributes a, P
 
     if (a.database.operation && strcmp(a.database.operation, "create") == 0)
     {
-        if (a.transaction.action != cfa_warn && !DONTDO)
+        if (EnforcePromise(a.transaction.action))
         {
             CfOut(cf_verbose, "", " -> Attempting to create the database %s", database);
             snprintf(query, CF_MAXVARSIZE - 1, "create database %s", database);
@@ -431,7 +432,7 @@ static int VerifyTablePromise(CfdbConn *cfdb, char *table_path, Rlist *columns, 
 
         if (a.database.operation && strcmp(a.database.operation, "create") == 0)
         {
-            if (!DONTDO && a.transaction.action != cfa_warn)
+            if (EnforcePromise(a.transaction.action))
             {
                 cfPS(cf_error, CF_CHG, "", pp, a, " -> Database.table %s doesn't seem to exist, creating\n",
                      table_path);
@@ -566,7 +567,7 @@ static int VerifyTablePromise(CfdbConn *cfdb, char *table_path, Rlist *columns, 
                 CfOut(cf_error, "", " !! Promised column \"%s\" missing from database table %s", name_table[i],
                       pp->promiser);
 
-                if (!DONTDO && a.transaction.action != cfa_warn)
+                if (EnforcePromise(a.transaction.action))
                 {
                     if (size_table[i] > 0)
                     {


### PR DESCRIPTION
Try to get rid of structures like the following for all promises.

switch (a.transaction.action)
{
  case cfa_fix:
   if (DONTDO)
     {
       /\* warn that we won't do it _/
     }
   else
     {
       /_ do it */
     }
   break;

  case cfa_warn:
    /\* warn that we won't do it */
    break;
}

This is error-prone (sometimes we miss one of the cases), and a bit messy. Use a function to test both cases instead.

This assumes that DONTDO and cfa_warn is equivalent.
