### PR TITLE
Fix edit_xml update of existing attribute, with acceptance test

### DIFF
--- a/cf-agent/files_editxml.c
+++ b/cf-agent/files_editxml.c
@@ -1306,7 +1306,7 @@ static bool SetAttributeInNode(char *rawname, char *rawvalue, xmlDocPtr doc, xml
     //set attribute in docnode
     cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Setting attribute \"%s\" in %s", pp->promiser,
           pp->this_server);
-    if ((attr = xmlNewProp(docnode, name, value)) == NULL)
+    if ((attr = xmlSetProp(docnode, name, value)) == NULL)
     {
         cfPS(cf_verbose, CF_INTERPT, "", pp, a,
              " !! Attribute was not successfully set in XML document");

--- a/tests/acceptance/10_files/11_xml_edits/staging/set_attribute_003.cf
+++ b/tests/acceptance/10_files/11_xml_edits/staging/set_attribute_003.cf
@@ -1,0 +1,92 @@
+######################################################################
+#
+# File editing edit_xml - test changing an existing attribute of a node
+#
+######################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+nova_edition::
+  host_licenses_paid => "5";
+}
+
+#######################################################
+
+bundle agent init
+{
+vars:
+        "states" slist => { "actual", "expected" };
+
+        "actual" string =>
+"<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>
+<Potatoes>
+  <Potato name=\"OnePotato\" topping=\"broccoli\">
+  </Potato>
+  <Potato name=\"TwoPotato\">
+  </Potato>
+  <Potato name=\"ThreePotato\">
+  </Potato>
+</Potatoes>";
+
+        "expected" string =>
+"<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>
+<Potatoes>
+  <Potato name=\"OnePotato\" topping=\"sourcream\">
+  </Potato>
+  <Potato name=\"TwoPotato\">
+  </Potato>
+  <Potato name=\"ThreePotato\">
+  </Potato>
+</Potatoes>";
+
+files:
+        "$(G.testfile).$(states)"
+            create => "true",
+            edit_line => init_insert("$(init.$(states))"),
+            edit_defaults => init_empty;
+}
+
+bundle edit_line init_insert(str)
+{
+insert_lines:
+        "$(str)";
+}
+
+body edit_defaults init_empty
+{
+        empty_file_before_editing => "true";
+}
+
+#######################################################
+bundle agent test
+{
+vars:
+      "attribute_name" string => "topping";
+
+files:
+        "$(G.testfile).actual"
+            create => "true",
+            edit_xml => test_set("$(test.attribute_name)");
+}
+
+bundle edit_xml test_set(str)
+{
+set_attribute:
+        "$(str)"
+        select_xpath => "/Potatoes/Potato[@name=\'OnePotato\']",
+        attribute_value => "sourcream";
+}
+
+#######################################################
+
+bundle agent check
+{
+methods:
+        "any" usebundle => default_check_diff("$(G.testfile).actual",
+                                              "$(G.testfile).expected",
+                                              "$(this.promise_filename)");
+}
+


### PR DESCRIPTION
Redmine 2034: https://cfengine.com/dev/issues/2034

The xmlNewProp() libxml2 call, used in SetAttributeInNode(), does not alter the value of an existing attribute, resulting in an inability to keep promises about the value of any existing attribute.

The xmlSetProp call will create an attribute that does not exist, so replacing xmlNewProp with xmlSetProp resolves the issue.

The acceptance test is a copy of set_attribute_002.cf, slightly modified.
