### PR TITLE
This adds a command line option to make cfengine compatible with launchd...

### DIFF
--- a/src/cf-execd.c
+++ b/src/cf-execd.c
@@ -81,7 +81,7 @@ static const char *ID = "The executor daemon is a scheduler and wrapper for\n"
     "agent and can email it to a specified address. It can\n"
     "splay the start time of executions across the network\n" "and work as a class-based clock for scheduling.";
 
-static const struct option OPTIONS[15] =
+static const struct option OPTIONS[16] =
 {
     {"help", no_argument, 0, 'h'},
     {"debug", no_argument, 0, 'd'},
@@ -95,12 +95,13 @@ static const struct option OPTIONS[15] =
     {"inform", no_argument, 0, 'I'},
     {"diagnostic", no_argument, 0, 'x'},
     {"no-fork", no_argument, 0, 'F'},
+    {"launchd-compatible", no_argument, 0, 'X'},
     {"no-winsrv", no_argument, 0, 'W'},
     {"ld-library-path", required_argument, 0, 'L'},
     {NULL, 0, 0, '\0'}
 };
 
-static const char *HINTS[15] =
+static const char *HINTS[16] =
 {
     "Print the help message",
     "Enable debugging output",
@@ -114,6 +115,7 @@ static const char *HINTS[15] =
     "Print basic information about changes made to the system, i.e. promises repaired",
     "Activate internal diagnostics (developers only)",
     "Run as a foreground processes (do not fork)",
+    "Compatible with launchd daemon on OS X (stay in foreground)",
     "Do not run as a service on windows - use this when running from a command shell (Cfengine Nova only)",
     "Set the internal value of LD_LIBRARY_PATH for child processes",
     NULL
@@ -158,7 +160,7 @@ static GenericAgentConfig CheckOpts(int argc, char **argv)
     char ld_library_path[CF_BUFSIZE];
     GenericAgentConfig config = GenericAgentDefaultConfig(cf_executor);
 
-    while ((c = getopt_long(argc, argv, "dvnKIf:D:N:VxL:hFV1gMW", OPTIONS, &optindex)) != EOF)
+    while ((c = getopt_long(argc, argv, "dvnKIf:D:N:VxL:hFV1gMXW", OPTIONS, &optindex)) != EOF)
     {
         switch ((char) c)
         {
@@ -218,6 +220,10 @@ static GenericAgentConfig CheckOpts(int argc, char **argv)
 
         case 'F':
             ONCE = true;
+            NO_FORK = true;
+            break;
+
+        case 'X':
             NO_FORK = true;
             break;
 


### PR DESCRIPTION
Launchd on OSX requires that daemons do not fork, in order to work as a watchdog service. This small patch adds a command line option to run cf-execd in foreground mode for compatibility.

For reference, se "Behavior for Processes Managed by launchd" in https://developer.apple.com/library/mac/#documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html#//apple_ref/doc/uid/10000172i-SW7-BCIEDDBJ
