### PR TITLE
The operands of a logical && or || shall be primary-expressions (MISRA 12.5)

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -206,7 +206,7 @@ static void SetACLDefaults(char *path, Acl *acl)
 
 // default on directories: acl_directory_inherit => parent
 
-    if (acl->acl_directory_inherit == cfacl_noinherit && IsDir(path))
+    if ((acl->acl_directory_inherit == cfacl_noinherit) && (IsDir(path)))
     {
         acl->acl_directory_inherit = cfacl_nochange;
     }
@@ -372,7 +372,7 @@ static int CheckModeSyntax(char **mode_p, char *valid_ops, char *valid_nperms, P
 
 // mode is allowed to be empty
 
-    if (*mode == '\0' || *mode == ':')
+    if ((*mode == '\0') || (*mode == ':'))
     {
         return true;
     }
@@ -402,7 +402,7 @@ static int CheckModeSyntax(char **mode_p, char *valid_ops, char *valid_nperms, P
             }
         }
 
-        if (*mode == '\0' || *mode == ':')      // end of mode-string
+        if ((*mode == '\0') || (*mode == ':'))      // end of mode-string
         {
             valid = true;
             break;

--- a/src/addr_lib.c
+++ b/src/addr_lib.c
@@ -162,7 +162,7 @@ int FuzzySetMatch(char *s1, char *s2)
                     sscanf(buffer1, "%ld-%ld", &from, &to);
                     sscanf(buffer2, "%ld", &cmp);
 
-                    if (from < 0 || to < 0)
+                    if ((from < 0) || (to < 0))
                     {
                         CfDebug("Couldn't read range\n");
                         return -1;
@@ -325,7 +325,7 @@ int FuzzyHostMatch(char *arg0, char *arg1, char *refhost)
 
     sscanf(arg1, "%ld-%ld", &start, &end);
 
-    if (cmp < start || cmp > end)
+    if ((cmp < start) || (cmp > end))
     {
         return 1;
     }
@@ -461,7 +461,7 @@ int FuzzyMatchParse(char *s)
             {
                 sscanf(buffer1, "%ld-%ld", &from, &to);
 
-                if (from < 0 || to < 0)
+                if ((from < 0) || (to < 0))
                 {
                     CfOut(cf_error, "", "Error in IP range - looks like address, or bad hostname");
                     return false;

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -27,7 +27,7 @@
 
 static void *CheckResult(void *ptr, const char *fn, bool check_result)
 {
-    if (ptr == NULL && check_result)
+    if ((ptr == NULL) && (check_result))
     {
         fputs(fn, stderr);
         fputs(": Unable to allocate memory\n", stderr);
@@ -43,7 +43,7 @@ void *xmalloc(size_t size)
 
 void *xcalloc(size_t nmemb, size_t size)
 {
-    return CheckResult(calloc(nmemb, size), "xcalloc", nmemb != 0 && size != 0);
+    return CheckResult(calloc(nmemb, size), "xcalloc", (nmemb != 0) && (size != 0));
 }
 
 void *xrealloc(void *ptr, size_t size)

--- a/src/attributes.c
+++ b/src/attributes.c
@@ -63,7 +63,7 @@ Attributes GetFilesAttributes(const Promise *pp)
     attr.template = (char *)GetConstraintValue("edit_template", pp, CF_SCALAR);
     attr.haveeditline = GetBundleConstraint("edit_line", pp);
     attr.haveeditxml = GetBundleConstraint("edit_xml", pp);
-    attr.haveedit = attr.haveeditline || attr.haveeditxml || attr.template;
+    attr.haveedit = (attr.haveeditline) || (attr.haveeditxml) || (attr.template);
 
 /* Files, specialist */
 
@@ -106,9 +106,9 @@ Attributes GetFilesAttributes(const Promise *pp)
         ShowAttributes(attr);
     }
 
-    if (attr.haverename || attr.havedelete || attr.haveperms || attr.havechange ||
-        attr.havecopy || attr.havelink || attr.haveedit || attr.create || attr.touch ||
-        attr.transformer || attr.acl.acl_entries)
+    if ((attr.haverename) || (attr.havedelete) || (attr.haveperms) || (attr.havechange) ||
+        (attr.havecopy) || (attr.havelink) || (attr.haveedit) || (attr.create) || (attr.touch) ||
+        (attr.transformer) || (attr.acl.acl_entries))
     {
     }
     else
@@ -119,9 +119,9 @@ Attributes GetFilesAttributes(const Promise *pp)
         }
     }
 
-    if ((THIS_AGENT_TYPE == cf_common) && attr.create && attr.havecopy)
+    if ((THIS_AGENT_TYPE == cf_common) && (attr.create) && (attr.havecopy))
     {
-        if (attr.copy.compare != cfa_checksum && attr.copy.compare != cfa_hash)
+        if (((attr.copy.compare) != (cfa_checksum)) && ((attr.copy.compare) != cfa_hash))
         {
             CfOut(cf_error, "",
                   " !! Promise constraint conflicts - %s file will never be copied as created file is always newer",
@@ -136,7 +136,7 @@ Attributes GetFilesAttributes(const Promise *pp)
         }
     }
 
-    if ((THIS_AGENT_TYPE == cf_common) && attr.create && attr.havelink)
+    if ((THIS_AGENT_TYPE == cf_common) && (attr.create) && (attr.havelink))
     {
         CfOut(cf_error, "", " !! Promise constraint conflicts - %s cannot be created and linked at the same time",
               pp->promiser);
@@ -528,7 +528,7 @@ FilePerms GetPermissionConstraints(const Promise *pp)
     p.plus_flags = 0;
     p.minus_flags = 0;
 
-    if (list && !ParseFlagString(list, &p.plus_flags, &p.minus_flags))
+    if (list && (!ParseFlagString(list, &p.plus_flags, &p.minus_flags)))
     {
         CfOut(cf_error, "", "Problem validating a BSD flag string");
         PromiseRef(cf_error, pp);
@@ -596,7 +596,7 @@ FileSelect GetSelectConstraints(const Promise *pp)
         PromiseRef(cf_error, pp);
     }
 
-    if (s.name || s.path || s.filetypes || s.issymlinkto || s.perms || s.bsdflags)
+    if ((s.name) || (s.path) || (s.filetypes) || (s.issymlinkto) || (s.perms) || (s.bsdflags))
     {
         entries = true;
     }
@@ -636,7 +636,7 @@ FileSelect GetSelectConstraints(const Promise *pp)
     s.exec_regex = (char *) GetConstraintValue("exec_regex", pp, CF_SCALAR);
     s.exec_program = (char *) GetConstraintValue("exec_program", pp, CF_SCALAR);
 
-    if (s.owners || s.min_size || s.exec_regex || s.exec_program)
+    if ((s.owners) || (s.min_size) || (s.exec_regex) || (s.exec_program))
     {
         entries = true;
     }
@@ -750,7 +750,7 @@ DefineClasses GetClassDefinitionConstraints(const Promise *pp)
 
     pt = GetConstraintValue("timer_policy", pp, CF_SCALAR);
 
-    if (pt && strncmp(pt, "abs", 3) == 0)
+    if (pt && (strncmp(pt, "abs", 3) == 0))
     {
         c.timer = cfpreserve;
     }
@@ -771,7 +771,7 @@ FileDelete GetDeleteConstraints(const Promise *pp)
 
     value = (char *) GetConstraintValue("dirlinks", pp, CF_SCALAR);
 
-    if (value && strcmp(value, "keep") == 0)
+    if (value && (strcmp(value, "keep") == 0))
     {
         f.dirlinks = cfa_linkkeep;
     }
@@ -816,7 +816,7 @@ FileChange GetChangeMgtConstraints(const Promise *pp)
 
     value = (char *) GetConstraintValue("hash", pp, CF_SCALAR);
 
-    if (value && strcmp(value, "best") == 0)
+    if (value && (strcmp(value, "best") == 0))
     {
 #ifdef HAVE_NOVA
         c.hash = cf_sha512;
@@ -824,23 +824,23 @@ FileChange GetChangeMgtConstraints(const Promise *pp)
         c.hash = cf_besthash;
 #endif
     }
-    else if (value && strcmp(value, "md5") == 0)
+    else if (value && (strcmp(value, "md5") == 0))
     {
         c.hash = cf_md5;
     }
-    else if (value && strcmp(value, "sha1") == 0)
+    else if (value && (strcmp(value, "sha1") == 0))
     {
         c.hash = cf_sha1;
     }
-    else if (value && strcmp(value, "sha256") == 0)
+    else if (value && (strcmp(value, "sha256") == 0))
     {
         c.hash = cf_sha256;
     }
-    else if (value && strcmp(value, "sha384") == 0)
+    else if (value && (strcmp(value, "sha384") == 0))
     {
         c.hash = cf_sha384;
     }
-    else if (value && strcmp(value, "sha512") == 0)
+    else if (value && (strcmp(value, "sha512") == 0))
     {
         c.hash = cf_sha512;
     }
@@ -849,7 +849,7 @@ FileChange GetChangeMgtConstraints(const Promise *pp)
         c.hash = CF_DEFAULT_DIGEST;
     }
 
-    if (FIPS_MODE && c.hash == cf_md5)
+    if (FIPS_MODE && (c.hash == cf_md5))
     {
         CfOut(cf_error, "", " !! FIPS mode is enabled, and md5 is not an approved algorithm");
         PromiseRef(cf_error, pp);
@@ -857,15 +857,15 @@ FileChange GetChangeMgtConstraints(const Promise *pp)
 
     value = (char *) GetConstraintValue("report_changes", pp, CF_SCALAR);
 
-    if (value && strcmp(value, "content") == 0)
+    if (value && (strcmp(value, "content") == 0))
     {
         c.report_changes = cfa_contentchange;
     }
-    else if (value && strcmp(value, "stats") == 0)
+    else if (value && (strcmp(value, "stats") == 0))
     {
         c.report_changes = cfa_statschange;
     }
-    else if (value && strcmp(value, "all") == 0)
+    else if (value && (strcmp(value, "all") == 0))
     {
         c.report_changes = cfa_allchanges;
     }
@@ -917,11 +917,11 @@ FileCopy GetCopyConstraints(const Promise *pp)
 
     value = (char *) GetConstraintValue("copy_backup", pp, CF_SCALAR);
 
-    if (value && strcmp(value, "false") == 0)
+    if (value && (strcmp(value, "false") == 0))
     {
         f.backup = cfa_nobackup;
     }
-    else if (value && strcmp(value, "timestamp") == 0)
+    else if (value && (strcmp(value, "timestamp") == 0))
     {
         f.backup = cfa_timestamp;
     }
@@ -967,11 +967,11 @@ FileLink GetLinkConstraints(const Promise *pp)
 
     value = (char *) GetConstraintValue("when_no_source", pp, CF_SCALAR);
 
-    if (value && strcmp(value, "force") == 0)
+    if (value && (strcmp(value, "force") == 0))
     {
         f.when_no_file = cfa_force;
     }
-    else if (value && strcmp(value, "delete") == 0)
+    else if (value && (strcmp(value, "delete") == 0))
     {
         f.when_no_file = cfa_delete;
     }
@@ -982,7 +982,7 @@ FileLink GetLinkConstraints(const Promise *pp)
 
     value = (char *) GetConstraintValue("when_linking_children", pp, CF_SCALAR);
 
-    if (value && strcmp(value, "override_file") == 0)
+    if (value && (strcmp(value, "override_file") == 0))
     {
         f.when_linking_children = cfa_override;
     }
@@ -1005,22 +1005,22 @@ EditDefaults GetEditDefaults(const Promise *pp)
 
     e.maxfilesize = GetIntConstraint("max_file_size", pp);
 
-    if (e.maxfilesize == CF_NOINT || e.maxfilesize == 0)
+    if ((e.maxfilesize == CF_NOINT) || (e.maxfilesize == 0))
     {
         e.maxfilesize = EDITFILESIZE;
     }
 
     value = (char *) GetConstraintValue("edit_backup", pp, CF_SCALAR);
 
-    if (value && strcmp(value, "false") == 0)
+    if (value && (strcmp(value, "false") == 0))
     {
         e.backup = cfa_nobackup;
     }
-    else if (value && strcmp(value, "timestamp") == 0)
+    else if (value && (strcmp(value, "timestamp") == 0))
     {
         e.backup = cfa_timestamp;
     }
-    else if (value && strcmp(value, "rotate") == 0)
+    else if (value && (strcmp(value, "rotate") == 0))
     {
         e.backup = cfa_rotate;
         e.rotate = GetIntConstraint("rotate", pp);
@@ -1232,7 +1232,7 @@ ProcessSelect GetProcessFilterConstraints(const Promise *pp)
 
     IntRange2Int(value, &p.min_thread, &p.max_thread, pp);
 
-    if (p.owner || p.status || p.command || p.tty)
+    if ((p.owner) || (p.status) || (p.command) || (p.tty))
     {
         entries = true;
     }
@@ -1349,7 +1349,7 @@ EditLocation GetLocationAttributes(const Promise *pp)
 
     value = GetConstraintValue("before_after", pp, CF_SCALAR);
 
-    if (value && strcmp(value, "before") == 0)
+    if (value && (strcmp(value, "before") == 0))
     {
         e.before_after = cfe_before;
     }
@@ -1487,7 +1487,7 @@ EditColumn GetColumnConstraints(const Promise *pp)
     c.column_separator = GetConstraintValue("field_separator", pp, CF_SCALAR);
     c.select_column = GetIntConstraint("select_field", pp);
 
-    if (c.select_column != CF_NOINT && GetBooleanConstraint("start_fields_from_zero", pp))
+    if (((c.select_column) != CF_NOINT) && (GetBooleanConstraint("start_fields_from_zero", pp)))
     {
         c.select_column++;
     }
@@ -1617,7 +1617,7 @@ Report GetReportConstraints(const Promise *pp)
 
     r.to_file = GetConstraintValue("report_to_file", pp, CF_SCALAR);
 
-    if (r.result && (r.haveprintfile || r.filename || r.showstate || r.to_file || r.lastseen))
+    if ((r.result) && ((r.haveprintfile) || (r.filename) || (r.showstate) || (r.to_file) || (r.lastseen)))
     {
         CfOut(cf_error, "", " !! bundle_return_value promise for \"%s\" in bundle \"%s\" with too many constraints (ignored)", pp->promiser, pp->bundle);
     }
@@ -1706,7 +1706,7 @@ Database GetDatabaseConstraints(const Promise *pp)
     value = GetConstraintValue("db_server_type", pp, CF_SCALAR);
     d.db_server_type = Str2dbType(value);
 
-    if (value && d.db_server_type == cfd_notype)
+    if (value && ((d.db_server_type) == cfd_notype))
     {
         CfOut(cf_error, "", "Unsupported database type \"%s\" in databases promise", value);
         PromiseRef(cf_error, pp);

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -182,11 +182,11 @@ void SetPolicyServer(char *name)
 
     // update file if different and we know what to put there
 
-    if (NULL_OR_EMPTY(name) && !NULL_OR_EMPTY(fileContents))
+    if ((NULL_OR_EMPTY(name)) && (!NULL_OR_EMPTY(fileContents)))
     {
         snprintf(name, CF_MAXVARSIZE, "%s", fileContents);
     }
-    else if (!NULL_OR_EMPTY(name) && strcmp(name, fileContents) != 0)
+    else if ((!NULL_OR_EMPTY(name)) && (strcmp(name, fileContents) != 0))
     {
         if ((fout = fopen(file, "w")) == NULL)
         {

--- a/src/cf-execd-runner.c
+++ b/src/cf-execd-runner.c
@@ -92,7 +92,7 @@ static bool TwinExists(void)
     snprintf(twinfilename, CF_BUFSIZE, "%s/%s", CFWORKDIR, TwinFilename());
     MapName(twinfilename);
 
-    return stat(twinfilename, &sb) == 0 && IsExecutable(twinfilename);
+    return (stat(twinfilename, &sb) == 0) && (IsExecutable(twinfilename));
 }
 
 /* Buffer has to be at least CF_BUFSIZE bytes long */
@@ -183,7 +183,7 @@ void LocalExec(const ExecConfig *config)
 
     CfOut(cf_verbose, "", " -> Command is executing...%s\n", esc_command);
 
-    while (!feof(pp) && CfReadLine(line, CF_BUFSIZE, pp))
+    while ((!feof(pp)) && (CfReadLine(line, CF_BUFSIZE, pp)))
     {
         if (ferror(pp))
         {
@@ -627,7 +627,7 @@ static int Dialogue(int sd, char *s)
 
         CfDebug("%c", ch);
 
-        if (ch == '\n' || ch == '\0')
+        if ((ch == '\n') || (ch == '\0'))
         {
             charpos = 0;
 

--- a/src/cf-key.c
+++ b/src/cf-key.c
@@ -251,7 +251,7 @@ static int RemovePublicKey(const char *id)
     {
         char *c = strstr(dirp->d_name, suffix);
 
-        if (c && c[strlen(suffix)] == '\0')     /* dirp->d_name ends with suffix */
+        if (c && (c[strlen(suffix)] == '\0'))     /* dirp->d_name ends with suffix */
         {
             char keyfilename[CF_BUFSIZE];
 
@@ -298,7 +298,7 @@ static int RemoveKeys(const char *host)
     int removed_by_ip = RemovePublicKey(ip);
     int removed_by_digest = RemovePublicKey(digest);
 
-    if (removed_by_ip == -1 || removed_by_digest == -1)
+    if ((removed_by_ip == -1) || (removed_by_digest == -1))
     {
         CfOut(cf_error, "", "Unable to remove keys for the host %s",
               remove_keys_host);

--- a/src/cf-promises.c
+++ b/src/cf-promises.c
@@ -125,7 +125,7 @@ GenericAgentConfig CheckOpts(int argc, char **argv)
         {
         case 'f':
 
-            if (optarg && strlen(optarg) < 5)
+            if (optarg && (strlen(optarg) < 5))
             {
                 FatalError(" -f used but argument \"%s\" incorrect", optarg);
             }

--- a/src/cf-report.c
+++ b/src/cf-report.c
@@ -758,7 +758,7 @@ static void KeepReportsPromises()
             all = true;
         }
 
-        if (all || strcmp("last_seen", rp->item) == 0)
+        if (all || (strcmp("last_seen", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating last-seen report...\n");
             ShowLastSeen();
@@ -782,7 +782,7 @@ static void KeepReportsPromises()
             ShowChecksums();
         }
 
-        if (all || strcmp("performance", rp->item) == 0)
+        if (all || (strcmp("performance", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating performance report...\n");
             ShowPerformance();
@@ -794,25 +794,25 @@ static void KeepReportsPromises()
             ShowCurrentAudit();
         }
 
-        if (all || strcmp("classes", rp->item) == 0)
+        if (all || (strcmp("classes", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating classes report...\n");
             ShowClasses();
         }
 
-        if (all || strcmp("monitor_now", rp->item) == 0)
+        if (all || (strcmp("monitor_now", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating monitor recent-history report...\n");
             MagnifyNow();
         }
 
-        if (all || strcmp("monitor_summary", rp->item) == 0)
+        if (all || (strcmp("monitor_summary", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating monitor history summary...\n");
             SummarizeAverages();
         }
 
-        if (all || strcmp("monitor_history", rp->item) == 0)
+        if (all || (strcmp("monitor_history", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating monitor full history report...\n");
             WriteGraphFiles();
@@ -820,7 +820,7 @@ static void KeepReportsPromises()
             LongHaul(CFSTARTTIME);
         }
 
-        if (all || strcmp("compliance", rp->item) == 0)
+        if (all || (strcmp("compliance", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating compliance summary (Cfengine Nova and above)...\n");
             SummarizeCompliance(XML, HTML, CSV, EMBEDDED, STYLESHEET, BANNER, FOOTER, WEBDRIVER);
@@ -832,37 +832,37 @@ static void KeepReportsPromises()
             SummarizePromiseNotKept(XML, HTML, CSV, EMBEDDED, STYLESHEET, BANNER, FOOTER, WEBDRIVER);
         }
 
-        if (all || strcmp("file_changes", rp->item) == 0)
+        if (all || (strcmp("file_changes", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating file change summary (Cfengine Nova and above)...\n");
             SummarizeFileChanges(XML, HTML, CSV, EMBEDDED, STYLESHEET, BANNER, FOOTER, WEBDRIVER);
         }
 
-        if (all || strcmp("installed_software", rp->item) == 0)
+        if (all || (strcmp("installed_software", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating software version summary (Cfengine Nova and above)...\n");
             SummarizeSoftware(XML, HTML, CSV, EMBEDDED, STYLESHEET, BANNER, FOOTER, WEBDRIVER);
         }
 
-        if (all || strcmp("software_patches", rp->item) == 0)
+        if (all || (strcmp("software_patches", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating software update version summary (Cfengine Nova and above)...\n");
             SummarizeUpdates(XML, HTML, CSV, EMBEDDED, STYLESHEET, BANNER, FOOTER, WEBDRIVER);
         }
 
-        if (all || strcmp("setuid", rp->item) == 0)
+        if (all || (strcmp("setuid", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating setuid report (Cfengine Nova and above)...\n");
             SummarizeSetuid(XML, HTML, CSV, EMBEDDED, STYLESHEET, BANNER, FOOTER, WEBDRIVER);
         }
 
-        if (all || strcmp("variables", rp->item) == 0)
+        if (all || (strcmp("variables", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating variables report (Cfengine Nova and above)...\n");
             SummarizeVariables(XML, HTML, CSV, EMBEDDED, STYLESHEET, BANNER, FOOTER, WEBDRIVER);
         }
 
-        if (all || strcmp("value", rp->item) == 0)
+        if (all || (strcmp("value", rp->item) == 0))
         {
             CfOut(cf_verbose, "", " -> Creating value report (Cfengine Nova and above)...\n");
             SummarizeValue(XML, HTML, CSV, EMBEDDED, STYLESHEET, BANNER, FOOTER, WEBDRIVER);
@@ -1015,7 +1015,7 @@ static void ShowLastSeen()
     }
     assert(writer);
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         time_t tid = time(NULL);
         snprintf(name, CF_BUFSIZE, "Peers as last seen by %s", VFQNAME);
@@ -1035,7 +1035,7 @@ static void ShowLastSeen()
         return;
     }
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         WriterWriteF(writer, "</table></div>\n");
         CfHtmlFooter(writer, FOOTER);
@@ -1112,7 +1112,7 @@ static void ShowPerformance()
     memset(&value, 0, sizeof(value));
     memset(&entry, 0, sizeof(entry));
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         snprintf(name, CF_BUFSIZE, "Promises last kept by %s", VFQNAME);
         CfHtmlHeader(writer, name, STYLESHEET, WEBDRIVER, BANNER);
@@ -1157,7 +1157,7 @@ static void ShowPerformance()
 
                 CfOut(cf_inform, "", "Deleting expired entry for %s\n", eventname);
 
-                if (measure < 0 || average < 0 || measure > 4 * SECONDS_PER_WEEK)
+                if ((measure < 0) || (average < 0) || (measure > (4 * SECONDS_PER_WEEK)))
                 {
                     DBCursorDeleteEntry(dbcp);
                 }
@@ -1207,7 +1207,7 @@ static void ShowPerformance()
         }
     }
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         WriterWriteF(writer, "</table>");
         WriterWriteF(writer, "</div>\n");
@@ -1288,7 +1288,7 @@ static void ShowClasses()
 
     memset(&entry, 0, sizeof(entry));
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         time_t now = time(NULL);
 
@@ -1409,7 +1409,7 @@ static void ShowClasses()
         }
     }
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         WriterWriteF(writer, "</table>");
         WriterWriteF(writer, "<h4>All classes</h4>\n");
@@ -1425,10 +1425,10 @@ static void ShowClasses()
             continue;
         }
 
-        if (strncmp(ip->name, "Min", 3) == 0 || strncmp(ip->name, "Hr", 2) == 0 || strncmp(ip->name, "Q", 1) == 0
-            || strncmp(ip->name, "Yr", 1) == 0 || strncmp(ip->name, "Day", 1) == 0
-            || strncmp(ip->name, "Morning", 1) == 0 || strncmp(ip->name, "Afternoon", 1) == 0
-            || strncmp(ip->name, "Evening", 1) == 0 || strncmp(ip->name, "Night", 1) == 0)
+        if ((strncmp(ip->name, "Min", 3) == 0) || (strncmp(ip->name, "Hr", 2) == 0) || (strncmp(ip->name, "Q", 1) == 0)
+            || (strncmp(ip->name, "Yr", 1) == 0) || (strncmp(ip->name, "Day", 1) == 0)
+            || (strncmp(ip->name, "Morning", 1) == 0) || (strncmp(ip->name, "Afternoon", 1) == 0)
+            || (strncmp(ip->name, "Evening", 1) == 0) || (strncmp(ip->name, "Night", 1) == 0))
         {
             continue;
         }
@@ -1457,7 +1457,7 @@ static void ShowClasses()
         }
     }
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         WriterWriteF(writer, "</table>");
         WriterWriteF(writer, "</div>\n");
@@ -1521,7 +1521,7 @@ static void ShowChecksums()
     }
     assert(writer);
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         CfHtmlHeader(writer, "File hashes", STYLESHEET, WEBDRIVER, BANNER);
         WriterWriteF(writer, "<div id=\"reporttext\">\n");
@@ -1587,7 +1587,7 @@ static void ShowChecksums()
         memset(&value, 0, sizeof(value));
     }
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         WriterWriteF(writer, "</table>");
         WriterWriteF(writer, "</div>\n");
@@ -1662,7 +1662,7 @@ static void ShowLocks(int active)
     }
     assert(writer);
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         time_t now = time(NULL);
 
@@ -1753,7 +1753,7 @@ static void ShowLocks(int active)
         }
     }
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         WriterWriteF(writer, "</table>");
         WriterWriteF(writer, "</div>\n");
@@ -1830,7 +1830,7 @@ static void ShowCurrentAudit()
     }
     assert(writer);
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         time_t now = time(NULL);
 
@@ -1969,7 +1969,7 @@ static void ShowCurrentAudit()
         }
     }
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         WriterWriteF(writer, "</table>");
         CfHtmlFooter(writer, FOOTER);
@@ -2001,7 +2001,7 @@ static char *Format(char *s, int width)
         buffer[i] = '\0';
         count++;
 
-        if ((count > width - 5) && ispunct((int)*sp))
+        if ((count > (width - 5)) && (ispunct((int)*sp)))
         {
             strcat(buffer, "<br>");
             i += strlen("<br>");
@@ -2173,7 +2173,7 @@ static void SummarizeAverages()
     }
     assert(writer);
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         snprintf(name, CF_BUFSIZE, "Monitor summary for %s", VFQNAME);
         CfHtmlHeader(writer, name, STYLESHEET, WEBDRIVER, BANNER);
@@ -2234,7 +2234,7 @@ static void SummarizeAverages()
 
     CloseDB(dbp);
 
-    if (HTML && !EMBEDDED)
+    if (HTML && (!EMBEDDED))
     {
         WriterWriteF(writer, "</table>");
         CfHtmlFooter(writer, FOOTER);

--- a/src/cf-serverd-functions.c
+++ b/src/cf-serverd-functions.c
@@ -119,7 +119,7 @@ GenericAgentConfig CheckOpts(int argc, char **argv)
         {
         case 'f':
 
-            if (optarg && strlen(optarg) < 5)
+            if (optarg && (strlen(optarg) < 5))
             {
                 FatalError(" -f used but argument \"%s\" incorrect", optarg);
             }

--- a/src/cf_sql.c
+++ b/src/cf_sql.c
@@ -458,7 +458,7 @@ char **CfFetchRow(CfdbConn *cfdb)
 
 char *CfFetchColumn(CfdbConn *cfdb, int col)
 {
-    if (cfdb->rowdata && cfdb->rowdata[col])
+    if ((cfdb->rowdata) && (cfdb->rowdata[col]))
     {
         return cfdb->rowdata[col];
     }

--- a/src/cfstream.c
+++ b/src/cfstream.c
@@ -200,7 +200,7 @@ void cfPS(enum cfreport level, char status, char *errstr, const Promise *pp, Att
             AppendItem(&mess, output, NULL);
         }
 
-        if (pp && pp->audit)
+        if (pp && (pp->audit))
         {
             snprintf(output, CF_BUFSIZE - 1, "I: Made in version \'%s\' of \'%s\' near line %zu",
                      v, pp->audit->filename, pp->offset.line);
@@ -245,7 +245,7 @@ void cfPS(enum cfreport level, char status, char *errstr, const Promise *pp, Att
     {
     case cf_inform:
 
-        if (INFORM || verbose || DEBUG || attr.transaction.report_level == cf_inform)
+        if (INFORM || verbose || DEBUG || (attr.transaction.report_level == cf_inform))
         {
             LogList(stdout, mess, verbose);
         }
@@ -407,7 +407,7 @@ static void MakeLog(Item *mess, enum cfreport level)
 {
     Item *ip;
 
-    if (!IsPrivileged() || DONTDO)
+    if ((!IsPrivileged()) || DONTDO)
     {
         return;
     }

--- a/src/client_code.c
+++ b/src/client_code.c
@@ -416,7 +416,7 @@ int cf_remote_stat(char *file, struct stat *buf, char *stattype, Attributes attr
         cfst.cf_filename = xstrdup(file);
         cfst.cf_server = xstrdup(pp->this_server);
 
-        if ((cfst.cf_filename == NULL) || (cfst.cf_server) == NULL)
+        if ((cfst.cf_filename == NULL) || (cfst.cf_server == NULL))
         {
             FatalError("Memory allocation in cf_rstat");
         }
@@ -768,7 +768,7 @@ int CopyRegularFileNet(char *source, char *new, off_t size, Attributes attr, Pro
 
         /* If the first thing we get is an error message, break. */
 
-        if (n_read_total == 0 && strncmp(buf, CF_FAILEDSTR, strlen(CF_FAILEDSTR)) == 0)
+        if ((n_read_total == 0) && (strncmp(buf, CF_FAILEDSTR, strlen(CF_FAILEDSTR)) == 0))
         {
             cfPS(cf_inform, CF_INTERPT, "", pp, attr, "Network access to %s:%s denied\n", pp->this_server, source);
             close(dd);
@@ -790,7 +790,7 @@ int CopyRegularFileNet(char *source, char *new, off_t size, Attributes attr, Pro
 
         sscanf(buf, "t %d", &value);
 
-        if ((value > 0) && strncmp(buf + CF_INBAND_OFFSET, "BAD: ", 5) == 0)
+        if ((value > 0) && (strncmp(buf + CF_INBAND_OFFSET, "BAD: ", 5) == 0))
         {
             cfPS(cf_inform, CF_INTERPT, "", pp, attr, "Network access to cleartext %s:%s denied\n", pp->this_server,
                  source);
@@ -826,7 +826,7 @@ int CopyRegularFileNet(char *source, char *new, off_t size, Attributes attr, Pro
 
     if (last_write_made_hole)
     {
-        if (FullWrite(dd, "", 1) < 0 || ftruncate(dd, n_read_total) < 0)
+        if ((FullWrite(dd, "", 1) < 0) || (ftruncate(dd, n_read_total) < 0))
         {
             cfPS(cf_error, CF_FAIL, "", pp, attr, "FullWrite or ftruncate error in CopyReg, source %s\n", source);
             free(buf);
@@ -916,7 +916,7 @@ int EncryptCopyRegularFileNet(char *source, char *new, off_t size, Attributes at
 
         /* If the first thing we get is an error message, break. */
 
-        if (n_read_total == 0 && strncmp(buf + CF_INBAND_OFFSET, CF_FAILEDSTR, strlen(CF_FAILEDSTR)) == 0)
+        if ((n_read_total == 0) && (strncmp(buf + CF_INBAND_OFFSET, CF_FAILEDSTR, strlen(CF_FAILEDSTR)) == 0))
         {
             cfPS(cf_inform, CF_INTERPT, "", pp, attr, "Network access to %s:%s denied\n", pp->this_server, source);
             close(dd);
@@ -973,7 +973,7 @@ int EncryptCopyRegularFileNet(char *source, char *new, off_t size, Attributes at
 
     if (last_write_made_hole)
     {
-        if (FullWrite(dd, "", 1) < 0 || ftruncate(dd, n_read_total) < 0)
+        if ((FullWrite(dd, "", 1) < 0) || (ftruncate(dd, n_read_total) < 0))
         {
             cfPS(cf_error, CF_FAIL, "", pp, attr, "FullWrite or ftruncate error in CopyReg, source %s\n", source);
             free(buf);
@@ -1014,7 +1014,7 @@ int ServerConnect(AgentConnection *conn, char *host, Attributes attr, Promise *p
 
     CfOut(cf_verbose, "", "Set cfengine port number to %s = %u\n", strport, (int) ntohs(shortport));
 
-    if (attr.copy.timeout == (short) CF_NOINT || attr.copy.timeout <= 0)
+    if ((attr.copy.timeout == (short) CF_NOINT) || (attr.copy.timeout <= 0))
     {
         tv.tv_sec = CONNTIMEOUT;
     }
@@ -1242,7 +1242,7 @@ static AgentConnection *GetIdleConnectionToServer(const char *server)
             return NULL;
         }
 
-        if ((strcmp(ipname, svp->server) == 0) && svp->conn && svp->conn->sd > 0)
+        if ((strcmp(ipname, svp->server) == 0) && (svp->conn) && (svp->conn->sd > 0))
         {
             CfOut(cf_verbose, "", "Connection to %s is already open and ready...\n", ipname);
             svp->busy = true;
@@ -1502,7 +1502,7 @@ static int TryConnect(AgentConnection *conn, struct timeval *tvp, struct sockadd
                 return false;
             }
 
-            if (valopt || res <= 0)
+            if (valopt || (res <= 0))
             {
                 CfOut(cf_inform, "connect", " !! Error connecting to server (timeout)");
                 return false;

--- a/src/client_protocol.c
+++ b/src/client_protocol.c
@@ -63,7 +63,7 @@ int IdentifyAgent(int sd, char *localip, int family)
     memset(sendbuff, 0, CF_BUFSIZE);
     memset(dnsname, 0, CF_BUFSIZE);
 
-    if (!SKIPIDENTIFY && (strcmp(VDOMAIN, CF_START_DOMAIN) == 0))
+    if ((!SKIPIDENTIFY) && (strcmp(VDOMAIN, CF_START_DOMAIN) == 0))
     {
         CfOut(cf_error, "", "Undefined domain name");
         return false;
@@ -156,7 +156,7 @@ int IdentifyAgent(int sd, char *localip, int family)
 
 /* Some resolvers will not return FQNAME and missing PTR will give numerical result */
 
-    if ((strlen(VDOMAIN) > 0) && !IsIPV6Address(dnsname) && !strchr(dnsname, '.'))
+    if ((strlen(VDOMAIN) > 0) && (!IsIPV6Address(dnsname)) && (!strchr(dnsname, '.')))
     {
         CfDebug("Appending domain %s to %s\n", VDOMAIN, dnsname);
         strcat(dnsname, ".");
@@ -200,7 +200,7 @@ int AuthenticateAgent(AgentConnection *conn, Attributes attr, Promise *pp)
     char enterprise_field = 'c';
     RSA *server_pubkey = NULL;
 
-    if (PUBKEY == NULL || PRIVKEY == NULL)
+    if ((PUBKEY == NULL) || (PRIVKEY == NULL))
     {
         CfOut(cf_error, "", "No public/private key pair found\n");
         return false;
@@ -324,7 +324,7 @@ int AuthenticateAgent(AgentConnection *conn, Attributes attr, Promise *pp)
         return false;
     }
 
-    if (HashesMatch(digest, in, CF_DEFAULT_DIGEST) || HashesMatch(digest, in, cf_md5))  // Legacy
+    if ((HashesMatch(digest, in, CF_DEFAULT_DIGEST)) || (HashesMatch(digest, in, cf_md5)))  // Legacy
     {
         if (implicitly_trust_server == false)        /* challenge reply was correct */
         {

--- a/src/communication.c
+++ b/src/communication.c
@@ -103,11 +103,11 @@ void DePort(char *address)
     {
         chop = ld;
     }
-    else if (dcount > 1 && fc != NULL)
+    else if ((dcount > 1) && (fc != NULL))
     {
         chop = fc;
     }
-    else if (ccount > 1 && fd != NULL)
+    else if ((ccount > 1) && (fd != NULL))
     {
         chop = fd;
     }
@@ -202,7 +202,7 @@ int IsIPV4Address(char *name)
 
     for (sp = name; *sp != '\0'; sp++)
     {
-        if (!isdigit((int) *sp) && (*sp != '.'))
+        if ((!isdigit((int) *sp)) && (*sp != '.'))
         {
             return false;
         }

--- a/src/conversion.c
+++ b/src/conversion.c
@@ -190,7 +190,7 @@ enum cfmeasurepolicy MeasurePolicy2Value(char *s)
 
     for (i = 0; names[i] != NULL; i++)
     {
-        if (s && strcmp(s, names[i]) == 0)
+        if (s && (strcmp(s, names[i]) == 0))
         {
             return (enum cfmeasurepolicy) i;
         }
@@ -217,7 +217,7 @@ enum cfhypervisors Str2Hypervisors(char *s)
 
     for (i = 0; names[i] != NULL; i++)
     {
-        if (s && strcmp(s, names[i]) == 0)
+        if (s && (strcmp(s, names[i]) == 0))
         {
             return (enum cfhypervisors) i;
         }
@@ -240,7 +240,7 @@ enum cfenvironment_state Str2EnvState(char *s)
 
     for (i = 0; names[i] != NULL; i++)
     {
-        if (s && strcmp(s, names[i]) == 0)
+        if (s && (strcmp(s, names[i]) == 0))
         {
             return (enum cfenvironment_state) i;
         }
@@ -260,7 +260,7 @@ enum insert_match String2InsertMatch(char *s)
 
     for (i = 0; names[i] != NULL; i++)
     {
-        if (s && strcmp(s, names[i]) == 0)
+        if (s && (strcmp(s, names[i]) == 0))
         {
             return i;
         }
@@ -281,7 +281,7 @@ int SyslogPriority2Int(char *s)
 
     for (i = 0; types[i] != NULL; i++)
     {
-        if (s && strcmp(s, types[i]) == 0)
+        if (s && (strcmp(s, types[i]) == 0))
         {
             return i;
         }
@@ -299,7 +299,7 @@ enum cfdbtype Str2dbType(char *s)
 
     for (i = 0; types[i] != NULL; i++)
     {
-        if (s && strcmp(s, types[i]) == 0)
+        if (s && (strcmp(s, types[i]) == 0))
         {
             return (enum cfdbtype) i;
         }
@@ -317,7 +317,7 @@ enum package_actions Str2PackageAction(char *s)
 
     for (i = 0; types[i] != NULL; i++)
     {
-        if (s && strcmp(s, types[i]) == 0)
+        if (s && (strcmp(s, types[i]) == 0))
         {
             return (enum package_actions) i;
         }
@@ -335,7 +335,7 @@ enum version_cmp Str2PackageSelect(char *s)
 
     for (i = 0; types[i] != NULL; i++)
     {
-        if (s && strcmp(s, types[i]) == 0)
+        if (s && (strcmp(s, types[i]) == 0))
         {
             return (enum version_cmp) i;
         }
@@ -353,7 +353,7 @@ enum action_policy Str2ActionPolicy(char *s)
 
     for (i = 0; types[i] != NULL; i++)
     {
-        if (s && strcmp(s, types[i]) == 0)
+        if (s && (strcmp(s, types[i]) == 0))
         {
             return (enum action_policy) i;
         }
@@ -449,7 +449,7 @@ enum cfreport String2ReportLevel(char *s)
 
     for (i = 0; types[i] != NULL; i++)
     {
-        if (s && strcmp(s, types[i]) == 0)
+        if (s && (strcmp(s, types[i]) == 0))
         {
             return (enum cfreport) i;
         }
@@ -466,7 +466,7 @@ enum cfhashes String2HashType(char *typestr)
 
     for (i = 0; CF_DIGEST_TYPES[i][0] != NULL; i++)
     {
-        if (typestr && strcmp(typestr, CF_DIGEST_TYPES[i][0]) == 0)
+        if (typestr && (strcmp(typestr, CF_DIGEST_TYPES[i][0]) == 0))
         {
             return (enum cfhashes) i;
         }
@@ -484,7 +484,7 @@ enum cflinktype String2LinkType(char *s)
 
     for (i = 0; types[i] != NULL; i++)
     {
-        if (s && strcmp(s, types[i]) == 0)
+        if (s && (strcmp(s, types[i]) == 0))
         {
             return (enum cflinktype) i;
         }
@@ -502,7 +502,7 @@ enum cfcomparison String2Comparison(char *s)
 
     for (i = 0; types[i] != NULL; i++)
     {
-        if (s && strcmp(s, types[i]) == 0)
+        if (s && (strcmp(s, types[i]) == 0))
         {
             return (enum cfcomparison) i;
         }
@@ -520,7 +520,7 @@ enum representations String2Representation(char *s)
 
     for (i = 0; types[i] != NULL; i++)
     {
-        if (s && strcmp(s, types[i]) == 0)
+        if (s && (strcmp(s, types[i]) == 0))
         {
             return (enum representations) i;
         }
@@ -537,7 +537,7 @@ enum cfsbundle Type2Cfs(char *name)
 
     for (i = 0; i < (int) cfs_nobtype; i++)
     {
-        if (name && strcmp(CF_REMACCESS_SUBTYPES[i].subtype, name) == 0)
+        if (name && (strcmp(CF_REMACCESS_SUBTYPES[i].subtype, name) == 0))
         {
             break;
         }
@@ -557,7 +557,7 @@ enum cfdatatype Typename2Datatype(char *name)
 
     for (i = 0; i < (int) cf_notype; i++)
     {
-        if (name && strcmp(CF_DATATYPES[i], name) == 0)
+        if (name && (strcmp(CF_DATATYPES[i], name) == 0))
         {
             break;
         }
@@ -577,7 +577,7 @@ enum cfagenttype Agent2Type(char *name)
 
     for (i = 0; i < (int) cf_noagent; i++)
     {
-        if (name && strcmp(CF_AGENTTYPES[i], name) == 0)
+        if (name && (strcmp(CF_AGENTTYPES[i], name) == 0))
         {
             break;
         }
@@ -594,7 +594,7 @@ enum cfdatatype GetControlDatatype(const char *varname, const BodySyntax *bp)
 
     for (i = 0; bp[i].range != NULL; i++)
     {
-        if (varname && strcmp(bp[i].lval, varname) == 0)
+        if (varname && (strcmp(bp[i].lval, varname) == 0))
         {
             return bp[i].dtype;
         }
@@ -661,7 +661,7 @@ long Str2Int(const char *s)
 
 // Test whether remainder is space only
 
-    if (a == CF_NOINT || !IsSpace(remainder))
+    if ((a == CF_NOINT) || (!IsSpace(remainder)))
     {
         if (THIS_AGENT_TYPE == cf_common)
         {
@@ -696,7 +696,7 @@ long Str2Int(const char *s)
             a = 1024 * 1024 * 1024 * a;
             break;
         case '%':
-            if (a < 0 || a > 100)
+            if ((a < 0) || (a > 100))
             {
                 CfOut(cf_error, "", "Percentage out of range (%ld)", a);
                 return CF_NOINT;
@@ -968,7 +968,7 @@ double Str2Double(const char *s)
 
     sscanf(s, "%lf%c%s", &a, &c, remainder);
 
-    if (a == CF_NODOUBLE || !IsSpace(remainder))
+    if ((a == CF_NODOUBLE) || (!IsSpace(remainder)))
     {
         snprintf(output, CF_BUFSIZE, "Error reading assumed real value %s (anomalous remainder %s)\n", s, remainder);
         ReportError(output);
@@ -996,7 +996,7 @@ double Str2Double(const char *s)
             a = 1024 * 1024 * 1024 * a;
             break;
         case '%':
-            if (a < 0 || a > 100)
+            if ((a < 0) || (a > 100))
             {
                 CfOut(cf_error, "", "Percentage out of range (%.2lf)", a);
                 return CF_NOINT;
@@ -1050,7 +1050,7 @@ void IntRange2Int(char *intrange, long *min, long *max, const Promise *pp)
 
     DeleteItemList(split);
 
-    if (lmin == CF_HIGHINIT || lmax == CF_LOWINIT)
+    if ((lmin == CF_HIGHINIT) || (lmax == CF_LOWINIT))
     {
         PromiseRef(cf_error, pp);
         FatalError("Could not make sense of integer range [%s]", intrange);
@@ -1295,7 +1295,7 @@ void CommPrefix(char *execstr, char *comm)
 {
     char *sp;
 
-    for (sp = execstr; *sp != ' ' && *sp != '\0'; sp++)
+    for (sp = execstr; (*sp != ' ') && (*sp != '\0'); sp++)
     {
     }
 

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -127,7 +127,7 @@ void LoadSecretKeys()
     CfOut(cf_verbose, "", " -> Loaded public key %s\n", CFPUBKEYFILE);
     fclose(fp);
 
-    if (BN_num_bits(PUBKEY->e) < 2 || !BN_is_odd(PUBKEY->e))
+    if ((BN_num_bits(PUBKEY->e) < 2) || (!BN_is_odd(PUBKEY->e)))
     {
         FatalError("RSA Exponent too small or not odd");
     }
@@ -159,7 +159,7 @@ void LoadSecretKeys()
 
 // need to use cf_stat
 
-    if (stat(name, &sb) == -1 && stat(guard, &sb) != -1)
+    if ((stat(name, &sb) == -1) && (stat(guard, &sb) != -1))
         // copy localhost.pub to root-HASH.pub on policy server
     {
         LastSaw(POLICY_SERVER, digest, cf_connect);
@@ -250,7 +250,7 @@ RSA *HavePublicKey(char *username, char *ipaddress, char *digest)
 
     fclose(fp);
 
-    if (BN_num_bits(newkey->e) < 2 || !BN_is_odd(newkey->e))
+    if ((BN_num_bits(newkey->e) < 2) || (!BN_is_odd(newkey->e)))
     {
         FatalError("RSA Exponent too small or not odd");
     }

--- a/src/dbm_migration_bundles.c
+++ b/src/dbm_migration_bundles.c
@@ -72,7 +72,7 @@ static bool BundlesMigrationVersion0(DBHandle *db)
         errors = true;
     }
 
-    if (!errors && !WriteDB(db, "version", "1", sizeof("1")))
+    if ((!errors) && (!WriteDB(db, "version", "1", sizeof("1"))))
     {
         errors = true;
     }

--- a/src/dbm_migration_lastseen.c
+++ b/src/dbm_migration_lastseen.c
@@ -67,11 +67,11 @@ static bool LastseenMigrationVersion0(DBHandle *db)
         }
 
         /* Only look for old [+-]kH -> IP<QPoint> entries */
-        if (key[0] != '+' && key[0] != '-')
+        if ((key[0] != '+') && (key[0] != '-'))
         {
             /* Warn about completely unexpected keys */
 
-            if (key[0] != 'q' && key[0] != 'k' && key[0] != 'a')
+            if ((key[0] != 'q') && (key[0] != 'k') && (key[0] != 'a'))
             {
                 CfOut(cf_inform, "", "LastseenMigrationVersion0: Malformed key found: %s", key);
             }
@@ -124,10 +124,10 @@ static bool LastseenMigrationVersion0(DBHandle *db)
            Ignore malformed connection quality data
         */
 
-        if (!isfinite(old_data_q.q)
-            || old_data_q.q < 0
-            || !isfinite(old_data_q.expect)
-            || !isfinite(old_data_q.var))
+        if ((!isfinite(old_data_q.q))
+            || (old_data_q.q < 0)
+            || (!isfinite(old_data_q.expect))
+            || (!isfinite(old_data_q.var)))
         {
             CfOut(cf_inform, "", "Ignoring malformed connection quality data for %s", key);
             DBCursorDeleteEntry(cursor);
@@ -171,7 +171,7 @@ static bool LastseenMigrationVersion0(DBHandle *db)
         errors = true;
     }
 
-    if (!errors && !WriteDB(db, "version", "1", sizeof("1")))
+    if ((!errors) && (!WriteDB(db, "version", "1", sizeof("1"))))
     {
         errors = true;
     }

--- a/src/dir.c
+++ b/src/dir.c
@@ -32,7 +32,7 @@
 
 Dir *OpenDirForPromise(const char *dirname, Attributes attr, Promise *pp)
 {
-    if (attr.copy.servers == NULL || strcmp(attr.copy.servers->item, "localhost") == 0)
+    if ((attr.copy.servers == NULL) || (strcmp(attr.copy.servers->item, "localhost") == 0))
     {
         return OpenDirLocal(dirname);
     }

--- a/src/env_monitor.c
+++ b/src/env_monitor.c
@@ -454,7 +454,7 @@ static void LeapDetection(void)
     {
         /* First do some anomaly rejection. Sudden jumps must be numerical errors. */
 
-        if (LDT_BUF[i][last_pos] > 0 && CF_THIS[i] / LDT_BUF[i][last_pos] > 1000)
+        if ((LDT_BUF[i][last_pos] > 0) && ((CF_THIS[i] / LDT_BUF[i][last_pos]) > 1000))
         {
             CF_THIS[i] = LDT_BUF[i][last_pos];
         }
@@ -787,7 +787,7 @@ static void UpdateDistributions(char *timekey, Averages *av)
             position =
                 CF_GRAINS / 2 + (int) (0.5 + (CF_THIS[i] - av->Q[i].expect) * CF_GRAINS / (4 * sqrt((av->Q[i].var))));
 
-            if (0 <= position && position < CF_GRAINS)
+            if ((0 <= position) && (position < CF_GRAINS))
             {
                 HISTOGRAM[i][day][position]++;
             }
@@ -832,7 +832,7 @@ static double WAverage(double anew, double aold, double age)
 
 /* First do some database corruption self-healing */
 
-    if (aold > cf_sane_monitor_limit && anew > cf_sane_monitor_limit)
+    if ((aold > cf_sane_monitor_limit) && (anew > cf_sane_monitor_limit))
     {
         return 0;
     }
@@ -849,7 +849,7 @@ static double WAverage(double anew, double aold, double age)
 
 /* Now look at the self-learning */
 
-    if (FORGETRATE > 0.9 || FORGETRATE < 0.1)
+    if ((FORGETRATE > 0.9) || (FORGETRATE < 0.1))
     {
         FORGETRATE = 0.6;
     }
@@ -865,7 +865,7 @@ static double WAverage(double anew, double aold, double age)
         wold = FORGETRATE;
     }
 
-    if (aold == 0 && anew == 0)
+    if ((aold == 0) && (anew == 0))
     {
         return 0;
     }
@@ -907,7 +907,7 @@ static double SetClasses(char *name, double variable, double av_expect, double a
 
     CfDebug(" delta = %lf,sigma = %lf, lsigma = %lf, sig = %lf\n", delta, sigma, lsigma, sig);
 
-    if (sigma == 0.0 || lsigma == 0.0)
+    if ((sigma == 0.0) || (lsigma == 0.0))
     {
         CfDebug(" No sigma variation .. can't measure class\n");
 

--- a/src/exec_tools.c
+++ b/src/exec_tools.c
@@ -218,7 +218,7 @@ char **ArgSplitCommand(const char *comm)
         {
             arg = xstrndup(s, end - s);
             s = end;
-            if (*s == '"' || *s == '\'' || *s == '`')   /* Skip second delimeter */
+            if ((*s == '"') || (*s == '\'') || (*s == '`'))   /* Skip second delimeter */
                 s++;
         }
 

--- a/src/files_copy.c
+++ b/src/files_copy.c
@@ -41,7 +41,7 @@ void *CopyFileSources(char *destination, Attributes attr, Promise *pp, const Rep
 
     CfDebug("CopyFileSources(%s,%s)", source, destination);
 
-    if (pp->conn != NULL && !pp->conn->authenticated)
+    if ((pp->conn != NULL) && (!pp->conn->authenticated))
     {
         cfPS(cf_verbose, CF_FAIL, "", pp, attr, "No authenticated source %s in files.copyfrom promise\n", source);
         return NULL;
@@ -135,7 +135,7 @@ bool CopyRegularFileDiskReport(char *source, char *destination, Attributes attr,
 {
     bool make_holes = false;
 
-    if(pp && pp->makeholes)
+    if(pp && (pp->makeholes))
     {
         make_holes = true;
     }
@@ -270,7 +270,7 @@ bool CopyRegularFileDisk(char *source, char *destination, bool make_holes)
     {
         /* Write a null character and truncate it again.  */
 
-        if (FullWrite(dd, "", 1) < 0 || ftruncate(dd, n_read_total) < 0)
+        if ((FullWrite(dd, "", 1) < 0) || (ftruncate(dd, n_read_total) < 0))
         {
             CfOut(cf_error, "write", "cfengine: full_write or ftruncate error in CopyReg\n");
             free(buf);
@@ -298,7 +298,7 @@ int FSWrite(char *new, int dd, char *buf, int towrite, int *last_write_made_hole
 
     intp = 0;
 
-    if (pp && pp->makeholes)
+    if (pp && (pp->makeholes))
     {
         buf[n_read] = 1;        /* Sentinel to stop loop.  */
 

--- a/src/files_edit.c
+++ b/src/files_edit.c
@@ -90,15 +90,15 @@ void FinishEditContext(EditContext *ec, Attributes a, Promise *pp, const ReportC
 
     EDIT_MODEL = false;
 
-    if (DONTDO || a.transaction.action == cfa_warn)
+    if (DONTDO || (a.transaction.action == cfa_warn))
     {
-        if (ec && !CompareToFile(ec->file_start, ec->filename, a, pp) && ec->num_edits > 0)
+        if (ec && (!CompareToFile(ec->file_start, ec->filename, a, pp)) && (ec->num_edits > 0))
         {
             cfPS(cf_error, CF_WARN, "", pp, a, " -> Should edit file %s but only a warning promised", ec->filename);
         }
         return;
     }
-    else if (ec && ec->num_edits > 0)
+    else if (ec && (ec->num_edits > 0))
     {
         if (a.haveeditline)
         {

--- a/src/files_hashes.c
+++ b/src/files_hashes.c
@@ -198,7 +198,7 @@ int CompareFileHashes(char *file1, char *file2, struct stat *sstat, struct stat 
         return true;
     }
 
-    if (attr.copy.servers == NULL || strcmp(attr.copy.servers->item, "localhost") == 0)
+    if ((attr.copy.servers == NULL) || (strcmp(attr.copy.servers->item, "localhost") == 0))
     {
         HashFile(file1, digest1, CF_DEFAULT_DIGEST);
         HashFile(file2, digest2, CF_DEFAULT_DIGEST);
@@ -235,7 +235,7 @@ int CompareBinaryFiles(char *file1, char *file2, struct stat *sstat, struct stat
         return true;
     }
 
-    if (attr.copy.servers == NULL || strcmp(attr.copy.servers->item, "localhost") == 0)
+    if ((attr.copy.servers == NULL) || (strcmp(attr.copy.servers->item, "localhost") == 0))
     {
         fd1 = open(file1, O_RDONLY | O_BINARY, 0400);
         fd2 = open(file2, O_RDONLY | O_BINARY, 0400);

--- a/src/files_interfaces.c
+++ b/src/files_interfaces.c
@@ -153,7 +153,7 @@ void SourceSearchAndCopy(char *from, char *to, int maxrecurse, Attributes attr, 
             return;
         }
 
-        if (attr.recursion.travlinks || attr.copy.link_type == cfa_notlinked)
+        if ((attr.recursion.travlinks) || (attr.copy.link_type == cfa_notlinked))
         {
             /* No point in checking if there are untrusted symlinks here,
                since this is from a trusted source, by defintion */
@@ -177,7 +177,7 @@ void SourceSearchAndCopy(char *from, char *to, int maxrecurse, Attributes attr, 
 
         if (attr.copy.collapse)
         {
-            if (!S_ISDIR(sb.st_mode) && !JoinPath(newto, dirp->d_name))
+            if ((!S_ISDIR(sb.st_mode)) && (!JoinPath(newto, dirp->d_name)))
             {
                 CloseDir(dirh);
                 return;
@@ -192,7 +192,7 @@ void SourceSearchAndCopy(char *from, char *to, int maxrecurse, Attributes attr, 
             }
         }
 
-        if (attr.recursion.xdev && DeviceBoundary(&sb, pp))
+        if ((attr.recursion.xdev) && (DeviceBoundary(&sb, pp)))
         {
             CfOut(cf_verbose, "", " !! Skipping %s on different device\n", newfrom);
             continue;
@@ -215,7 +215,7 @@ void SourceSearchAndCopy(char *from, char *to, int maxrecurse, Attributes attr, 
 
             /* Only copy dirs if we are tracking subdirs */
 
-            if (!attr.copy.collapse && (cfstat(newto, &dsb) == -1))
+            if ((!attr.copy.collapse) && (cfstat(newto, &dsb) == -1))
             {
                 if (cf_mkdir(newto, 0700) == -1)
                 {
@@ -399,7 +399,7 @@ static void PurgeLocalFiles(Item *filelist, char *localdir, Attributes attr, Pro
 
     /* If we purge with no authentication we wipe out EVERYTHING ! */
 
-    if (pp->conn && !pp->conn->authenticated)
+    if ((pp->conn) && (!pp->conn->authenticated))
     {
         CfOut(cf_verbose, "", " !! Not purge local files %s - no authenticated contact with a source\n", localdir);
         return;
@@ -577,10 +577,10 @@ static void CfCopyFile(char *sourcefile, char *destfile, struct stat ssb, Attrib
 
     if (found != -1)
     {
-        if ((S_ISLNK(dsb.st_mode) && (attr.copy.link_type == cfa_notlinked))
-            || (S_ISLNK(dsb.st_mode) && !S_ISLNK(ssb.st_mode)))
+        if (((S_ISLNK(dsb.st_mode)) && (attr.copy.link_type == cfa_notlinked))
+            || ((S_ISLNK(dsb.st_mode)) && (!S_ISLNK(ssb.st_mode))))
         {
-            if (!S_ISLNK(ssb.st_mode) && (attr.copy.type_check && (attr.copy.link_type != cfa_notlinked)))
+            if ((!S_ISLNK(ssb.st_mode)) && ((attr.copy.type_check) && (attr.copy.link_type != cfa_notlinked)))
             {
                 cfPS(cf_error, CF_FAIL, "", pp, attr,
                      "file image exists but destination type is silly (file/dir/link doesn't match)\n");
@@ -612,7 +612,7 @@ static void CfCopyFile(char *sourcefile, char *destfile, struct stat ssb, Attrib
 
     if (attr.copy.min_size != CF_NOINT)
     {
-        if (ssb.st_size < attr.copy.min_size || ssb.st_size > attr.copy.max_size)
+        if ((ssb.st_size < attr.copy.min_size) || (ssb.st_size > attr.copy.max_size))
         {
             cfPS(cf_verbose, CF_NOP, "", pp, attr, " -> Source file %s size is not in the permitted safety range\n",
                  sourcefile);
@@ -629,7 +629,7 @@ static void CfCopyFile(char *sourcefile, char *destfile, struct stat ssb, Attrib
             return;
         }
 
-        if (S_ISREG(srcmode) || (S_ISLNK(srcmode) && attr.copy.link_type == cfa_notlinked))
+        if ((S_ISREG(srcmode)) || ((S_ISLNK(srcmode)) && (attr.copy.link_type == cfa_notlinked)))
         {
             if (DONTDO)
             {
@@ -650,7 +650,7 @@ static void CfCopyFile(char *sourcefile, char *destfile, struct stat ssb, Attrib
                 }
             }
 
-            if (S_ISLNK(srcmode) && attr.copy.link_type != cfa_notlinked)
+            if ((S_ISLNK(srcmode)) && (attr.copy.link_type != cfa_notlinked))
             {
                 CfOut(cf_verbose, "", " -> %s is a symbolic link\n", sourcefile);
                 LinkCopy(sourcefile, destfile, &ssb, attr, pp, report_context);
@@ -736,7 +736,7 @@ static void CfCopyFile(char *sourcefile, char *destfile, struct stat ssb, Attrib
 #endif /* NOT MINGW */
         }
 
-        if (S_ISLNK(srcmode) && attr.copy.link_type != cfa_notlinked)
+        if ((S_ISLNK(srcmode)) && (attr.copy.link_type != cfa_notlinked))
         {
             LinkCopy(sourcefile, destfile, &ssb, attr, pp, report_context);
         }
@@ -762,15 +762,15 @@ static void CfCopyFile(char *sourcefile, char *destfile, struct stat ssb, Attrib
             ok_to_copy = true;
         }
 
-        if (attr.copy.type_check && attr.copy.link_type != cfa_notlinked)
+        if ((attr.copy.type_check) && (attr.copy.link_type != cfa_notlinked))
         {
-            if ((S_ISDIR(dsb.st_mode) && !S_ISDIR(ssb.st_mode)) ||
-                (S_ISREG(dsb.st_mode) && !S_ISREG(ssb.st_mode)) ||
-                (S_ISBLK(dsb.st_mode) && !S_ISBLK(ssb.st_mode)) ||
-                (S_ISCHR(dsb.st_mode) && !S_ISCHR(ssb.st_mode)) ||
-                (S_ISSOCK(dsb.st_mode) && !S_ISSOCK(ssb.st_mode)) ||
-                (S_ISFIFO(dsb.st_mode) && !S_ISFIFO(ssb.st_mode)) || (S_ISLNK(dsb.st_mode) && !S_ISLNK(ssb.st_mode)))
-
+            if (((S_ISDIR(dsb.st_mode)) && (!S_ISDIR(ssb.st_mode))) ||
+                ((S_ISREG(dsb.st_mode)) && (!S_ISREG(ssb.st_mode))) ||
+                ((S_ISBLK(dsb.st_mode)) && (!S_ISBLK(ssb.st_mode))) ||
+                ((S_ISCHR(dsb.st_mode)) && (!S_ISCHR(ssb.st_mode))) ||
+                ((S_ISSOCK(dsb.st_mode)) && (!S_ISSOCK(ssb.st_mode))) ||
+                ((S_ISFIFO(dsb.st_mode)) && (!S_ISFIFO(ssb.st_mode))) ||
+                ((S_ISLNK(dsb.st_mode)) && (!S_ISLNK(ssb.st_mode))))
             {
                 cfPS(cf_inform, CF_FAIL, "", pp, attr,
                      "Promised file copy %s exists but type mismatch with source=%s\n", destfile, sourcefile);
@@ -786,9 +786,9 @@ static void CfCopyFile(char *sourcefile, char *destfile, struct stat ssb, Attrib
             return;
         }
 
-        if (attr.copy.force_update || ok_to_copy || S_ISLNK(ssb.st_mode))       /* Always check links */
+        if ((attr.copy.force_update) || ok_to_copy || (S_ISLNK(ssb.st_mode)))       /* Always check links */
         {
-            if (S_ISREG(srcmode) || attr.copy.link_type == cfa_notlinked)
+            if ((S_ISREG(srcmode)) || (attr.copy.link_type == cfa_notlinked))
             {
                 if (DONTDO)
                 {
@@ -870,7 +870,7 @@ int cf_stat(char *file, struct stat *buf, Attributes attr, Promise *pp)
 {
     int res;
 
-    if (attr.copy.servers == NULL || strcmp(attr.copy.servers->item, "localhost") == 0)
+    if ((attr.copy.servers == NULL) || (strcmp(attr.copy.servers->item, "localhost") == 0))
     {
         res = cfstat(file, buf);
         CheckForFileHoles(buf, pp);
@@ -888,7 +888,7 @@ int cf_lstat(char *file, struct stat *buf, Attributes attr, Promise *pp)
 {
     int res;
 
-    if (attr.copy.servers == NULL || strcmp(attr.copy.servers->item, "localhost") == 0)
+    if ((attr.copy.servers == NULL) || (strcmp(attr.copy.servers->item, "localhost") == 0))
     {
         res = lstat(file, buf);
         CheckForFileHoles(buf, pp);
@@ -911,7 +911,7 @@ int cf_readlink(char *sourcefile, char *linkbuf, int buffsize, Attributes attr, 
 
     memset(linkbuf, 0, buffsize);
 
-    if (attr.copy.servers == NULL || strcmp(attr.copy.servers->item, "localhost") == 0)
+    if ((attr.copy.servers == NULL) || (strcmp(attr.copy.servers->item, "localhost") == 0))
     {
         return readlink(sourcefile, linkbuf, buffsize - 1);
     }
@@ -993,7 +993,7 @@ int CfReadLine(char *buff, int size, FILE *fp)
 
 int FileSanityChecks(char *path, Attributes a, Promise *pp)
 {
-    if (a.havelink && a.havecopy)
+    if ((a.havelink) && (a.havecopy))
     {
         CfOut(cf_error, "",
               " !! Promise constraint conflicts - %s file cannot both be a copy of and a link to the source", path);
@@ -1001,7 +1001,7 @@ int FileSanityChecks(char *path, Attributes a, Promise *pp)
         return false;
     }
 
-    if (a.havelink && !a.link.source)
+    if ((a.havelink) && (!a.link.source))
     {
         CfOut(cf_error, "", " !! Promise to establish a link at %s has no source", path);
         PromiseRef(cf_error, pp);
@@ -1012,7 +1012,7 @@ int FileSanityChecks(char *path, Attributes a, Promise *pp)
  * so we can't distinguish between link and copy source. In post-verification
  * all bodies are already expanded, so we don't have the information either */
 
-    if (a.havecopy && a.copy.source && !FullTextMatch(CF_ABSPATHRANGE, a.copy.source))
+    if ((a.havecopy) && (a.copy.source) && (!FullTextMatch(CF_ABSPATHRANGE, a.copy.source)))
     {
         /* FIXME: somehow redo a PromiseRef to be able to embed it into a string */
         CfOut(cf_error, "", " !! Non-absolute path in source attribute (have no invariant meaning): %s", a.copy.source);
@@ -1020,7 +1020,7 @@ int FileSanityChecks(char *path, Attributes a, Promise *pp)
         FatalError("Bailing out");
     }
 
-    if (a.haveeditline && a.haveeditxml)
+    if ((a.haveeditline) && (a.haveeditxml))
     {
         CfOut(cf_error, "", " !! Promise constraint conflicts - %s editing file as both line and xml makes no sense",
               path);
@@ -1028,21 +1028,21 @@ int FileSanityChecks(char *path, Attributes a, Promise *pp)
         return false;
     }
 
-    if (a.havedepthsearch && a.haveedit)
+    if ((a.havedepthsearch) && (a.haveedit))
     {
         CfOut(cf_error, "", " !! Recursive depth_searches are not compatible with general file editing");
         PromiseRef(cf_error, pp);
         return false;
     }
 
-    if (a.havedelete && (a.create || a.havecopy || a.haveedit || a.haverename))
+    if ((a.havedelete) && ((a.create) || (a.havecopy) || (a.haveedit) || (a.haverename)))
     {
         CfOut(cf_error, "", " !! Promise constraint conflicts - %s cannot be deleted and exist at the same time", path);
         PromiseRef(cf_error, pp);
         return false;
     }
 
-    if (a.haverename && (a.create || a.havecopy || a.haveedit))
+    if ((a.haverename) && ((a.create) || (a.havecopy) || (a.haveedit)))
     {
         CfOut(cf_error, "",
               " !! Promise constraint conflicts - %s cannot be renamed/moved and exist there at the same time", path);
@@ -1050,7 +1050,7 @@ int FileSanityChecks(char *path, Attributes a, Promise *pp)
         return false;
     }
 
-    if (a.havedelete && a.havedepthsearch && !a.haveselect)
+    if ((a.havedelete) && (a.havedepthsearch) && (!a.haveselect))
     {
         CfOut(cf_error, "",
               " !! Dangerous or ambiguous promise - %s specifies recursive deletion but has no file selection criteria",
@@ -1059,21 +1059,21 @@ int FileSanityChecks(char *path, Attributes a, Promise *pp)
         return false;
     }
 
-    if (a.haveselect && !a.select.result)
+    if ((a.haveselect) && (!a.select.result))
     {
         CfOut(cf_error, "", " !! File select constraint body promised no result (check body definition)");
         PromiseRef(cf_error, pp);
         return false;
     }
 
-    if (a.havedelete && a.haverename)
+    if ((a.havedelete) && (a.haverename))
     {
         CfOut(cf_error, "", " !! File %s cannot promise both deletion and renaming", path);
         PromiseRef(cf_error, pp);
         return false;
     }
 
-    if (a.havecopy && a.havedepthsearch && a.havedelete)
+    if ((a.havecopy) && (a.havedepthsearch) && (a.havedelete))
     {
         CfOut(cf_inform, "",
               " !! Warning: depth_search of %s applies to both delete and copy, but these refer to different searches (source/destination)",
@@ -1081,14 +1081,14 @@ int FileSanityChecks(char *path, Attributes a, Promise *pp)
         PromiseRef(cf_inform, pp);
     }
 
-    if (a.transaction.background && a.transaction.audit)
+    if ((a.transaction.background) && (a.transaction.audit))
     {
         CfOut(cf_error, "", " !! Auditing cannot be performed on backgrounded promises (this might change).");
         PromiseRef(cf_error, pp);
         return false;
     }
 
-    if ((a.havecopy || a.havelink) && a.transformer)
+    if (((a.havecopy) || (a.havelink)) && (a.transformer))
     {
         CfOut(cf_error, "", " !! File object(s) %s cannot both be a copy of source and transformed simultaneously",
               pp->promiser);
@@ -1096,14 +1096,14 @@ int FileSanityChecks(char *path, Attributes a, Promise *pp)
         return false;
     }
 
-    if (a.haveselect && a.select.result == NULL)
+    if ((a.haveselect) && (a.select.result == NULL))
     {
         CfOut(cf_error, "", " !! Missing file_result attribute in file_select body");
         PromiseRef(cf_error, pp);
         return false;
     }
 
-    if (a.havedepthsearch && a.change.report_diffs)
+    if ((a.havedepthsearch) && (a.change.report_diffs))
     {
         CfOut(cf_error, "", " !! Difference reporting is not allowed during a depth_search");
         PromiseRef(cf_error, pp);
@@ -1181,7 +1181,7 @@ static int CompareForFileCopy(char *sourcefile, char *destfile, struct stat *ssb
     case cfa_atime:
 
         ok_to_copy = (dsb->st_ctime < ssb->st_ctime) ||
-            (dsb->st_mtime < ssb->st_mtime) || CompareBinaryFiles(sourcefile, destfile, ssb, dsb, attr, pp);
+            (dsb->st_mtime < ssb->st_mtime) || (CompareBinaryFiles(sourcefile, destfile, ssb, dsb, attr, pp));
 
         if (ok_to_copy)
         {
@@ -1223,7 +1223,7 @@ void LinkCopy(char *sourcefile, char *destfile, struct stat *sb, Attributes attr
 
     linkbuf[0] = '\0';
 
-    if (S_ISLNK(sb->st_mode) && cf_readlink(sourcefile, linkbuf, CF_BUFSIZE, attr, pp) == -1)
+    if ((S_ISLNK(sb->st_mode)) && (cf_readlink(sourcefile, linkbuf, CF_BUFSIZE, attr, pp) == -1))
     {
         cfPS(cf_error, CF_FAIL, "", pp, attr, "Can't readlink %s\n", sourcefile);
         return;
@@ -1232,7 +1232,7 @@ void LinkCopy(char *sourcefile, char *destfile, struct stat *sb, Attributes attr
     {
         CfOut(cf_verbose, "", "Checking link from %s to %s\n", destfile, linkbuf);
 
-        if (attr.copy.link_type == cfa_absolute && !IsAbsoluteFileName(linkbuf))        /* Not absolute path - must fix */
+        if ((attr.copy.link_type == cfa_absolute) && (!IsAbsoluteFileName(linkbuf)))        /* Not absolute path - must fix */
         {
             char vbuff[CF_BUFSIZE];
 
@@ -1293,7 +1293,7 @@ void LinkCopy(char *sourcefile, char *destfile, struct stat *sb, Attributes attr
         return;
     }
 
-    if (status == CF_CHG || status == CF_NOP)
+    if ((status == CF_CHG) || (status == CF_NOP))
     {
         if (lstat(destfile, &dsb) == -1)
         {
@@ -1363,7 +1363,7 @@ int CopyRegularFile(char *source, char *dest, struct stat sstat, struct stat dst
 
     CfDebug("CopyRegularFile(%s,%s)\n", source, dest);
 
-    discardbackup = (attr.copy.backup == cfa_nobackup || attr.copy.backup == cfa_repos_store);
+    discardbackup = ((attr.copy.backup == cfa_nobackup) || (attr.copy.backup == cfa_repos_store));
 
     if (DONTDO)
     {
@@ -1396,7 +1396,7 @@ int CopyRegularFile(char *source, char *dest, struct stat sstat, struct stat dst
 
     if (sstat.st_nlink > 1)     /* Preserve hard links, if possible */
     {
-        if (CompressedArrayElementExists(pp->inode_cache, sstat.st_ino) && (strcmp(dest, linkable) != 0))
+        if ((CompressedArrayElementExists(pp->inode_cache, sstat.st_ino)) && (strcmp(dest, linkable) != 0))
         {
             unlink(dest);
             MakeHardLink(dest, linkable, attr, pp);
@@ -1404,7 +1404,7 @@ int CopyRegularFile(char *source, char *dest, struct stat sstat, struct stat dst
         }
     }
 
-    if (attr.copy.servers != NULL && strcmp(attr.copy.servers->item, "localhost") != 0)
+    if ((attr.copy.servers != NULL) && (strcmp(attr.copy.servers->item, "localhost") != 0))
     {
         CfDebug("This is a remote copy from server: %s\n", (char *) attr.copy.servers->item);
         remote = true;
@@ -1549,7 +1549,7 @@ int CopyRegularFile(char *source, char *dest, struct stat sstat, struct stat dst
         return false;
     }
 
-    if (S_ISREG(dstat.st_mode) && dstat.st_size != sstat.st_size)
+    if ((S_ISREG(dstat.st_mode)) && (dstat.st_size != sstat.st_size))
     {
         cfPS(cf_error, CF_FAIL, "", pp, attr,
              " !! New file %s seems to have been corrupted in transit (dest %d and src %d), aborting!\n", new,
@@ -1681,11 +1681,11 @@ int CopyRegularFile(char *source, char *dest, struct stat sstat, struct stat dst
     }
 #endif
 
-    if (!discardbackup && backupisdir)
+    if ((!discardbackup) && backupisdir)
     {
         CfOut(cf_inform, "", "Cannot move a directory to repository, leaving at %s", backup);
     }
-    else if (!discardbackup && ArchiveToRepository(backup, attr, pp, report_context))
+    else if ((!discardbackup) && (ArchiveToRepository(backup, attr, pp, report_context)))
     {
         unlink(backup);
     }

--- a/src/files_lib.c
+++ b/src/files_lib.c
@@ -128,7 +128,7 @@ int CompareToFile(Item *liststart, char *file, Attributes a, Promise *pp)
         return false;
     }
 
-    if (liststart == NULL && statbuf.st_size == 0)
+    if ((liststart == NULL) && (statbuf.st_size == 0))
     {
         return true;
     }
@@ -175,7 +175,7 @@ static int ItemListsEqual(Item *list1, Item *list2, int warnings, Attributes a, 
         {
             if (warnings)
             {
-                if (ip1 == list1 || ip2 == list2)
+                if ((ip1 == list1) || (ip2 == list2))
                 {
                     cfPS(cf_error, CF_WARN, "", pp, a,
                          " ! File content wants to change from from/to full/empty but only a warning promised");

--- a/src/files_links.c
+++ b/src/files_links.c
@@ -55,7 +55,7 @@ char VerifyLink(char *destination, char *source, Attributes attr, Promise *pp,
 
     memset(to, 0, CF_BUFSIZE);
 
-    if (!IsAbsoluteFileName(source) && (*source != '.'))        /* links without a directory reference */
+    if ((!IsAbsoluteFileName(source)) && (*source != '.'))        /* links without a directory reference */
     {
         snprintf(to, CF_BUFSIZE - 1, "./%s", source);
     }
@@ -83,14 +83,14 @@ char VerifyLink(char *destination, char *source, Attributes attr, Promise *pp,
         source_file_exists = false;
     }
 
-    if (!source_file_exists && (attr.link.when_no_file != cfa_force) && (attr.link.when_no_file != cfa_delete))
+    if ((!source_file_exists) && (attr.link.when_no_file != cfa_force) && (attr.link.when_no_file != cfa_delete))
     {
         CfOut(cf_inform, "", "Source %s for linking is absent", absto);
         cfPS(cf_verbose, CF_FAIL, "", pp, attr, " !! Unable to create link %s -> %s, no source", destination, to);
         return CF_WARN;
     }
 
-    if (!source_file_exists && attr.link.when_no_file == cfa_delete)
+    if ((!source_file_exists) && (attr.link.when_no_file == cfa_delete))
     {
         KillGhostLink(destination, attr, pp);
         return CF_CHG;
@@ -122,7 +122,7 @@ char VerifyLink(char *destination, char *source, Attributes attr, Promise *pp,
     {
         int ok = false;
 
-        if (attr.link.link_type == cfa_symlink && strcmp(linkbuf, to) != 0 && strcmp(linkbuf, source) != 0)
+        if ((attr.link.link_type == cfa_symlink) && (strcmp(linkbuf, to) != 0) && (strcmp(linkbuf, source) != 0))
         {
             ok = true;
         }
@@ -258,7 +258,7 @@ char VerifyRelativeLink(char *destination, char *source, Attributes attr, Promis
         commonfrom++;
     }
 
-    while (!(IsAbsoluteFileName(commonto) && IsAbsoluteFileName(commonfrom)))
+    while (!((IsAbsoluteFileName(commonto)) && (IsAbsoluteFileName(commonfrom))))
     {
         commonto--;
         commonfrom--;
@@ -307,7 +307,7 @@ char VerifyHardLink(char *destination, char *source, Attributes attr, Promise *p
 
     memset(to, 0, CF_BUFSIZE);
 
-    if (!IsAbsoluteFileName(source) && (*source != '.'))        /* links without a directory reference */
+    if ((!IsAbsoluteFileName(source)) && (*source != '.'))        /* links without a directory reference */
     {
         snprintf(to, CF_BUFSIZE - 1, ".%c%s", FILE_SEPARATOR, source);
     }
@@ -351,12 +351,12 @@ char VerifyHardLink(char *destination, char *source, Attributes attr, Promise *p
     /* the files could be on different devices, but unix doesn't */
     /* allow this behaviour so the tests below are theoretical... */
 
-    if (dsb.st_ino != ssb.st_ino && dsb.st_dev != ssb.st_dev)
+    if ((dsb.st_ino != ssb.st_ino) && (dsb.st_dev != ssb.st_dev))
     {
         CfOut(cf_verbose, "", " !! If this is POSIX, unable to determine if %s is hard link is correct\n", destination);
         CfOut(cf_verbose, "", " !! since it points to a different filesystem!\n");
 
-        if (dsb.st_mode == ssb.st_mode && dsb.st_size == ssb.st_size)
+        if ((dsb.st_mode == ssb.st_mode) && (dsb.st_size == ssb.st_size))
         {
             cfPS(cf_verbose, CF_NOP, "", pp, attr, "Hard link (%s->%s) on different device APPEARS okay\n", destination,
                  to);
@@ -364,7 +364,7 @@ char VerifyHardLink(char *destination, char *source, Attributes attr, Promise *p
         }
     }
 
-    if (dsb.st_ino == ssb.st_ino && dsb.st_dev == ssb.st_dev)
+    if ((dsb.st_ino == ssb.st_ino) && (dsb.st_dev == ssb.st_dev))
     {
         cfPS(cf_verbose, CF_NOP, "", pp, attr, " -> Hard link (%s->%s) exists and is okay\n", destination, to);
         return CF_NOP;
@@ -423,7 +423,7 @@ int KillGhostLink(char *name, Attributes attr, Promise *pp)
 
     if (cfstat(tmp, &statbuf) == -1)    /* link points nowhere */
     {
-        if (attr.link.when_no_file == cfa_delete || attr.recursion.rmdeadlinks)
+        if ((attr.link.when_no_file == cfa_delete) || (attr.recursion.rmdeadlinks))
         {
             CfOut(cf_verbose, "", " !! %s is a link which points to %s, but that file doesn't seem to exist\n", name,
                   linkbuf);
@@ -447,7 +447,7 @@ int KillGhostLink(char *name, Attributes attr, Promise *pp)
 #if !defined(__MINGW32__)
 static int MakeLink(char *from, char *to, Attributes attr, Promise *pp)
 {
-    if (DONTDO || attr.transaction.action == cfa_warn)
+    if (DONTDO || (attr.transaction.action == cfa_warn))
     {
         CfOut(cf_error, "", " !! Need to link files %s -> %s\n", from, to);
         return false;
@@ -598,7 +598,7 @@ int ExpandLinks(char *dest, char *from, int level)      /* recursive */
                         return true;
                     }
 
-                    if (!lastnode && !ExpandLinks(buff, dest, level + 1))
+                    if ((!lastnode) && (!ExpandLinks(buff, dest, level + 1)))
                     {
                         return false;
                     }
@@ -618,7 +618,7 @@ int ExpandLinks(char *dest, char *from, int level)      /* recursive */
 
                     memset(buff, 0, CF_BUFSIZE);
 
-                    if (!lastnode && !ExpandLinks(buff, dest, level + 1))
+                    if ((!lastnode) && (!ExpandLinks(buff, dest, level + 1)))
                     {
                         return false;
                     }

--- a/src/files_names.c
+++ b/src/files_names.c
@@ -332,11 +332,11 @@ void AddSlash(char *str)
         }
     }
 
-    if (f && !b)
+    if (f && (!b))
     {
         sep = "/";
     }
-    else if (b && !f)
+    else if (b && (!f))
     {
         sep = "\\";
     }
@@ -493,7 +493,7 @@ void CanonifyNameInPlace(char *s)
 {
     for (; *s != '\0'; s++)
     {
-        if (!isalnum((int)*s) || *s == '.')
+        if ((!isalnum((int)*s)) || (*s == '.'))
         {
             *s = '_';
         }
@@ -551,7 +551,7 @@ int CompareCSVName(const char *s1, const char *s2)
     const char *sp1, *sp2;
     char ch1, ch2;
 
-    for (sp1 = s1, sp2 = s2; *sp1 != '\0' || *sp2 != '\0'; sp1++, sp2++)
+    for (sp1 = s1, sp2 = s2; (*sp1 != '\0') || (*sp2 != '\0'); sp1++, sp2++)
     {
         ch1 = (*sp1 == ',') ? '_' : *sp1;
         ch2 = (*sp2 == ',') ? '_' : *sp2;
@@ -658,7 +658,7 @@ void Chop(char *str)            /* remove trailing spaces */
         return;
     }
 
-    for (i = strlen(str) - 1; i >= 0 && isspace((int) str[i]); i--)
+    for (i = strlen(str) - 1; (i >= 0) && (isspace((int) str[i])); i--)
     {
         str[i] = '\0';
     }
@@ -676,7 +676,7 @@ void StripTrailingNewline(char *str)
         return;
     }
 
-    for (; c >= str && (*c == '\0' || *c == '\n'); --c)
+    for (; (c >= str) && ((*c == '\0') || (*c == '\n')); --c)
     {
         *c = '\0';
     }
@@ -705,7 +705,7 @@ int CompressPath(char *dest, char *src)
             continue;
         }
 
-        for (nodelen = 0; sp[nodelen] != '\0' && !IsFileSep(sp[nodelen]); nodelen++)
+        for (nodelen = 0; (sp[nodelen] != '\0') && (!IsFileSep(sp[nodelen])); nodelen++)
         {
             if (nodelen > CF_MAXLINKSIZE)
             {
@@ -754,7 +754,7 @@ char *ScanPastChars(char *scanpast, char *input)
 {
     char *pos = input;
 
-    while (*pos != '\0' && strchr(scanpast, *pos))
+    while ((*pos != '\0') && (strchr(scanpast, *pos)))
     {
         pos++;
     }
@@ -793,7 +793,7 @@ int IsAbsoluteFileName(const char *f)
 
 bool IsFileOutsideDefaultRepository(const char *f)
 {
-    return (*f == '.') || IsAbsoluteFileName(f);
+    return (*f == '.') || (IsAbsoluteFileName(f));
 }
 
 /*******************************************************************/

--- a/src/files_properties.c
+++ b/src/files_properties.c
@@ -121,7 +121,7 @@ int ConsiderFile(const char *nodename, char *path, Attributes attr, Promise *pp)
 
     for (sp = nodename; *sp != '\0'; sp++)      /* Check for files like ".. ." */
     {
-        if ((*sp != '.') && !isspace((int)*sp))
+        if ((*sp != '.') && (!isspace((int)*sp)))
         {
             return true;
         }
@@ -133,7 +133,7 @@ int ConsiderFile(const char *nodename, char *path, Attributes attr, Promise *pp)
         return true;
     }
 
-    if (statbuf.st_size == 0 && !(VERBOSE || INFORM))   /* No sense in warning about empty files */
+    if ((statbuf.st_size == 0) && (!(VERBOSE || INFORM)))   /* No sense in warning about empty files */
     {
         return false;
     }

--- a/src/files_repository.c
+++ b/src/files_repository.c
@@ -53,7 +53,7 @@ void SetRepositoryChar(char c)
 
 bool GetRepositoryPath(const char *file, Attributes attr, char *destination)
 {
-    if (attr.repository == NULL && VREPOSITORY == NULL)
+    if ((attr.repository == NULL) && (VREPOSITORY == NULL))
     {
         return false;
     }

--- a/src/files_select.c
+++ b/src/files_select.c
@@ -113,7 +113,7 @@ int SelectLeaf(char *path, struct stat *sb, Attributes attr, Promise *pp)
         PrependAlphaList(&leaf_attr, "file_types");
     }
 
-    if (attr.select.owners && SelectOwnerMatch(path, sb, attr.select.owners))
+    if ((attr.select.owners) && (SelectOwnerMatch(path, sb, attr.select.owners)))
     {
         PrependAlphaList(&leaf_attr, "owner");
     }
@@ -127,7 +127,7 @@ int SelectLeaf(char *path, struct stat *sb, Attributes attr, Promise *pp)
     PrependAlphaList(&leaf_attr, "group");
 
 #else /* NOT MINGW */
-    if (attr.select.groups && SelectGroupMatch(sb, attr.select.groups))
+    if ((attr.select.groups) && (SelectGroupMatch(sb, attr.select.groups)))
     {
         PrependAlphaList(&leaf_attr, "group");
     }
@@ -170,17 +170,17 @@ int SelectLeaf(char *path, struct stat *sb, Attributes attr, Promise *pp)
         PrependAlphaList(&leaf_attr, "mtime");
     }
 
-    if (attr.select.issymlinkto && SelectIsSymLinkTo(path, attr.select.issymlinkto))
+    if ((attr.select.issymlinkto) && (SelectIsSymLinkTo(path, attr.select.issymlinkto)))
     {
         PrependAlphaList(&leaf_attr, "issymlinkto");
     }
 
-    if (attr.select.exec_regex && SelectExecRegexMatch(path, attr.select.exec_regex, attr.select.exec_program))
+    if ((attr.select.exec_regex) && (SelectExecRegexMatch(path, attr.select.exec_regex, attr.select.exec_program)))
     {
         PrependAlphaList(&leaf_attr, "exec_regex");
     }
 
-    if (attr.select.exec_program && SelectExecProgram(path, attr.select.exec_program))
+    if ((attr.select.exec_program) && (SelectExecProgram(path, attr.select.exec_program)))
     {
         PrependAlphaList(&leaf_attr, "exec_program");
     }
@@ -200,7 +200,7 @@ int SelectLeaf(char *path, struct stat *sb, Attributes attr, Promise *pp)
 
 static int SelectSizeMatch(size_t size, size_t min, size_t max)
 {
-    if (size <= max && size >= min)
+    if ((size <= max) && (size >= min))
     {
         return true;
     }
@@ -310,7 +310,7 @@ static int SelectOwnerMatch(char *path, struct stat *lstatptr, Rlist *crit)
             return true;
         }
 
-        if (gotOwner && FullTextMatch((char *) rp->item, ownerName))
+        if (gotOwner && (FullTextMatch((char *) rp->item, ownerName)))
         {
             CfDebug(" - ? Select owner match\n");
             DeleteAlphaList(&leafattrib);
@@ -563,7 +563,7 @@ static int SelectGroupMatch(struct stat *lstatptr, Rlist *crit)
             return true;
         }
 
-        if (gr && FullTextMatch((char *) rp->item, gr->gr_name))
+        if (gr && (FullTextMatch((char *) rp->item, gr->gr_name)))
         {
             CfDebug(" - ? Select owner match\n");
             DeleteAlphaList(&leafattrib);

--- a/src/html.c
+++ b/src/html.c
@@ -41,7 +41,7 @@ void CfHtmlHeader(Writer *writer, char *title, char *css, char *webdriver, char 
             "    <link rel=\"stylesheet\" href=\"hand_%s\" type=\"text/css\" media=\"handheld\" />\n"
             "  </head>\n" "  <body>\n", title, css, css);
 
-    if (header && strlen(header) > 0)
+    if (header && (strlen(header) > 0))
     {
         if (strlen(LICENSE_COMPANY) > 0)
         {

--- a/src/install.c
+++ b/src/install.c
@@ -41,7 +41,7 @@ int RelevantBundle(const char *agent, const char *blocktype)
 {
     Item *ip;
 
-    if (strcmp(agent, CF_AGENTTYPES[cf_common]) == 0 || strcmp(CF_COMMONC, blocktype) == 0)
+    if ((strcmp(agent, CF_AGENTTYPES[cf_common]) == 0) || (strcmp(CF_COMMONC, blocktype) == 0))
     {
         return true;
     }
@@ -235,9 +235,9 @@ Promise *AppendPromise(SubType *type, char *promiser, Rval promisee, char *class
         spe = xstrdup("any");
     }
 
-    if (strcmp(type->name, "classes") == 0 || strcmp(type->name, "vars") == 0)
+    if ((strcmp(type->name, "classes") == 0) || (strcmp(type->name, "vars") == 0))
     {
-        if (isdigit((int)*promiser) && Str2Int(promiser) != CF_NOINT)
+        if ((isdigit((int)*promiser)) && (Str2Int(promiser) != CF_NOINT))
         {
             yyerror("Variable or class identifier is purely numerical, which is not allowed");
         }

--- a/src/instrumentation.c
+++ b/src/instrumentation.c
@@ -172,7 +172,7 @@ void NoteClassUsage(AlphaList baselist, int purge)
 
     for (ip = AlphaListIteratorNext(&it); ip != NULL; ip = AlphaListIteratorNext(&it))
     {
-        if (IGNORECLASS(ip->name))
+        if ((IGNORECLASS(ip->name)))
         {
             CfDebug("Ignoring class %s (not packing)", ip->name);
             continue;

--- a/src/item_lib.c
+++ b/src/item_lib.c
@@ -125,7 +125,7 @@ Item *ReturnItemInClass(Item *list, char *item, char *classes)
 
     for (ptr = list; ptr != NULL; ptr = ptr->next)
     {
-        if (strcmp(ptr->name, item) == 0 && strcmp(ptr->classes, classes) == 0)
+        if ((strcmp(ptr->name, item) == 0) && (strcmp(ptr->classes, classes) == 0))
         {
             return ptr;
         }
@@ -225,7 +225,7 @@ int IsItemInRegion(char *item, Item *begin_ptr, Item *end_ptr, Attributes a, Pro
 {
     Item *ip;
 
-    for (ip = begin_ptr; (ip != end_ptr && ip != NULL); ip = ip->next)
+    for (ip = begin_ptr; ((ip != end_ptr) && (ip != NULL)); ip = ip->next)
     {
         if (MatchPolicy(item, ip->name, a, pp))
         {
@@ -460,9 +460,9 @@ int SelectItemMatching(Item *start, char *regex, Item *begin_ptr, Item *end_ptr,
         }
     }
 
-    if (*match != CF_UNDEFINED_ITEM && *prev == CF_UNDEFINED_ITEM)
+    if ((*match != CF_UNDEFINED_ITEM) && (*prev == CF_UNDEFINED_ITEM))
     {
-        for (ip = start; ip != NULL && ip != *match; ip = ip->next)
+        for (ip = start; (ip != NULL) && (ip != *match); ip = ip->next)
         {
             *prev = ip;
         }
@@ -600,7 +600,7 @@ void InsertAfter(Item **filestart, Item *ptr, char *string)
 {
     Item *ip;
 
-    if (*filestart == NULL || ptr == CF_UNDEFINED_ITEM)
+    if ((*filestart == NULL) || (ptr == CF_UNDEFINED_ITEM))
     {
         AppendItem(filestart, string, NULL);
         return;
@@ -633,7 +633,7 @@ int NeighbourItemMatches(Item *file_start, Item *location, char *string, enum cf
     {
         if (pos == cfe_before)
         {
-            if (ip->next && ip->next == location)
+            if ((ip->next) && (ip->next == location))
             {
                 if (MatchPolicy(string, ip->name, a, pp))
                 {
@@ -650,7 +650,7 @@ int NeighbourItemMatches(Item *file_start, Item *location, char *string, enum cf
         {
             if (ip == location)
             {
-                if (ip->next && MatchPolicy(string, ip->next->name, a, pp))
+                if ((ip->next) && (MatchPolicy(string, ip->next->name, a, pp)))
                 {
                     return true;
                 }
@@ -903,7 +903,7 @@ void DeleteItem(Item **liststart, Item *item)
         }
         else
         {
-            for (ip = *liststart; ip != NULL && ip->next != item && ip->next != NULL; ip = ip->next)
+            for (ip = *liststart; (ip != NULL) && (ip->next != item) && (ip->next != NULL); ip = ip->next)
             {
             }
 

--- a/src/iteration.c
+++ b/src/iteration.c
@@ -86,7 +86,7 @@ Rlist *NewIterationContext(const char *scopeid, Rlist *namelist)
             OrthogAppendRlist(&deref_listoflists, new, CF_LIST);
             rp->state_ptr = new->rval.item;
 
-            while (rp->state_ptr && strcmp(rp->state_ptr->item, CF_NULL_VALUE) == 0)
+            while ((rp->state_ptr) && (strcmp(rp->state_ptr->item, CF_NULL_VALUE) == 0))
             {
                 if (rp->state_ptr)
                 {
@@ -172,7 +172,7 @@ static int IncrementIterationContextInternal(Rlist *iterator, int level)
 
         CfDebug(" <- Incrementing wheel (%s) to \"%s\"\n", cp->lval, (char *) iterator->state_ptr->item);
 
-        while (iterator->state_ptr && strcmp(iterator->state_ptr->item, CF_NULL_VALUE) == 0)
+        while ((iterator->state_ptr) && (strcmp(iterator->state_ptr->item, CF_NULL_VALUE) == 0))
         {
             if (IncrementIterationContextInternal(iterator->next, level + 1))
             {
@@ -224,7 +224,7 @@ int EndOfIteration(Rlist *iterator)
             continue;
         }
 
-        if (state && state->next != NULL)
+        if (state && (state->next != NULL))
         {
             return false;
         }
@@ -250,7 +250,7 @@ int NullIterators(Rlist *iterator)
     {
         state = rp->state_ptr;
 
-        if (state && strcmp(state->item, CF_NULL_VALUE) == 0)
+        if (state && (strcmp(state->item, CF_NULL_VALUE) == 0))
         {
             return true;
         }

--- a/src/keyring.c
+++ b/src/keyring.c
@@ -35,7 +35,7 @@ bool HostKeyAddressUnknown(const char *value)
 
 // Is there some other non-ip string left over?
 
-    if (!(strchr(value, '.') || strchr(value, ':')))
+    if (!((strchr(value, '.')) || (strchr(value, ':'))))
     {
         return false;
     }

--- a/src/lastseen.c
+++ b/src/lastseen.c
@@ -224,7 +224,7 @@ static bool Address2HostkeyInDB(DBHandle *db, const char *address, char *result)
 
 bool Address2Hostkey(const char *address, char *result)
 {
-    if (strcmp(address, "127.0.0.1") == 0 || strcmp(address, "::1") == 0 || strcmp(address, VIPADDRESS) == 0)
+    if ((strcmp(address, "127.0.0.1") == 0) || (strcmp(address, "::1") == 0) || (strcmp(address, VIPADDRESS) == 0))
     {
         if (PUBKEY)
         {
@@ -339,7 +339,7 @@ int LastSeenHostKeyCount(void)
             {
                 /* Only look for valid "hostkey" entries */
 
-                if (key[0] != 'k' || value == NULL)
+                if ((key[0] != 'k') || (value == NULL))
                 {
                     continue;
                 }

--- a/src/logging.c
+++ b/src/logging.c
@@ -148,7 +148,7 @@ void EndAudit(void)
  */
 static bool IsPromiseValuableForStatus(const Promise *pp)
 {
-    return pp && pp->agentsubtype != NULL && !IsStrIn(pp->agentsubtype, NO_STATUS_TYPES);
+    return pp && (pp->agentsubtype != NULL) && (!IsStrIn(pp->agentsubtype, NO_STATUS_TYPES));
 }
 
 /*****************************************************************************/
@@ -160,7 +160,7 @@ static bool IsPromiseValuableForStatus(const Promise *pp)
 
 static bool IsPromiseValuableForLogging(const Promise *pp)
 {
-    return pp && pp->agentsubtype != NULL && !IsStrIn(pp->agentsubtype, NO_LOG_TYPES);
+    return pp && (pp->agentsubtype != NULL) && (!IsStrIn(pp->agentsubtype, NO_LOG_TYPES));
 }
 
 /*****************************************************************************/
@@ -337,7 +337,7 @@ void ClassAuditLog(const Promise *pp, Attributes attr, char *str, char status, c
         break;
     }
 
-    if (!(attr.transaction.audit || AUDIT))
+    if (!((attr.transaction.audit) || AUDIT))
     {
         return;
     }
@@ -347,7 +347,7 @@ void ClassAuditLog(const Promise *pp, Attributes attr, char *str, char status, c
         return;
     }
 
-    if (AUDITDBP == NULL || THIS_AGENT_TYPE != cf_agent)
+    if ((AUDITDBP == NULL) || (THIS_AGENT_TYPE != cf_agent))
     {
         CloseDB(AUDITDBP);
         return;
@@ -383,7 +383,7 @@ void ClassAuditLog(const Promise *pp, Attributes attr, char *str, char status, c
         strncpy(newaudit.comment, str, CF_AUDIT_COMMENT - 1);
         strncpy(newaudit.filename, ap->filename, CF_AUDIT_COMMENT - 1);
 
-        if (ap->version == NULL || strlen(ap->version) == 0)
+        if ((ap->version == NULL) || (strlen(ap->version) == 0))
         {
             CfDebug("Promised in %s bundle %s (unamed version last edited at %s) at/before line %d\n",
                     ap->filename, pp->bundle, ap->date, lineno);
@@ -410,7 +410,7 @@ void ClassAuditLog(const Promise *pp, Attributes attr, char *str, char status, c
 
     newaudit.status = status;
 
-    if (AUDITDBP && (attr.transaction.audit || AUDIT))
+    if (AUDITDBP && ((attr.transaction.audit) || AUDIT))
     {
         WriteDB(AUDITDBP, key, &newaudit, sizeof(newaudit));
     }
@@ -486,7 +486,7 @@ void PromiseLog(char *s)
     time_t now = time(NULL);
     FILE *fout;
 
-    if (s == NULL || strlen(s) == 0)
+    if ((s == NULL) || (strlen(s) == 0))
     {
         return;
     }

--- a/src/manual.c
+++ b/src/manual.c
@@ -113,8 +113,8 @@ void TexinfoManual(const char *source_dir, const char *output_file)
     {
         st = (CF_ALL_SUBTYPES[i]);
 
-        if (st == CF_COMMON_SUBTYPES || st == CF_EXEC_SUBTYPES || st == CF_REMACCESS_SUBTYPES
-            || st == CF_KNOWLEDGE_SUBTYPES || st == CF_MEASUREMENT_SUBTYPES)
+        if ((st == CF_COMMON_SUBTYPES) || (st == CF_EXEC_SUBTYPES) || (st == CF_REMACCESS_SUBTYPES)
+            || (st == CF_KNOWLEDGE_SUBTYPES) || (st == CF_MEASUREMENT_SUBTYPES))
 
         {
             CfOut(cf_verbose, "", "Dealing with chapter / bundle type %s\n", st->bundle_type);
@@ -388,13 +388,13 @@ static void TexinfoPromiseTypesFor(const char *source_dir, FILE *fout, const Sub
     {
         CfOut(cf_verbose, "", " - Dealing with promise type %s\n", st[j].subtype);
 
-        if (strcmp("*", st[j].subtype) == 0 && strcmp("*", st[j].bundle_type) == 0)
+        if ((strcmp("*", st[j].subtype) == 0) && (strcmp("*", st[j].bundle_type) == 0))
         {
             fprintf(fout, "\n\n@node Miscellaneous in common promises\n@section @code{%s} promises\n\n", 
                     st[j].subtype);
             snprintf(filename, CF_BUFSIZE - 1, "promise_common_intro.texinfo");
         }
-        else if (strcmp("*", st[j].subtype) == 0 && (strcmp("edit_line", st[j].bundle_type) == 0 || strcmp("edit_xml", st[j].bundle_type) == 0))
+        else if ((strcmp("*", st[j].subtype) == 0) && ((strcmp("edit_line", st[j].bundle_type) == 0) || (strcmp("edit_xml", st[j].bundle_type) == 0)))
         {
             fprintf(fout, "\n\n@node Miscellaneous in %s promises\n@section Miscelleneous in @code{%s} promises\n\n", st[j].bundle_type, st[j].bundle_type);
             snprintf(filename, CF_BUFSIZE - 1, "promises/%s_intro.texinfo", st[j].bundle_type);
@@ -594,7 +594,7 @@ static void TexinfoShowRange(FILE *fout, char *s, enum cfdatatype type)
         return;
     }
 
-    if (type == cf_opts || type == cf_olist)
+    if ((type == cf_opts) || (type == cf_olist))
     {
         list = SplitStringAsRList(s, ',');
         fprintf(fout, "@noindent @b{Allowed input range}: @*\n@example");
@@ -732,7 +732,7 @@ char *ReadTexinfoFileF(const char *source_dir, const char *fmt, ...)
     buffer[file_size] = '\0';
     int cnt = fread(buffer, sizeof(char), file_size, fp);
 
-    if (ferror(fp) || cnt != file_size)
+    if ((ferror(fp)) || (cnt != file_size))
     {
         CfOut(cf_inform, "fread", "Could not read manual source %s\n", filename);
         free(buffer);

--- a/src/matching.c
+++ b/src/matching.c
@@ -110,7 +110,7 @@ static int RegExMatchFullString(pcre *rx, const char *teststring)
 
     if (RegExMatchSubString(rx, teststring, &match_start, &match_len))
     {
-        return match_start == 0 && match_len == strlen(teststring);
+        return (match_start == 0) && (match_len == strlen(teststring));
     }
     else
     {
@@ -197,7 +197,7 @@ char *ExtractFirstReference(const char *regexp, const char *teststring)
 
     pcre *rx;
 
-    if (regexp == NULL || teststring == NULL)
+    if ((regexp == NULL) || (teststring == NULL))
     {
         return nothing;
     }
@@ -271,7 +271,7 @@ int IsRegex(char *str)
             special = r_literal;
             continue;
         }
-        else if (bracket && *sp != ']')
+        else if (bracket && (*sp != ']'))
         {
             if (*sp == '[')
             {
@@ -335,7 +335,7 @@ int IsRegex(char *str)
 
     }
 
-    if (bracket != 0 || paren != 0 || special == r_literal)
+    if ((bracket != 0) || (paren != 0) || (special == r_literal))
     {
         return false;
     }
@@ -380,7 +380,7 @@ int IsPathRegex(char *str)
                 break;
             default:
 
-                if (*sp == FILE_SEPARATOR && (r || s))
+                if ((*sp == FILE_SEPARATOR) && (r || s))
                 {
                     CfOut(cf_error, "",
                           "Path regular expression %s seems to use expressions containing the directory symbol %c", str,
@@ -405,7 +405,7 @@ int IsRegexItemIn(Item *list, char *regex)
 
     for (ptr = list; ptr != NULL; ptr = ptr->next)
     {
-        if (ptr->classes && IsExcluded(ptr->classes, NULL)) // This NULL might be wrong
+        if ((ptr->classes) && (IsExcluded(ptr->classes, NULL))) // This NULL might be wrong
         {
             continue;
         }
@@ -419,7 +419,7 @@ int IsRegexItemIn(Item *list, char *regex)
 
         /* Make it commutative */
 
-        if (FullTextMatch(regex, ptr->name) || FullTextMatch(ptr->name, regex))
+        if ((FullTextMatch(regex, ptr->name)) || (FullTextMatch(ptr->name, regex)))
         {
             CfDebug("IsRegexItem(%s,%s)\n", regex, ptr->name);
             return (true);
@@ -465,7 +465,7 @@ int MatchPolicy(char *camel, char *haystack, Attributes a, Promise *pp)
 
             if (opt == cf_exact_match)
             {
-                if (rp->next != NULL || rp != a.insert_match)
+                if ((rp->next != NULL) || (rp != a.insert_match))
                 {
                     CfOut(cf_error, "", " !! Multiple policies conflict with \"exact_match\", using exact match");
                     PromiseRef(cf_error, pp);
@@ -492,13 +492,13 @@ int MatchPolicy(char *camel, char *haystack, Attributes a, Promise *pp)
                 {
                 }
 
-                for (lastchar = final + strlen(final) - 1; lastchar > firstchar && isspace((int)*lastchar); lastchar--)
+                for (lastchar = final + strlen(final) - 1; (lastchar > firstchar) && (isspace((int)*lastchar)); lastchar--)
                 {
                 }
 
                 for (sp = final, spto = work; *sp != '\0'; sp++)
                 {
-                    if (sp > firstchar && sp < lastchar)
+                    if ((sp > firstchar) && (sp < lastchar))
                     {
                         if (isspace((int)*sp))
                         {
@@ -545,7 +545,7 @@ int MatchPolicy(char *camel, char *haystack, Attributes a, Promise *pp)
                 }
             }
 
-            ok = ok || FullTextMatch(final, haystack);
+            ok = ok || (FullTextMatch(final, haystack));
         }
 
         if (!ok)                // All lines in region need to match to avoid insertions
@@ -630,7 +630,7 @@ void EscapeSpecialChars(char *str, char *strEsc, int strEscSz, char *noEscSeq, c
         if (strchr(noEscList,*sp))
         {
         }        
-        else if (*sp != '\0' && !isalnum((int)*sp))
+        else if ((*sp != '\0') && (!isalnum((int)*sp)))
         {
             strEsc[strEscPos++] = '\\';
         }

--- a/src/modes.c
+++ b/src/modes.c
@@ -172,7 +172,7 @@ int ParseModeString(const char *modestring, mode_t *plusmask, mode_t *minusmask)
                 return false;
             }
 
-            while (isdigit((int) *sp) && (*sp != '\0'))
+            while ((isdigit((int) *sp)) && (*sp != '\0'))
             {
                 sp++;
             }
@@ -185,7 +185,7 @@ int ParseModeString(const char *modestring, mode_t *plusmask, mode_t *minusmask)
                 return false;
             }
 
-            if (found_sort != unknown && found_sort != sort)
+            if ((found_sort != unknown) && (found_sort != sort))
             {
                 CfOut(cf_inform, "", "Symbolic and numeric form for modes mixed");
             }
@@ -200,9 +200,9 @@ int ParseModeString(const char *modestring, mode_t *plusmask, mode_t *minusmask)
             break;
 
         case '\0':
-            if (state == who || value == 0)
+            if ((state == who) || (value == 0))
             {
-                if (strcmp(modestring, "0000") != 0 && strcmp(modestring, "000") != 0)
+                if ((strcmp(modestring, "0000") != 0) && (strcmp(modestring, "000") != 0))
                 {
                     CfOut(cf_error, "", "mode string is incomplete");
                     return false;
@@ -214,7 +214,7 @@ int ParseModeString(const char *modestring, mode_t *plusmask, mode_t *minusmask)
                 return false;
             }
 
-            if (found_sort != unknown && found_sort != sort)
+            if ((found_sort != unknown) && (found_sort != sort))
             {
                 CfOut(cf_inform, "", "Symbolic and numeric form for modes mixed");
             }

--- a/src/mon_cpu.c
+++ b/src/mon_cpu.c
@@ -76,7 +76,7 @@ void MonCPUGatherData(double *cf_this)
         {
             if (sscanf(cpuname, "cpu%ld", &cpuidx) == 1)
             {
-                if (cpuidx < 0 || cpuidx >= MON_CPU_MAX)
+                if ((cpuidx < 0) || (cpuidx >= MON_CPU_MAX))
                 {
                     continue;
                 }
@@ -93,7 +93,7 @@ void MonCPUGatherData(double *cf_this)
 
         dq = (q - LAST_CPU_Q[cpuidx]) / (double) (total_time - LAST_CPU_T[cpuidx]);     /* % Utilization */
 
-        if (dq > 100 || dq < 0) // Counter wrap around
+        if ((dq > 100) || (dq < 0)) // Counter wrap around
         {
             dq = 50;
         }

--- a/src/mon_network.c
+++ b/src/mon_network.c
@@ -173,7 +173,7 @@ void MonNetworkGatherData(double *cf_this)
             break;
         }
 
-        if (!(strstr(vbuff, ":") || strstr(vbuff, ".")))
+        if (!((strstr(vbuff, ":")) || (strstr(vbuff, "."))))
         {
             continue;
         }
@@ -182,25 +182,25 @@ void MonNetworkGatherData(double *cf_this)
 
         // If this is old style, we look for chapter headings, e.g. "TCP: IPv4"
 
-        if (strncmp(vbuff,"UDP:",4) == 0 && strstr(vbuff+4,"6"))
+        if ((strncmp(vbuff,"UDP:",4) == 0) && (strstr(vbuff+4,"6")))
         {
             packet = cfn_udp6;
             type = cfn_old;
             continue;
         }
-        else if (strncmp(vbuff,"TCP:",4) == 0 && strstr(vbuff+4,"6"))       
+        else if ((strncmp(vbuff,"TCP:",4) == 0) && (strstr(vbuff+4,"6")))
         {
             packet = cfn_tcp6;
             type = cfn_old;
             continue;
         }
-        else if (strncmp(vbuff,"UDP:",4) == 0 && strstr(vbuff+4,"4"))
+        else if ((strncmp(vbuff,"UDP:",4) == 0) && (strstr(vbuff+4,"4")))
         {
             packet = cfn_udp4;
             type = cfn_old;
             continue;
         }
-        else if (strncmp(vbuff,"TCP:",4) == 0 && strstr(vbuff+4,"4"))
+        else if ((strncmp(vbuff,"TCP:",4) == 0) && (strstr(vbuff+4,"4")))
         {
             packet = cfn_tcp4;
             type = cfn_old;
@@ -288,7 +288,7 @@ void MonNetworkGatherData(double *cf_this)
 
         // Now look at outgoing
         
-        for (sp = remote + strlen(remote) - 1; (sp >= remote) && isdigit((int) *sp); sp--)
+        for (sp = remote + strlen(remote) - 1; (sp >= remote) && (isdigit((int) *sp)); sp--)
         {
         }
 

--- a/src/mon_network_sniffer.c
+++ b/src/mon_network_sniffer.c
@@ -197,7 +197,7 @@ static void AnalyzeArrival(long iteration, char *arrival, double *cf_this)
    IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto ICMP (1), length 84) 192.168.1.103 > 128.39.89.10: ICMP echo request, id 48474, seq 2, length 64
 */
 
-    for (arr = strstr(arrival, "length"); arr != NULL && *arr != ')'; arr++)
+    for (arr = strstr(arrival, "length"); (arr != NULL) && (*arr != ')'); arr++)
     {
     }
 
@@ -210,7 +210,7 @@ static void AnalyzeArrival(long iteration, char *arrival, double *cf_this)
         arr++;
     }
 
-    if (strstr(arrival, "proto TCP") || strstr(arrival, "ack"))
+    if ((strstr(arrival, "proto TCP")) || (strstr(arrival, "ack")))
     {
         sscanf(arr, "%s %*c %s %c ", src, dest, &flag);
         DePort(src);

--- a/src/net.c
+++ b/src/net.c
@@ -35,7 +35,7 @@
 static bool LastRecvTimedOut(void)
 {
 #ifndef MINGW
-	if (errno == EAGAIN || errno == EWOULDBLOCK)
+	if ((errno == EAGAIN) || (errno == EWOULDBLOCK))
 	{
 		return true;
 	}
@@ -151,12 +151,12 @@ int RecvSocketStream(int sd, char buffer[CF_BUFSIZE], int toget, int nothing)
     {
         got = recv(sd, buffer + already, toget - already, 0);
 
-        if (got == -1 && errno == EINTR)
+        if ((got == -1) && (errno == EINTR))
         {
             continue;
         }
 
-        if (got == -1 && LastRecvTimedOut())
+        if ((got == -1) && (LastRecvTimedOut()))
         {
             CfOut(cf_error, "recv", "!! Timeout - remote end did not respond with the expected amount of data (received=%d, expecting=%d)",
                   already, toget);
@@ -194,7 +194,7 @@ int SendSocketStream(int sd, char buffer[CF_BUFSIZE], int tosend, int flags)
 
         sent = send(sd, buffer + already, tosend - already, flags);
 
-        if (sent == -1 && errno == EINTR)
+        if ((sent == -1) && (errno == EINTR))
         {
             continue;
         }

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -151,7 +151,7 @@ int LoadMountInfo(Rlist **list)
 
         sscanf(vbuff, "%s%s%s", buf1, buf2, buf3);
 
-        if (vbuff[0] == '\0' || vbuff[0] == '\n')
+        if ((vbuff[0] == '\0') || (vbuff[0] == '\n'))
         {
             break;
         }
@@ -167,12 +167,12 @@ int LoadMountInfo(Rlist **list)
             CfOut(cf_error, "", "Use the -n option to run safely.");
         }
 
-        if (strstr(vbuff, "retrying") || strstr(vbuff, "denied") || strstr(vbuff, "backgrounding"))
+        if ((strstr(vbuff, "retrying")) || (strstr(vbuff, "denied")) || (strstr(vbuff, "backgrounding")))
         {
             continue;
         }
 
-        if (strstr(vbuff, "exceeded") || strstr(vbuff, "busy"))
+        if ((strstr(vbuff, "exceeded")) || (strstr(vbuff, "busy")))
         {
             continue;
         }
@@ -561,7 +561,7 @@ int VerifyMount(char *name, Attributes a, Promise *pp)
 
         CfReadLine(line, CF_BUFSIZE, pfp);
 
-        if (strstr(line, "busy") || strstr(line, "Busy"))
+        if ((strstr(line, "busy")) || (strstr(line, "Busy")))
         {
             cfPS(cf_inform, CF_INTERPT, "", pp, a, " !! The device under %s cannot be mounted\n", mountpt);
             cf_pclose(pfp);
@@ -597,7 +597,7 @@ int VerifyUnmount(char *name, Attributes a, Promise *pp)
 
         CfReadLine(line, CF_BUFSIZE, pfp);
 
-        if (strstr(line, "busy") || strstr(line, "Busy"))
+        if ((strstr(line, "busy")) || (strstr(line, "Busy")))
         {
             cfPS(cf_inform, CF_INTERPT, "", pp, a, " !! The device under %s cannot be unmounted\n", mountpt);
             cf_pclose(pfp);
@@ -693,7 +693,7 @@ void MountAll()
             break;
         }
 
-        if (strstr(line, "already mounted") || strstr(line, "exceeded") || strstr(line, "determined"))
+        if ((strstr(line, "already mounted")) || (strstr(line, "exceeded")) || (strstr(line, "determined")))
         {
             continue;
         }
@@ -703,13 +703,13 @@ void MountAll()
             continue;
         }
 
-        if (strstr(line, "denied") || strstr(line, "RPC"))
+        if ((strstr(line, "denied")) || (strstr(line, "RPC")))
         {
             CfOut(cf_error, "", "There was a mount error, trying to mount one of the filesystems on this host.\n");
             break;
         }
 
-        if (strstr(line, "trying") && !strstr(line, "NFS version 2") && !strstr(line, "vers 3"))
+        if ((strstr(line, "trying")) && (!strstr(line, "NFS version 2")) && (!strstr(line, "vers 3")))
         {
             CfOut(cf_error, "", "Attempting abort because mount went into a retry loop.\n");
             break;

--- a/src/ontology.c
+++ b/src/ontology.c
@@ -84,7 +84,7 @@ Topic *GetTopic(Topic *list, char *topic_name)
         }
         else
         {
-            if ((strcmp(name, tp->topic_name)) == 0 && (strcmp(context, tp->topic_context) == 0))
+            if (((strcmp(name, tp->topic_name)) == 0) && (strcmp(context, tp->topic_context) == 0))
             {
                 return tp;
             }

--- a/src/patches.c
+++ b/src/patches.c
@@ -363,7 +363,7 @@ char *cf_strtimestamp_utc(const time_t time, char *buf)
 static char *cf_format_strtimestamp(struct tm *tm, char *buf)
 {
     /* Security checks */
-    if (tm->tm_year < -2899 || tm->tm_year > 8099)
+    if ((tm->tm_year < -2899) || (tm->tm_year > 8099))
     {
         CfOut(cf_error, "", "Unable to format timestamp: passed year is out of range: %d", tm->tm_year + 1900);
         return NULL;

--- a/src/pipes.c
+++ b/src/pipes.c
@@ -35,7 +35,7 @@ int VerifyCommandRetcode(int retcode, int fallback, Attributes a, Promise *pp)
     int result = true;
     int matched = false;
 
-    if (a.classes.retcode_kept || a.classes.retcode_repaired || a.classes.retcode_failed)
+    if ((a.classes.retcode_kept) || (a.classes.retcode_repaired) || (a.classes.retcode_failed))
     {
 
         snprintf(retcodeStr, sizeof(retcodeStr), "%d", retcode);
@@ -113,7 +113,7 @@ FILE *cf_popen(const char *command, char *type)
 
     CfDebug("cf_popen(%s)\n", command);
 
-    if ((*type != 'r' && *type != 'w') || (type[1] != '\0'))
+    if (((*type != 'r') && (*type != 'w')) || (type[1] != '\0'))
     {
         errno = EINVAL;
         return NULL;
@@ -248,7 +248,7 @@ FILE *cf_popensetuid(const char *command, char *type, uid_t uid, gid_t gid, char
 
     CfDebug("cf_popensetuid(%s,%s,%ju,%ju)\n", command, type, (uintmax_t)uid, (uintmax_t)gid);
 
-    if ((*type != 'r' && *type != 'w') || (type[1] != '\0'))
+    if (((*type != 'r') && (*type != 'w')) || (type[1] != '\0'))
     {
         errno = EINVAL;
         return NULL;
@@ -319,7 +319,7 @@ FILE *cf_popensetuid(const char *command, char *type, uid_t uid, gid_t gid, char
 
         argv = ArgSplitCommand(command);
 
-        if (chrootv && strlen(chrootv) != 0)
+        if (chrootv && (strlen(chrootv) != 0))
         {
             if (chroot(chrootv) == -1)
             {
@@ -329,7 +329,7 @@ FILE *cf_popensetuid(const char *command, char *type, uid_t uid, gid_t gid, char
             }
         }
 
-        if (chdirv && strlen(chdirv) != 0)
+        if (chdirv && (strlen(chdirv) != 0))
         {
             if (chdir(chdirv) == -1)
             {
@@ -408,7 +408,7 @@ FILE *cf_popen_sh(const char *command, char *type)
 
     CfDebug("cf_popen_sh(%s)\n", command);
 
-    if ((*type != 'r' && *type != 'w') || (type[1] != '\0'))
+    if (((*type != 'r') && (*type != 'w')) || (type[1] != '\0'))
     {
         errno = EINVAL;
         return NULL;
@@ -535,7 +535,7 @@ FILE *cf_popen_shsetuid(const char *command, char *type, uid_t uid, gid_t gid, c
 
     CfDebug("cf_popen_shsetuid(%s,%s,%ju,%ju)\n", command, type, (uintmax_t)uid, (uintmax_t)gid);
 
-    if ((*type != 'r' && *type != 'w') || (type[1] != '\0'))
+    if (((*type != 'r') && (*type != 'w')) || (type[1] != '\0'))
     {
         errno = EINVAL;
         return NULL;
@@ -604,7 +604,7 @@ FILE *cf_popen_shsetuid(const char *command, char *type, uid_t uid, gid_t gid, c
             }
         }
 
-        if (chrootv && strlen(chrootv) != 0)
+        if (chrootv && (strlen(chrootv) != 0))
         {
             if (chroot(chrootv) == -1)
             {
@@ -613,7 +613,7 @@ FILE *cf_popen_shsetuid(const char *command, char *type, uid_t uid, gid_t gid, c
             }
         }
 
-        if (chdirv && strlen(chdirv) != 0)
+        if (chdirv && (strlen(chdirv) != 0))
         {
             if (chdir(chdirv) == -1)
             {

--- a/src/processes_select.c
+++ b/src/processes_select.c
@@ -170,7 +170,7 @@ static int SelectProcRangeMatch(char *name1, char *name2, int min, int max, char
     int i;
     long value;
 
-    if (min == CF_NOINT || max == CF_NOINT)
+    if ((min == CF_NOINT) || (max == CF_NOINT))
     {
         return false;
     }
@@ -186,7 +186,7 @@ static int SelectProcRangeMatch(char *name1, char *name2, int min, int max, char
             return false;
         }
 
-        if (min <= value && value <= max)
+        if ((min <= value) && (value <= max))
         {
             return true;
         }
@@ -206,7 +206,7 @@ static int SelectProcTimeCounterRangeMatch(char *name1, char *name2, time_t min,
     int i;
     time_t value;
 
-    if (min == CF_NOINT || max == CF_NOINT)
+    if ((min == CF_NOINT) || (max == CF_NOINT))
     {
         return false;
     }
@@ -222,7 +222,7 @@ static int SelectProcTimeCounterRangeMatch(char *name1, char *name2, time_t min,
             return false;
         }
 
-        if (min <= value && value <= max)
+        if ((min <= value) && (value <= max))
         {
             CfOut(cf_verbose, "", "Selection filter matched counter range %s/%s = %s in [%jd,%jd] (= %jd secs)\n",
                   name1, name2, line[i], (intmax_t)min, (intmax_t)max, (intmax_t)value);
@@ -246,7 +246,7 @@ static int SelectProcTimeAbsRangeMatch(char *name1, char *name2, time_t min, tim
     int i;
     time_t value;
 
-    if (min == CF_NOINT || max == CF_NOINT)
+    if ((min == CF_NOINT) || (max == CF_NOINT))
     {
         return false;
     }
@@ -262,7 +262,7 @@ static int SelectProcTimeAbsRangeMatch(char *name1, char *name2, time_t min, tim
             return false;
         }
 
-        if (min <= value && value <= max)
+        if ((min <= value) && (value <= max))
         {
             CfOut(cf_verbose, "", "Selection filter matched absolute %s/%s = %s in [%jd,%jd]\n", name1, name2, line[i],
                   (intmax_t)min, (intmax_t)max);
@@ -316,7 +316,7 @@ static int SplitProcLine(char *proc, char **names, int *start, int *end, char **
 
     CfDebug("SplitProcLine(%s)\n", proc);
 
-    if (proc == NULL || strlen(proc) == 0)
+    if ((proc == NULL) || (strlen(proc) == 0))
     {
         return false;
     }
@@ -327,14 +327,14 @@ static int SplitProcLine(char *proc, char **names, int *start, int *end, char **
 
     sp = proc;
 
-    for (i = 0; i < CF_PROCCOLS && names[i] != NULL; i++)
+    for (i = 0; (i < CF_PROCCOLS) && (names[i] != NULL); i++)
     {
         while (*sp == ' ')
         {
             sp++;
         }
 
-        if (strcmp(names[i], "CMD") == 0 || strcmp(names[i], "COMMAND") == 0)
+        if ((strcmp(names[i], "CMD") == 0) || (strcmp(names[i], "COMMAND") == 0))
         {
             sscanf(sp, "%127[^\n]", cols1[i]);
             sp += strlen(cols1[i]);
@@ -346,7 +346,7 @@ static int SplitProcLine(char *proc, char **names, int *start, int *end, char **
         }
 
         // Some ps stimes may contain spaces, e.g. "Jan 25"
-        if (strcmp(names[i], "STIME") == 0 && strlen(cols1[i]) == 3)
+        if ((strcmp(names[i], "STIME") == 0) && (strlen(cols1[i]) == 3))
         {
             char s[CF_SMALLBUF] = { 0 };
             sscanf(sp, "%127s", s);
@@ -358,10 +358,10 @@ static int SplitProcLine(char *proc, char **names, int *start, int *end, char **
 
 // Now try looking at columne alignment
 
-    for (i = 0; i < CF_PROCCOLS && names[i] != NULL; i++)
+    for (i = 0; (i < CF_PROCCOLS) && (names[i] != NULL); i++)
     {
         // Start from the header/column tab marker and count backwards until we find 0 or space
-        for (s = start[i]; (s >= 0) && !isspace((int) *(proc + s)); s--)
+        for (s = start[i]; (s >= 0) && (!isspace((int) *(proc + s))); s--)
         {
         }
 
@@ -376,13 +376,13 @@ static int SplitProcLine(char *proc, char **names, int *start, int *end, char **
             s++;
         }
 
-        if (strcmp(names[i], "CMD") == 0 || strcmp(names[i], "COMMAND") == 0)
+        if ((strcmp(names[i], "CMD") == 0) || (strcmp(names[i], "COMMAND") == 0))
         {
             e = strlen(proc);
         }
         else
         {
-            for (e = end[i]; (e <= end[i] + 10) && !isspace((int) *(proc + e)); e++)
+            for (e = end[i]; (e <= end[i] + 10) && (!isspace((int) *(proc + e))); e++)
             {
             }
 

--- a/src/recursion.c
+++ b/src/recursion.c
@@ -122,9 +122,9 @@ int DepthSearch(char *name, struct stat *sb, int rlevel, Attributes attr, Promis
 
         /* See if we are supposed to treat links to dirs as dirs and descend */
 
-        if (attr.recursion.travlinks && S_ISLNK(lsb.st_mode))
+        if ((attr.recursion.travlinks) && (S_ISLNK(lsb.st_mode)))
         {
-            if (lsb.st_uid != 0 && lsb.st_uid != getuid())
+            if ((lsb.st_uid != 0) && (lsb.st_uid != getuid()))
             {
                 CfOut(cf_inform, "",
                       "File %s is an untrusted link: cfengine will not follow it with a destructive operation", path);
@@ -140,7 +140,7 @@ int DepthSearch(char *name, struct stat *sb, int rlevel, Attributes attr, Promis
             }
         }
 
-        if (attr.recursion.xdev && DeviceBoundary(&lsb, pp))
+        if ((attr.recursion.xdev) && (DeviceBoundary(&lsb, pp)))
         {
             CfOut(cf_verbose, "", "Skipping %s on different device - use xdev option to change this\n", path);
             continue;
@@ -153,7 +153,7 @@ int DepthSearch(char *name, struct stat *sb, int rlevel, Attributes attr, Promis
                 continue;
             }
 
-            if (attr.recursion.depth > 1 && rlevel <= attr.recursion.depth)
+            if ((attr.recursion.depth > 1) && (rlevel <= attr.recursion.depth))
             {
                 CfOut(cf_verbose, "", " ->>  Entering %s (%d)\n", path, rlevel);
                 goback = DepthSearch(path, &lsb, rlevel + 1, attr, pp, report_context);
@@ -199,7 +199,7 @@ static int PushDirState(char *name, struct stat *sb)
 
 static void PopDirState(int goback, char *name, struct stat *sb, Recursion r)
 {
-    if (goback && r.travlinks)
+    if (goback && (r.travlinks))
     {
         if (chdir(name) == -1)
         {
@@ -227,7 +227,7 @@ int SkipDirLinks(char *path, const char *lastnode, Recursion r)
 
     if (r.exclude_dirs)
     {
-        if (MatchRlistItem(r.exclude_dirs, path) || MatchRlistItem(r.exclude_dirs, lastnode))
+        if ((MatchRlistItem(r.exclude_dirs, path)) || (MatchRlistItem(r.exclude_dirs, lastnode)))
         {
             CfOut(cf_verbose, "", "Skipping matched excluded directory %s\n", path);
             return true;
@@ -236,7 +236,7 @@ int SkipDirLinks(char *path, const char *lastnode, Recursion r)
 
     if (r.include_dirs)
     {
-        if (!(MatchRlistItem(r.include_dirs, path) || MatchRlistItem(r.include_dirs, lastnode)))
+        if (!((MatchRlistItem(r.include_dirs, path)) || (MatchRlistItem(r.include_dirs, lastnode))))
         {
             CfOut(cf_verbose, "", "Skipping matched non-included directory %s\n", path);
             return true;

--- a/src/reporting.c
+++ b/src/reporting.c
@@ -970,7 +970,7 @@ static void ShowPromiseTypesFor(const char *s)
 
         for (j = 0; st[j].bundle_type != NULL; j++)
         {
-            if (strcmp(s, st[j].bundle_type) == 0 || strcmp("*", st[j].bundle_type) == 0)
+            if ((strcmp(s, st[j].bundle_type) == 0) || (strcmp("*", st[j].bundle_type) == 0))
             {
                 printf("<h4>PROMISE TYPE %s</h4>\n", st[j].subtype);
                 ShowBodyParts(st[j].bs);

--- a/src/server.c
+++ b/src/server.c
@@ -159,7 +159,7 @@ void ServerEntryPoint(int sd_reply, char *ipaddr, ServerAccess sv)
     
     CfOut(cf_verbose, "", "Obtained IP address of %s on socket %d from accept\n", ipaddr, sd_reply);
     
-    if (sv.nonattackerlist && !IsMatchItemIn(sv.nonattackerlist, MapAddress(ipaddr)))
+    if ((sv.nonattackerlist) && (!IsMatchItemIn(sv.nonattackerlist, MapAddress(ipaddr))))
     {
         CfOut(cf_error, "", "Not allowing connection from non-authorized IP %s\n", ipaddr);
         cf_closesocket(sd_reply);
@@ -522,7 +522,7 @@ static int BusyWithConnection(ServerConnectionState *conn)
         memset(filename, 0, CF_BUFSIZE);
         sscanf(recvbuffer, "GET %d %[^\n]", &(get_args.buf_size), filename);
 
-        if (get_args.buf_size < 0 || get_args.buf_size > CF_BUFSIZE)
+        if ((get_args.buf_size < 0) || (get_args.buf_size > CF_BUFSIZE))
         {
             CfOut(cf_inform, "", "GET buffer out of bounds\n");
             RefuseAccess(conn, sendbuffer, 0, recvbuffer);
@@ -582,7 +582,7 @@ static int BusyWithConnection(ServerConnectionState *conn)
             return true;
         }
 
-        if (get_args.buf_size < 0 || get_args.buf_size > 8192)
+        if ((get_args.buf_size < 0) || (get_args.buf_size > 8192))
         {
             CfOut(cf_inform, "", "SGET bounding error\n");
             RefuseAccess(conn, sendbuffer, 0, recvbuffer);
@@ -626,7 +626,7 @@ static int BusyWithConnection(ServerConnectionState *conn)
         memset(buffer, 0, CF_BUFSIZE);
         sscanf(recvbuffer, "SOPENDIR %u", &len);
 
-        if (len >= sizeof(out) || received != len + CF_PROTO_OFFSET)
+        if ((len >= sizeof(out)) || (received != (len + CF_PROTO_OFFSET)))
         {
             CfOut(cf_verbose, "", "Protocol error OPENDIR: %d\n", len);
             RefuseAccess(conn, sendbuffer, 0, recvbuffer);
@@ -698,7 +698,7 @@ static int BusyWithConnection(ServerConnectionState *conn)
         memset(buffer, 0, CF_BUFSIZE);
         sscanf(recvbuffer, "SSYNCH %u", &len);
 
-        if (len >= sizeof(out) || received != len + CF_PROTO_OFFSET)
+        if ((len >= sizeof(out)) || (received != (len + CF_PROTO_OFFSET)))
         {
             CfOut(cf_verbose, "", "Protocol error SSYNCH: %d\n", len);
             RefuseAccess(conn, sendbuffer, 0, recvbuffer);
@@ -745,7 +745,7 @@ static int BusyWithConnection(ServerConnectionState *conn)
 
         trem = (time_t) time_no_see;
 
-        if (time_no_see == 0 || filename[0] == '\0')
+        if ((time_no_see == 0) || (filename[0] == '\0'))
         {
             break;
         }
@@ -786,7 +786,7 @@ static int BusyWithConnection(ServerConnectionState *conn)
 
         sscanf(recvbuffer, "SMD5 %u", &len);
 
-        if (len >= sizeof(out) || received != len + CF_PROTO_OFFSET)
+        if ((len >= sizeof(out)) || (received != (len + CF_PROTO_OFFSET)))
         {
             CfOut(cf_inform, "", "Decryption error\n");
             RefuseAccess(conn, sendbuffer, 0, recvbuffer);
@@ -821,7 +821,7 @@ static int BusyWithConnection(ServerConnectionState *conn)
 
         sscanf(recvbuffer, "SVAR %u", &len);
 
-        if (len >= sizeof(out) || received != len + CF_PROTO_OFFSET)
+        if ((len >= sizeof(out)) || (received != (len + CF_PROTO_OFFSET)))
         {
             CfOut(cf_inform, "", "Decrypt error SVAR\n");
             RefuseAccess(conn, sendbuffer, 0, "decrypt error SVAR");
@@ -864,7 +864,7 @@ static int BusyWithConnection(ServerConnectionState *conn)
 
         sscanf(recvbuffer, "SCONTEXT %u", &len);
 
-        if (len >= sizeof(out) || received != len + CF_PROTO_OFFSET)
+        if ((len >= sizeof(out)) || (received != (len + CF_PROTO_OFFSET)))
         {
             CfOut(cf_inform, "", "Decrypt error SCONTEXT, len,received = %d,%d\n", len, received);
             RefuseAccess(conn, sendbuffer, 0, "decrypt error SCONTEXT");
@@ -907,7 +907,7 @@ static int BusyWithConnection(ServerConnectionState *conn)
 
         sscanf(recvbuffer, "SQUERY %u", &len);
 
-        if (len >= sizeof(out) || received != len + CF_PROTO_OFFSET)
+        if ((len >= sizeof(out)) || (received != (len + CF_PROTO_OFFSET)))
         {
             CfOut(cf_inform, "", "Decrypt error SQUERY\n");
             RefuseAccess(conn, sendbuffer, 0, "decrypt error SQUERY");
@@ -949,7 +949,7 @@ static int BusyWithConnection(ServerConnectionState *conn)
 
         sscanf(recvbuffer, "SCALLBACK %u", &len);
 
-        if (len >= sizeof(out) || received != len + CF_PROTO_OFFSET)
+        if ((len >= sizeof(out)) || (received != (len + CF_PROTO_OFFSET)))
         {
             CfOut(cf_inform, "", "Decrypt error CALL_ME_BACK\n");
             RefuseAccess(conn, sendbuffer, 0, "decrypt error CALL_ME_BACK");
@@ -1089,14 +1089,14 @@ static void DoExec(ServerConnectionState *conn, char *sendbuffer, char *args)
 
     for (sp = args; *sp != '\0'; sp++)  /* Blank out -K -f */
     {
-        if (*sp == ';' || *sp == '&' || *sp == '|')
+        if ((*sp == ';') || (*sp == '&') || (*sp == '|'))
         {
             sprintf(sendbuffer, "You are not authorized to activate these classes/roles on host %s\n", VFQNAME);
             SendTransaction(conn->sd_reply, sendbuffer, 0, CF_DONE);
             return;
         }
 
-        if (OptionFound(args, sp, "-K") || OptionFound(args, sp, "-f"))
+        if ((OptionFound(args, sp, "-K")) || (OptionFound(args, sp, "-f")))
         {
             *sp = ' ';
             *(sp + 1) = ' ';
@@ -1115,7 +1115,7 @@ static void DoExec(ServerConnectionState *conn, char *sendbuffer, char *args)
                 *(sp + i) = ' ';
             }
         }
-        else if (OptionFound(args, sp, "--define") || OptionFound(args, sp, "-D"))
+        else if ((OptionFound(args, sp, "--define")) || (OptionFound(args, sp, "-D")))
         {
             CfOut(cf_verbose, "", "Attempt to activate a predefined role..\n");
 
@@ -1261,7 +1261,7 @@ static int VerifyConnection(ServerConnectionState *conn, char buf[CF_BUFSIZE])
    on trust. Once we have a positive key ID, the IP address is irrelevant fr authentication...
    We can save a lot of time by not looking this up ... */
 
-    if ((conn->trust == false) || IsMatchItemIn(SV.skipverify, MapAddress(conn->ipaddr)))
+    if ((conn->trust == false) || (IsMatchItemIn(SV.skipverify, MapAddress(conn->ipaddr))))
     {
         CfOut(cf_verbose, "", "Allowing %s to connect without (re)checking ID\n", ip_assert);
         CfOut(cf_verbose, "", "Non-verified Host ID is %s (Using skipverify)\n", dns_assert);
@@ -1578,8 +1578,8 @@ static int AccessControl(const char *req_path, ServerConnectionState *conn, int 
         strncpy(transpath, ap->path, CF_BUFSIZE - 1);
         MapName(transpath);
 
-        if ((strlen(transrequest) > strlen(transpath)) && strncmp(transpath, transrequest, strlen(transpath)) == 0
-            && transrequest[strlen(transpath)] == FILE_SEPARATOR)
+        if ((strlen(transrequest) > strlen(transpath)) && (strncmp(transpath, transrequest, strlen(transpath)) == 0)
+            && (transrequest[strlen(transpath)] == FILE_SEPARATOR))
         {
             res = true;         /* Substring means must be a / to link, else just a substring og filename */
         }
@@ -1608,7 +1608,7 @@ static int AccessControl(const char *req_path, ServerConnectionState *conn, int 
                 continue;
             }
 
-            if (!encrypt && (ap->encrypt == true))
+            if ((!encrypt) && (ap->encrypt == true))
             {
                 CfOut(cf_error, "", "File %s requires encrypt connection...will not serve\n", transpath);
                 access = false;
@@ -1617,14 +1617,14 @@ static int AccessControl(const char *req_path, ServerConnectionState *conn, int 
             {
                 CfDebug("Checking whether to map root privileges..\n");
 
-                if (IsMatchItemIn(ap->maproot, MapAddress(conn->ipaddr)) || IsRegexItemIn(ap->maproot, conn->hostname))
+                if ((IsMatchItemIn(ap->maproot, MapAddress(conn->ipaddr))) || (IsRegexItemIn(ap->maproot, conn->hostname)))
                 {
                     conn->maproot = true;
                     CfOut(cf_verbose, "", "Mapping root privileges to access non-root files\n");
                 }
 
-                if (IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr))
-                    || IsRegexItemIn(ap->accesslist, conn->hostname))
+                if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)))
+                    || (IsRegexItemIn(ap->accesslist, conn->hostname)))
                 {
                     access = true;
                     CfDebug("Access privileges - match found\n");
@@ -1713,7 +1713,7 @@ static int LiteralAccessControl(char *in, ServerConnectionState *conn, int encry
         {
             CfOut(cf_verbose, "", "Found a matching rule in access list (%s in %s)\n", name, ap->path);
 
-            if (!ap->literal && !ap->variable)
+            if ((!ap->literal) && (!ap->variable))
             {
                 CfOut(cf_error, "",
                       "Variable/query \"%s\" requires a literal server item...cannot set variable directly by path\n",
@@ -1722,7 +1722,7 @@ static int LiteralAccessControl(char *in, ServerConnectionState *conn, int encry
                 break;
             }
 
-            if (!encrypt && (ap->encrypt == true))
+            if ((!encrypt) && (ap->encrypt == true))
             {
                 CfOut(cf_error, "", "Variable %s requires encrypt connection...will not serve\n", name);
                 access = false;
@@ -1732,7 +1732,7 @@ static int LiteralAccessControl(char *in, ServerConnectionState *conn, int encry
             {
                 CfDebug("Checking whether to map root privileges..\n");
 
-                if (IsMatchItemIn(ap->maproot, MapAddress(conn->ipaddr)) || IsRegexItemIn(ap->maproot, conn->hostname))
+                if ((IsMatchItemIn(ap->maproot, MapAddress(conn->ipaddr))) || (IsRegexItemIn(ap->maproot, conn->hostname)))
                 {
                     conn->maproot = true;
                     CfOut(cf_verbose, "", "Mapping root privileges\n");
@@ -1742,8 +1742,8 @@ static int LiteralAccessControl(char *in, ServerConnectionState *conn, int encry
                     CfOut(cf_verbose, "", "No root privileges granted\n");
                 }
 
-                if (IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr))
-                    || IsRegexItemIn(ap->accesslist, conn->hostname))
+                if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)))
+                    || (IsRegexItemIn(ap->accesslist, conn->hostname)))
                 {
                     access = true;
                     CfDebug("Access privileges - match found\n");
@@ -1756,8 +1756,8 @@ static int LiteralAccessControl(char *in, ServerConnectionState *conn, int encry
     {
         if (strcmp(ap->path, name) == 0)
         {
-            if (IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr))
-                || IsRegexItemIn(ap->accesslist, conn->hostname))
+            if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)))
+                || (IsRegexItemIn(ap->accesslist, conn->hostname)))
             {
                 access = false;
                 CfOut(cf_verbose, "", "Host %s explicitly denied access to %s\n", conn->hostname, name);
@@ -1869,7 +1869,7 @@ static Item *ContextAccessControl(char *in, ServerConnectionState *conn, int enc
                     continue;
                 }
 
-                if (!encrypt && (ap->encrypt == true))
+                if ((!encrypt) && (ap->encrypt == true))
                 {
                     CfOut(cf_error, "", "Context %s requires encrypt connection...will not serve\n", ip->name);
                     access = false;
@@ -1879,8 +1879,8 @@ static Item *ContextAccessControl(char *in, ServerConnectionState *conn, int enc
                 {
                     CfDebug("Checking whether to map root privileges..\n");
 
-                    if (IsMatchItemIn(ap->maproot, MapAddress(conn->ipaddr))
-                        || IsRegexItemIn(ap->maproot, conn->hostname))
+                    if ((IsMatchItemIn(ap->maproot, MapAddress(conn->ipaddr)))
+                        || (IsRegexItemIn(ap->maproot, conn->hostname)))
                     {
                         conn->maproot = true;
                         CfOut(cf_verbose, "", "Mapping root privileges\n");
@@ -1890,8 +1890,8 @@ static Item *ContextAccessControl(char *in, ServerConnectionState *conn, int enc
                         CfOut(cf_verbose, "", "No root privileges granted\n");
                     }
 
-                    if (IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr))
-                        || IsRegexItemIn(ap->accesslist, conn->hostname))
+                    if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)))
+                        || (IsRegexItemIn(ap->accesslist, conn->hostname)))
                     {
                         access = true;
                         CfDebug("Access privileges - match found\n");
@@ -1904,8 +1904,8 @@ static Item *ContextAccessControl(char *in, ServerConnectionState *conn, int enc
         {
             if (strcmp(ap->path, ip->name) == 0)
             {
-                if (IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr))
-                    || IsRegexItemIn(ap->accesslist, conn->hostname))
+                if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)))
+                    || (IsRegexItemIn(ap->accesslist, conn->hostname)))
                 {
                     access = false;
                     CfOut(cf_verbose, "", "Host %s explicitly denied access to context %s\n", conn->hostname, ip->name);
@@ -1977,10 +1977,11 @@ static int AuthorizeRoles(ServerConnectionState *conn, char *args)
             if (FullTextMatch(ap->path, rp->item))
             {
                 /* We have a pattern covering this class - so are we allowed to activate it? */
-                if (IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)) ||
-                    IsRegexItemIn(ap->accesslist, conn->hostname) ||
-                    IsRegexItemIn(ap->accesslist, userid1) ||
-                    IsRegexItemIn(ap->accesslist, userid2) || IsRegexItemIn(ap->accesslist, conn->username))
+                if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr))) ||
+                    (IsRegexItemIn(ap->accesslist, conn->hostname)) ||
+                    (IsRegexItemIn(ap->accesslist, userid1)) ||
+                    (IsRegexItemIn(ap->accesslist, userid2)) ||
+                    (IsRegexItemIn(ap->accesslist, conn->username)))
                 {
                     CfOut(cf_verbose, "", "Attempt to define role/class %s is permitted", ScalarValue(rp));
                     permitted = true;
@@ -2024,7 +2025,7 @@ static int AuthenticationDialogue(ServerConnectionState *conn, char *recvbuffer,
     int digestLen = 0;
     enum cfhashes digestType;
 
-    if (PRIVKEY == NULL || PUBKEY == NULL)
+    if ((PRIVKEY == NULL) || (PUBKEY == NULL))
     {
         CfOut(cf_error, "", "No public/private key pair exists, create one with cf-key\n");
         return false;
@@ -2048,7 +2049,7 @@ static int AuthenticationDialogue(ServerConnectionState *conn, char *recvbuffer,
 
     sscanf(recvbuffer, "%s %c %u %u %c", sauth, &iscrypt, &crypt_len, &nonce_len, &enterprise_field);
 
-    if (crypt_len == 0 || nonce_len == 0 || strlen(sauth) == 0)
+    if ((crypt_len == 0) || (nonce_len == 0) || (strlen(sauth) == 0))
     {
         CfOut(cf_inform, "", "Protocol format error in authentation from IP %s\n", conn->hostname);
         return false;
@@ -2415,7 +2416,7 @@ static int StatFile(ServerConnectionState *conn, char *sendbuffer, char *ofilena
     }
 #endif /* NOT MINGW */
 
-    if (!islink && (cfstat(filename, &statbuf) == -1))
+    if ((!islink) && (cfstat(filename, &statbuf) == -1))
     {
         CfOut(cf_verbose, "stat", "BAD: unable to stat file %s\n", filename);
         SendTransaction(conn->sd_reply, sendbuffer, 0, CF_DONE);
@@ -2777,7 +2778,7 @@ static void CompareLocalHash(ServerConnectionState *conn, char *sendbuffer, char
 
     HashFile(filename, digest2, CF_DEFAULT_DIGEST);
 
-    if (HashesMatch(digest1, digest2, CF_DEFAULT_DIGEST) || HashesMatch(digest1, digest2, cf_md5))
+    if ((HashesMatch(digest1, digest2, CF_DEFAULT_DIGEST)) || (HashesMatch(digest1, digest2, cf_md5)))
     {
         sprintf(sendbuffer, "%s", CFD_FALSE);
         CfDebug("Hashes matched ok\n");
@@ -3048,7 +3049,7 @@ static int OptionFound(char *args, char *pos, char *word)
 
 /* Single options do not have to have spaces between */
 
-    if (strlen(word) == 2 && strncmp(pos, word, 2) == 0)
+    if ((strlen(word) == 2) && (strncmp(pos, word, 2) == 0))
     {
         return true;
     }
@@ -3064,7 +3065,7 @@ static int OptionFound(char *args, char *pos, char *word)
     {
         return true;
     }
-    else if (*(pos - 1) == ' ' && (pos[len] == ' ' || pos[len] == '\0'))
+    else if ((*(pos - 1) == ' ') && ((pos[len] == ' ') || (pos[len] == '\0')))
     {
         return true;
     }
@@ -3174,7 +3175,7 @@ static int TransferRights(char *filename, int sd, ServerFileGetState *args, char
 
     uid_t uid = (args->connect)->uid;
 
-    if (uid != 0 && !args->connect->maproot)    /* should remote root be local root */
+    if ((uid != 0) && (!args->connect->maproot))    /* should remote root be local root */
     {
         if (sb->st_uid == uid)
         {
@@ -3271,7 +3272,7 @@ static int CheckStoreKey(ServerConnectionState *conn, RSA *key)
 
 /* Finally, if we're still here, we should consider trusting a new key ... */
 
-    if ((SV.trustkeylist != NULL) && IsMatchItemIn(SV.trustkeylist, MapAddress(conn->ipaddr)))
+    if ((SV.trustkeylist != NULL) && (IsMatchItemIn(SV.trustkeylist, MapAddress(conn->ipaddr))))
     {
         CfOut(cf_verbose, "", "Host %s/%s was found in the list of hosts to trust\n", conn->hostname, conn->ipaddr);
         conn->trust = true;

--- a/src/server_transform.c
+++ b/src/server_transform.c
@@ -457,7 +457,7 @@ static void KeepContextBundles(Policy *policy, const ReportContext *report_conte
 
             for (sp = bp->subtypes; sp != NULL; sp = sp->next)  /* get schedule */
             {
-                if (strcmp(sp->name, "vars") != 0 && strcmp(sp->name, "classes") != 0)
+                if ((strcmp(sp->name, "vars") != 0) && (strcmp(sp->name, "classes") != 0))
                 {
                     continue;
                 }
@@ -499,7 +499,7 @@ static void KeepPromiseBundles(Policy *policy, const ReportContext *report_conte
 
             for (sp = bp->subtypes; sp != NULL; sp = sp->next)  /* get schedule */
             {
-                if (strcmp(sp->name, "access") != 0 && strcmp(sp->name, "roles") != 0)
+                if ((strcmp(sp->name, "access") != 0) && (strcmp(sp->name, "roles") != 0))
                 {
                     continue;
                 }
@@ -549,25 +549,25 @@ static void KeepServerPromise(Promise *pp)
 
     sp = (char *) GetConstraintValue("resource_type", pp, CF_SCALAR);
 
-    if (strcmp(pp->agentsubtype, "access") == 0 && sp && strcmp(sp, "literal") == 0)
+    if ((strcmp(pp->agentsubtype, "access") == 0) && sp && (strcmp(sp, "literal") == 0))
     {
         KeepLiteralAccessPromise(pp, "literal");
         return;
     }
 
-    if (strcmp(pp->agentsubtype, "access") == 0 && sp && strcmp(sp, "variable") == 0)
+    if ((strcmp(pp->agentsubtype, "access") == 0) && sp && (strcmp(sp, "variable") == 0))
     {
         KeepLiteralAccessPromise(pp, "variable");
         return;
     }
     
-    if (strcmp(pp->agentsubtype, "access") == 0 && sp && strcmp(sp, "query") == 0)
+    if ((strcmp(pp->agentsubtype, "access") == 0) && sp && (strcmp(sp, "query") == 0))
     {
         KeepQueryAccessPromise(pp, "query");
         return;
     }
 
-    if (strcmp(pp->agentsubtype, "access") == 0 && sp && strcmp(sp, "context") == 0)
+    if ((strcmp(pp->agentsubtype, "access") == 0) && sp && (strcmp(sp, "context") == 0))
     {
         KeepLiteralAccessPromise(pp, "context");
         return;
@@ -672,7 +672,7 @@ void KeepLiteralAccessPromise(Promise *pp, char *type)
     Auth *ap = NULL, *dp = NULL;
     char *handle = GetConstraintValue("handle", pp, CF_SCALAR);
 
-    if (handle == NULL && strcmp(type,"literal") == 0)
+    if ((handle == NULL) && (strcmp(type,"literal") == 0))
     {
         CfOut(cf_error, "", "Access to literal server data requires you to define a promise handle for reference");
         return;
@@ -895,7 +895,7 @@ static void KeepServerRolePromise(Promise *pp)
 
         default:
 
-            if (strcmp(cp->lval, "comment") == 0 || strcmp(cp->lval, "handle") == 0)
+            if ((strcmp(cp->lval, "comment") == 0) || (strcmp(cp->lval, "handle") == 0))
             {
             }
             else

--- a/src/signals.c
+++ b/src/signals.c
@@ -52,8 +52,8 @@ void HandleSignals(int signum)
     CfOut(cf_error, "", "This sub-task started really at %s\n", cf_ctime(&CFINITSTARTTIME));
     fflush(stdout);
 
-    if (signum == SIGTERM || signum == SIGINT || signum == SIGHUP || signum == SIGSEGV || signum == SIGKILL
-        || signum == SIGPIPE)
+    if ((signum == SIGTERM) || (signum == SIGINT) || (signum == SIGHUP) || (signum == SIGSEGV) || (signum == SIGKILL)
+        || (signum == SIGPIPE))
     {
         exit(0);
     }

--- a/src/sort.c
+++ b/src/sort.c
@@ -75,7 +75,7 @@ static void *Sort(void *list, LessFn less, GetNextElementFn next, PutNextElement
             qsize = insize;
 
             /* now we have two lists; merge them */
-            while (psize > 0 || (qsize > 0 && q))
+            while ((psize > 0) || ((qsize > 0) && q))
             {
                 /* decide whether next element of merge comes from p or q */
                 if (psize == 0)
@@ -85,7 +85,7 @@ static void *Sort(void *list, LessFn less, GetNextElementFn next, PutNextElement
                     q = next(q);
                     qsize--;
                 }
-                else if (qsize == 0 || !q)
+                else if ((qsize == 0) || (!q))
                 {
                     /* q is empty; e must come from p. */
                     e = p;

--- a/src/string_lib.c
+++ b/src/string_lib.c
@@ -52,7 +52,7 @@ char ToLower(char ch)
 
 char ToUpper(char ch)
 {
-    if (isdigit((int) ch) || ispunct((int) ch))
+    if ((isdigit((int) ch)) || (ispunct((int) ch)))
     {
         return (ch);
     }
@@ -153,7 +153,7 @@ int StringSafeCompare(const char *a, const char *b)
         return 0;
     }
 
-    if (a == NULL || b == NULL)
+    if ((a == NULL) || (b == NULL))
     {
         return -1;
     }
@@ -168,7 +168,7 @@ bool StringSafeEqual(const char *a, const char *b)
         return true;
     }
 
-    if (a == NULL || b == NULL)
+    if ((a == NULL) || (b == NULL))
     {
         return false;
     }
@@ -229,12 +229,12 @@ int GetStringListElement(char *strList, int index, char *outBuf, int outBufSz)
 
     for (sp = strList; *sp != '\0'; sp++)
     {
-        if ((sp[0] == '{' || sp[0] == ',') && sp[1] == '\'')
+        if (((sp[0] == '{') || (sp[0] == ',')) && (sp[1] == '\''))
         {
             elStart = sp + 2;
         }
 
-        else if ((sp[0] == '\'') && (sp[1] == ',' || sp[1] == '}'))
+        else if ((sp[0] == '\'') && ((sp[1] == ',') || (sp[1] == '}')))
         {
             elEnd = sp;
 
@@ -267,7 +267,7 @@ char *SearchAndReplace(const char *source, const char *search, const char *repla
 {
     const char *source_ptr = source;
 
-    if (source == NULL || search == NULL || replace == NULL)
+    if ((source == NULL) || (search == NULL) || (replace == NULL))
     {
         FatalError("Programming error: NULL argument is passed to SearchAndReplace");
     }
@@ -512,7 +512,7 @@ bool StringMatchFull(const char *regex, const char *str)
 
     if (StringMatchInternal(regex, str, &start, &end))
     {
-        return start == 0 && end == strlen(str);
+        return (start == 0) && (end == strlen(str));
     }
     else
     {
@@ -619,7 +619,7 @@ int SubStrnCopyChr(char *to, const char *from, int len, char sep)
         return 0;
     }
 
-    if (from && strlen(from) == 0)
+    if (from && (strlen(from) == 0))
     {
         return 0;
     }
@@ -631,7 +631,7 @@ int SubStrnCopyChr(char *to, const char *from, int len, char sep)
             break;
         }
 
-        if (*sp == '\\' && *(sp + 1) == sep)
+        if ((*sp == '\\') && (*(sp + 1) == sep))
         {
             *sto++ = *++sp;
         }
@@ -659,14 +659,14 @@ int CountChar(const char *string, char sep)
         return 0;
     }
 
-    if (string && strlen(string) == 0)
+    if (string && (strlen(string) == 0))
     {
         return 0;
     }
 
     for (const char *sp = string; *sp != '\0'; sp++)
     {
-        if (*sp == '\\' && *(sp + 1) == sep)
+        if ((*sp == '\\') && (*(sp + 1) == sep))
         {
             ++sp;
         }

--- a/src/sysinfo.c
+++ b/src/sysinfo.c
@@ -166,7 +166,7 @@ void CalculateDomainName(const char *nodename, const char *dnsname, char *fqname
         strlcpy(fqname, nodename, CF_BUFSIZE);
     }
 
-    if (strncmp(nodename, fqname, strlen(nodename)) == 0 && fqname[strlen(nodename)] == '.')
+    if ((strncmp(nodename, fqname, strlen(nodename)) == 0) && (fqname[strlen(nodename)] == '.'))
     {
         /* If hostname is not qualified */
         strcpy(domain, fqname + strlen(nodename) + 1);
@@ -396,7 +396,7 @@ void GetNameInfo3()
     {
         snprintf(shortname, CF_MAXVARSIZE - 1, "%s", CanonifyName(components[i]));
 
-        if (VSYSTEMHARDCLASS == mingw || VSYSTEMHARDCLASS == cfnt)
+        if ((VSYSTEMHARDCLASS == mingw) || (VSYSTEMHARDCLASS == cfnt))
         {
             // twin has own dir, and is named agent
             if (i == 0)
@@ -431,7 +431,7 @@ void GetNameInfo3()
     {
         snprintf(shortname, CF_MAXVARSIZE - 1, "%s", CanonifyName(components[0]));
 
-        if (VSYSTEMHARDCLASS == mingw || VSYSTEMHARDCLASS == cfnt)
+        if ((VSYSTEMHARDCLASS == mingw) || (VSYSTEMHARDCLASS == cfnt))
         {
             snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin%c%s.exe", CFWORKDIR, FILE_SEPARATOR, FILE_SEPARATOR,
                      components[1]);

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -54,7 +54,7 @@ static bool WriteLockData(CF_DB *dbp, char *lock_id, LockData *lock_data);
 
 void SummarizeTransaction(Attributes attr, const Promise *pp, const char *logname)
 {
-    if (logname && attr.transaction.log_string)
+    if (logname && (attr.transaction.log_string))
     {
         char buffer[CF_EXPANDSIZE];
 
@@ -88,7 +88,7 @@ void SummarizeTransaction(Attributes attr, const Promise *pp, const char *lognam
     }
     else if (attr.transaction.log_failed)
     {
-        if (logname && strcmp(logname, attr.transaction.log_failed) == 0)
+        if (logname && (strcmp(logname, attr.transaction.log_failed) == 0))
         {
             cfPS(cf_log, CF_NOP, "", pp, attr, "%s", attr.transaction.log_string);
         }
@@ -271,7 +271,7 @@ CfLock AcquireLock(char *operand, char *host, time_t now, Attributes attr, Promi
 
                     err = GracefulTerminate(pid);
 
-                    if (err || errno == ESRCH || errno == ETIMEDOUT)
+                    if (err || (errno == ESRCH) || (errno == ETIMEDOUT))
                     {
                         LogLockCompletion(cflog, pid, "Lock expired, process killed", cc_operator, cc_operand);
                         unlink(cflock);
@@ -904,7 +904,7 @@ int ShiftChange(void)
 
 bool EnforcePromise(enum cfopaction action)
 {
-    return (!DONTDO && action != cfa_warn);
+    return ((!DONTDO) && (action != cfa_warn));
 }
 
 static char SYSLOG_HOST[CF_BUFSIZE] = "localhost";

--- a/src/unix.c
+++ b/src/unix.c
@@ -146,7 +146,7 @@ int IsExecutable(const char *file)
         return false;
     }
 
-    if (getuid() == sb.st_uid || getuid() == 0)
+    if ((getuid() == sb.st_uid) || (getuid() == 0))
     {
         if (sb.st_mode & 0100)
         {
@@ -302,7 +302,7 @@ int DoAllSignals(Item *siglist, Attributes a, Promise *pp)
 
             if (!DONTDO)
             {
-                if (signal == SIGKILL || signal == SIGTERM)
+                if ((signal == SIGKILL) || (signal == SIGTERM))
                 {
                     killed = true;
                 }
@@ -431,7 +431,7 @@ int LoadProcessTable(Item **procdata)
         memset(vbuff, 0, CF_BUFSIZE);
         CfReadLine(vbuff, CF_BUFSIZE, prp);
 
-        for (sp = vbuff + strlen(vbuff) - 1; sp > vbuff && isspace((int)*sp); sp--)
+        for (sp = vbuff + strlen(vbuff) - 1; (sp > vbuff) && (isspace((int)*sp)); sp--)
         {
             *sp = '\0';
         }
@@ -540,7 +540,7 @@ static void GetMacAddress(enum cfagenttype ag, int fd, struct ifreq *ifr, struct
 {
     char name[CF_MAXVARSIZE];
 
-    if (ag != cf_know && ag != cf_gendoc)
+    if ((ag != cf_know) && (ag != cf_gendoc))
     {
         snprintf(name, CF_MAXVARSIZE, "hardware_mac[%s]", ifp->ifr_name);
     }
@@ -612,7 +612,7 @@ void GetInterfacesInfo(enum cfagenttype ag)
 # ifdef SIOCGIFCONF
     if (ioctl(fd, SIOCGIFCONF, &list) == -1 || (list.ifc_len < (sizeof(struct ifreq))))
 # else
-    if (ioctl(fd, OSIOCGIFCONF, &list) == -1 || (list.ifc_len < (sizeof(struct ifreq))))
+    if ((ioctl(fd, OSIOCGIFCONF, &list) == -1) || (list.ifc_len < (sizeof(struct ifreq))))
 # endif
     {
         CfOut(cf_error, "ioctl", "Couldn't get interfaces - old kernel? Try setting CF_IFREQ to 1024");
@@ -630,7 +630,7 @@ void GetInterfacesInfo(enum cfagenttype ag)
             continue;
         }
 
-        if (ifp->ifr_name == NULL || strlen(ifp->ifr_name) == 0)
+        if ((ifp->ifr_name == NULL) || (strlen(ifp->ifr_name) == 0))
         {
             continue;
         }
@@ -691,7 +691,7 @@ void GetInterfacesInfo(enum cfagenttype ag)
                 continue;
             }
 
-            if ((ifr.ifr_flags & IFF_UP) && !(ifr.ifr_flags & IFF_LOOPBACK))
+            if ((ifr.ifr_flags & IFF_UP) && (!(ifr.ifr_flags & IFF_LOOPBACK)))
             {
                 sin = (struct sockaddr_in *) &ifp->ifr_addr;
 
@@ -788,7 +788,7 @@ void GetInterfacesInfo(enum cfagenttype ag)
 
                 strcpy(ip, inet_ntoa(sin->sin_addr));
 
-                if (ag != cf_know && ag != cf_gendoc)
+                if ((ag != cf_know) && (ag != cf_gendoc))
                 {
                     snprintf(name, CF_MAXVARSIZE - 1, "ipv4[%s]", CanonifyName(ifp->ifr_name));
                 }
@@ -807,7 +807,7 @@ void GetInterfacesInfo(enum cfagenttype ag)
                     {
                         *sp = '\0';
 
-                        if (ag != cf_know && ag != cf_gendoc)
+                        if ((ag != cf_know) && (ag != cf_gendoc))
                         {
                             snprintf(name, CF_MAXVARSIZE - 1, "ipv4_%d[%s]", i--, CanonifyName(ifp->ifr_name));
                         }
@@ -919,7 +919,7 @@ static void FindV6InterfacesInfo(void)
                     }
                 }
 
-                if (IsIPV6Address(ip->name) && (strcmp(ip->name, "::1") != 0))
+                if ((IsIPV6Address(ip->name)) && ((strcmp(ip->name, "::1") != 0)))
                 {
                     CfOut(cf_verbose, "", "Found IPv6 address %s\n", ip->name);
                     AppendItem(&IPADDRESSES, ip->name, "");

--- a/src/vercmp.c
+++ b/src/vercmp.c
@@ -46,7 +46,7 @@ static VersionCmpResult InvertResult(VersionCmpResult result)
 
 static VersionCmpResult AndResults(VersionCmpResult lhs, VersionCmpResult rhs)
 {
-    if (lhs == VERCMP_ERROR || rhs == VERCMP_ERROR)
+    if ((lhs == VERCMP_ERROR) || (rhs == VERCMP_ERROR))
     {
         return VERCMP_ERROR;
     }

--- a/src/vercmp_internal.c
+++ b/src/vercmp_internal.c
@@ -47,7 +47,7 @@ bool ComparePackageVersionsInternal(const char *v1, const char *v2, enum version
 
     CfOut(cf_verbose, "", " -> Check for compatible versioning model in (%s,%s)\n", v1, v2);
 
-    for (rp_pr = separators_pr, rp_in = separators_in; rp_pr != NULL && rp_in != NULL;
+    for (rp_pr = separators_pr, rp_in = separators_in; (rp_pr != NULL) && (rp_in != NULL);
          rp_pr = rp_pr->next, rp_in = rp_in->next)
     {
         if (strcmp(rp_pr->item, rp_in->item) != 0)
@@ -56,7 +56,7 @@ bool ComparePackageVersionsInternal(const char *v1, const char *v2, enum version
             break;
         }
 
-        if (rp_pr->next == NULL && rp_in->next == NULL)
+        if ((rp_pr->next == NULL) && (rp_in->next == NULL))
         {
             result = true;
             break;
@@ -76,7 +76,7 @@ bool ComparePackageVersionsInternal(const char *v1, const char *v2, enum version
 
     if (result)
     {
-        for (rp_pr = numbers_pr, rp_in = numbers_in; rp_pr != NULL && rp_in != NULL;
+        for (rp_pr = numbers_pr, rp_in = numbers_in; (rp_pr != NULL) && (rp_in != NULL);
              rp_pr = rp_pr->next, rp_in = rp_in->next)
         {
             cmp_result = strcmp(rp_pr->item, rp_in->item);
@@ -150,14 +150,14 @@ bool ComparePackageVersionsInternal(const char *v1, const char *v2, enum version
 
         if (rp_pr != NULL)
         {
-            if (cmp == cfa_lt || cmp == cfa_le)
+            if ((cmp == cfa_lt) || (cmp == cfa_le))
             {
                 version_matched = true;
             }
         }
         if (rp_in != NULL)
         {
-            if (cmp == cfa_gt || cmp == cfa_ge)
+            if ((cmp == cfa_gt) || (cmp == cfa_ge))
             {
                 version_matched = true;
             }

--- a/src/verify_databases.c
+++ b/src/verify_databases.c
@@ -163,7 +163,7 @@ static void VerifySQLPromise(Attributes a, Promise *pp)
     {
         /* If we haven't said create then db should already exist */
 
-        if (a.database.operation && strcmp(a.database.operation, "create") != 0)
+        if ((a.database.operation) && (strcmp(a.database.operation, "create") != 0))
         {
             CfOut(cf_error, "", "Could not connect an existing database %s - check server configuration?\n", database);
             PromiseRef(cf_error, pp);
@@ -175,7 +175,7 @@ static void VerifySQLPromise(Attributes a, Promise *pp)
 
 /* Check change of existential constraints */
 
-    if (a.database.operation && strcmp(a.database.operation, "create") == 0)
+    if ((a.database.operation) && (strcmp(a.database.operation, "create") == 0))
     {
         CfConnectDB(&cfdb, a.database.db_server_type, a.database.db_server_host, a.database.db_server_owner,
                     a.database.db_server_password, a.database.db_connect_db);
@@ -188,7 +188,7 @@ static void VerifySQLPromise(Attributes a, Promise *pp)
 
         /* Don't drop the db if we really want to drop a table */
 
-        if (strlen(table) == 0 || (strlen(table) > 0 && strcmp(a.database.operation, "drop") != 0))
+        if ((strlen(table) == 0) || ((strlen(table) > 0) && (strcmp(a.database.operation, "drop") != 0)))
         {
             VerifyDatabasePromise(&cfdb, database, a, pp);
         }
@@ -286,9 +286,9 @@ static int VerifyDatabasePromise(CfdbConn *cfdb, char *database, Attributes a, P
         CfOut(cf_verbose, "", " !! Database \"%s\" does not seem to exist on this connection", database);
     }
 
-    if (a.database.operation && strcmp(a.database.operation, "drop") == 0)
+    if ((a.database.operation) && (strcmp(a.database.operation, "drop") == 0))
     {
-        if (a.transaction.action != cfa_warn && !DONTDO)
+        if (((a.transaction.action) != cfa_warn) && (!DONTDO))
         {
             CfOut(cf_verbose, "", " -> Attempting to delete the database %s", database);
             snprintf(query, CF_MAXVARSIZE - 1, "drop database %s", database);
@@ -302,9 +302,9 @@ static int VerifyDatabasePromise(CfdbConn *cfdb, char *database, Attributes a, P
         }
     }
 
-    if (a.database.operation && strcmp(a.database.operation, "create") == 0)
+    if ((a.database.operation) && (strcmp(a.database.operation, "create") == 0))
     {
-        if (a.transaction.action != cfa_warn && !DONTDO)
+        if (((a.transaction.action) != cfa_warn) && (!DONTDO))
         {
             CfOut(cf_verbose, "", " -> Attempting to create the database %s", database);
             snprintf(query, CF_MAXVARSIZE - 1, "create database %s", database);
@@ -328,14 +328,14 @@ static int CheckDatabaseSanity(Attributes a, Promise *pp)
     Rlist *rp;
     int retval = true, commas = 0;
 
-    if (a.database.type && strcmp(a.database.type, "ms_registry") == 0)
+    if ((a.database.type) && (strcmp(a.database.type, "ms_registry") == 0))
     {
         retval = CheckRegistrySanity(a, pp);
     }
-    else if (a.database.type && strcmp(a.database.type, "sql") == 0)
+    else if ((a.database.type) && (strcmp(a.database.type, "sql") == 0))
     {
-        if (strchr(pp->promiser, '.') == NULL && strchr(pp->promiser, '/') == NULL
-            && strchr(pp->promiser, '\\') == NULL)
+        if ((strchr(pp->promiser, '.') == NULL) && (strchr(pp->promiser, '/') == NULL)
+            && (strchr(pp->promiser, '\\') == NULL))
         {
             if (a.database.columns)
             {
@@ -372,7 +372,7 @@ static int CheckDatabaseSanity(Attributes a, Promise *pp)
         {
             commas = CountChar(rp->item, ',');
 
-            if (commas > 2 && commas < 1)
+            if ((commas > 2) && (commas < 1))
             {
                 CfOut(cf_error, "", "SQL Column format should be NAME,TYPE[,SIZE]");
                 retval = false;
@@ -381,12 +381,12 @@ static int CheckDatabaseSanity(Attributes a, Promise *pp)
 
     }
 
-    if (a.database.operation && strcmp(a.database.operation, "create") == 0)
+    if ((a.database.operation) && (strcmp(a.database.operation, "create") == 0))
     {
     }
 
-    if (a.database.operation
-        && (strcmp(a.database.operation, "delete") == 0 || strcmp(a.database.operation, "drop") == 0))
+    if ((a.database.operation)
+        && ((strcmp(a.database.operation, "delete") == 0) || (strcmp(a.database.operation, "drop") == 0)))
     {
         if (pp->ref == NULL)
         {
@@ -405,7 +405,7 @@ static int CheckRegistrySanity(Attributes a, Promise *pp)
 
     ValidateRegistryPromiser(pp->promiser, a, pp);
 
-    if (a.database.operation && strcmp(a.database.operation, "create") == 0)
+    if ((a.database.operation) && (strcmp(a.database.operation, "create") == 0))
     {
         if (a.database.rows == NULL)
         {
@@ -419,8 +419,8 @@ static int CheckRegistrySanity(Attributes a, Promise *pp)
         }
     }
 
-    if (a.database.operation
-        && (strcmp(a.database.operation, "delete") == 0 || strcmp(a.database.operation, "drop") == 0))
+    if ((a.database.operation)
+        && ((strcmp(a.database.operation, "delete") == 0) || (strcmp(a.database.operation, "drop") == 0)))
     {
         if (a.database.columns == NULL)
         {
@@ -512,9 +512,9 @@ static int VerifyTablePromise(CfdbConn *cfdb, char *table_path, Rlist *columns, 
     {
         CfOut(cf_error, "", " !! The database did not contain the promised table \"%s\"\n", table_path);
 
-        if (a.database.operation && strcmp(a.database.operation, "create") == 0)
+        if ((a.database.operation) && (strcmp(a.database.operation, "create") == 0))
         {
-            if (!DONTDO && a.transaction.action != cfa_warn)
+            if ((!DONTDO) && ((a.transaction.action) != cfa_warn))
             {
                 cfPS(cf_error, CF_CHG, "", pp, a, " -> Database.table %s doesn't seem to exist, creating\n",
                      table_path);
@@ -575,7 +575,7 @@ static int VerifyTablePromise(CfdbConn *cfdb, char *table_path, Rlist *columns, 
 
         CfOut(cf_verbose, "", "    ... discovered column (%s,%s,%d)", name, type, size);
 
-        if (sizestr && size == CF_NOINT)
+        if (sizestr && (size == CF_NOINT))
         {
             cfPS(cf_verbose, CF_NOP, "", pp, a,
                  " !! Integer size of SQL datatype could not be determined or was not specified - invalid promise.");
@@ -621,7 +621,7 @@ static int VerifyTablePromise(CfdbConn *cfdb, char *table_path, Rlist *columns, 
             cfPS(cf_error, CF_FAIL, "", pp, a,
                  "Column \"%s\" found in database.table \"%s\" is not part of its promise.", name, table_path);
 
-            if (a.database.operation && strcmp(a.database.operation, "drop") == 0)
+            if ((a.database.operation) && (strcmp(a.database.operation, "drop") == 0))
             {
                 cfPS(cf_error, CF_FAIL, "", pp, a,
                      "Cfengine will not promise to repair this, as the operation is potentially too destructive.");
@@ -636,7 +636,7 @@ static int VerifyTablePromise(CfdbConn *cfdb, char *table_path, Rlist *columns, 
 
 /* Now look for deviations - only if we have promised to create missing */
 
-    if (a.database.operation && strcmp(a.database.operation, "drop") == 0)
+    if ((a.database.operation) && (strcmp(a.database.operation, "drop") == 0))
     {
         return retval;
     }
@@ -650,7 +650,7 @@ static int VerifyTablePromise(CfdbConn *cfdb, char *table_path, Rlist *columns, 
                 CfOut(cf_error, "", " !! Promised column \"%s\" missing from database table %s", name_table[i],
                       pp->promiser);
 
-                if (!DONTDO && a.transaction.action != cfa_warn)
+                if ((!DONTDO) && ((a.transaction.action) != cfa_warn))
                 {
                     if (size_table[i] > 0)
                     {
@@ -935,7 +935,7 @@ static void DeleteSQLColumns(char **name_table, char **type_table, int *size_tab
 {
     int i;
 
-    if (name_table == NULL || type_table == NULL || size_table == NULL)
+    if ((name_table == NULL) || (type_table == NULL) || (size_table == NULL))
     {
         return;
     }
@@ -974,8 +974,8 @@ static int CheckSQLDataType(char *type, char *ref_type, Promise *pp)
 
     for (i = 0; aliases[i][0] != NULL; i++)
     {
-        if (strcmp(ref_type, aliases[i][0]) == 0 || strcmp(ref_type, aliases[i][1]) == 0
-            || strcmp(type, aliases[i][0]) == 0 || strcmp(type, aliases[i][1]) == 0)
+        if ((strcmp(ref_type, aliases[i][0]) == 0) || (strcmp(ref_type, aliases[i][1]) == 0)
+            || (strcmp(type, aliases[i][0]) == 0) || (strcmp(type, aliases[i][1]) == 0))
         {
             if ((strcmp(type, ref_type) != 0) && (strcmp(aliases[i][0], ref_type) != 0))
             {

--- a/src/verify_exec.c
+++ b/src/verify_exec.c
@@ -53,7 +53,7 @@ void VerifyExecPromise(Promise *pp)
 
 static int ExecSanityChecks(Attributes a, Promise *pp)
 {
-    if (a.contain.nooutput && a.contain.preview)
+    if ((a.contain.nooutput) && (a.contain.preview))
     {
         CfOut(cf_error, "", "no_output and preview are mutually exclusive (broken promise)");
         PromiseRef(cf_error, pp);
@@ -173,7 +173,7 @@ static void VerifyExec(Attributes a, Promise *pp)
 
     BeginMeasure();
 
-    if (DONTDO && !a.contain.preview)
+    if (DONTDO && (!a.contain.preview))
     {
         CfOut(cf_error, "", "-> Would execute script %s\n", execstr);
     }
@@ -200,7 +200,7 @@ static void VerifyExec(Attributes a, Promise *pp)
             outsourced = false;
         }
 
-        if (outsourced || !a.transaction.background)    // work done here: either by child or non-background parent
+        if (outsourced || (!a.transaction.background))    // work done here: either by child or non-background parent
         {
             if (a.contain.timeout != CF_NOINT)
             {
@@ -271,7 +271,7 @@ static void VerifyExec(Attributes a, Promise *pp)
                 {
                     ModuleProtocol(execstr, line, !a.contain.nooutput, pp->namespace);
                 }
-                else if (!a.contain.nooutput && NonEmptyLine(line))
+                else if ((!a.contain.nooutput) && (NonEmptyLine(line)))
                 {
                     lineOutLen = strlen(comm) + strlen(line) + 12;
 
@@ -332,7 +332,7 @@ static void VerifyExec(Attributes a, Promise *pp)
         snprintf(eventname, CF_BUFSIZE - 1, "Exec(%s)", execstr);
 
 #ifndef MINGW
-        if (a.transaction.background && outsourced)
+        if ((a.transaction.background) && outsourced)
         {
             CfOut(cf_verbose, "", " -> Backgrounded command (%s) is done - exiting\n", execstr);
             exit(0);

--- a/src/verify_files.c
+++ b/src/verify_files.c
@@ -57,7 +57,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
 
 /* Do a search for promiser objects matching wildpath */
 
-    if (!IsPathRegex(wildpath) || (pathtype && (strcmp(pathtype, "literal") == 0)))
+    if ((!IsPathRegex(wildpath)) || (pathtype && (strcmp(pathtype, "literal") == 0)))
     {
         CfOut(cf_verbose, "", " -> Using literal pathtype for %s\n", wildpath);
         (*fnptr) (wildpath, pp, report_context);
@@ -73,7 +73,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
 
     for (ip = path; ip != NULL; ip = ip->next)
     {
-        if (ip->name == NULL || strlen(ip->name) == 0)
+        if ((ip->name == NULL) || (strlen(ip->name) == 0))
         {
             continue;
         }
@@ -104,7 +104,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
 
         if (cfstat(pbuffer, &statbuf) != -1)
         {
-            if (S_ISDIR(statbuf.st_mode) && statbuf.st_uid != agentuid && statbuf.st_uid != 0)
+            if ((S_ISDIR(statbuf.st_mode)) && ((statbuf.st_uid) != agentuid) && ((statbuf.st_uid) != 0))
             {
                 CfOut(cf_inform, "",
                       "Directory %s in search path %s is controlled by another user (uid %ju) - trusting its content is potentially risky (possible race)\n",
@@ -145,7 +145,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
                     continue;
                 }
 
-                if (!lastnode && !S_ISDIR(statbuf.st_mode))
+                if ((!lastnode) && (!S_ISDIR(statbuf.st_mode)))
                 {
                     CfDebug("Skipping non-directory %s\n", dirp->d_name);
                     continue;
@@ -174,7 +174,7 @@ void LocateFilePromiserGroup(char *wildpath, Promise *pp, void (*fnptr) (char *p
 
                 /* The next level might still contain regexs, so go again as long as expansion is not nullpotent */
 
-                if (!lastnode && (strcmp(nextbuffer, wildpath) != 0))
+                if ((!lastnode) && (strcmp(nextbuffer, wildpath) != 0))
                 {
                     LocateFilePromiserGroup(nextbuffer, pp, fnptr, report_context);
                 }
@@ -254,7 +254,7 @@ void VerifyFilePromise(char *path, Promise *pp, const ReportContext *report_cont
 
     if (lstat(path, &oslb) == -1)       /* Careful if the object is a link */
     {
-        if (a.create || a.touch)
+        if ((a.create) || (a.touch))
         {
             if (!CfCreateFile(path, pp, a, report_context))
             {
@@ -272,14 +272,14 @@ void VerifyFilePromise(char *path, Promise *pp, const ReportContext *report_cont
     }
     else
     {
-        if (a.create || a.touch)
+        if ((a.create) || (a.touch))
         {
             cfPS(cf_verbose, CF_NOP, "", pp, a, " -> File \"%s\" exists as promised", path);
         }
         exists = true;
     }
 
-    if (a.havedelete && !exists)
+    if ((a.havedelete) && (!exists))
     {
         cfPS(cf_verbose, CF_NOP, "", pp, a, " -> File \"%s\" does not exist as promised", path);
     }
@@ -302,7 +302,7 @@ void VerifyFilePromise(char *path, Promise *pp, const ReportContext *report_cont
         chdir(basedir);
     }
 
-    if (exists && !VerifyFileLeaf(path, &oslb, a, pp, report_context))
+    if (exists && (!VerifyFileLeaf(path, &oslb, a, pp, report_context)))
     {
         if (!S_ISDIR(oslb.st_mode))
         {
@@ -314,7 +314,7 @@ void VerifyFilePromise(char *path, Promise *pp, const ReportContext *report_cont
 
     if (cfstat(path, &osb) == -1)
     {
-        if (a.create || a.touch)
+        if ((a.create) || (a.touch))
         {
             if (!CfCreateFile(path, pp, a, report_context))
             {
@@ -367,7 +367,7 @@ void VerifyFilePromise(char *path, Promise *pp, const ReportContext *report_cont
 
 /* Phase 1 - */
 
-    if (exists && (a.havedelete || a.haverename || a.haveperms || a.havechange || a.transformer))
+    if (exists && ((a.havedelete) || (a.haverename) || (a.haveperms) || (a.havechange) || (a.transformer)))
     {
         lstat(path, &oslb);     /* if doesn't exist have to stat again anyway */
 
@@ -399,7 +399,7 @@ void VerifyFilePromise(char *path, Promise *pp, const ReportContext *report_cont
             }
         }
 
-        if (a.change.report_changes == cfa_contentchange || a.change.report_changes == cfa_allchanges)
+        if (((a.change.report_changes) == cfa_contentchange) || ((a.change.report_changes) == cfa_allchanges))
         {
             if (a.havedepthsearch)
             {
@@ -421,7 +421,7 @@ void VerifyFilePromise(char *path, Promise *pp, const ReportContext *report_cont
 
 /* Phase 2b link after copy in case need file first */
 
-    if (a.havelink && a.link.link_children)
+    if ((a.havelink) && (a.link.link_children))
     {
         ScheduleLinkChildrenOperation(path, a.link.source, 1, a, pp, report_context);
     }
@@ -439,7 +439,7 @@ void VerifyFilePromise(char *path, Promise *pp, const ReportContext *report_cont
 
 // Once more in case a file has been created as a result of editing or copying
 
-    if (cfstat(path, &osb) != -1 && S_ISREG(osb.st_mode))
+    if ((cfstat(path, &osb) != -1) && (S_ISREG(osb.st_mode)))
     {
         VerifyFileLeaf(path, &osb, a, pp, report_context);
     }
@@ -504,7 +504,7 @@ int ScheduleEditOperation(char *filename, Attributes a, Promise *pp, const Repor
         {
             method_deref = strchr(edit_bundle_name,':') + 1;
         }
-        else if (strchr(edit_bundle_name, ':') == NULL && strcmp(pp->namespace, "default") != 0)
+        else if ((strchr(edit_bundle_name, ':') == NULL) && (strcmp(pp->namespace, "default") != 0))
         {
             snprintf(qualified_edit, CF_BUFSIZE, "%s:%s", pp->namespace, edit_bundle_name);
             method_deref = qualified_edit;
@@ -617,7 +617,7 @@ void *FindAndVerifyFilesPromises(Promise *pp, const ReportContext *report_contex
     PromiseBanner(pp);
     FindFilePromiserObjects(pp, report_context);
 
-    if (AM_BACKGROUND_PROCESS && !pp->done)
+    if (AM_BACKGROUND_PROCESS && (!pp->done))
     {
         CfOut(cf_verbose, "", "Exiting backgrounded promise");
         PromiseRef(cf_verbose, pp);
@@ -632,7 +632,7 @@ void *FindAndVerifyFilesPromises(Promise *pp, const ReportContext *report_contex
 static void FindFilePromiserObjects(Promise *pp, const ReportContext *report_context)
 {
     char *val = GetConstraintValue("pathtype", pp, CF_SCALAR);
-    int literal = GetBooleanConstraint("copy_from", pp) || ((val != NULL) && (strcmp(val, "literal") == 0));
+    int literal = (GetBooleanConstraint("copy_from", pp)) || ((val != NULL) && (strcmp(val, "literal") == 0));
 
 /* Check if we are searching over a regular expression */
 

--- a/src/verify_measurements.c
+++ b/src/verify_measurements.c
@@ -84,7 +84,7 @@ static int CheckMeasureSanity(Attributes a, Promise *pp)
     }
     else
     {
-        if (a.measure.history_type && strcmp(a.measure.history_type, "weekly") == 0)
+        if ((a.measure.history_type) && (strcmp(a.measure.history_type, "weekly") == 0))
         {
             switch (a.measure.data_type)
             {
@@ -104,7 +104,7 @@ static int CheckMeasureSanity(Attributes a, Promise *pp)
         }
     }
 
-    if (a.measure.select_line_matching && a.measure.select_line_number != CF_NOINT)
+    if ((a.measure.select_line_matching) && (a.measure.select_line_number != CF_NOINT))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
              "The promiser \"%s\" cannot select both a line by pattern and by number\n", pp->promiser);
@@ -118,7 +118,7 @@ static int CheckMeasureSanity(Attributes a, Promise *pp)
     }
     else
     {
-        if (!strchr(a.measure.extraction_regex, '(') && !strchr(a.measure.extraction_regex, ')'))
+        if ((!strchr(a.measure.extraction_regex, '(')) && (!strchr(a.measure.extraction_regex, ')')))
         {
             cfPS(cf_error, CF_INTERPT, "", pp, a,
                  "The extraction_regex must contain a single backreference for the extraction\n");

--- a/src/verify_methods.c
+++ b/src/verify_methods.c
@@ -93,7 +93,7 @@ int VerifyMethod(char *attrname, Attributes a, Promise *pp, const ReportContext 
     {
         method_deref = strchr(method_name,':') + 1;
     }
-    else if (strchr(method_name, ':') == NULL && strcmp(pp->namespace, "default") != 0)
+    else if ((strchr(method_name, ':') == NULL) && (strcmp(pp->namespace, "default") != 0))
     {
         snprintf(qualified_method, CF_BUFSIZE, "%s:%s", pp->namespace, method_name);
         method_deref = qualified_method;
@@ -156,7 +156,7 @@ int VerifyMethod(char *attrname, Attributes a, Promise *pp, const ReportContext 
             CfOut(cf_error, "",
                   " !! A variable seems to have been used for the name of the method. In this case, the promiser also needs to contain the unique name of the method");
         }
-        if (bp && bp->name)
+        if (bp && (bp->name))
         {
             cfPS(cf_error, CF_FAIL, "", pp, a, " !! Method \"%s\" was used but was not defined!\n", bp->name);
         }

--- a/src/verify_packages.c
+++ b/src/verify_packages.c
@@ -158,7 +158,7 @@ static int PackageSanityCheck(Attributes a, Promise *pp)
         return false;
     }
 
-    if (!a.packages.package_commands_useshell && a.packages.package_list_command && !IsExecutable(GetArg0(a.packages.package_list_command)))
+    if ((!a.packages.package_commands_useshell) && (a.packages.package_list_command) && (!IsExecutable(GetArg0(a.packages.package_list_command))))
     {
         cfPS(cf_error, CF_FAIL, "", pp, a,
              "The proposed package list command \"%s\" was not executable",
@@ -170,7 +170,7 @@ static int PackageSanityCheck(Attributes a, Promise *pp)
 #endif /* NOT MINGW */
 
 
-    if (a.packages.package_list_command == NULL && a.packages.package_file_repositories == NULL)
+    if ((a.packages.package_list_command == NULL) && (a.packages.package_file_repositories == NULL))
     {
         cfPS(cf_error, CF_FAIL, "", pp, a,
              " !! You must supply a method for determining the list of existing packages (a command or repository list) e.g. use the standard library generic package_method");
@@ -191,16 +191,16 @@ static int PackageSanityCheck(Attributes a, Promise *pp)
         }
     }
 
-    if (a.packages.package_name_regex || a.packages.package_version_regex || a.packages.package_arch_regex)
+    if ((a.packages.package_name_regex) || (a.packages.package_version_regex) || (a.packages.package_arch_regex))
     {
         if (a.packages.package_name_regex == NULL)
         {
             cfPS(cf_error, CF_FAIL, "", pp, a, " !! You must supply name regex if you supplied version or arch regex for parsing promiser string");
             return false;
         }
-        if (a.packages.package_name_regex && a.packages.package_version_regex && a.packages.package_arch_regex)
+        if ((a.packages.package_name_regex) && (a.packages.package_version_regex) && (a.packages.package_arch_regex))
         {
-            if (a.packages.package_version || a.packages.package_architectures)
+            if ((a.packages.package_version) || (a.packages.package_architectures))
             {
                 cfPS(cf_error, CF_FAIL, "", pp, a,
                      " !! You must either supply all regexs for (name,version,arch) or a separate version number and architecture");
@@ -209,7 +209,7 @@ static int PackageSanityCheck(Attributes a, Promise *pp)
         }
         else
         {
-            if (a.packages.package_version && a.packages.package_architectures)
+            if ((a.packages.package_version) && (a.packages.package_architectures))
             {
                 cfPS(cf_error, CF_FAIL, "", pp, a,
                      " !! You must either supply all regexs for (name,version,arch) or a separate version number and architecture");
@@ -217,14 +217,14 @@ static int PackageSanityCheck(Attributes a, Promise *pp)
             }
         }
 
-        if (a.packages.package_version_regex && a.packages.package_version)
+        if ((a.packages.package_version_regex) && (a.packages.package_version))
         {
             cfPS(cf_error, CF_FAIL, "", pp, a,
                  " !! You must either supply version regex or a separate version number");
             return false;
         }
 
-        if (a.packages.package_arch_regex && a.packages.package_architectures)
+        if ((a.packages.package_arch_regex) && (a.packages.package_architectures))
         {
             cfPS(cf_error, CF_FAIL, "", pp, a,
                  " !! You must either supply arch regex or a separate architecture");
@@ -254,7 +254,7 @@ static int PackageSanityCheck(Attributes a, Promise *pp)
         }
     }
 
-    if ((a.packages.package_noverify_returncode != CF_NOINT) && a.packages.package_noverify_regex)
+    if ((a.packages.package_noverify_returncode != CF_NOINT) && (a.packages.package_noverify_regex))
     {
         cfPS(cf_verbose, CF_FAIL, "", pp, a,
              "!! Both package_noverify_returncode and package_noverify_regex are defined, pick one of them");
@@ -590,7 +590,7 @@ static int VerifyInstalledPackages(PackageManager **all_mgrs, const char *defaul
         CfOut(cf_verbose, "", "   Reading patches from %s\n", GetArg0(a.packages.package_patch_list_command));
         CfOut(cf_verbose, "", " ???????????????????????????????????????????????????????????????\n");
 
-        if (!a.packages.package_commands_useshell && !IsExecutable(GetArg0(a.packages.package_patch_list_command)))
+        if ((!a.packages.package_commands_useshell) && (!IsExecutable(GetArg0(a.packages.package_patch_list_command))))
         {
             CfOut(cf_error, "", "The proposed patch list command \"%s\" was not executable",
                   a.packages.package_patch_list_command);
@@ -621,8 +621,8 @@ static int VerifyInstalledPackages(PackageManager **all_mgrs, const char *defaul
             CfReadLine(vbuff, CF_BUFSIZE, fin);
 
             // assume patch_list_command lists available patches/updates by default
-            if (a.packages.package_patch_installed_regex == NULL
-                || !FullTextMatch(a.packages.package_patch_installed_regex, vbuff))
+            if ((a.packages.package_patch_installed_regex == NULL)
+                || (!FullTextMatch(a.packages.package_patch_installed_regex, vbuff)))
             {
                 PrependPatchItem(&(manager->patch_avail), vbuff, manager->patch_list, default_arch, a, pp);
                 continue;
@@ -752,7 +752,7 @@ static int IsNewerThanInstalled(const char *n, const char *v, const char *a, cha
 
     for (pi = mp->pack_list; pi != NULL; pi = pi->next)
     {
-        if ((strcmp(n, pi->name) == 0) && (strcmp(a, "*") == 0  || strcmp(a, pi->arch) == 0))
+        if ((strcmp(n, pi->name) == 0) && (((strcmp(a, "*") == 0)) || (strcmp(a, pi->arch) == 0)))
         {
             CfOut(cf_verbose, "", "Found installed package (%s,%s,%s)", pi->name, pi->version, pi->arch);
 
@@ -801,14 +801,14 @@ static void SchedulePackageOp(const char *name, const char *version, const char 
 
 /* Now we need to know the name-convention expected by the package manager */
 
-    if (a.packages.package_name_convention || a.packages.package_delete_convention)
+    if ((a.packages.package_name_convention) || (a.packages.package_delete_convention))
     {
         SetNewScope("cf_pack_context");
         NewScalar("cf_pack_context", "name", name, cf_str);
         NewScalar("cf_pack_context", "version", version, cf_str);
         NewScalar("cf_pack_context", "arch", arch, cf_str);
 
-        if (a.packages.package_delete_convention && (a.packages.package_policy == cfa_deletepack))
+        if ((a.packages.package_delete_convention) && (a.packages.package_policy == cfa_deletepack))
         {
             ExpandScalar(a.packages.package_delete_convention, reference);
             strlcpy(id, reference, CF_EXPANDSIZE);
@@ -838,8 +838,8 @@ static void SchedulePackageOp(const char *name, const char *version, const char 
               "!! Package name contians '*' -- perhaps a missing attribute (name/version/arch) should be specified");
     }
 
-    if (a.packages.package_select == cfa_eq || a.packages.package_select == cfa_ge ||
-        a.packages.package_select == cfa_le || a.packages.package_select == cfa_cmp_none)
+    if ((a.packages.package_select == cfa_eq) || (a.packages.package_select == cfa_ge) ||
+        (a.packages.package_select == cfa_le) || (a.packages.package_select == cfa_cmp_none))
     {
         CfOut(cf_verbose, "", " -> Package version seems to match criteria");
         package_select_in_range = true;
@@ -866,7 +866,7 @@ static void SchedulePackageOp(const char *name, const char *version, const char 
         if (installed == 0)
         {
             if ((a.packages.package_file_repositories != NULL) &&
-                (a.packages.package_select == cfa_gt || a.packages.package_select == cfa_ge))
+                ((a.packages.package_select == cfa_gt) || (a.packages.package_select == cfa_ge)))
             {
                 SetNewScope("cf_pack_context_anyver");
                 NewScalar("cf_pack_context_anyver", "name", name, cf_str);
@@ -998,7 +998,7 @@ static void SchedulePackageOp(const char *name, const char *version, const char 
         *instArch = '\0';
 
         if ((a.packages.package_file_repositories != NULL) &&
-            (a.packages.package_select == cfa_gt || a.packages.package_select == cfa_ge))
+            ((a.packages.package_select == cfa_gt) || (a.packages.package_select == cfa_ge)))
         {
             SetNewScope("cf_pack_context_anyver");
             NewScalar("cf_pack_context_anyver", "name", name, cf_str);
@@ -1043,7 +1043,7 @@ static void SchedulePackageOp(const char *name, const char *version, const char 
             }
         }
 
-        if ((matched && package_select_in_range && !no_version_specified) || installed)
+        if ((matched && package_select_in_range && (!no_version_specified)) || installed)
         {
             if (a.packages.package_update_command == NULL)
             {
@@ -1117,7 +1117,7 @@ static void SchedulePackageOp(const char *name, const char *version, const char 
 
     case cfa_patch:
 
-        if (matched && !installed)
+        if (matched && (!installed))
         {
             CfOut(cf_verbose, "", " -> Schedule package for patching\n");
             manager =
@@ -1279,7 +1279,7 @@ static int VersionCheckSchedulePackage(Attributes a, Promise *pp, int matches, i
         break;
 
     default:
-        if (!installed || !matches)
+        if ((!installed) || (!matches))
         {
             return true;
         }
@@ -1299,7 +1299,7 @@ static void CheckPackageState(Attributes a, Promise *pp, const char *name, const
     VersionCmpResult installed = PackageMatch(name, "*", arch, a, pp);
     VersionCmpResult matches = PackageMatch(name, version, arch, a, pp);
 
-    if (installed == VERCMP_ERROR || matches == VERCMP_ERROR)
+    if ((installed == VERCMP_ERROR) || (matches == VERCMP_ERROR))
     {
         cfPS(cf_error, CF_FAIL, "", pp, a, "Failure trying to compare package versions");
         return;
@@ -1332,7 +1332,7 @@ static void VerifyPromisedPatch(Attributes a, Promise *pp)
             VersionCmpResult installed1 = PatchMatch(name, "*", "*", a, pp);
             VersionCmpResult matches1 = PatchMatch(name, version, arch, a, pp);
 
-            if (installed1 == VERCMP_ERROR || matches1 == VERCMP_ERROR)
+            if ((installed1 == VERCMP_ERROR) || (matches1 == VERCMP_ERROR))
             {
                 cfPS(cf_error, CF_FAIL, "", pp, a, "Failure trying to compare package versions");
                 return;
@@ -1350,7 +1350,7 @@ static void VerifyPromisedPatch(Attributes a, Promise *pp)
             installed = PatchMatch(name, "*", "*", a, pp);
             matches = PatchMatch(name, version, arch, a, pp);
 
-            if (installed == VERCMP_ERROR || matches == VERCMP_ERROR)
+            if ((installed == VERCMP_ERROR) || (matches == VERCMP_ERROR))
             {
                 cfPS(cf_error, CF_FAIL, "", pp, a, "Failure trying to compare package versions");
                 return;
@@ -1366,7 +1366,7 @@ static void VerifyPromisedPatch(Attributes a, Promise *pp)
         installed = PatchMatch(name, "*", "*", a, pp);
         matches = PatchMatch(name, version, arch, a, pp);
 
-        if (installed == VERCMP_ERROR || matches == VERCMP_ERROR)
+        if ((installed == VERCMP_ERROR) || (matches == VERCMP_ERROR))
         {
             cfPS(cf_error, CF_FAIL, "", pp, a, "Failure trying to compare package versions");
             return;
@@ -1384,7 +1384,7 @@ static void VerifyPromisedPatch(Attributes a, Promise *pp)
             VersionCmpResult installed1 = PatchMatch(name, "*", "*", a, pp);
             VersionCmpResult matches1 = PatchMatch(name, version, arch, a, pp);
 
-            if (installed1 == VERCMP_ERROR || matches1 == VERCMP_ERROR)
+            if ((installed1 == VERCMP_ERROR) || (matches1 == VERCMP_ERROR))
             {
                 cfPS(cf_error, CF_FAIL, "", pp, a, "Failure trying to compare package versions");
                 return;
@@ -1402,7 +1402,7 @@ static void VerifyPromisedPatch(Attributes a, Promise *pp)
             installed = PatchMatch(name, "*", "*", a, pp);
             matches = PatchMatch(name, version, arch, a, pp);
 
-            if (installed == VERCMP_ERROR || matches == VERCMP_ERROR)
+            if ((installed == VERCMP_ERROR) || (matches == VERCMP_ERROR))
             {
                 cfPS(cf_error, CF_FAIL, "", pp, a, "Failure trying to compare package versions");
                 return;
@@ -1654,7 +1654,7 @@ static int ExecuteSchedule(PackageManager *schedule, enum package_actions action
 
                     char *sp, *offset = command_string + strlen(command_string);
 
-                    if (a.packages.package_file_repositories && (action == cfa_addpack || action == cfa_update))
+                    if ((a.packages.package_file_repositories) && ((action == cfa_addpack) || (action == cfa_update)))
                     {
                         if ((sp = PrefixLocalRepository(a.packages.package_file_repositories, pi->name)) != NULL)
                         {
@@ -1694,7 +1694,7 @@ static int ExecuteSchedule(PackageManager *schedule, enum package_actions action
                     {
                         char *sp, *offset = command_string + strlen(command_string);
 
-                        if (a.packages.package_file_repositories && (action == cfa_addpack || action == cfa_update))
+                        if ((a.packages.package_file_repositories) && ((action == cfa_addpack) || (action == cfa_update)))
                         {
                             if ((sp = PrefixLocalRepository(a.packages.package_file_repositories, pi->name)) != NULL)
                             {
@@ -1990,7 +1990,7 @@ static PackageManager *NewPackageManager(PackageManager **lists, char *mgr, enum
 
     CfOut(cf_verbose, "", " -> Looking for a package manager called %s", mgr);
 
-    if (mgr == NULL || strlen(mgr) == 0)
+    if ((mgr == NULL) || (strlen(mgr) == 0))
     {
         CfOut(cf_error, "", " !! Attempted to create a package manager with no name");
         return NULL;
@@ -2070,7 +2070,7 @@ int ExecPackageCommand(char *command, int verify, int setCmdClasses, Attributes 
     FILE *pfp;
     int packmanRetval = 0;
 
-    if (!a.packages.package_commands_useshell && !IsExecutable(GetArg0(command)))
+    if ((!a.packages.package_commands_useshell) && (!IsExecutable(GetArg0(command))))
     {
         cfPS(cf_error, CF_FAIL, "", pp, a, "The proposed package schedule command \"%s\" was not executable", command);
         return false;
@@ -2104,11 +2104,11 @@ int ExecPackageCommand(char *command, int verify, int setCmdClasses, Attributes 
     CfOut(cf_verbose, "", "Executing %-.60s...\n", command);
 
 /* Look for short command summary */
-    for (cmd = command; *cmd != '\0' && *cmd != ' '; cmd++)
+    for (cmd = command; (*cmd != '\0') && (*cmd != ' '); cmd++)
     {
     }
 
-    while (*(cmd - 1) != FILE_SEPARATOR && cmd >= command)
+    while ((*(cmd - 1) != FILE_SEPARATOR) && (cmd >= command))
     {
         cmd--;
     }
@@ -2128,7 +2128,7 @@ int ExecPackageCommand(char *command, int verify, int setCmdClasses, Attributes 
         ReplaceStr(line, lineSafe, sizeof(lineSafe), "%", "%%");
         CfOut(cf_inform, "", "Q:%20.20s ...:%s", cmd, lineSafe);
 
-        if (verify && line[0] != '\0')
+        if (verify && (line[0] != '\0'))
         {
             if (a.packages.package_noverify_regex)
             {
@@ -2144,7 +2144,7 @@ int ExecPackageCommand(char *command, int verify, int setCmdClasses, Attributes 
 
     packmanRetval = cf_pclose(pfp);
 
-    if (verify && a.packages.package_noverify_returncode != CF_NOINT)
+    if (verify && (a.packages.package_noverify_returncode != CF_NOINT))
     {
         if (a.packages.package_noverify_returncode == packmanRetval)
         {
@@ -2156,7 +2156,7 @@ int ExecPackageCommand(char *command, int verify, int setCmdClasses, Attributes 
             cfPS(cf_inform, CF_NOP, "", pp, a, "-> Package verification succeeded (returned %d)", packmanRetval);
         }
     }
-    else if (verify && a.packages.package_noverify_regex)
+    else if (verify && (a.packages.package_noverify_regex))
     {
         if (retval)             // set status if we succeeded above
         {
@@ -2176,7 +2176,7 @@ int PrependPackageItem(PackageItem ** list, const char *name, const char *versio
 {
     PackageItem *pi;
 
-    if (strlen(name) == 0 || strlen(version) == 0 || strlen(arch) == 0)
+    if ((strlen(name) == 0) || (strlen(version) == 0) || (strlen(arch) == 0))
     {
         return false;
     }
@@ -2209,14 +2209,14 @@ static int PackageInItemList(PackageItem * list, char *name, char *version, char
 {
     PackageItem *pi;
 
-    if (strlen(name) == 0 || strlen(version) == 0 || strlen(arch) == 0)
+    if ((strlen(name) == 0) || (strlen(version) == 0) || (strlen(arch) == 0))
     {
         return false;
     }
 
     for (pi = list; pi != NULL; pi = pi->next)
     {
-        if (strcmp(pi->name, name) == 0 && strcmp(pi->version, version) == 0 && strcmp(pi->arch, arch) == 0)
+        if ((strcmp(pi->name, name) == 0) && (strcmp(pi->version, version) == 0) && (strcmp(pi->arch, arch) == 0))
         {
             return true;
         }
@@ -2247,7 +2247,7 @@ static int PrependPatchItem(PackageItem ** list, char *item, PackageItem * chkli
         strncpy(arch, default_arch, CF_MAXVARSIZE - 1);
     }
 
-    if (strcmp(name, "CF_NOMATCH") == 0 || strcmp(version, "CF_NOMATCH") == 0 || strcmp(arch, "CF_NOMATCH") == 0)
+    if ((strcmp(name, "CF_NOMATCH") == 0) || (strcmp(version, "CF_NOMATCH") == 0) || (strcmp(arch, "CF_NOMATCH") == 0))
     {
         return false;
     }
@@ -2276,12 +2276,12 @@ static int PrependMultiLinePackageItem(PackageItem ** list, char *item, int rese
 
     if (reset)
     {
-        if (strcmp(name, "CF_NOMATCH") == 0 || strcmp(version, "CF_NOMATCH") == 0)
+        if ((strcmp(name, "CF_NOMATCH") == 0) || (strcmp(version, "CF_NOMATCH") == 0))
         {
             return false;
         }
 
-        if (strcmp(name, "") != 0 || strcmp(version, "") != 0)
+        if ((strcmp(name, "") != 0) || (strcmp(version, "") != 0))
         {
             CfDebug(" -? Extracted package name \"%s\"\n", name);
             CfDebug(" -?      with version \"%s\"\n", version);
@@ -2307,7 +2307,7 @@ static int PrependMultiLinePackageItem(PackageItem ** list, char *item, int rese
         sscanf(vbuff, "%s", version);   /* trim */
     }
 
-    if (a.packages.package_list_arch_regex && FullTextMatch(a.packages.package_list_arch_regex, item))
+    if ((a.packages.package_list_arch_regex) && (FullTextMatch(a.packages.package_list_arch_regex, item)))
     {
         if (a.packages.package_list_arch_regex)
         {
@@ -2342,7 +2342,7 @@ static int PrependListPackageItem(PackageItem ** list, char *item, const char *d
         strlcpy(arch, default_arch, CF_MAXVARSIZE);
     }
 
-    if (strcmp(name, "CF_NOMATCH") == 0 || strcmp(version, "CF_NOMATCH") == 0 || strcmp(arch, "CF_NOMATCH") == 0)
+    if ((strcmp(name, "CF_NOMATCH") == 0) || (strcmp(version, "CF_NOMATCH") == 0) || (strcmp(arch, "CF_NOMATCH") == 0))
     {
         return false;
     }
@@ -2372,7 +2372,7 @@ static char *GetDefaultArch(const char *command)
 
     char arch[CF_BUFSIZE];
 
-    if (CfReadLine(arch, CF_BUFSIZE, fp) == false || strlen(arch) == 0)
+    if ((CfReadLine(arch, CF_BUFSIZE, fp) == false) || (strlen(arch) == 0))
     {
         cf_pclose(fp);
         return NULL;

--- a/src/verify_processes.c
+++ b/src/verify_processes.c
@@ -55,11 +55,11 @@ static int ProcessSanityChecks(Attributes a, Promise *pp)
 {
     int promised_zero, ret = true;
 
-    promised_zero = (a.process_count.min_range == 0 && a.process_count.max_range == 0);
+    promised_zero = ((a.process_count.min_range == 0) && (a.process_count.max_range == 0));
 
     if (a.restart_class)
     {
-        if (IsStringIn(a.signals, "term") || IsStringIn(a.signals, "kill"))
+        if ((IsStringIn(a.signals, "term")) || (IsStringIn(a.signals, "kill")))
         {
             CfOut(cf_inform, "", " -> (warning) Promise %s kills then restarts - never strictly converges",
                   pp->promiser);
@@ -75,7 +75,7 @@ static int ProcessSanityChecks(Attributes a, Promise *pp)
         }
     }
 
-    if (promised_zero && a.restart_class)
+    if (promised_zero && (a.restart_class))
     {
         CfOut(cf_error, "", "Promise constraint conflicts - %s processes cannot have zero count if restarted",
               pp->promiser);
@@ -83,7 +83,7 @@ static int ProcessSanityChecks(Attributes a, Promise *pp)
         ret = false;
     }
 
-    if (a.haveselect && !a.process_select.process_result)
+    if ((a.haveselect) && (!a.process_select.process_result))
     {
         CfOut(cf_error, "", " !! Process select constraint body promised no result (check body definition)");
         PromiseRef(cf_error, pp);
@@ -138,7 +138,7 @@ static void VerifyProcessOp(Item *procdata, Attributes a, Promise *pp)
 
     if (a.process_count.min_range != CF_NOINT)  /* if a range is specified */
     {
-        if (matches < a.process_count.min_range || matches > a.process_count.max_range)
+        if ((matches < a.process_count.min_range) || (matches > a.process_count.max_range))
         {
             cfPS(cf_error, CF_CHG, "", pp, a, " !! Process count for \'%s\' was out of promised range (%d found)\n", pp->promiser, matches);
             AddEphemeralClasses(a.process_count.out_of_range_define, pp->namespace);
@@ -172,7 +172,7 @@ static void VerifyProcessOp(Item *procdata, Attributes a, Promise *pp)
 
 /* signal/kill promises for existing matches */
 
-    if (do_signals && matches > 0)
+    if (do_signals && (matches > 0))
     {
         if (a.process_stop != NULL)
         {
@@ -203,7 +203,7 @@ static void VerifyProcessOp(Item *procdata, Attributes a, Promise *pp)
 
 /* delegated promise to restart killed or non-existent entries */
 
-    need_to_restart = (a.restart_class != NULL) && (killed || matches == 0);
+    need_to_restart = (a.restart_class != NULL) && (killed || (matches == 0));
 
     DeleteItemList(killlist);
 
@@ -275,7 +275,7 @@ static int FindPidMatches(Item *procdata, Item **killlist, Attributes a, Promise
 
             if (pid == 1)
             {
-                if ((RlistLen(a.signals) == 1) && IsStringIn(a.signals, "hup"))
+                if ((RlistLen(a.signals) == 1) && (IsStringIn(a.signals, "hup")))
                 {
                     CfOut(cf_verbose, "", "(Okay to send only HUP to init)\n");
                 }
@@ -285,23 +285,23 @@ static int FindPidMatches(Item *procdata, Item **killlist, Attributes a, Promise
                 }
             }
 
-            if (pid < 4 && a.signals)
+            if ((pid < 4) && (a.signals))
             {
                 CfOut(cf_verbose, "", "Will not signal or restart processes 0,1,2,3 (occurred while looking for %s)\n",
                       pp->promiser);
                 continue;
             }
 
-            promised_zero = a.process_count.min_range == 0 && a.process_count.max_range == 0;
+            promised_zero = (a.process_count.min_range == 0) && (a.process_count.max_range == 0);
 
-            if (a.transaction.action == cfa_warn && promised_zero)
+            if ((a.transaction.action == cfa_warn) && promised_zero)
             {
                 CfOut(cf_error, "", "Process alert: %s\n", procdata->name);     /* legend */
                 CfOut(cf_error, "", "Process alert: %s\n", ip->name);
                 continue;
             }
 
-            if (pid == cfengine_pid && a.signals)
+            if ((pid == cfengine_pid) && (a.signals))
             {
                 CfOut(cf_verbose, "", " !! cf-agent will not signal itself!\n");
                 continue;

--- a/src/verify_reports.c
+++ b/src/verify_reports.c
@@ -133,7 +133,7 @@ static void PrintFile(Attributes a, Promise *pp)
         return;
     }
 
-    while (!feof(fp) && (lines < a.report.numlines))
+    while ((!feof(fp)) && (lines < a.report.numlines))
     {
         buffer[0] = '\0';
         fgets(buffer, CF_BUFSIZE, fp);
@@ -184,7 +184,7 @@ static void ShowState(char *type)
 
                 if (IsSocketType(type))
                 {
-                    if (strncmp(type, "incoming", 8) == 0 || strncmp(type, "outgoing", 8) == 0)
+                    if ((strncmp(type, "incoming", 8) == 0) || (strncmp(type, "outgoing", 8) == 0))
                     {
                         if (strncmp(buffer, "tcp", 3) == 0)
                         {
@@ -250,7 +250,7 @@ static void ShowState(char *type)
         CfOut(cf_error, "", "\n");
         CfOut(cf_error, "", "R: The peak measured state was q = %d:\n", conns);
 
-        if (IsSocketType(type) || IsTCPType(type))
+        if ((IsSocketType(type)) || (IsTCPType(type)))
         {
             for (ip = addresses; ip != NULL; ip = ip->next)
             {
@@ -259,7 +259,7 @@ static void ShowState(char *type)
                 buffer[0] = '\0';
                 sscanf(ip->name, "%s", buffer);
 
-                if (!IsIPV4Address(buffer) && !IsIPV6Address(buffer))
+                if ((!IsIPV4Address(buffer)) && (!IsIPV6Address(buffer)))
                 {
                     CfOut(cf_verbose, "", "Rejecting address %s\n", ip->name);
                     continue;

--- a/src/verify_storage.c
+++ b/src/verify_storage.c
@@ -83,14 +83,14 @@ void VerifyStoragePromise(char *path, Promise *pp, const ReportContext *report_c
 
     if (a.mount.unmount)
     {
-        if (a.mount.mount_source || a.mount.mount_server)
+        if ((a.mount.mount_source) || (a.mount.mount_server))
         {
             CfOut(cf_verbose, "", " !! An unmount promise indicates a mount-source information - probably in error\n");
         }
     }
     else if (a.havemount)
     {
-        if (a.mount.mount_source == NULL || a.mount.mount_server == NULL)
+        if ((a.mount.mount_source == NULL) || (a.mount.mount_server == NULL))
         {
             CfOut(cf_error, "", " !! Insufficient specification in mount promise - need source and server\n");
             return;
@@ -107,7 +107,7 @@ void VerifyStoragePromise(char *path, Promise *pp, const ReportContext *report_c
 /* Do mounts first */
 
 #ifndef MINGW
-    if (!MOUNTEDFSLIST && !LoadMountInfo(&MOUNTEDFSLIST))
+    if ((!MOUNTEDFSLIST) && (!LoadMountInfo(&MOUNTEDFSLIST)))
     {
         CfOut(cf_error, "", "Couldn't obtain a list of mounted filesystems - aborting\n");
         YieldCurrentLock(thislock);
@@ -334,7 +334,7 @@ static int FileSystemMountedCorrectly(Rlist *list, char *name, char *options, At
 
             found = true;
 
-            if (a.mount.mount_source && (strcmp(mp->source, a.mount.mount_source) != 0))
+            if ((a.mount.mount_source) && (strcmp(mp->source, a.mount.mount_source) != 0))
             {
                 CfOut(cf_inform, "", "A different file system (%s:%s) is mounted on %s than what is promised\n",
                       mp->host, mp->source, name);
@@ -401,7 +401,7 @@ static int IsForeignFileSystem(struct stat *childstat, char *dir)
 
             if (!strcmp(entry->mounton, dir))
             {
-                if (entry->options && strstr(entry->options, "nfs"))
+                if ((entry->options) && (strstr(entry->options, "nfs")))
                 {
                     return (true);
                 }


### PR DESCRIPTION
"Primary expressions" are defined in ISO 9899:1990, section 6.3.1. Essentially they are either a single identifier,
or a constant, or a parenthesised expression. The effect of this rule is to require that if an operand is other than
a single identifier or constant then it must be parenthesised. Parentheses are important in this situation both for
readability of code and for ensuring that the behaviour is as the programmer intended. Where an expression consists
of either a sequence of only logical && or a sequence of only logical ||, extra parentheses are not required.
