### PR TITLE
Fix poor promiser form for commands promise

### DIFF
--- a/docs/reference/functions/usemodule_example.texinfo
+++ b/docs/reference/functions/usemodule_example.texinfo
@@ -24,7 +24,7 @@ classes:
 
 commands:
 
-  "/bin/echo promiser text" args => "test $(user)";
+  "/bin/echo" args => "test $(user)";
 }
 
 @end verbatim


### PR DESCRIPTION
Spaces in commands type promisers cause warnings about binary not
existing. Any spaces in the promiser should be in the args attribute.
Closes Redmine 1277
