### PR TITLE
Implementation of $(sys.cpus) on HP-UX using mpctl()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -399,6 +399,7 @@ AC_CHECK_HEADERS(winsock2.h)
 AC_CHECK_HEADERS(zone.h)
 AC_CHECK_HEADERS(sys/uio.h)
 AC_CHECK_HEADERS(sys/types.h)
+AC_CHECK_HEADERS(sys/mpctl.h)	dnl For HP-UX $(sys.cpus) - Mantis #1069
 AC_CHECK_HEADERS(sys/jail.h, [], [], [AC_INCLUDES_DEFAULT
 #ifdef HAVE_SYS_PARAM_H
 # include <sys/param.h>

--- a/src/sysinfo.c
+++ b/src/sysinfo.c
@@ -35,6 +35,11 @@
 # include <zone.h>
 #endif
 
+// HP-UX mpctl() for $(sys.cpus) on HP-UX - Mantis #1069
+#ifdef HAVE_SYS_MPCTL_H
+# include <sys/mpctl.h>
+#endif
+
 void CalculateDomainName(const char *nodename, const char *dnsname, char *fqname, char *uqname, char *domain);
 
 #ifdef LINUX
@@ -2099,13 +2104,15 @@ const char *GetWorkDir(void)
 
 static void GetCPUInfo()
 {
-    FILE *fp;
     char buf[CF_BUFSIZE];
     int count = 0;
 
+#ifdef LINUX
+    FILE *fp;
+
     if ((fp = fopen("/proc/stat", "r")) == NULL)
     {
-        CfOut(cf_verbose, "", "Unable to find proc/cpu data\n");
+        CfOut(cf_verbose, "", "Unable to read /proc/stat cpu data\n");
         return;
     }
 
@@ -2122,6 +2129,29 @@ static void GetCPUInfo()
 
     fclose(fp);
     count--;
+#endif /* LINUX */
+
+#ifdef HAVE_SYS_MPCTL_H
+// Itanium processors have Intel Hyper-Threading virtual-core capability,
+// and the MPC_GETNUMCORES_SYS operation counts each HT virtual core,
+// which is equivalent to what the /proc/stat scan delivers for Linux.
+//
+// A build on 11i v3 PA would have the GETNUMCORES define, but if run on an
+// 11i v1 system it would fail since that OS release has only GETNUMSPUS.
+// So in the presence of GETNUMCORES, we check for an invalid arg error
+// and fall back to GETNUMSPUS if necessary. An 11i v1 build would work
+// normally on 11i v3, because on PA-RISC cores == spus since there's no
+// HT on PA-RISC, and 11i v1 only runs on PA-RISC.
+#ifdef MPC_GETNUMCORES_SYS
+    if ((count = mpctl(MPC_GETNUMCORES_SYS, 0, 0)) == -1) {
+        if (errno == EINVAL) {
+            count = mpctl(MPC_GETNUMSPUS_SYS, 0, 0);
+        }
+    }
+#else
+    count = mpctl(MPC_GETNUMSPUS_SYS, 0, 0);	// PA-RISC processor count
+#endif
+#endif /* HAVE_SYS_MPCTL_H */
 
     if (count < 1)
     {


### PR DESCRIPTION
Uses the HP-UX mpctl() function to query the number of processors available system-wide (as opposed to within a processor set) in order to populate the $(sys.cpus) variable.

In HP-UX running on Intel Itanium Hyper-Thread Technology processors, where each CPU core has two virtual cores, the total number of virtual - rather than physical - cores is provided, which corresponds to the behavior of the Linux scan of the /proc/stat file with HTT is enabled on x86 platforms.

On a PA-RISC system, the total number of physical cores is set. The PA-8900 processor has two physical cores per CPU socket, so an rp8420 with 16 PA-8900 processors will set $(sys.cpus) to 32, as expected.

It may be worthwhile to implement a $(sys.cpusockets) variable too, in light of things like Oracle and Red Hat licensing.

The mpctl() function is documented at this page: http://h20000.www2.hp.com/bc/docs/support/SupportManual/c02264569/c02264569.pdf
