### PR TITLE
Critical fix for broken edit_template handler. 

### DIFF
--- a/src/files_operators.c
+++ b/src/files_operators.c
@@ -544,6 +544,7 @@ int ScheduleEditOperation(char *filename, Attributes a, Promise *pp, const Repor
         if ((bp = MakeTemporaryBundleFromTemplate(a,pp)))
         {
             BannerSubBundle(bp,params);
+            a.haveeditline = true;
 
             DeleteScope(bp->name);
             NewScope(bp->name);


### PR DESCRIPTION
The addition of infrastructure for edit_xml (by me) broke the edit_template function due to a trivial condition that was no longer met. Simple fix, but v. important
