### PR TITLE
Stdlib debian fix

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -2715,8 +2715,8 @@ vars:
   "stopcommand[udevmonitor]"  string => "/etc/init.d/udevmonitor stop";
   "pattern[udevmonitor]"      string => ".*udevadm.*monitor.*";
 
-  "startcommand[www]"     string => "/etc/init.d/httpd stop";
-  "stopcommand[www]"      string => "/etc/init.d/httpd stop";
+  "startcommand[www]"     string => "/etc/init.d/apache2 start";
+  "stopcommand[www]"      string => "/etc/init.d/apache2 stop";
   "pattern[www]"          string => ".*apache2.*";
 
 


### PR DESCRIPTION
- Add debian paths in bundle common paths
- Fix startcommand[www] with good values for debian in bundle agent standard_services
