### PR TITLE
Added DeleteTimeClass, called in SetReferenceTime before AddTimeClass

### DIFF
--- a/src/env_context.c
+++ b/src/env_context.c
@@ -503,7 +503,7 @@ void HardClass(const char *oclass)
     Item *ip;
     char class[CF_MAXVARSIZE];
 
-    strcpy(class, oclass);    
+    strcpy(class, oclass);
     Chop(class);
     CanonifyNameInPlace(class);
 
@@ -554,6 +554,17 @@ void HardClass(const char *oclass)
             }
         }
     }
+}
+
+/*******************************************************************/
+
+void DeleteHardClass(const char *oclass)
+{
+    char class[CF_MAXVARSIZE];
+
+    strncpy(class, oclass, CF_MAXVARSIZE);
+
+    DeleteFromAlphaList(&VHARDHEAP, oclass);
 }
 
 /*******************************************************************/
@@ -1059,7 +1070,7 @@ static ExpressionValue EvalTokenAsClass(const char *classname, void *namespace)
 
     if (strcmp(classname, "any") == 0)
        {
-       return true;       
+       return true;
        }
     
     if (strchr(classname, ':'))

--- a/src/env_context.h
+++ b/src/env_context.h
@@ -76,6 +76,7 @@ void DeletePersistentContext(const char *name);
 void LoadPersistentContext(void);
 void AddEphemeralClasses(const Rlist *classlist, const char *ns);
 void HardClass(const char *oclass);
+void DeleteHardClass(const char *oclass);
 void NewClass(const char *oclass, const char *namespace);      /* Copies oclass */
 void NewBundleClass(const char *oclass, const char *bundle, const char *namespace);
 Rlist *SplitContextExpression(const char *context, Promise *pp);

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -31,6 +31,7 @@
 /* Prototypes */
 
 static void AddTimeClass(time_t time);
+static void RemoveTimeClass(time_t time);
 
 /*************************************************************************/
 
@@ -78,6 +79,7 @@ void SetReferenceTime(int setclasses)
 
     if (setclasses)
     {
+        RemoveTimeClass(tloc);
         AddTimeClass(tloc);
     }
 }
@@ -96,6 +98,108 @@ void SetStartTime(void)
     CFINITSTARTTIME = tloc;
 
     CfDebug("Job start time set to %s\n", cf_ctime(&tloc));
+}
+
+/*********************************************************************/
+
+static void RemoveTimeClass(time_t time)
+{
+    int i, j;
+    struct tm parsed_time;
+    char buf[CF_BUFSIZE];
+
+    if (localtime_r(&time, &parsed_time) == NULL)
+    {
+        CfOut(cf_error, "localtime_r", "Unable to parse passed time");
+        return;
+    }
+
+/* Lifecycle */
+
+    for( i = 0; i < 3; i++ )
+    {
+        snprintf(buf, CF_BUFSIZE, "Lcycle_%d", i);
+        DeleteHardClass(buf);
+    }
+
+/* Year */
+
+    snprintf(buf, CF_BUFSIZE, "Yr%04d", parsed_time.tm_year - 1 + 1900);
+    DeleteHardClass(buf);
+    snprintf(buf, CF_BUFSIZE, "Yr%04d", parsed_time.tm_year + 1900);
+    DeleteHardClass(buf);
+
+/* Month */
+
+    for( i = 0; i < 12; i++ )
+    {
+        DeleteHardClass(MONTH_TEXT[i]);
+    }
+
+/* Day of week */
+
+    for( i = 0; i < 7; i++ )
+    {
+        HardClass(DAY_TEXT[i]);
+    }
+
+/* Day */
+
+    for( i = 1; i < 32; i++ )
+    {
+        snprintf(buf, CF_BUFSIZE, "Day%d", i);
+        DeleteHardClass(buf);
+    }
+
+/* Shift */
+
+    for( i = 0; i < 4; i++ )
+    {
+        DeleteHardClass(SHIFT_TEXT[i]);
+    }
+
+/* Hour */
+
+    for( i = 0; i < 24; i++ )
+    {
+        snprintf(buf, CF_BUFSIZE, "Hr%02d", i);
+        DeleteHardClass(buf);
+    }
+
+/* GMT hour */
+
+    for( i = 0; i < 24; i++ )
+    {
+        snprintf(buf, CF_BUFSIZE, "GMT_Hr%02d", i);
+        DeleteHardClass(buf);
+    }
+
+/* Quarter */
+
+    for( i = 1; i <= 4; i++ )
+    {
+        snprintf(buf, CF_BUFSIZE, "Q%d", i);
+        DeleteHardClass(buf);
+        for( j = 0; j < 24; j++ )
+        {
+            snprintf(buf, CF_BUFSIZE, "Hr%02d_Q%d", j, i);
+            DeleteHardClass(buf);
+        }
+    }
+
+/* Minute */
+
+    for( i = 0; i < 60; i++ )
+    {
+        snprintf(buf, CF_BUFSIZE, "Min%02d", i);
+        DeleteHardClass(buf);
+    }
+
+    for( i = 0; i < 60; i += 5 )
+    {
+        snprintf(buf, CF_BUFSIZE, "Min%02d_%02d", i, (i + 5) % 60);
+        HardClass(buf);
+    }
 }
 
 /*********************************************************************/


### PR DESCRIPTION
Correcting SetReferenceTime as used by cf-execd to reset all time-based hard classes so that the schedule can be adhered to correctly.  Currently, no time classes are reset between cf-execd evaluations of ScheduleRun
