### PR TITLE
Fix compilation on Mac

### DIFF
--- a/src/platform.h
+++ b/src/platform.h
@@ -381,11 +381,15 @@ int getnetgrent(char **host, char **user, char **domain);
 #endif
 
 #if !HAVE_DECL_SETNETGRENT
+# ifndef DARWIN // netdb.h on Mac defines setnetgrend as void
 int setnetgrent(const char *netgroup);
+# endif
 #endif
 
 #if !HAVE_DECL_ENDNETGRENT
+# ifndef DARWIN // netdb.h on Mac defines endnetgrend as void
 int endnetgrent(void);
+# endif
 #endif
 
 #ifndef HAVE_UNAME


### PR DESCRIPTION
On Darwin, netdb.h declares setnetgrend/endnetgrend with void return type. 

void        endnetgrent(void);
void        setnetgrent(const char *);

HAVE_DECL_SETNETGREND/ENDNETGREND are not set by configure, compilation fails on Mac with

platform.h:384: error: conflicting types for 'setnetgrent'
/usr/include/netdb.h:316: error: previous declaration of 'setnetgrent' was here
platform.h:388: error: conflicting types for 'endnetgrent'
/usr/include/netdb.h:315: error: previous declaration of 'endnetgrent' was here

Probably better to fix this in configure, for all BSDs.
