### PR TITLE
fix problem with empty texinfo menus for ref manual (resulting in standalone </ul> html tags)

### DIFF
--- a/src/manual.c
+++ b/src/manual.c
@@ -439,14 +439,17 @@ static void TexinfoBodyParts(const char *source_dir, FILE *fout, const BodySynta
         return;
     }
 
-    fprintf(fout, "@menu\n");
-
-    for (i = 0; bs[i].lval != NULL; ++i)
+    if (bs[0].lval != NULL)
     {
-        fprintf(fout, "* %s in %s::\n", bs[i].lval, context);
-    }
+        fprintf(fout, "@menu\n");
 
-    fprintf(fout, "@end menu\n");
+        for (i = 0; bs[i].lval != NULL; ++i)
+        {
+            fprintf(fout, "* %s in %s::\n", bs[i].lval, context);
+        }
+
+        fprintf(fout, "@end menu\n");
+    }
 
     for (i = 0; bs[i].lval != NULL; i++)
     {


### PR DESCRIPTION
We have had some problems in auto-publishing the reference manual.

The problem manifests itself as standalone closing tags for lists (i.e. </ul> with no corresponding <ul> tag before it) in the html output of makeinfo.

The cause is empty menus in texinfo, i.e.:
@menu
@end menu
which makeinfo (html generator) erroneously outputs as a standalone </ul> tag in the html format.

This commit is a quick and easy fix to avoid making empty texinfo menus, please review and make appropriate changes if need be.
