### PR TITLE
env_context: namespaces are delimited by ":" rather than "." [bug 1616]

### DIFF
--- a/docs/reference/bodyparts/depends_on_notes.texinfo
+++ b/docs/reference/bodyparts/depends_on_notes.texinfo
@@ -12,4 +12,4 @@ promises have already been verified and kept: i.e. as long as the
 dependent promises are either kept or repaired the dependee can be
 verified.
 
-Handles in other namespaces may be referred to by @var{namespace.handle}.
+Handles in other namespaces may be referred to by @var{namespace:handle}.

--- a/src/env_context.c
+++ b/src/env_context.c
@@ -1699,7 +1699,7 @@ void MarkPromiseHandleDone(const Promise *pp)
        return;
     }
     
-    snprintf(name, CF_BUFSIZE, "%s.%s", pp->namespace, handle);    
+    snprintf(name, CF_BUFSIZE, "%s:%s", pp->namespace, handle);
     IdempPrependAlphaList(&VHANDLES, name);
 
 }


### PR DESCRIPTION
In MissingDependencies() we look for "namespace:handle", while that
function would fill the array with "namespace.handle" strings.

Updated the doc for consistency, too.

Note: I preferred the colon ":" delimiter, because it's the one used in classes, too.
