### PR TITLE
Fix non-convergent HP-UX shared lib perms in failsafe.cf (R#1179)

### DIFF
--- a/masterfiles/failsafe/failsafe.cf
+++ b/masterfiles/failsafe/failsafe.cf
@@ -148,17 +148,9 @@ bundle agent update
    "$(sys.workdir)/lib"
            comment => "Make sure cfengine libraries have right file permissions",
             handle => "update_files_sys_workdir_lib",
-             perms => u_m("644"),
+             perms => u_shared_lib_perms,
       depth_search => u_recurse_basedir("inf"),
             action => u_immediate;
-
-   "$(sys.workdir)/lib"
-           comment => "Make sure cfengine libraries have right file permissions for only HP-UX",
-            handle => "update_files_sys_workdir_lib_hpux",
-             perms => u_m("755"),
-      depth_search => u_recurse_basedir("inf"),
-            action => u_immediate,
-        ifvarclass => "hpux";
 
    "/usr/local/sbin"
            comment => "Ensure cfengine binaries were copied to /usr/local/sbin",
@@ -186,6 +178,16 @@ bundle agent update
 body perms u_m(p)
 {
  mode  => "$(p)";
+}
+
+#########################################################
+
+body perms u_shared_lib_perms
+{
+ !hpux::
+   mode => "0644";
+ hpux::
+   mode => "0755";  # Mantis 1114, Redmine 1179
 }
 
 #########################################################


### PR DESCRIPTION
HP-UX shared libraries must be executable, since the OS uses the file perms to set the permissions on the memory map, and the memory pages for a mapped shared library must have execute permissions in order for the shared library to be used.

An earlier commit (6edd6f9a8000c4fecc5e521ef048eeb69c3c99b5) added code to set the correct 755 permissions for HP-UX, but did not add an exception for non-HP-UX systems for 644 permissions. This led to a non-convergent pair of promises, one of which set mode 644 and the other which set 755 each time CFEngine ran on an HP-UX system.

This commit corrects that problem: it creates a new "perms" body - u_shared_lib_perms - which sets mode 755 in "hpux" context and 644 otherwise, and eliminates the duplicate promiser, providing convergence on HP-UX systems while also simplifying the failsafe.cf.
