### PR TITLE
Change text "cf-agent was not able to..." to "CFEngine was not ..", clos...

### DIFF
--- a/src/generic_agent.c
+++ b/src/generic_agent.c
@@ -229,7 +229,7 @@ Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportC
         else
         {
             CfOut(cf_error, "",
-                  "cf-agent was not able to get confirmation of promises from cf-promises, so going to failsafe\n");
+                  "CFEngine was not able to get confirmation of promises from cf-promises, so going to failsafe\n");
             SetInputFile("failsafe.cf");
             policy = ReadPromises(ag, agents, config, report_context);
         }


### PR DESCRIPTION
...e #1010

This text is printed for all generic agents, so it is misleading when
the agent is cf-promises for example.
