### PR TITLE
Split cf-know into cf-gendoc and cf-know

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,8 @@ src/cf-runagent
 src/cf-runagent.exe
 src/cf-serverd
 src/cf-serverd.exe
+src/cf-gendoc
+src/cf-gendoc.exe
 
 # autogen
 

--- a/docs/reference/Makefile.am
+++ b/docs/reference/Makefile.am
@@ -1,16 +1,15 @@
 TEX_INCLUDEDIR=$(srcdir)/../tex-include
 
-.PRECIOUS: ../../src/cf-know
+.PRECIOUS: ../../src/cf-gendoc
 
-../../src/cf-know:
-	$(MAKE) -C ../../src $(AM_MAKEFLAGS) cf-know
+../../src/cf-gendoc:
+	$(MAKE) -C ../../src $(AM_MAKEFLAGS) cf-gendoc
 
-cf3-Reference.texinfo: ../../src/cf-know \
+cf3-Reference.texinfo: ../../src/cf-gendoc \
     generate_manual.cf \
     $(filter-out cf3-Reference.texinfo,$(wildcard *.texinfo)) \
     $(wildcard */*.texinfo)
-	chmod g-w generate_manual.cf
-	$(AM_V_GEN)../../src/cf-know -f ./generate_manual.cf
+	$(AM_V_GEN)../../src/cf-gendoc -i . -o $@
 
 %.html: %.texinfo
 	$(AM_V_GEN)$(MAKEINFO) \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -174,6 +174,9 @@ sbin_PROGRAMS = \
         cf-runagent \
         cf-serverd
 
+noinst_PROGRAMS = \
+        cf-gendoc
+
 if HAVE_NOVA
 if MONGO
   sbin_PROGRAMS += cf-hub
@@ -230,15 +233,21 @@ endif
 endif
 
 cf_know_SOURCES = \
-        cf-know.c \
-        manual.c manual.h \
-        export_xml.c export_xml.h
+        cf-know.c
 
 cf_know_LDADD = libpromises.la
 
 if HAVE_NOVA
 cf_know_LDADD += ../nova/src/libcfknow.la
 endif
+
+
+cf_gendoc_LDADD = libpromises.la
+
+cf_gendoc_SOURCES = \
+	cf-gendoc.c \
+        manual.c manual.h \
+        export_xml.c export_xml.h
 
 CLEANFILES = *.gcno *.gcda
 

--- a/src/cf-gendoc.c
+++ b/src/cf-gendoc.c
@@ -1,0 +1,156 @@
+/* 
+
+   Copyright (C) Cfengine AS
+
+   This file is part of Cfengine 3 - written and maintained by Cfengine AS.
+ 
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+   
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License  
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of Cfengine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include "generic_agent.h"
+
+#include "env_context.h"
+#include "constraints.h"
+#include "files_names.h"
+#include "ontology.h"
+#include "export_xml.h"
+#include "item_lib.h"
+#include "sort.h"
+#include "conversion.h"
+#include "reporting.h"
+#include "expand.h"
+
+static void GenerateManual(void);
+static void GenerateXml(void);
+
+static GenericAgentConfig CheckOpts(int argc, char **argv);
+
+char SOURCE_DIR[CF_BUFSIZE];
+char OUTPUT_FILE[CF_BUFSIZE];
+
+int GENERATE_XML = false;
+
+static const char *ID = "The documentation generation tool produces reference manual for CFEngine.";
+
+static const struct option OPTIONS[] =
+{
+    {"help", no_argument, 0, 'h'},
+    {"xml", no_argument, 0, 'x'},
+    {"input-dir", required_argument, 0, 'i'},
+    {"output-file", required_argument, 0, 'o'},
+    {NULL, 0, 0, '\0'}
+};
+
+static const char *HINTS[] =
+{
+    "Print the help message",
+    "Generate documentation in XML format",
+    "Input directory for Texinfo fragments (defaults to current directory)",
+    "Output file for XML documentation",
+    NULL
+};
+
+/*****************************************************************************/
+
+int main(int argc, char *argv[])
+{
+    GenericAgentConfig config = CheckOpts(argc, argv);
+
+    ReportContext *report_context = OpenReports("gendoc");
+    GenericInitialize("gendoc", config, report_context);
+
+    if (GENERATE_XML)
+    {
+        GenerateXml();
+    }
+    else
+    {
+        GenerateManual();
+    }
+
+    ReportContextDestroy(report_context);
+    return 0;
+}
+
+static GenericAgentConfig CheckOpts(int argc, char **argv)
+{
+    extern char *optarg;
+    int optindex = 0;
+    int c;
+    GenericAgentConfig config = GenericAgentDefaultConfig(cf_gendoc);
+
+    getcwd(SOURCE_DIR, CF_BUFSIZE);
+    snprintf(OUTPUT_FILE, CF_BUFSIZE, "%scf3-Reference.texinfo", SOURCE_DIR);
+
+    while ((c = getopt_long(argc, argv, "hxi:o:", OPTIONS, &optindex)) != EOF)
+    {
+        switch ((char) c)
+        {
+        case 'h':
+            Syntax("cf-gendoc - reference manual generator", OPTIONS, HINTS, ID);
+            exit(0);
+
+        case 'x':
+            GENERATE_XML = true;
+            break;
+
+        case 'i':
+            strlcpy(SOURCE_DIR, optarg, CF_BUFSIZE);
+
+        case 'o':
+            strlcpy(OUTPUT_FILE, optarg, CF_BUFSIZE);
+            break;
+
+        default:
+            Syntax("cf-gendoc - reference manual generator", OPTIONS, HINTS, ID);
+            exit(1);
+        }
+    }
+
+    if (argv[optind] != NULL)
+    {
+        CfOut(cf_error, "", "Unexpected argument with no preceding option: %s\n", argv[optind]);
+    }
+
+    return config;
+}
+
+static void GenerateManual(void)
+{
+    TexinfoManual(SOURCE_DIR, OUTPUT_FILE);
+}
+
+static void GenerateXml(void)
+{
+    if (OUTPUT_FILE == NULL)
+    {
+        /* Reconsider this once agents do not output any error messages to stdout */
+        FatalError("Please specify output file");
+    }
+    else
+    {
+        FILE *out = fopen(OUTPUT_FILE, "w");
+
+        if (out == NULL)
+        {
+            FatalError("Unable to open %s for writing\n", OUTPUT_FILE);
+        }
+        XmlManual(SOURCE_DIR, out);
+    }
+}

--- a/src/cf3.defs.h
+++ b/src/cf3.defs.h
@@ -656,6 +656,7 @@ enum cfx_format
 #define CF_REPORTC  "reporter"
 #define CF_KEYGEN   "keygenerator"
 #define CF_HUBC     "hub"
+#define CF_GENDOC   "gendoc"
 
 enum cfagenttype
 {
@@ -669,6 +670,7 @@ enum cfagenttype
     cf_report,
     cf_keygen,
     cf_hub,
+    cf_gendoc,
     cf_noagent
 };
 

--- a/src/constants.c
+++ b/src/constants.c
@@ -94,6 +94,7 @@ const char *CF_AGENTTYPES[] =   /* see enum cfagenttype */
     CF_REPORTC,
     CF_KEYGEN,
     CF_HUBC,
+    CF_GENDOC,
     "<notype>",
 };
 

--- a/src/export_xml.c
+++ b/src/export_xml.c
@@ -280,11 +280,11 @@ void XmlExportPromiseType(Writer *writer, const SubTypeSyntax *st)
         /* XML ELEMENT -- INTRO */
         if (strcmp("*", st[i].bundle_type) == 0)
         {
-            filebuffer = ReadTexinfoFileF("promise_common_intro.texinfo");
+            filebuffer = ReadTexinfoFileF(MANUAL_DIRECTORY, "promise_common_intro.texinfo");
         }
         else
         {
-            filebuffer = ReadTexinfoFileF("promises/%s_intro.texinfo", st[i].subtype);
+            filebuffer = ReadTexinfoFileF(MANUAL_DIRECTORY, "promises/%s_intro.texinfo", st[i].subtype);
         }
         XmlTag(writer, XMLTAG_INTRO, filebuffer, 0);
         free(filebuffer);
@@ -292,12 +292,12 @@ void XmlExportPromiseType(Writer *writer, const SubTypeSyntax *st)
         if (strcmp("*", st[i].bundle_type) != 0)
         {
             /* XML ELEMENT -- LONG DESCRIPTION */
-            filebuffer = ReadTexinfoFileF("promises/%s_notes.texinfo", st[i].subtype);
+            filebuffer = ReadTexinfoFileF(MANUAL_DIRECTORY, "promises/%s_notes.texinfo", st[i].subtype);
             XmlTag(writer, XMLTAG_LONGDESCRIPTION, filebuffer, 0);
             free(filebuffer);
 
             /* XML ELEMENT -- EXAMPLE */
-            filebuffer = ReadTexinfoFileF("promises/%s_example.texinfo", st[i].subtype);
+            filebuffer = ReadTexinfoFileF(MANUAL_DIRECTORY, "promises/%s_example.texinfo", st[i].subtype);
             XmlTag(writer, XMLTAG_EXAMPLE, filebuffer, 0);
             free(filebuffer);
         }
@@ -369,12 +369,12 @@ void XmlExportConstraint(Writer *writer, const BodySyntax *bs)
         XmlTag(writer, XMLTAG_DESCRIPTION, bs->description, 0);
 
         /* XML ELEMENT -- LONG-DESCRIPTION */
-        filebuffer = ReadTexinfoFileF("bodyparts/%s_notes.texinfo", bs->lval);
+        filebuffer = ReadTexinfoFileF(MANUAL_DIRECTORY, "bodyparts/%s_notes.texinfo", bs->lval);
         XmlTag(writer, XMLTAG_LONGDESCRIPTION, filebuffer, 0);
         free(filebuffer);
 
         /* XML ELEMENT -- EXAMPLE */
-        filebuffer = ReadTexinfoFileF("bodyparts/%s_example.texinfo", bs->lval);
+        filebuffer = ReadTexinfoFileF(MANUAL_DIRECTORY, "bodyparts/%s_example.texinfo", bs->lval);
         XmlTag(writer, XMLTAG_EXAMPLE, filebuffer, 0);
         free(filebuffer);
     }

--- a/src/generic_agent.c
+++ b/src/generic_agent.c
@@ -182,7 +182,7 @@ Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportC
 
     Policy *policy = NULL;
 
-    if (ag != cf_keygen)        // && ag != cf_know)
+    if (ag != cf_keygen && ag != cf_gendoc)
     {
         if (!MissingInputFile())
         {
@@ -1952,7 +1952,7 @@ static bool VerifyBundleSequence(const Policy *policy, enum cfagenttype agent, R
     int ok = true;
     FnCall *fp;
 
-    if ((THIS_AGENT_TYPE != cf_agent) && (THIS_AGENT_TYPE != cf_know) && (THIS_AGENT_TYPE != cf_common))
+    if ((THIS_AGENT_TYPE != cf_agent) && (THIS_AGENT_TYPE != cf_know) && (THIS_AGENT_TYPE != cf_common) && (THIS_AGENT_TYPE != cf_gendoc))
     {
         return true;
     }

--- a/src/manual.c
+++ b/src/manual.c
@@ -37,23 +37,22 @@
 #include "sort.h"
 
 extern char BUILD_DIR[CF_BUFSIZE];
-extern char MANDIR[CF_BUFSIZE];
 
 static void TexinfoHeader(FILE *fout);
 static void TexinfoFooter(FILE *fout);
-static void TexinfoBodyParts(FILE *fout, const BodySyntax *bs, const char *context);
-static void TexinfoSubBodyParts(FILE *fout, BodySyntax *bs);
+static void TexinfoBodyParts(const char *source_dir, FILE *fout, const BodySyntax *bs, const char *context);
+static void TexinfoSubBodyParts(const char *source_dir, FILE *fout, BodySyntax *bs);
 static void TexinfoShowRange(FILE *fout, char *s, enum cfdatatype type);
-static void IncludeManualFile(FILE *fout, char *filename);
-static void TexinfoPromiseTypesFor(FILE *fout, const SubTypeSyntax *st);
-static void TexinfoSpecialFunction(FILE *fout, FnCallType fn);
-static void TexinfoVariables(FILE *fout, char *scope);
+static void IncludeManualFile(const char *source_dir, FILE *fout, char *filename);
+static void TexinfoPromiseTypesFor(const char *source_dir, FILE *fout, const SubTypeSyntax *st);
+static void TexinfoSpecialFunction(const char *source_dir, FILE *fout, FnCallType fn);
+static void TexinfoVariables(const char *source_dir, FILE *fout, char *scope);
 static char *TexInfoEscape(char *s);
 static void PrintPattern(FILE *fout, const char *pattern);
 
 /*****************************************************************************/
 
-void TexinfoManual(char *mandir)
+void TexinfoManual(const char *source_dir, const char *output_file)
 {
     char filename[CF_BUFSIZE];
     const SubTypeSyntax *st;
@@ -61,9 +60,7 @@ void TexinfoManual(char *mandir)
     FILE *fout;
     int i;
 
-    snprintf(filename, CF_BUFSIZE - 1, "%scf3-Reference.texinfo", BUILD_DIR);
-
-    if ((fout = fopen(filename, "w")) == NULL)
+    if ((fout = fopen(output_file, "w")) == NULL)
     {
         CfOut(cf_error, "fopen", "Unable to open %s for writing\n", filename);
         return;
@@ -78,7 +75,7 @@ void TexinfoManual(char *mandir)
     fprintf(fout, "@c *****************************************************\n");
 
     fprintf(fout, "@node Getting started\n@chapter CFEngine %s -- Getting started\n\n", Version());
-    IncludeManualFile(fout, "reference_basics.texinfo");
+    IncludeManualFile(source_dir, fout, "reference_basics.texinfo");
 
 /* Control promises */
 
@@ -87,7 +84,7 @@ void TexinfoManual(char *mandir)
     fprintf(fout, "@c *****************************************************\n");
 
     fprintf(fout, "@node Control Promises\n@chapter Control promises\n\n");
-    IncludeManualFile(fout, "reference_control_intro.texinfo");
+    IncludeManualFile(source_dir, fout, "reference_control_intro.texinfo");
 
     fprintf(fout, "@menu\n");
     for (i = 0; CF_ALL_BODIES[i].bundle_type != NULL; ++i)
@@ -101,11 +98,11 @@ void TexinfoManual(char *mandir)
         fprintf(fout, "@node control %s\n@section @code{%s} control promises\n\n", CF_ALL_BODIES[i].bundle_type,
                 CF_ALL_BODIES[i].bundle_type);
         snprintf(filename, CF_BUFSIZE - 1, "control/%s_example.texinfo", CF_ALL_BODIES[i].bundle_type);
-        IncludeManualFile(fout, filename);
+        IncludeManualFile(source_dir, fout, filename);
         snprintf(filename, CF_BUFSIZE - 1, "control/%s_notes.texinfo", CF_ALL_BODIES[i].bundle_type);
-        IncludeManualFile(fout, filename);
+        IncludeManualFile(source_dir, fout, filename);
 
-        TexinfoBodyParts(fout, CF_ALL_BODIES[i].bs, CF_ALL_BODIES[i].bundle_type);
+        TexinfoBodyParts(source_dir, fout, CF_ALL_BODIES[i].bs, CF_ALL_BODIES[i].bundle_type);
     }
 
 /* Components */
@@ -137,9 +134,9 @@ void TexinfoManual(char *mandir)
         {
             PrependItem(&done, st->bundle_type, NULL);
             snprintf(filename, CF_BUFSIZE - 1, "bundletypes/%s_example.texinfo", st->bundle_type);
-            IncludeManualFile(fout, filename);
+            IncludeManualFile(source_dir, fout, filename);
             snprintf(filename, CF_BUFSIZE - 1, "bundletypes/%s_notes.texinfo", st->bundle_type);
-            IncludeManualFile(fout, filename);
+            IncludeManualFile(source_dir, fout, filename);
 
             fprintf(fout, "@menu\n");
             for (int k = 0; k < CF3_MODULES; ++k)
@@ -175,7 +172,7 @@ void TexinfoManual(char *mandir)
             fprintf(fout, "@end menu\n");
         }
 
-        TexinfoPromiseTypesFor(fout, st);
+        TexinfoPromiseTypesFor(source_dir, fout, st);
     }
 
 /* Special functions */
@@ -199,12 +196,12 @@ void TexinfoManual(char *mandir)
 
     fprintf(fout, "@node Introduction to functions\n@section Introduction to functions\n\n");
 
-    IncludeManualFile(fout, "functions_intro.texinfo");
+    IncludeManualFile(source_dir, fout, "functions_intro.texinfo");
 
     for (i = 0; CF_FNCALL_TYPES[i].name != NULL; i++)
     {
         fprintf(fout, "@node Function %s\n@section Function %s \n\n", CF_FNCALL_TYPES[i].name, CF_FNCALL_TYPES[i].name);
-        TexinfoSpecialFunction(fout, CF_FNCALL_TYPES[i]);
+        TexinfoSpecialFunction(source_dir, fout, CF_FNCALL_TYPES[i]);
     }
 
 /* Special variables */
@@ -239,9 +236,12 @@ void TexinfoManual(char *mandir)
     NewScope("edit");
     NewScalar("edit", "filename", "x", cf_str);
 
+    NewScope("match");
+    NewScalar("match", "0", "x", cf_str);
+
     for (const char **s = scopes; *s != NULL; ++s)
     {
-        TexinfoVariables(fout, (char *) *s);
+        TexinfoVariables(source_dir, fout, (char *) *s);
     }
 
 // Log files
@@ -252,7 +252,7 @@ void TexinfoManual(char *mandir)
     fprintf(fout, "@c *****************************************************\n");
 
     fprintf(fout, "@node Logs and records\n@chapter Logs and records\n\n");
-    IncludeManualFile(fout, "reference_logs.texinfo");
+    IncludeManualFile(source_dir, fout, "reference_logs.texinfo");
 
     TexinfoFooter(fout);
 
@@ -375,7 +375,7 @@ static void TexinfoFooter(FILE *fout)
 
 /*****************************************************************************/
 
-static void TexinfoPromiseTypesFor(FILE *fout, const SubTypeSyntax *st)
+static void TexinfoPromiseTypesFor(const char *source_dir, FILE *fout, const SubTypeSyntax *st)
 {
     int j;
     char filename[CF_BUFSIZE];
@@ -411,13 +411,13 @@ static void TexinfoPromiseTypesFor(FILE *fout, const SubTypeSyntax *st)
                     st[j].bundle_type, st[j].subtype, st[j].bundle_type);
             }
             snprintf(filename, CF_BUFSIZE - 1, "promises/%s_intro.texinfo", st[j].subtype);
-            IncludeManualFile(fout, filename);
+            IncludeManualFile(source_dir, fout, filename);
             snprintf(filename, CF_BUFSIZE - 1, "promises/%s_example.texinfo", st[j].subtype);
-            IncludeManualFile(fout, filename);
+            IncludeManualFile(source_dir, fout, filename);
             snprintf(filename, CF_BUFSIZE - 1, "promises/%s_notes.texinfo", st[j].subtype);
         }
-        IncludeManualFile(fout, filename);
-        TexinfoBodyParts(fout, st[j].bs, st[j].subtype);
+        IncludeManualFile(source_dir, fout, filename);
+        TexinfoBodyParts(source_dir, fout, st[j].bs, st[j].subtype);
     }
 }
 
@@ -425,7 +425,7 @@ static void TexinfoPromiseTypesFor(FILE *fout, const SubTypeSyntax *st)
 /* Level                                                                     */
 /*****************************************************************************/
 
-static void TexinfoBodyParts(FILE *fout, const BodySyntax *bs, const char *context)
+static void TexinfoBodyParts(const char *source_dir, FILE *fout, const BodySyntax *bs, const char *context)
 {
     int i;
     char filename[CF_BUFSIZE];
@@ -457,7 +457,7 @@ static void TexinfoBodyParts(FILE *fout, const BodySyntax *bs, const char *conte
         {
             fprintf(fout, "\n\n@node %s in %s\n@subsection @code{%s} (body template)\n@noindent @b{Type}: %s\n\n",
                     bs[i].lval, context, bs[i].lval, CF_DATATYPES[bs[i].dtype]);
-            TexinfoSubBodyParts(fout, (BodySyntax *) bs[i].range);
+            TexinfoSubBodyParts(source_dir, fout, (BodySyntax *) bs[i].range);
         }
         else
         {
@@ -475,17 +475,17 @@ static void TexinfoBodyParts(FILE *fout, const BodySyntax *bs, const char *conte
             fprintf(fout, "\n@noindent @b{Synopsis}: %s\n\n", bs[i].description);
             fprintf(fout, "\n@noindent @b{Example}:@*\n");
             snprintf(filename, CF_BUFSIZE - 1, "bodyparts/%s_example.texinfo", bs[i].lval);
-            IncludeManualFile(fout, filename);
+            IncludeManualFile(source_dir, fout, filename);
             fprintf(fout, "\n@noindent @b{Notes}:@*\n");
             snprintf(filename, CF_BUFSIZE - 1, "bodyparts/%s_notes.texinfo", bs[i].lval);
-            IncludeManualFile(fout, filename);
+            IncludeManualFile(source_dir, fout, filename);
         }
     }
 }
 
 /*******************************************************************/
 
-static void TexinfoVariables(FILE *fout, char *scope)
+static void TexinfoVariables(const char *source_dir, FILE *fout, char *scope)
 {
     char filename[CF_BUFSIZE], varname[CF_BUFSIZE];
     Rlist *rp, *list = NULL;
@@ -496,7 +496,7 @@ static void TexinfoVariables(FILE *fout, char *scope)
 
     fprintf(fout, "\n\n@node Variable context %s\n@section Variable context @code{%s}\n\n", scope, scope);
     snprintf(filename, CF_BUFSIZE - 1, "varcontexts/%s_intro.texinfo", scope);
-    IncludeManualFile(fout, filename);
+    IncludeManualFile(source_dir, fout, filename);
 
     fprintf(fout, "@menu\n");
 
@@ -531,7 +531,7 @@ static void TexinfoVariables(FILE *fout, char *scope)
             fprintf(fout, "@node Variable %s.%s\n@subsection Variable %s.%s \n\n", scope, (char *) rp->item, scope,
                     (char *) rp->item);
             snprintf(filename, CF_BUFSIZE - 1, "vars/%s_%s.texinfo", scope, (char *) rp->item);
-            IncludeManualFile(fout, filename);
+            IncludeManualFile(source_dir, fout, filename);
         }
     }
     else
@@ -598,7 +598,7 @@ static void TexinfoShowRange(FILE *fout, char *s, enum cfdatatype type)
 
 /*****************************************************************************/
 
-static void TexinfoSubBodyParts(FILE *fout, BodySyntax *bs)
+static void TexinfoSubBodyParts(const char *source_dir, FILE *fout, BodySyntax *bs)
 {
     int i;
     char filename[CF_BUFSIZE];
@@ -620,7 +620,7 @@ static void TexinfoSubBodyParts(FILE *fout, BodySyntax *bs)
         else if (bs[i].dtype == cf_body)
         {
             fprintf(fout, "@item @code{%s}\n@b{Type}: %s\n\n", bs[i].lval, CF_DATATYPES[bs[i].dtype]);
-            TexinfoSubBodyParts(fout, (BodySyntax *) bs[i].range);
+            TexinfoSubBodyParts(source_dir, fout, (BodySyntax *) bs[i].range);
         }
         else
         {
@@ -637,10 +637,10 @@ static void TexinfoSubBodyParts(FILE *fout, BodySyntax *bs)
 
             fprintf(fout, "\n@b{Example}:@*\n");
             snprintf(filename, CF_BUFSIZE - 1, "bodyparts/%s_example.texinfo", bs[i].lval);
-            IncludeManualFile(fout, filename);
+            IncludeManualFile(source_dir, fout, filename);
             fprintf(fout, "\n@b{Notes}:@*\n");
             snprintf(filename, CF_BUFSIZE - 1, "bodyparts/%s_notes.texinfo", bs[i].lval);
-            IncludeManualFile(fout, filename);
+            IncludeManualFile(source_dir, fout, filename);
         }
     }
 
@@ -672,7 +672,7 @@ static bool GenerateStub(const char *filename)
 
 /*****************************************************************************/
 
-char *ReadTexinfoFileF(const char *fmt, ...)
+char *ReadTexinfoFileF(const char *source_dir, const char *fmt, ...)
 {
     Writer *filenamew = StringWriter();
 
@@ -684,7 +684,7 @@ char *ReadTexinfoFileF(const char *fmt, ...)
     va_list ap;
 
     va_start(ap, fmt);
-    WriterWriteF(filenamew, "%s/", MANDIR);
+    WriterWriteF(filenamew, "%s/", source_dir);
     WriterWriteVF(filenamew, fmt, ap);
     va_end(ap);
 
@@ -732,9 +732,9 @@ char *ReadTexinfoFileF(const char *fmt, ...)
 
 /*****************************************************************************/
 
-static void IncludeManualFile(FILE *fout, char *file)
+static void IncludeManualFile(const char *source_dir, FILE *fout, char *file)
 {
-    char *contents = ReadTexinfoFileF("%s", file);
+    char *contents = ReadTexinfoFileF(source_dir, "%s", file);
 
     if (contents)
     {
@@ -744,7 +744,7 @@ static void IncludeManualFile(FILE *fout, char *file)
 
 /*****************************************************************************/
 
-static void TexinfoSpecialFunction(FILE *fout, FnCallType fn)
+static void TexinfoSpecialFunction(const char *source_dir, FILE *fout, FnCallType fn)
 {
     char filename[CF_BUFSIZE];
     const FnCallArg *args = fn.args;
@@ -783,11 +783,11 @@ static void TexinfoSpecialFunction(FILE *fout, FnCallType fn)
     fprintf(fout, "\n@noindent @b{Example}:@*\n");
 
     snprintf(filename, CF_BUFSIZE - 1, "functions/%s_example.texinfo", fn.name);
-    IncludeManualFile(fout, filename);
+    IncludeManualFile(source_dir, fout, filename);
 
     fprintf(fout, "\n@noindent @b{Notes}:@*\n");
     snprintf(filename, CF_BUFSIZE - 1, "functions/%s_notes.texinfo", fn.name);
-    IncludeManualFile(fout, filename);
+    IncludeManualFile(source_dir, fout, filename);
 }
 
 /*****************************************************************************/

--- a/src/manual.h
+++ b/src/manual.h
@@ -25,6 +25,6 @@
 #ifndef CFENGINE_MANUAL_H
 #define CFENGINE_MANUAL_H
 
-char *ReadTexinfoFileF(const char *fmt, ...);
+char *ReadTexinfoFileF(const char *source_dir, const char *fmt, ...);
 
 #endif

--- a/src/prototypes3.h
+++ b/src/prototypes3.h
@@ -486,7 +486,7 @@ void AuditStatusMessage(Writer *writer, char status);
 
 /* manual.c */
 
-void TexinfoManual(char *mandir);
+void TexinfoManual(const char *source_dir, const char *output_file);
 
 /* matching.c */
 

--- a/src/unix.c
+++ b/src/unix.c
@@ -539,7 +539,7 @@ static void GetMacAddress(enum cfagenttype ag, int fd, struct ifreq *ifr, struct
 {
     char name[CF_MAXVARSIZE];
 
-    if (ag != cf_know)
+    if (ag != cf_know && ag != cf_gendoc)
     {
         snprintf(name, CF_MAXVARSIZE, "hardware_mac[%s]", ifp->ifr_name);
     }
@@ -791,7 +791,7 @@ void GetInterfacesInfo(enum cfagenttype ag)
 
                 strcpy(ip, inet_ntoa(sin->sin_addr));
 
-                if (ag != cf_know)
+                if (ag != cf_know && ag != cf_gendoc)
                 {
                     snprintf(name, CF_MAXVARSIZE - 1, "ipv4[%s]", CanonifyName(ifp->ifr_name));
                 }
@@ -810,7 +810,7 @@ void GetInterfacesInfo(enum cfagenttype ag)
                     {
                         *sp = '\0';
 
-                        if (ag != cf_know)
+                        if (ag != cf_know && ag != cf_gendoc)
                         {
                             snprintf(name, CF_MAXVARSIZE - 1, "ipv4_%d[%s]", i--, CanonifyName(ifp->ifr_name));
                         }


### PR DESCRIPTION
Reference manual generation is not necessary on target systems, as it needs
.texinfo fragments from the source code tree. Separating this tool allows to
turn it into build-time one, and significant chunk of binary code is hence not
distributed and installed to users' systems.
