### PR TITLE
Kill globals VINPUTFILE and MINUSF, with fire

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -74,7 +74,7 @@ extern int PR_NOTKEPT;
 /*******************************************************************/
 
 static void ThisAgentInit(void);
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 static void CheckAgentAccess(Rlist *list);
 static void KeepAgentPromise(Promise *pp, const ReportContext *report_context);
 static int NewTypeContext(enum typesequence type);
@@ -83,7 +83,7 @@ static void ClassBanner(enum typesequence type);
 static void ParallelFindAndVerifyFilesPromises(Promise *pp, const ReportContext *report_context);
 static bool VerifyBootstrap(void);
 static void KeepPromiseBundles(Policy *policy, Rlist *bundlesequence, const ReportContext *report_context);
-static void KeepPromises(Policy *policy, GenericAgentConfig config, const ReportContext *report_context);
+static void KeepPromises(Policy *policy, GenericAgentConfig *config, const ReportContext *report_context);
 static int NoteBundleCompliance(const Bundle *bundle, int save_pr_kept, int save_pr_repaired, int save_pr_notkept);
 
 /*******************************************************************/
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 {
     int ret = 0;
 
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("agent");
     Policy *policy = GenericInitialize("agent", config, report_context);
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
     NoteClassUsage(VHARDHEAP, true);
 #ifdef HAVE_NOVA
     Nova_NoteVarUsageDB();
-    Nova_TrackExecution();
+    Nova_TrackExecution(config->input_file);
 #endif
     PurgeLocks();
 
@@ -159,6 +159,7 @@ int main(int argc, char *argv[])
     }
 
     EndAudit();
+    GenericAgentConfigDestroy(config);
 
     return ret;
 }
@@ -167,13 +168,13 @@ int main(int argc, char *argv[])
 /* Level 1                                                         */
 /*******************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     char *sp;
     int optindex = 0;
     int c, alpha = false, v6 = false;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_AGENT);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_AGENT);
 
 /* Because of the MacOS linker we have to call this from each agent
    individually before Generic Initialize */
@@ -190,14 +191,13 @@ static GenericAgentConfig CheckOpts(int argc, char **argv)
                 FatalError(" -f used but argument \"%s\" incorrect", optarg);
             }
 
-            SetInputFile(optarg);
-            MINUSF = true;
+            GenericAgentConfigSetInputFile(config, optarg);
             break;
 
         case 'b':
             if (optarg)
             {
-                config.bundlesequence = SplitStringAsRList(optarg, ',');
+                config->bundlesequence = SplitStringAsRList(optarg, ',');
                 CBUNDLESEQUENCE_STR = optarg;
             }
             break;
@@ -209,7 +209,7 @@ static GenericAgentConfig CheckOpts(int argc, char **argv)
 
         case 'B':
             BOOTSTRAP = true;
-            MINUSF = true;
+            GenericAgentConfigSetInputFile(config, "promises.cf");
             IGNORELOCK = true;
             HardClass("bootstrap_mode");
             break;
@@ -356,12 +356,12 @@ static void ThisAgentInit(void)
 
 /*******************************************************************/
 
-static void KeepPromises(Policy *policy, GenericAgentConfig config, const ReportContext *report_context)
+static void KeepPromises(Policy *policy, GenericAgentConfig *config, const ReportContext *report_context)
 {
     double efficiency, model;
 
     KeepControlPromises(policy);
-    KeepPromiseBundles(policy, config.bundlesequence, report_context);
+    KeepPromiseBundles(policy, config->bundlesequence, report_context);
 
 // TOPICS counts the number of currently defined promises
 // OCCUR counts the number of objects touched while verifying config

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -59,14 +59,14 @@ static pthread_attr_t threads_attrs;
 
 /*******************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 static void ThisAgentInit(void);
-static bool ScheduleRun(Policy **policy, ExecConfig *exec_config, const ReportContext *report_context);
+static bool ScheduleRun(Policy **policy, GenericAgentConfig *config, ExecConfig *exec_config, const ReportContext *report_context);
 static void Apoptosis(void);
 
 static bool LocalExecInThread(const ExecConfig *config);
 
-void StartServer(Policy *policy, ExecConfig *config, const ReportContext *report_context);
+void StartServer(Policy *policy, GenericAgentConfig *config, ExecConfig *exec_config, const ReportContext *report_context);
 void KeepPromises(Policy *policy, ExecConfig *config);
 
 static ExecConfig *CopyExecConfig(const ExecConfig *config);
@@ -125,7 +125,7 @@ static const char *HINTS[sizeof(OPTIONS)/sizeof(OPTIONS[0])] =
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("executor");
     Policy *policy = GenericInitialize("executor", config, report_context);
@@ -153,10 +153,11 @@ int main(int argc, char *argv[])
     else
 #endif /* __MINGW32__ */
     {
-        StartServer(policy, &exec_config, report_context);
+        StartServer(policy, config, &exec_config, report_context);
     }
 
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
 
     return 0;
 }
@@ -165,13 +166,13 @@ int main(int argc, char *argv[])
 /* Level 1                                                                   */
 /*****************************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
     char ld_library_path[CF_BUFSIZE];
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_EXECUTOR);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_EXECUTOR);
 
     while ((c = getopt_long(argc, argv, "dvnKIf:D:N:VxL:hFOV1gMW", OPTIONS, &optindex)) != EOF)
     {
@@ -184,8 +185,7 @@ static GenericAgentConfig CheckOpts(int argc, char **argv)
                 FatalError(" -f used but argument \"%s\" incorrect", optarg);
             }
 
-            SetInputFile(optarg);
-            MINUSF = true;
+            GenericAgentConfigSetInputFile(config, optarg);
             break;
 
         case 'd':
@@ -412,7 +412,7 @@ void KeepPromises(Policy *policy, ExecConfig *config)
 /*****************************************************************************/
 
 /* Might be called back from NovaWin_StartExecService */
-void StartServer(Policy *policy, ExecConfig *config, const ReportContext *report_context)
+void StartServer(Policy *policy, GenericAgentConfig *config, ExecConfig *exec_config, const ReportContext *report_context)
 {
 #if !defined(__MINGW32__)
     time_t now = time(NULL);
@@ -496,22 +496,22 @@ void StartServer(Policy *policy, ExecConfig *config, const ReportContext *report
     {
         CfOut(cf_verbose, "", "Sleeping for splaytime %d seconds\n\n", SPLAYTIME);
         sleep(SPLAYTIME);
-        LocalExec(config);
+        LocalExec(exec_config);
         CloseLog();
     }
     else
     {
         while (!IsPendingTermination())
         {
-            if (ScheduleRun(&policy, config, report_context))
+            if (ScheduleRun(&policy, config, exec_config, report_context))
             {
                 CfOut(cf_verbose, "", "Sleeping for splaytime %d seconds\n\n", SPLAYTIME);
                 sleep(SPLAYTIME);
 
-                if (!LocalExecInThread(config))
+                if (!LocalExecInThread(exec_config))
                 {
                     CfOut(cf_inform, "", "Unable to run agent in thread, falling back to blocking execution");
-                    LocalExec(config);
+                    LocalExec(exec_config);
                 }
             }
         }
@@ -635,13 +635,13 @@ typedef enum
     RELOAD_FULL
 } Reload;
 
-static Reload CheckNewPromises(const ReportContext *report_context)
+static Reload CheckNewPromises(const char *input_file, const ReportContext *report_context)
 {
-    if (NewPromiseProposals())
+    if (NewPromiseProposals(input_file))
     {
         CfOut(cf_verbose, "", " -> New promises detected...\n");
 
-        if (CheckPromises(AGENT_TYPE_EXECUTOR, report_context))
+        if (CheckPromises(AGENT_TYPE_EXECUTOR, input_file, report_context))
         {
             return RELOAD_FULL;
         }
@@ -659,7 +659,7 @@ static Reload CheckNewPromises(const ReportContext *report_context)
     return RELOAD_ENVIRONMENT;
 }
 
-static bool ScheduleRun(Policy **policy, ExecConfig *exec_config, const ReportContext *report_context)
+static bool ScheduleRun(Policy **policy, GenericAgentConfig *config, ExecConfig *exec_config, const ReportContext *report_context)
 {
     Item *ip;
 
@@ -678,11 +678,11 @@ static bool ScheduleRun(Policy **policy, ExecConfig *exec_config, const ReportCo
      * FIXME: this logic duplicates the one from cf-serverd.c. Unify ASAP.
      */
 
-    if (CheckNewPromises(report_context) == RELOAD_FULL)
+    if (CheckNewPromises(config->input_file, report_context) == RELOAD_FULL)
     {
         /* Full reload */
 
-        CfOut(cf_inform, "", "Re-reading promise file %s..\n", VINPUTFILE);
+        CfOut(cf_inform, "", "Re-reading promise file %s..\n", config->input_file);
 
         DeleteAlphaList(&VHEAP);
         InitAlphaList(&VHEAP);
@@ -731,9 +731,7 @@ static bool ScheduleRun(Policy **policy, ExecConfig *exec_config, const ReportCo
 
         SetReferenceTime(true);
 
-        GenericAgentConfig config = {
-            .bundlesequence = NULL
-        };
+        GenericAgentConfigSetBundleSequence(config, NULL);
 
         *policy = ReadPromises(AGENT_TYPE_EXECUTOR, CF_EXECC, config, report_context);
         KeepPromises(*policy, exec_config);

--- a/cf-gendoc/cf-gendoc.c
+++ b/cf-gendoc/cf-gendoc.c
@@ -40,7 +40,7 @@
 static void GenerateManual(void);
 static void GenerateXml(void);
 
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 
 char SOURCE_DIR[CF_BUFSIZE];
 char OUTPUT_FILE[CF_BUFSIZE];
@@ -71,7 +71,7 @@ static const char *HINTS[] =
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("gendoc");
     GenericInitialize("gendoc", config, report_context);
@@ -86,15 +86,16 @@ int main(int argc, char *argv[])
     }
 
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
     return 0;
 }
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_GENDOC);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_GENDOC);
 
     getcwd(SOURCE_DIR, CF_BUFSIZE);
     snprintf(OUTPUT_FILE, CF_BUFSIZE, "%scf3-Reference.texinfo", SOURCE_DIR);

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -46,7 +46,7 @@ bool LICENSE_INSTALL = false;
 char LICENSE_SOURCE[MAX_FILENAME];
 const char *remove_keys_host;
 
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 
 static void ShowLastSeenHosts(void);
 static int RemoveKeys(const char *host);
@@ -92,7 +92,7 @@ static const char *HINTS[17] =
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     THIS_AGENT_TYPE = AGENT_TYPE_KEYGEN;
 
@@ -119,6 +119,7 @@ int main(int argc, char *argv[])
     KeepKeyPromises();
 
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
     return 0;
 }
 
@@ -126,12 +127,12 @@ int main(int argc, char *argv[])
 /* Level                                                                     */
 /*****************************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_KEYGEN);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_KEYGEN);
 
     while ((c = getopt_long(argc, argv, "dvf:VMsr:hl:", OPTIONS, &optindex)) != EOF)
     {

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -37,7 +37,7 @@
 /*****************************************************************************/
 
 static void ThisAgentInit(void);
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 static void KeepPromises(Policy *policy, const ReportContext *report_context);
 
 /*****************************************************************************/
@@ -96,7 +96,7 @@ static const char *HINTS[14] =
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("monitor");
     Policy *policy = GenericInitialize("monitor", config, report_context);
@@ -106,25 +106,25 @@ int main(int argc, char *argv[])
     MonitorStartServer(policy, report_context);
 
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
     return 0;
 }
 
 /*******************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_MONITOR);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_MONITOR);
 
     while ((c = getopt_long(argc, argv, "dvnIf:VSxHTKMFh", OPTIONS, &optindex)) != EOF)
     {
         switch ((char) c)
         {
         case 'f':
-            SetInputFile(optarg);
-            MINUSF = true;
+            GenericAgentConfigSetInputFile(config, optarg);
             break;
 
         case 'd':

--- a/cf-report/cf-report.c
+++ b/cf-report/cf-report.c
@@ -52,7 +52,7 @@
 #include <assert.h>
 
 static void ThisAgentInit(void);
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 
 static void KeepReportsControlPromises(Policy *policy);
 static void KeepReportsPromises(void);
@@ -293,7 +293,7 @@ char *CFRH[][2] =
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("reporter");
     Policy *policy = NULL;
@@ -308,7 +308,9 @@ int main(int argc, char *argv[])
     ThisAgentInit();
     KeepReportsControlPromises(policy);
     KeepReportsPromises();
+
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
     return 0;
 }
 
@@ -318,20 +320,19 @@ int main(int argc, char *argv[])
 
 /*****************************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_REPORT);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_REPORT);
 
     while ((c = getopt_long(argc, argv, "CghdvVf:st:ar:PXHLMIRSKE:x:i:1:p:k:c:qF:o:", OPTIONS, &optindex)) != EOF)
     {
         switch ((char) c)
         {
         case 'f':
-            SetInputFile(optarg);
-            MINUSF = true;
+            GenericAgentConfigSetInputFile(config, optarg);
             break;
 
         case 'd':

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -43,7 +43,7 @@
 #include "string_lib.h"
 
 static void ThisAgentInit(void);
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 
 static int HailServer(char *host, Attributes a, Promise *pp);
 static int ParseHostname(char *hostname, char *new_hostname);
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
     int pid;
 #endif
 
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
     ReportContext *report_context = OpenReports("runagent");
 
     Policy *policy = GenericInitialize("runagent", config, report_context);
@@ -212,6 +212,8 @@ int main(int argc, char *argv[])
 #endif
 
     DeletePromise(pp);
+
+    GenericAgentConfigDestroy(config);
     ReportContextDestroy(report_context);
 
     return 0;
@@ -219,12 +221,12 @@ int main(int argc, char *argv[])
 
 /*******************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_RUNAGENT);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_RUNAGENT);
 
     DEFINECLASSES[0] = '\0';
     SENDCLASSES[0] = '\0';
@@ -234,8 +236,7 @@ static GenericAgentConfig CheckOpts(int argc, char **argv)
         switch ((char) c)
         {
         case 'f':
-            SetInputFile(optarg);
-            MINUSF = true;
+            GenericAgentConfigSetInputFile(config, optarg);
             break;
 
         case 'b':

--- a/cf-serverd/cf-serverd-functions.h
+++ b/cf-serverd/cf-serverd-functions.h
@@ -42,15 +42,15 @@
 #include "reporting.h"
 
 void ThisAgentInit(void);
-GenericAgentConfig CheckOpts(int argc, char **argv);
+GenericAgentConfig *CheckOpts(int argc, char **argv);
 int OpenReceiverChannel(void);
-void CheckFileChanges(Policy **policy, GenericAgentConfig config, const ReportContext *report_context);
+void CheckFileChanges(Policy **policy, GenericAgentConfig *config, const ReportContext *report_context);
 int InitServer(size_t queue_size);
 
 #if !defined(HAVE_GETADDRINFO)
 in_addr_t GetInetAddr(char *host);
 #endif
 
-void StartServer(Policy *policy, GenericAgentConfig config, const ReportContext *report_context);
+void StartServer(Policy *policy, GenericAgentConfig *config, const ReportContext *report_context);
 
 #endif // CFSERVERDFUNCTIONS_H

--- a/cf-serverd/cf-serverd.c
+++ b/cf-serverd/cf-serverd.c
@@ -26,7 +26,7 @@
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("server");
     Policy *policy = GenericInitialize("server", config, report_context);
@@ -37,5 +37,6 @@ int main(int argc, char *argv[])
     StartServer(policy, config, report_context);
 
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
     return 0;
 }

--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -59,7 +59,6 @@ extern char VMONTH[];
 extern char VSHIFT[];
 
 extern const char *CLASSTEXT[];
-extern char VINPUTFILE[];
 extern int AUDIT;
 extern char PURGE;
 
@@ -90,7 +89,6 @@ extern int CFPARANOID;
 
 extern int DONTDO;
 extern int IGNORELOCK;
-extern int MINUSF;
 
 extern const char *VPSCOMM[];
 extern const char *VPSOPTS[];

--- a/libpromises/cf3globals.c
+++ b/libpromises/cf3globals.c
@@ -158,7 +158,6 @@ char PURGE = 'n';
 
 int ERRORCOUNT = 0;
 char VPREFIX[CF_MAXVARSIZE] = { 0 };
-char VINPUTFILE[CF_BUFSIZE] = { 0 };
 
 char CONTEXTID[CF_MAXVARSIZE] = { 0 };
 char CFPUBKEYFILE[CF_BUFSIZE] = { 0 };
@@ -239,7 +238,6 @@ int VIFELAPSED = 1;
 int VEXPIREAFTER = 120;
 char BINDINTERFACE[CF_BUFSIZE] = { 0 };
 
-int MINUSF = false;
 int EXCLAIM = true;
 
 Item *VSETUIDLIST = NULL;

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -33,16 +33,17 @@ typedef struct
 {
     Rlist *bundlesequence;
     bool verify_promises;
+    char *input_file;
 } GenericAgentConfig;
 
-Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportContext *report_context);
-void InitializeGA(const ReportContext *report_context);
+Policy *GenericInitialize(char *agents, GenericAgentConfig *config, const ReportContext *report_context);
+void InitializeGA(GenericAgentConfig *config, const ReportContext *report_context);
 void Syntax(const char *comp, const struct option options[], const char *hints[], const char *id);
 void ManPage(const char *component, const struct option options[], const char *hints[], const char *id);
 void PrintVersionBanner(const char *component);
-int CheckPromises(AgentType ag, const ReportContext *report_context);
-Policy *ReadPromises(AgentType ag, char *agents, GenericAgentConfig config, const ReportContext *report_context);
-int NewPromiseProposals(void);
+int CheckPromises(AgentType ag, const char *input_file, const ReportContext *report_context);
+Policy *ReadPromises(AgentType ag, char *agents, GenericAgentConfig *config, const ReportContext *report_context);
+int NewPromiseProposals(const char *input_file);
 void CompilationReport(Policy *policy, char *fname);
 void HashVariables(Policy *policy, const char *name, const ReportContext *report_context);
 void HashControls(const Policy *policy);
@@ -57,11 +58,18 @@ void BannerBundle(Bundle *bp, Rlist *args);
 void BannerSubBundle(Bundle *bp, Rlist *args);
 void WritePID(char *filename);
 ReportContext *OpenCompilationReportFiles(const char *fname);
-GenericAgentConfig GenericAgentDefaultConfig(AgentType agent_type);
 void CheckLicenses(void);
 void ReloadPromises(AgentType ag);
-void SetInputFile(const char *filename);
 
 ReportContext *OpenReports(const char *agents);
 void CloseReports(const char *agents, ReportContext *report_context);
+
+
+
+GenericAgentConfig *GenericAgentConfigNewDefault(AgentType agent_type);
+void GenericAgentConfigDestroy(GenericAgentConfig *config);
+
+void GenericAgentConfigSetInputFile(GenericAgentConfig *config, const char *input_file);
+void GenericAgentConfigSetBundleSequence(GenericAgentConfig *config, const Rlist *bundlesequence);
+
 #endif

--- a/libpromises/instrumentation.c
+++ b/libpromises/instrumentation.c
@@ -166,13 +166,6 @@ void NoteClassUsage(AlphaList baselist, int purge)
     double lastseen;
     double vtrue = 1.0;         /* end with a rough probability */
 
-/* Only do this for the default policy, too much "downgrading" otherwise */
-
-    if (MINUSF)
-    {
-        return;
-    }
-
     AlphaListIterator it = AlphaListIteratorInit(&baselist);
 
     for (ip = AlphaListIteratorNext(&it); ip != NULL; ip = AlphaListIteratorNext(&it))


### PR DESCRIPTION
Behavior Change
Previously NoteClassUsage was preempted if the user had specified a file argument in cf-agent.
This appears to have been done for performance reasons while tsting. Now, NoteClassUsage is whether a
file argument is given or not.
