### PR TITLE
Fix a minor typo in namespaces, and introduce a constant to label namespace impact better

### DIFF
--- a/src/cf3.defs.h
+++ b/src/cf3.defs.h
@@ -135,6 +135,7 @@
 
 #define CF_DONE 't'
 #define CF_MORE 'm'
+#define CF_NS ':'   // namespace character separator
 
 /*****************************************************************************/
 

--- a/src/constraints.c
+++ b/src/constraints.c
@@ -891,10 +891,10 @@ PromiseIdent *NewPromiseId(char *handle, Promise *pp)
     char name[CF_BUFSIZE];
     ptr = xmalloc(sizeof(PromiseIdent));
 
-    snprintf(name, CF_BUFSIZE, "%s.%s", pp->namespace, handle);
+    snprintf(name, CF_BUFSIZE, "%s%c%s", pp->namespace, CF_NS, handle);
     ptr->filename = xstrdup(pp->audit->filename);
     ptr->line_number = pp->offset.line;
-    ptr->handle = xstrdup(handle);
+    ptr->handle = xstrdup(name);
     ptr->next = PROMISE_ID_LIST;
     PROMISE_ID_LIST = ptr;
     return ptr;
@@ -940,7 +940,7 @@ static PromiseIdent *PromiseIdExists(char *namespace, char *handle)
     PromiseIdent *key;
     char name[CF_BUFSIZE];
 
-    snprintf(name, CF_BUFSIZE, "%s.%s", namespace, handle);
+    snprintf(name, CF_BUFSIZE, "%s%c%s", namespace, CF_NS, handle);
     
     for (key = PROMISE_ID_LIST; key != NULL; key = key->next)
     {

--- a/src/policy.c
+++ b/src/policy.c
@@ -109,7 +109,7 @@ char *BundleQualifiedName(const Bundle *bundle)
     if (bundle->name)
     {
         const char *namespace = bundle->namespace ? bundle->namespace : DEFAULT_NAMESPACE;
-        return StringConcatenate(3, namespace, ".", bundle->name);
+        return StringConcatenate(3, namespace, ":", bundle->name);  // CF_NS == ':'
     }
 
     return NULL;

--- a/src/promises.c
+++ b/src/promises.c
@@ -374,11 +374,11 @@ Body *IsBody(Body *list, const char *namespace, const char *key)
 
     // bp->namespace is where the body belongs, namespace is where we are now
 
-        if (strchr(key,':') || strcmp(namespace,"default") == 0)
+        if (strchr(key, CF_NS) || strcmp(namespace,"default") == 0)
         {
-            if (strncmp(key,"default:",strlen("default:")) == 0)
+            if (strncmp(key,"default:",strlen("default:")) == 0) // CF_NS == ':'
             {
-                strcpy(fqname,strchr(key,':')+1);
+                strcpy(fqname,strchr(key,CF_NS)+1);
             }
             else
             {
@@ -387,7 +387,7 @@ Body *IsBody(Body *list, const char *namespace, const char *key)
         }
         else
         {
-            snprintf(fqname,CF_BUFSIZE-1, "%s:%s",namespace,key);
+            snprintf(fqname,CF_BUFSIZE-1, "%s%c%s", namespace, CF_NS, key);
         }
 
         if (strcmp(bp->name, fqname) == 0)
@@ -410,9 +410,9 @@ Bundle *IsBundle(Bundle *list, const char *key)
     {
         if (strcmp(bp->namespace,"default") == 0)
         {
-            if (strncmp(key,"default:",strlen("default:")) == 0)
+            if (strncmp(key,"default:",strlen("default:")) == 0)  // CF_NS == ':'
             {
-                strcpy(fqname,strchr(key,':')+1);
+                strcpy(fqname,strchr(key, CF_NS)+1);
             }
             else
             {
@@ -425,7 +425,7 @@ Bundle *IsBundle(Bundle *list, const char *key)
         }
         else
         {
-            snprintf(fqname,CF_BUFSIZE-1, "%s:%s",bp->namespace,key);
+            snprintf(fqname,CF_BUFSIZE-1, "%s%c%s", bp->namespace, CF_NS, key);
         }
 
         if (strcmp(bp->name, fqname) == 0)

--- a/src/scope.c
+++ b/src/scope.c
@@ -39,7 +39,7 @@ Scope *GetScope(const char *scope)
 {
     const char *name = scope;
 
-    if (strncmp(scope, "default:", strlen("default:")) == 0)
+    if (strncmp(scope, "default:", strlen("default:")) == 0)  // CF_NS == ':'
        {
        name = scope + strlen("default:");
        }
@@ -147,10 +147,10 @@ void AugmentScope(char *scope, char *namespace, Rlist *lvals, Rlist *rvals)
             
             GetNaked(naked, rpr->item);
 
-            if (IsQualifiedVariable(naked) && strchr(naked, ':') == NULL)
-               {
-               snprintf(qnaked, CF_MAXVARSIZE, "%s:%s", namespace, naked);
-               }
+            if (IsQualifiedVariable(naked) && strchr(naked, CF_NS) == NULL)
+            {
+                snprintf(qnaked, CF_MAXVARSIZE, "%s%c%s", namespace, CF_NS, naked);
+            }
             
             vtype = GetVariable(scope, qnaked, &retval); 
 
@@ -395,7 +395,7 @@ void SplitScopeName(const char *scope, char ns_out[CF_MAXVARSIZE], char bundle_o
 {
     assert(scope);
 
-    char *split_point = strstr(scope, ":");
+    char *split_point = strstr(scope, CF_NS);
     if (split_point)
     {
         strncpy(ns_out, scope, split_point - scope);
@@ -407,13 +407,15 @@ void SplitScopeName(const char *scope, char ns_out[CF_MAXVARSIZE], char bundle_o
     }
 }
 
+/*******************************************************************/
+
 void JoinScopeName(const char *ns, const char *bundle, char scope_out[CF_MAXVARSIZE])
 {
     assert(bundle);
 
     if (ns)
     {
-        snprintf(scope_out, CF_MAXVARSIZE, "%s:%s", ns, bundle);
+        snprintf(scope_out, CF_MAXVARSIZE, "%s%c%s", ns, CF_NS, bundle);
     }
     else
     {

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -179,25 +179,25 @@ void CheckConstraint(char *type, char *namespace, char *name, char *lval, Rval r
                     switch (rval.rtype)
                        {
                        case CF_SCALAR:
-                           if (strchr((char *)rval.item,':'))
+                           if (strchr((char *)rval.item, CF_NS))
                            {
                                strcpy(fqname,(char *)rval.item);
                            }
                            else
                            {
-                               snprintf(fqname,CF_BUFSIZE-1,"%s:%s",namespace,(char *)rval.item);
+                               snprintf(fqname,CF_BUFSIZE-1,"%s%c%s", namespace, CF_NS, (char *)rval.item);
                            }
                            break;
                            
                        case CF_FNCALL:
                            fp = (FnCall *) rval.item;
-                           if (strchr(fp->name,':'))
+                           if (strchr(fp->name, CF_NS))
                            {
                                strcpy(fqname,fp->name);
                            }
                            else
                            {                              
-                               snprintf(fqname,CF_BUFSIZE-1,"%s:%s",namespace,fp->name);
+                               snprintf(fqname,CF_BUFSIZE-1,"%s%c%s", namespace, CF_NS, fp->name);
                            }
                            break;
                        }

--- a/src/verify_files.c
+++ b/src/verify_files.c
@@ -500,13 +500,13 @@ int ScheduleEditOperation(char *filename, Attributes a, Promise *pp, const Repor
             return false;
         }
 
-        if (strncmp(edit_bundle_name,"default:",strlen("default:")) == 0)
+        if (strncmp(edit_bundle_name,"default:",strlen("default:")) == 0) // CF_NS == ':'
         {
-            method_deref = strchr(edit_bundle_name,':') + 1;
+            method_deref = strchr(edit_bundle_name, CF_NS) + 1;
         }
-        else if (strchr(edit_bundle_name, ':') == NULL && strcmp(pp->namespace, "default") != 0)
+        else if ((strchr(edit_bundle_name, CF_NS) == NULL) && (strcmp(pp->namespace, "default") != 0))
         {
-            snprintf(qualified_edit, CF_BUFSIZE, "%s:%s", pp->namespace, edit_bundle_name);
+            snprintf(qualified_edit, CF_BUFSIZE, "%s%c%s", pp->namespace, CF_NS, edit_bundle_name);
             method_deref = qualified_edit;
         }
         else            
@@ -558,9 +558,9 @@ int ScheduleEditOperation(char *filename, Attributes a, Promise *pp, const Repor
             return false;
         }
 
-        if (strncmp(edit_bundle_name,"default:",strlen("default:")) == 0)
+        if (strncmp(edit_bundle_name,"default:",strlen("default:")) == 0) // CF_NS == ':'
            {
-           method_deref = strchr(edit_bundle_name,':') + 1;
+           method_deref = strchr(edit_bundle_name, CF_NS) + 1;
            }
         else
            {

--- a/src/verify_methods.c
+++ b/src/verify_methods.c
@@ -89,13 +89,13 @@ int VerifyMethod(char *attrname, Attributes a, Promise *pp, const ReportContext 
 
     PromiseBanner(pp);
 
-    if (strncmp(method_name,"default:",strlen("default:")) == 0)
+    if (strncmp(method_name,"default:",strlen("default:")) == 0) // CF_NS == ':'
     {
-        method_deref = strchr(method_name,':') + 1;
+        method_deref = strchr(method_name, CF_NS) + 1;
     }
-    else if (strchr(method_name, ':') == NULL && strcmp(pp->namespace, "default") != 0)
+    else if ((strchr(method_name, CF_NS) == NULL) && (strcmp(pp->namespace, "default") != 0))
     {
-        snprintf(qualified_method, CF_BUFSIZE, "%s:%s", pp->namespace, method_name);
+        snprintf(qualified_method, CF_BUFSIZE, "%s%c%s", pp->namespace, CF_NS, method_name);
         method_deref = qualified_method;
     }
     else


### PR DESCRIPTION
This fix is necessary to compile 3.4.x  properly, after the recent additions related to classmatch into 3.4.x branch

Conflicts:

```
src/verify_files.c
src/verify_methods.c
```
