### PR TITLE
Ensure histogram data positions are within range

### DIFF
--- a/src/cf-report.c
+++ b/src/cf-report.c
@@ -2491,6 +2491,10 @@ static void WriteHistograms()
     for (position = 0; position < CF_GRAINS; position++)
     {
         fscanf(fp, "%d ", &position);
+        if (position < 0 || position >= CF_GRAINS)
+        {
+            FatalError("Invalid position detected in histogram data: %d", position);
+        }
 
         for (i = 0; i < CF_OBSERVABLES; i++)
         {


### PR DESCRIPTION
This will hopefully solve Bug #1080

Not able to reproduce, but one way of getting the code to crash is to read an invalid position index from file and try to access it. This does not always result in a crash on linux (unless the range is outside of legal)
