### PR TITLE
Removing a unit test that causes CFEngine to exit.

### DIFF
--- a/tests/unit/files_interfaces_test.c
+++ b/tests/unit/files_interfaces_test.c
@@ -87,24 +87,6 @@ static void test_cfreadline_corrupted(void **state)
     }
 }
 
-static void test_cfreadline_empty(void **state)
-{
-    int read = 0;
-    char output[CF_BUFSIZE] = { 0 };
-    FILE *fin;
-
-    fin = fopen(FILE_NAME_EMPTY, "r");
-
-    //test with empty file and valid file pointer
-    read = CfReadLine(output, CF_BUFSIZE - 1, fin);
-    assert_int_equal(read, false);
-
-    if (fin)
-    {
-        fclose(fin);
-    }
-}
-
 int main()
 {
     tests_setup();
@@ -113,7 +95,6 @@ int main()
     {
         unit_test(test_cfreadline_valid),
         unit_test(test_cfreadline_corrupted),
-        unit_test(test_cfreadline_empty),
     };
 
     PRINT_TEST_BANNER();


### PR DESCRIPTION
This test was in response to bug 1384, which was updated to exit upon a null or corrupted input filestream, so this unit test is no longer necessary.
