### PR TITLE
Fix context leak in edit_template files RM #1840

### DIFF
--- a/src/files_editline.c
+++ b/src/files_editline.c
@@ -279,6 +279,8 @@ Bundle *MakeTemporaryBundleFromTemplate(Attributes a, Promise *pp)
             DeleteItemList(lines);
             free(promiser);
             lines = NULL;
+
+            strcpy(context, "any"); // reset context for subsequent bare lines
         }
         else
         {


### PR DESCRIPTION
Reset context when a template block ends to ensure bare standalone lines, or subsequent [%CFEngine BEGIN %] blocks aren't affected.
