### PR TITLE
Missing BN_new() check for failure

### DIFF
--- a/src/client_protocol.c
+++ b/src/client_protocol.c
@@ -212,6 +212,12 @@ int AuthenticateAgent(AgentConnection *conn, Attributes attr, Promise *pp)
 /* Generate a random challenge to authenticate the server */
 
     nonce_challenge = BN_new();
+    if (nonce_challenge == NULL)
+    {
+        CfOut(cf_error, "", "Cannot allocate BIGNUM structure for server challenge\n");
+        return false;
+    }
+
     BN_rand(nonce_challenge, CF_NONCELEN, 0, 0);
     nonce_len = BN_bn2mpi(nonce_challenge, in);
 

--- a/src/server.c
+++ b/src/server.c
@@ -2204,6 +2204,13 @@ static int AuthenticationDialogue(ServerConnectionState *conn, char *recvbuffer,
     ThreadLock(cft_system);
 
     counter_challenge = BN_new();
+    if (counter_challenge == NULL)
+    {
+        CfOut(cf_error, "", "Cannot allocate BIGNUM structure for counter challenge\n");
+        RSA_free(newkey);
+        return false;
+    }
+
     BN_rand(counter_challenge, CF_NONCELEN, 0, 0);
     nonce_len = BN_bn2mpi(counter_challenge, in);
 


### PR DESCRIPTION
Hello,

I have found 2 BN_new() calls where return code was not checked.
