### PR TITLE
Change reload into restart (cosmetic test) option for Unix services

### DIFF
--- a/src/cf3.defs.h
+++ b/src/cf3.defs.h
@@ -2208,7 +2208,7 @@ enum cf_srv_policy
     cfsrv_start,
     cfsrv_stop,
     cfsrv_disable,
-    cfsrv_reload,
+    cfsrv_restart,
     cfsrv_nostatus
 };
 

--- a/src/conversion.c
+++ b/src/conversion.c
@@ -1117,7 +1117,7 @@ enum cf_acl_inherit Str2AclInherit(char *string)
 
 enum cf_srv_policy Str2ServicePolicy(char *string)
 {
-    static char *text[4] = { "start", "stop", "disable", "reload", NULL };
+    static char *text[4] = { "start", "stop", "disable", "restart", NULL };
     int i;
 
     for (i = 0; i < 3; i++)

--- a/src/mod_services.c
+++ b/src/mod_services.c
@@ -40,7 +40,7 @@ static const BodySyntax CF_SERVMETHOD_BODY[] =
 
 static const BodySyntax CF_SERVICES_BODIES[] =
 {
-    {"service_policy", cf_opts, "start,stop,disable,reload", "Policy for cfengine service status"},
+    {"service_policy", cf_opts, "start,stop,disable,restart", "Policy for cfengine service status"},
     {"service_dependencies", cf_slist, CF_IDRANGE, "A list of services on which the named service abstraction depends"},
     {"service_method", cf_body, CF_SERVMETHOD_BODY, "Details of promise body for the service abtraction feature"},
     {NULL, cf_notype, NULL, NULL}

--- a/src/verify_services.c
+++ b/src/verify_services.c
@@ -198,9 +198,9 @@ static void DoVerifyServices(Attributes a, Promise *pp, const ReportContext *rep
             AppendRlist(&args, "start", CF_SCALAR);
             break;
 
-        case cfsrv_reload:
+        case cfsrv_restart:
             AppendRlist(&args, pp->promiser, CF_SCALAR);
-            AppendRlist(&args, "reload", CF_SCALAR);
+            AppendRlist(&args, "restart", CF_SCALAR);
             break;
 
         case cfsrv_stop:
@@ -226,8 +226,8 @@ static void DoVerifyServices(Attributes a, Promise *pp, const ReportContext *rep
         NewScalar("this", "service_policy", "start", cf_str);
         break;
 
-    case cfsrv_reload:
-        NewScalar("this", "service_policy", "reload", cf_str);
+    case cfsrv_restart:
+        NewScalar("this", "service_policy", "restart", cf_str);
         break;
         
     case cfsrv_stop:


### PR DESCRIPTION
After consulting with the gods of UI, renaming the reload -> restart
