### PR TITLE
Kill global VINPUTFILE, with fire

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -74,7 +74,7 @@ extern int PR_NOTKEPT;
 /*******************************************************************/
 
 static void ThisAgentInit(void);
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 static void CheckAgentAccess(Rlist *list);
 static void KeepAgentPromise(Promise *pp, const ReportContext *report_context);
 static int NewTypeContext(enum typesequence type);
@@ -83,7 +83,7 @@ static void ClassBanner(enum typesequence type);
 static void ParallelFindAndVerifyFilesPromises(Promise *pp, const ReportContext *report_context);
 static bool VerifyBootstrap(void);
 static void KeepPromiseBundles(Policy *policy, Rlist *bundlesequence, const ReportContext *report_context);
-static void KeepPromises(Policy *policy, GenericAgentConfig config, const ReportContext *report_context);
+static void KeepPromises(Policy *policy, GenericAgentConfig *config, const ReportContext *report_context);
 static int NoteBundleCompliance(const Bundle *bundle, int save_pr_kept, int save_pr_repaired, int save_pr_notkept);
 
 /*******************************************************************/
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 {
     int ret = 0;
 
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("agent");
     Policy *policy = GenericInitialize("agent", config, report_context);
@@ -145,11 +145,16 @@ int main(int argc, char *argv[])
     BeginAudit();
     KeepPromises(policy, config, report_context);
     CloseReports("agent", report_context);
-    NoteClassUsage(VHEAP, true);
-    NoteClassUsage(VHARDHEAP, true);
+
+    // only note class usage when default policy is run
+    if (!config->input_file)
+    {
+        NoteClassUsage(VHEAP, true);
+        NoteClassUsage(VHARDHEAP, true);
+    }
 #ifdef HAVE_NOVA
     Nova_NoteVarUsageDB();
-    Nova_TrackExecution();
+    Nova_TrackExecution(config->input_file);
 #endif
     PurgeLocks();
 
@@ -159,6 +164,7 @@ int main(int argc, char *argv[])
     }
 
     EndAudit();
+    GenericAgentConfigDestroy(config);
 
     return ret;
 }
@@ -167,13 +173,13 @@ int main(int argc, char *argv[])
 /* Level 1                                                         */
 /*******************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     char *sp;
     int optindex = 0;
     int c, alpha = false, v6 = false;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_AGENT);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_AGENT);
 
 /* Because of the MacOS linker we have to call this from each agent
    individually before Generic Initialize */
@@ -190,14 +196,14 @@ static GenericAgentConfig CheckOpts(int argc, char **argv)
                 FatalError(" -f used but argument \"%s\" incorrect", optarg);
             }
 
-            SetInputFile(optarg);
+            GenericAgentConfigSetInputFile(config, optarg);
             MINUSF = true;
             break;
 
         case 'b':
             if (optarg)
             {
-                config.bundlesequence = SplitStringAsRList(optarg, ',');
+                config->bundlesequence = SplitStringAsRList(optarg, ',');
                 CBUNDLESEQUENCE_STR = optarg;
             }
             break;
@@ -210,6 +216,7 @@ static GenericAgentConfig CheckOpts(int argc, char **argv)
         case 'B':
             BOOTSTRAP = true;
             MINUSF = true;
+            GenericAgentConfigSetInputFile(config, "promises.cf");
             IGNORELOCK = true;
             HardClass("bootstrap_mode");
             break;
@@ -356,12 +363,12 @@ static void ThisAgentInit(void)
 
 /*******************************************************************/
 
-static void KeepPromises(Policy *policy, GenericAgentConfig config, const ReportContext *report_context)
+static void KeepPromises(Policy *policy, GenericAgentConfig *config, const ReportContext *report_context)
 {
     double efficiency, model;
 
     KeepControlPromises(policy);
-    KeepPromiseBundles(policy, config.bundlesequence, report_context);
+    KeepPromiseBundles(policy, config->bundlesequence, report_context);
 
 // TOPICS counts the number of currently defined promises
 // OCCUR counts the number of objects touched while verifying config

--- a/cf-gendoc/cf-gendoc.c
+++ b/cf-gendoc/cf-gendoc.c
@@ -40,7 +40,7 @@
 static void GenerateManual(void);
 static void GenerateXml(void);
 
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 
 char SOURCE_DIR[CF_BUFSIZE];
 char OUTPUT_FILE[CF_BUFSIZE];
@@ -71,7 +71,7 @@ static const char *HINTS[] =
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("gendoc");
     GenericInitialize("gendoc", config, report_context);
@@ -86,15 +86,16 @@ int main(int argc, char *argv[])
     }
 
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
     return 0;
 }
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_GENDOC);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_GENDOC);
 
     getcwd(SOURCE_DIR, CF_BUFSIZE);
     snprintf(OUTPUT_FILE, CF_BUFSIZE, "%scf3-Reference.texinfo", SOURCE_DIR);

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -46,7 +46,7 @@ bool LICENSE_INSTALL = false;
 char LICENSE_SOURCE[MAX_FILENAME];
 const char *remove_keys_host;
 
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 
 static void ShowLastSeenHosts(void);
 static int RemoveKeys(const char *host);
@@ -92,7 +92,7 @@ static const char *HINTS[17] =
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     THIS_AGENT_TYPE = AGENT_TYPE_KEYGEN;
 
@@ -119,6 +119,7 @@ int main(int argc, char *argv[])
     KeepKeyPromises();
 
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
     return 0;
 }
 
@@ -126,12 +127,12 @@ int main(int argc, char *argv[])
 /* Level                                                                     */
 /*****************************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_KEYGEN);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_KEYGEN);
 
     while ((c = getopt_long(argc, argv, "dvf:VMsr:hl:", OPTIONS, &optindex)) != EOF)
     {

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -37,7 +37,7 @@
 /*****************************************************************************/
 
 static void ThisAgentInit(void);
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 static void KeepPromises(Policy *policy, const ReportContext *report_context);
 
 /*****************************************************************************/
@@ -96,7 +96,7 @@ static const char *HINTS[14] =
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("monitor");
     Policy *policy = GenericInitialize("monitor", config, report_context);
@@ -106,24 +106,25 @@ int main(int argc, char *argv[])
     MonitorStartServer(policy, report_context);
 
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
     return 0;
 }
 
 /*******************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_MONITOR);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_MONITOR);
 
     while ((c = getopt_long(argc, argv, "dvnIf:VSxHTKMFh", OPTIONS, &optindex)) != EOF)
     {
         switch ((char) c)
         {
         case 'f':
-            SetInputFile(optarg);
+            GenericAgentConfigSetInputFile(config, optarg);
             MINUSF = true;
             break;
 

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -34,7 +34,7 @@
 /*******************************************************************/
 
 static void ThisAgentInit(void);
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 
 /*******************************************************************/
 /* Command line options                                            */
@@ -90,12 +90,14 @@ static const char *HINTS[] =
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
     ReportContext *report_context = OpenReports("common");
     
     GenericInitialize("common", config, report_context);
     ThisAgentInit();
     AnalyzePromiseConflicts();
+
+    GenericAgentConfigDestroy(config);
     CloseReports("commmon", report_context);
 
     if (ERRORCOUNT > 0)
@@ -114,12 +116,12 @@ int main(int argc, char *argv[])
 /* Level 1                                                         */
 /*******************************************************************/
 
-GenericAgentConfig CheckOpts(int argc, char **argv)
+GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_COMMON);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_COMMON);
 
     while ((c = getopt_long(argc, argv, "advnIf:D:N:VSrxMb:pg:h", OPTIONS, &optindex)) != EOF)
     {
@@ -132,7 +134,7 @@ GenericAgentConfig CheckOpts(int argc, char **argv)
                 FatalError(" -f used but argument \"%s\" incorrect", optarg);
             }
 
-            SetInputFile(optarg);
+            GenericAgentConfigSetInputFile(config, optarg);
             MINUSF = true;
             break;
 
@@ -144,8 +146,10 @@ GenericAgentConfig CheckOpts(int argc, char **argv)
         case 'b':
             if (optarg)
             {
-                config.bundlesequence = SplitStringAsRList(optarg, ',');
-                CBUNDLESEQUENCE_STR = optarg;
+                Rlist *bundlesequence = SplitStringAsRList(optarg, ',');
+                GenericAgentConfigSetBundleSequence(config, bundlesequence);
+                DeleteRlist(bundlesequence);
+                CBUNDLESEQUENCE_STR = optarg; // TODO: wtf is this
             }
             break;
 

--- a/cf-report/cf-report.c
+++ b/cf-report/cf-report.c
@@ -52,7 +52,7 @@
 #include <assert.h>
 
 static void ThisAgentInit(void);
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 
 static void KeepReportsControlPromises(Policy *policy);
 static void KeepReportsPromises(void);
@@ -293,7 +293,7 @@ char *CFRH[][2] =
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("reporter");
     Policy *policy = NULL;
@@ -308,7 +308,9 @@ int main(int argc, char *argv[])
     ThisAgentInit();
     KeepReportsControlPromises(policy);
     KeepReportsPromises();
+
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
     return 0;
 }
 
@@ -318,19 +320,19 @@ int main(int argc, char *argv[])
 
 /*****************************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_REPORT);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_REPORT);
 
     while ((c = getopt_long(argc, argv, "CghdvVf:st:ar:PXHLMIRSKE:x:i:1:p:k:c:qF:o:", OPTIONS, &optindex)) != EOF)
     {
         switch ((char) c)
         {
         case 'f':
-            SetInputFile(optarg);
+            GenericAgentConfigSetInputFile(config, optarg);
             MINUSF = true;
             break;
 

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -43,7 +43,7 @@
 #include "string_lib.h"
 
 static void ThisAgentInit(void);
-static GenericAgentConfig CheckOpts(int argc, char **argv);
+static GenericAgentConfig *CheckOpts(int argc, char **argv);
 
 static int HailServer(char *host, Attributes a, Promise *pp);
 static int ParseHostname(char *hostname, char *new_hostname);
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
     int pid;
 #endif
 
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
     ReportContext *report_context = OpenReports("runagent");
 
     Policy *policy = GenericInitialize("runagent", config, report_context);
@@ -212,6 +212,8 @@ int main(int argc, char *argv[])
 #endif
 
     DeletePromise(pp);
+
+    GenericAgentConfigDestroy(config);
     ReportContextDestroy(report_context);
 
     return 0;
@@ -219,12 +221,12 @@ int main(int argc, char *argv[])
 
 /*******************************************************************/
 
-static GenericAgentConfig CheckOpts(int argc, char **argv)
+static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_RUNAGENT);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_RUNAGENT);
 
     DEFINECLASSES[0] = '\0';
     SENDCLASSES[0] = '\0';
@@ -234,7 +236,7 @@ static GenericAgentConfig CheckOpts(int argc, char **argv)
         switch ((char) c)
         {
         case 'f':
-            SetInputFile(optarg);
+            GenericAgentConfigSetInputFile(config, optarg);
             MINUSF = true;
             break;
 

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -113,13 +113,13 @@ static void KeepHardClasses()
 #endif
 }
 
-GenericAgentConfig CheckOpts(int argc, char **argv)
+GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     char ld_library_path[CF_BUFSIZE];
     int optindex = 0;
     int c;
-    GenericAgentConfig config = GenericAgentDefaultConfig(AGENT_TYPE_SERVER);
+    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_SERVER);
 
     while ((c = getopt_long(argc, argv, "dvIKf:D:N:VSxLFMh", OPTIONS, &optindex)) != EOF)
     {
@@ -132,7 +132,7 @@ GenericAgentConfig CheckOpts(int argc, char **argv)
                 FatalError(" -f used but argument \"%s\" incorrect", optarg);
             }
 
-            SetInputFile(optarg);
+            GenericAgentConfigSetInputFile(config, optarg);
             MINUSF = true;
             break;
 
@@ -215,13 +215,13 @@ void ThisAgentInit(void)
 
 /*******************************************************************/
 
-void StartServer(Policy *policy, GenericAgentConfig config, const ReportContext *report_context)
+void StartServer(Policy *policy, GenericAgentConfig *config, const ReportContext *report_context)
 {
     int sd = -1, sd_reply;
     fd_set rset;
     struct timeval timeout;
     int ret_val;
-    Promise *pp = NewPromise("server_cfengine", VINPUTFILE);
+    Promise *pp = NewPromise("server_cfengine", config->input_file);
     Attributes dummyattr = { {0} };
     CfLock thislock;
     time_t starttime = time(NULL), last_collect = 0;
@@ -532,22 +532,22 @@ int OpenReceiverChannel(void)
 /* Level 3                                                           */
 /*********************************************************************/
 
-void CheckFileChanges(Policy **policy, GenericAgentConfig config, const ReportContext *report_context)
+void CheckFileChanges(Policy **policy, GenericAgentConfig *config, const ReportContext *report_context)
 {
     if (EnterpriseExpiry())
     {
         CfOut(cf_error, "", "!! This enterprise license is invalid.");
     }
 
-    CfDebug("Checking file updates on %s\n", VINPUTFILE);
+    CfDebug("Checking file updates on %s\n", config->input_file);
 
-    if (NewPromiseProposals())
+    if (NewPromiseProposals(config->input_file))
     {
         CfOut(cf_verbose, "", " -> New promises detected...\n");
 
-        if (CheckPromises(AGENT_TYPE_SERVER, report_context))
+        if (CheckPromises(AGENT_TYPE_SERVER, config->input_file, report_context))
         {
-            CfOut(cf_inform, "", "Rereading config files %s..\n", VINPUTFILE);
+            CfOut(cf_inform, "", "Rereading config files %s..\n", config->input_file);
 
             /* Free & reload -- lock this to avoid access errors during reload */
 

--- a/cf-serverd/cf-serverd-functions.h
+++ b/cf-serverd/cf-serverd-functions.h
@@ -42,15 +42,15 @@
 #include "reporting.h"
 
 void ThisAgentInit(void);
-GenericAgentConfig CheckOpts(int argc, char **argv);
+GenericAgentConfig *CheckOpts(int argc, char **argv);
 int OpenReceiverChannel(void);
-void CheckFileChanges(Policy **policy, GenericAgentConfig config, const ReportContext *report_context);
+void CheckFileChanges(Policy **policy, GenericAgentConfig *config, const ReportContext *report_context);
 int InitServer(size_t queue_size);
 
 #if !defined(HAVE_GETADDRINFO)
 in_addr_t GetInetAddr(char *host);
 #endif
 
-void StartServer(Policy *policy, GenericAgentConfig config, const ReportContext *report_context);
+void StartServer(Policy *policy, GenericAgentConfig *config, const ReportContext *report_context);
 
 #endif // CFSERVERDFUNCTIONS_H

--- a/cf-serverd/cf-serverd.c
+++ b/cf-serverd/cf-serverd.c
@@ -26,7 +26,7 @@
 
 int main(int argc, char *argv[])
 {
-    GenericAgentConfig config = CheckOpts(argc, argv);
+    GenericAgentConfig *config = CheckOpts(argc, argv);
 
     ReportContext *report_context = OpenReports("server");
     Policy *policy = GenericInitialize("server", config, report_context);
@@ -37,5 +37,6 @@ int main(int argc, char *argv[])
     StartServer(policy, config, report_context);
 
     ReportContextDestroy(report_context);
+    GenericAgentConfigDestroy(config);
     return 0;
 }

--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -59,7 +59,6 @@ extern char VMONTH[];
 extern char VSHIFT[];
 
 extern const char *CLASSTEXT[];
-extern char VINPUTFILE[];
 extern int AUDIT;
 extern char PURGE;
 
@@ -90,7 +89,7 @@ extern int CFPARANOID;
 
 extern int DONTDO;
 extern int IGNORELOCK;
-extern int MINUSF;
+extern bool MINUSF;
 
 extern const char *VPSCOMM[];
 extern const char *VPSOPTS[];

--- a/libpromises/cf3globals.c
+++ b/libpromises/cf3globals.c
@@ -158,7 +158,6 @@ char PURGE = 'n';
 
 int ERRORCOUNT = 0;
 char VPREFIX[CF_MAXVARSIZE] = { 0 };
-char VINPUTFILE[CF_BUFSIZE] = { 0 };
 
 char CONTEXTID[CF_MAXVARSIZE] = { 0 };
 char CFPUBKEYFILE[CF_BUFSIZE] = { 0 };
@@ -239,7 +238,7 @@ int VIFELAPSED = 1;
 int VEXPIREAFTER = 120;
 char BINDINTERFACE[CF_BUFSIZE] = { 0 };
 
-int MINUSF = false;
+bool MINUSF = false;
 int EXCLAIM = true;
 
 Item *VSETUIDLIST = NULL;

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -66,14 +66,14 @@ extern char *CFH[][2];
 static void VerifyPromises(Policy *policy, Rlist *bundlesequence, const ReportContext *report_context);
 static void SetAuditVersion(void);
 static void CheckWorkingDirectories(const ReportContext *report_context);
-static void Cf3ParseFile(Policy *policy, char *filename, _Bool check_not_writable_by_others);
-static void Cf3ParseFiles(Policy *policy, bool check_not_writable_by_others, const ReportContext *report_context);
-static int MissingInputFile(void);
+static void Cf3ParseFile(Policy *policy, const char *filename, const char *input_file, bool check_not_writable_by_others);
+static void Cf3ParseFiles(Policy *policy, const char *input_file, bool check_not_writable_by_others, const ReportContext *report_context);
+static bool MissingInputFile(const char *input_file);
 static void CheckControlPromises(char *scope, char *agent, Constraint *controllist);
 static void CheckVariablePromises(char *scope, Promise *varlist);
 static void CheckCommonClassPromises(Promise *classlist, const ReportContext *report_context);
 static void PrependAuditFile(char *file);
-static char *InputLocation(char *filename);
+static char *InputLocation(const char *filename, const char *input_file);
 
 #if !defined(__MINGW32__)
 static void OpenLog(int facility);
@@ -116,7 +116,7 @@ void CheckLicenses(void)
 
 /*****************************************************************************/
 
-Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportContext *report_context)
+Policy *GenericInitialize(char *agents, GenericAgentConfig *config, const ReportContext *report_context)
 {
     AgentType ag = Agent2Type(agents);
     char vbuff[CF_BUFSIZE];
@@ -130,7 +130,7 @@ Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportC
     CF_DEFAULT_DIGEST_LEN = CF_MD5_LEN;
 #endif
 
-    InitializeGA(report_context);
+    InitializeGA(config, report_context);
 
     SetReferenceTime(true);
     SetStartTime();
@@ -200,7 +200,7 @@ Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportC
 
     if (ag != AGENT_TYPE_KEYGEN && ag != AGENT_TYPE_GENDOC)
     {
-        if (!MissingInputFile())
+        if (!MissingInputFile(config->input_file))
         {
             bool check_promises = false;
 
@@ -209,12 +209,12 @@ Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportC
                 check_promises = true;
                 CfOut(cf_verbose, "", " -> Reports mode is enabled, force-validating policy");
             }
-            if (IsFileOutsideDefaultRepository(VINPUTFILE))
+            if (IsFileOutsideDefaultRepository(config->input_file))
             {
                 check_promises = true;
                 CfOut(cf_verbose, "", " -> Input file is outside default repository, validating it");
             }
-            if (NewPromiseProposals())
+            if (NewPromiseProposals(config->input_file))
             {
                 check_promises = true;
                 CfOut(cf_verbose, "", " -> Input file is changed since last validation, validating it");
@@ -222,7 +222,7 @@ Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportC
 
             if (check_promises)
             {
-                ok = CheckPromises(ag, report_context);
+                ok = CheckPromises(ag, config->input_file, report_context);
                 if (BOOTSTRAP && !ok)
                 {
                     CfOut(cf_verbose, "", " -> Policy is not valid, but proceeding with bootstrap");
@@ -244,20 +244,20 @@ Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportC
         {
             CfOut(cf_error, "",
                   "CFEngine was not able to get confirmation of promises from cf-promises, so going to failsafe\n");
-            SetInputFile("failsafe.cf");
+            GenericAgentConfigSetInputFile(config, "failsafe.cf");
             policy = ReadPromises(ag, agents, config, report_context);
         }
 
         if (SHOWREPORTS)
         {
-            CompilationReport(policy, VINPUTFILE);
+            CompilationReport(policy, config->input_file);
         }
 
         if (SHOW_PARSE_TREE)
         {
             Writer *writer = FileWriter(stdout);
 
-            PolicyPrintAsJson(writer, VINPUTFILE, policy->bundles, policy->bodies);
+            PolicyPrintAsJson(writer, config->input_file, policy->bundles, policy->bodies);
             WriterClose(writer);
         }
 
@@ -273,7 +273,7 @@ Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportC
 /* Level                                                                     */
 /*****************************************************************************/
 
-int CheckPromises(AgentType ag, const ReportContext *report_context)
+int CheckPromises(AgentType ag, const char *input_file, const ReportContext *report_context)
 {
     char cmd[CF_BUFSIZE], cfpromises[CF_MAXVARSIZE];
     char filename[CF_MAXVARSIZE];
@@ -302,17 +302,17 @@ int CheckPromises(AgentType ag, const ReportContext *report_context)
 
     snprintf(cmd, sizeof(cmd), "\"%s\" -f \"", cfpromises);
 
-    outsideRepo = IsFileOutsideDefaultRepository(VINPUTFILE);
+    outsideRepo = IsFileOutsideDefaultRepository(input_file);
 
     if (outsideRepo)
     {
-        strlcat(cmd, VINPUTFILE, CF_BUFSIZE);
+        strlcat(cmd, input_file, CF_BUFSIZE);
     }
     else
     {
         strlcat(cmd, CFWORKDIR, CF_BUFSIZE);
         strlcat(cmd, FILE_SEPARATOR_STR "inputs" FILE_SEPARATOR_STR, CF_BUFSIZE);
-        strlcat(cmd, VINPUTFILE, CF_BUFSIZE);
+        strlcat(cmd, input_file, CF_BUFSIZE);
     }
 
     strlcat(cmd, "\"", CF_BUFSIZE);
@@ -341,7 +341,7 @@ int CheckPromises(AgentType ag, const ReportContext *report_context)
         {
             if (MINUSF)
             {
-                snprintf(filename, CF_MAXVARSIZE, "%s/state/validated_%s", CFWORKDIR, CanonifyName(VINPUTFILE));
+                snprintf(filename, CF_MAXVARSIZE, "%s/state/validated_%s", CFWORKDIR, CanonifyName(input_file));
                 MapName(filename);
             }
             else
@@ -379,7 +379,7 @@ int CheckPromises(AgentType ag, const ReportContext *report_context)
 
 /*****************************************************************************/
 
-Policy *ReadPromises(AgentType ag, char *agents, GenericAgentConfig config,
+Policy *ReadPromises(AgentType ag, char *agents, GenericAgentConfig *config,
                      const ReportContext *report_context)
 {
     Rval retval;
@@ -405,7 +405,7 @@ Policy *ReadPromises(AgentType ag, char *agents, GenericAgentConfig config,
 /* Parse the files*/
 
     Policy *policy = PolicyNew();
-    Cf3ParseFiles(policy, check_not_writable_by_others, report_context);
+    Cf3ParseFiles(policy, config->input_file, check_not_writable_by_others, report_context);
     {
         Sequence *errors = SequenceCreate(100, PolicyErrorDestroy);
         if (!PolicyCheck(policy, errors))
@@ -442,7 +442,7 @@ Policy *ReadPromises(AgentType ag, char *agents, GenericAgentConfig config,
     WriterWriteF(report_context->report_writers[REPORT_OUTPUT_TYPE_HTML], "<div id=\"reporttext\">\n");
     WriterWriteF(report_context->report_writers[REPORT_OUTPUT_TYPE_HTML], "%s", CFH[cfx_promise][cfb]);
 
-    VerifyPromises(policy, config.bundlesequence, report_context);
+    VerifyPromises(policy, config->bundlesequence, report_context);
 
     WriterWriteF(report_context->report_writers[REPORT_OUTPUT_TYPE_HTML], "%s", CFH[cfx_promise][cfe]);
 
@@ -480,7 +480,7 @@ void CloseLog(void)
 /* Level 1                                                         */
 /*******************************************************************/
 
-void InitializeGA(const ReportContext *report_context)
+void InitializeGA(GenericAgentConfig *config, const ReportContext *report_context)
 {
     int force = false;
     struct stat statbuf, sb;
@@ -608,7 +608,7 @@ void InitializeGA(const ReportContext *report_context)
 
     if (!MINUSF)
     {
-        SetInputFile("promises.cf");
+        GenericAgentConfigSetInputFile(config, "promises.cf");
     }
 
     DetermineCfenginePort();
@@ -624,18 +624,18 @@ void InitializeGA(const ReportContext *report_context)
 
         if (!IsEnterprise() && cfstat(vbuff, &statbuf) == -1)
         {
-            SetInputFile("failsafe.cf");
+            GenericAgentConfigSetInputFile(config, "failsafe.cf");
         }
         else
         {
-            SetInputFile(vbuff);
+            GenericAgentConfigSetInputFile(config, vbuff);
         }
     }
 }
 
 /*******************************************************************/
 
-static void Cf3ParseFiles(Policy *policy, bool check_not_writable_by_others, const ReportContext *report_context)
+static void Cf3ParseFiles(Policy *policy, const char *input_file, bool check_not_writable_by_others, const ReportContext *report_context)
 {
     Rlist *rp, *sl;
 
@@ -645,7 +645,7 @@ static void Cf3ParseFiles(Policy *policy, bool check_not_writable_by_others, con
 
     PolicySetNameSpace(policy, "default");    
 
-    Cf3ParseFile(policy, VINPUTFILE, check_not_writable_by_others);
+    Cf3ParseFile(policy, input_file, input_file, check_not_writable_by_others);
 
     // Expand any lists in this list now
     HashVariables(policy, NULL, report_context);
@@ -673,13 +673,13 @@ static void Cf3ParseFiles(Policy *policy, bool check_not_writable_by_others, con
                 switch (returnval.rtype)
                 {
                 case CF_SCALAR:
-                    Cf3ParseFile(policy, (char *) returnval.item, check_not_writable_by_others);
+                    Cf3ParseFile(policy, (char *) returnval.item, input_file, check_not_writable_by_others);
                     break;
 
                 case CF_LIST:
                     for (sl = (Rlist *) returnval.item; sl != NULL; sl = sl->next)
                     {
-                        Cf3ParseFile(policy, (char *) sl->item, check_not_writable_by_others);
+                        Cf3ParseFile(policy, (char *) sl->item, input_file, check_not_writable_by_others);
                     }
                     break;
                 }
@@ -699,13 +699,13 @@ static void Cf3ParseFiles(Policy *policy, bool check_not_writable_by_others, con
 
 /*******************************************************************/
 
-static int MissingInputFile()
+static bool MissingInputFile(const char *input_file)
 {
     struct stat sb;
 
-    if (cfstat(InputLocation(VINPUTFILE), &sb) == -1)
+    if (cfstat(InputLocation(input_file, input_file), &sb) == -1)
     {
-        CfOut(cf_error, "stat", "There is no readable input file at %s", VINPUTFILE);
+        CfOut(cf_error, "stat", "There is no readable input file at %s", input_file);
         return true;
     }
 
@@ -714,7 +714,7 @@ static int MissingInputFile()
 
 /*******************************************************************/
 
-int NewPromiseProposals()
+int NewPromiseProposals(const char *input_file)
 {
     Rlist *rp, *sl;
     struct stat sb;
@@ -724,7 +724,7 @@ int NewPromiseProposals()
 
     if (MINUSF)
     {
-        snprintf(filename, CF_MAXVARSIZE, "%s/state/validated_%s", CFWORKDIR, CanonifyName(VINPUTFILE));
+        snprintf(filename, CF_MAXVARSIZE, "%s/state/validated_%s", CFWORKDIR, CanonifyName(input_file));
         MapName(filename);
     }
     else
@@ -759,9 +759,9 @@ int NewPromiseProposals()
         return true;
     }
 
-    if (cfstat(InputLocation(VINPUTFILE), &sb) == -1)
+    if (cfstat(InputLocation(input_file, input_file), &sb) == -1)
     {
-        CfOut(cf_verbose, "stat", "There is no readable input file at %s", VINPUTFILE);
+        CfOut(cf_verbose, "stat", "There is no readable input file at %s", input_file);
         return true;
     }
 
@@ -800,7 +800,7 @@ int NewPromiseProposals()
                 {
                 case CF_SCALAR:
 
-                    if (cfstat(InputLocation((char *) returnval.item), &sb) == -1)
+                    if (cfstat(InputLocation((char *) returnval.item, input_file), &sb) == -1)
                     {
                         CfOut(cf_error, "stat", "Unreadable promise proposals at %s", (char *) returnval.item);
                         result = true;
@@ -818,7 +818,7 @@ int NewPromiseProposals()
 
                     for (sl = (Rlist *) returnval.item; sl != NULL; sl = sl->next)
                     {
-                        if (cfstat(InputLocation((char *) sl->item), &sb) == -1)
+                        if (cfstat(InputLocation((char *) sl->item, input_file), &sb) == -1)
                         {
                             CfOut(cf_error, "stat", "Unreadable promise proposals at %s", (char *) sl->item);
                             result = true;
@@ -958,14 +958,18 @@ void CloseReports(const char *agents, ReportContext *report_context)
 /* Level                                                           */
 /*******************************************************************/
 
-static void Cf3ParseFile(Policy *policy, char *filename, bool check_not_writable_by_others)
+/*
+ * The difference between filename and input_input file is that the latter is the file specified by -f or
+ * equivalently the file containing body common control. This will hopefully be squashed in later refactoring.
+ */
+static void Cf3ParseFile(Policy *policy, const char *filename, const char *input_file, bool check_not_writable_by_others)
 {
     struct stat statbuf;
     char wfilename[CF_BUFSIZE];
 
     PolicySetNameSpace(policy, "default");    
 
-    strncpy(wfilename, InputLocation(filename), CF_BUFSIZE);
+    strncpy(wfilename, InputLocation(filename, input_file), CF_BUFSIZE);
 
     if (cfstat(wfilename, &statbuf) == -1)
     {
@@ -1226,15 +1230,15 @@ static void CheckWorkingDirectories(const ReportContext *report_context)
 /* Level 2                                                         */
 /*******************************************************************/
 
-static char *InputLocation(char *filename)
+static char *InputLocation(const char *filename, const char *input_file)
 {
     static char wfilename[CF_BUFSIZE], path[CF_BUFSIZE];
 
-    if (MINUSF && (filename != VINPUTFILE) && IsFileOutsideDefaultRepository(VINPUTFILE)
+    if (MINUSF && (filename != input_file) && IsFileOutsideDefaultRepository(input_file)
         && !IsAbsoluteFileName(filename))
     {
         /* If -f assume included relative files are in same directory */
-        strncpy(path, VINPUTFILE, CF_BUFSIZE - 1);
+        strncpy(path, input_file, CF_BUFSIZE - 1);
         ChopLastNode(path);
         snprintf(wfilename, CF_BUFSIZE - 1, "%s%c%s", path, FILE_SEPARATOR, filename);
     }
@@ -1248,13 +1252,6 @@ static char *InputLocation(char *filename)
     }
 
     return MapName(wfilename);
-}
-
-/*******************************************************************/
-
-void SetInputFile(const char *name)
-{
-    strlcpy(VINPUTFILE, name, CF_BUFSIZE);
 }
 
 /*******************************************************************/
@@ -1912,13 +1909,35 @@ static bool VerifyBundleSequence(const Policy *policy, AgentType agent, Rlist *b
 
 /*******************************************************************/
 
-GenericAgentConfig GenericAgentDefaultConfig(AgentType agent_type)
+GenericAgentConfig *GenericAgentConfigNewDefault(AgentType agent_type)
 {
-    GenericAgentConfig config = { 0 };
+    GenericAgentConfig *config = xmalloc(sizeof(GenericAgentConfig));
 
-    config.bundlesequence = NULL;
-    config.verify_promises = true;
+    config->bundlesequence = NULL;
+    config->verify_promises = true;
+    config->input_file = NULL;
 
     return config;
+}
+
+void GenericAgentConfigDestroy(GenericAgentConfig *config)
+{
+    if (config)
+    {
+        DeleteRlist(config->bundlesequence);
+        free(config->input_file);
+    }
+}
+
+void GenericAgentConfigSetInputFile(GenericAgentConfig *config, const char *input_file)
+{
+    free(config->input_file);
+    config->input_file = SafeStringDuplicate(input_file);
+}
+
+void GenericAgentConfigSetBundleSequence(GenericAgentConfig *config, const Rlist *bundlesequence)
+{
+    DeleteRlist(config->bundlesequence);
+    config->bundlesequence = CopyRlist(bundlesequence);
 }
 

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -33,16 +33,17 @@ typedef struct
 {
     Rlist *bundlesequence;
     bool verify_promises;
+    char *input_file;
 } GenericAgentConfig;
 
-Policy *GenericInitialize(char *agents, GenericAgentConfig config, const ReportContext *report_context);
-void InitializeGA(const ReportContext *report_context);
+Policy *GenericInitialize(char *agents, GenericAgentConfig *config, const ReportContext *report_context);
+void InitializeGA(GenericAgentConfig *config, const ReportContext *report_context);
 void Syntax(const char *comp, const struct option options[], const char *hints[], const char *id);
 void ManPage(const char *component, const struct option options[], const char *hints[], const char *id);
 void PrintVersionBanner(const char *component);
-int CheckPromises(AgentType ag, const ReportContext *report_context);
-Policy *ReadPromises(AgentType ag, char *agents, GenericAgentConfig config, const ReportContext *report_context);
-int NewPromiseProposals(void);
+int CheckPromises(AgentType ag, const char *input_file, const ReportContext *report_context);
+Policy *ReadPromises(AgentType ag, char *agents, GenericAgentConfig *config, const ReportContext *report_context);
+int NewPromiseProposals(const char *input_file);
 void CompilationReport(Policy *policy, char *fname);
 void HashVariables(Policy *policy, const char *name, const ReportContext *report_context);
 void HashControls(const Policy *policy);
@@ -57,11 +58,18 @@ void BannerBundle(Bundle *bp, Rlist *args);
 void BannerSubBundle(Bundle *bp, Rlist *args);
 void WritePID(char *filename);
 ReportContext *OpenCompilationReportFiles(const char *fname);
-GenericAgentConfig GenericAgentDefaultConfig(AgentType agent_type);
 void CheckLicenses(void);
 void ReloadPromises(AgentType ag);
-void SetInputFile(const char *filename);
 
 ReportContext *OpenReports(const char *agents);
 void CloseReports(const char *agents, ReportContext *report_context);
+
+
+
+GenericAgentConfig *GenericAgentConfigNewDefault(AgentType agent_type);
+void GenericAgentConfigDestroy(GenericAgentConfig *config);
+
+void GenericAgentConfigSetInputFile(GenericAgentConfig *config, const char *input_file);
+void GenericAgentConfigSetBundleSequence(GenericAgentConfig *config, const Rlist *bundlesequence);
+
 #endif

--- a/libpromises/instrumentation.c
+++ b/libpromises/instrumentation.c
@@ -166,8 +166,7 @@ void NoteClassUsage(AlphaList baselist, int purge)
     double lastseen;
     double vtrue = 1.0;         /* end with a rough probability */
 
-/* Only do this for the default policy, too much "downgrading" otherwise */
-
+    /* Only do this for the default policy, too much "downgrading" otherwise */
     if (MINUSF)
     {
         return;

--- a/tests/load/lastseen_load.c
+++ b/tests/load/lastseen_load.c
@@ -100,7 +100,7 @@ void DeleteItemList(Item *item)
     exit(42);
 }
 
-int MINUSF;
+bool MINUSF;
 
 char *MapAddress(char *addr)
 {

--- a/tests/unit/lastseen_migration_test.c
+++ b/tests/unit/lastseen_migration_test.c
@@ -271,7 +271,7 @@ pthread_mutex_t *cft_output;
 char VIPADDRESS[18];
 RSA *PUBKEY;
 int DEBUG;
-int MINUSF;
+bool MINUSF;
 
 char *MapAddress(char *addr)
 {

--- a/tests/unit/lastseen_test.c
+++ b/tests/unit/lastseen_test.c
@@ -215,7 +215,7 @@ RSA *PUBKEY;
 
 int DEBUG;
 
-int MINUSF;
+bool MINUSF;
 
 char *MapAddress(char *addr)
 {


### PR DESCRIPTION
Leaving global MINUSF intact for now, may need to be wrapped up in some
context object.
