### PR TITLE
Changed libexecdir to libdir when --enable-fhs is ticked

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,7 @@ AC_ARG_ENABLE([fhs],
 #
 
 AS_IF([test x"$enable_fhs" = xyes], [
-  projlibdir='${libexecdir}/cfengine'
+  projlibdir='${libdir}/cfengine'
   projdatadir='${exec_prefix}/share/cfengine'
   projdocdir='${exec_prefix}/share/doc/cfengine'
   WORKDIR='${localstatedir}/lib/cfengine'


### PR DESCRIPTION
libpromises.so goes into /usr/libexec when configured with --enable-fhs. This doesn't make any sense, since libexec is reserved for executables, not libraries. This patch fixes it such that libraries go into /usr/lib (or whatever libdir is configured to).
