### PR TITLE
Fix build with clang

### DIFF
--- a/src/files_select.c
+++ b/src/files_select.c
@@ -27,6 +27,7 @@
 
 #include "env_context.h"
 #include "files_names.h"
+#include "promises.h"
 
 static int SelectTypeMatch(struct stat *lstatptr, Rlist *crit);
 static int SelectOwnerMatch(char *path, struct stat *lstatptr, Rlist *crit);


### PR DESCRIPTION
Without this, clang produeces this error:

files_select.c:378:9: error: implicit declaration of function 'PromiseRef' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        PromiseRef(cf_error, pp);
        ^

See this build log for more detail:

http://pointyhat-west.isc.freebsd.org/errorlogs/amd64-errorlogs/e.9-exp-clang.20120902011351.pointyhat-west/cfengine-devel-3.4.0a2_1,1.log
