### PR TITLE
Turn run-time checks into compile-time ones

### DIFF
--- a/cf-agent/nfs.c
+++ b/cf-agent/nfs.c
@@ -198,72 +198,48 @@ int LoadMountInfo(Rlist **list)
             return false;
         }
 
-        switch (VSYSTEMHARDCLASS)
+#if defined(__sun) || defined(__hpux)
+        if (IsAbsoluteFileName(buf3))
         {
-        case darwin:
-        case linuxx:
-        case unix_sv:
-        case freebsd:
-        case netbsd:
-        case openbsd:
-        case qnx:
-        case crayos:
-        case dragonfly:
-            if (IsAbsoluteFileName(buf1))
-            {
-                strcpy(host, "localhost");
-                strcpy(mounton, buf3);
-            }
-            else
-            {
-                sscanf(buf1, "%[^:]:%s", host, source);
-                strcpy(mounton, buf3);
-            }
-
-            break;
-        case solaris:
-
-        case hp:
-            if (IsAbsoluteFileName(buf3))
-            {
-                strcpy(host, "localhost");
-                strcpy(mounton, buf1);
-            }
-            else
-            {
-                sscanf(buf1, "%[^:]:%s", host, source);
-                strcpy(mounton, buf1);
-            }
-
-            break;
-        case aix:
-            /* skip header */
-
-            if (IsAbsoluteFileName(buf1))
-            {
-                strcpy(host, "localhost");
-                strcpy(mounton, buf2);
-            }
-            else
-            {
-                strcpy(host, buf1);
-                strcpy(source, buf1);
-                strcpy(mounton, buf3);
-            }
-            break;
-
-        case cfnt:
-            strcpy(mounton, buf2);
-            strcpy(host, buf1);
-            break;
-
-        case cfsco:
-            CfOut(cf_error, "", "Don't understand SCO mount format, no data");
-
-        default:
-            printf("cfengine software error: case %d = %s\n", VSYSTEMHARDCLASS, CLASSTEXT[VSYSTEMHARDCLASS]);
-            FatalError("System error in GetMountInfo - no such class!");
+            strcpy(host, "localhost");
+            strcpy(mounton, buf1);
         }
+        else
+        {
+            sscanf(buf1, "%[^:]:%s", host, source);
+            strcpy(mounton, buf1);
+        }
+#elif defined(_AIX)
+        /* skip header */
+
+        if (IsAbsoluteFileName(buf1))
+        {
+            strcpy(host, "localhost");
+            strcpy(mounton, buf2);
+        }
+        else
+        {
+            strcpy(host, buf1);
+            strcpy(source, buf1);
+            strcpy(mounton, buf3);
+        }
+#elif defined(__CYGWIN__)
+        strcpy(mounton, buf2);
+        strcpy(host, buf1);
+#elif defined(sco) || defined(__SCO_DS)
+        CfOut(cf_error, "", "Don't understand SCO mount format, no data");
+#else
+        if (IsAbsoluteFileName(buf1))
+        {
+            strcpy(host, "localhost");
+            strcpy(mounton, buf3);
+        }
+        else
+        {
+            sscanf(buf1, "%[^:]:%s", host, source);
+            strcpy(mounton, buf3);
+        }
+#endif
 
         CfDebug("GOT: host=%s, source=%s, mounton=%s\n", host, source, mounton);
 
@@ -384,56 +360,30 @@ int VerifyInFstab(char *name, Attributes a, Promise *pp)
     mountpt = name;
     fstype = a.mount.mount_type;
 
-    switch (VSYSTEMHARDCLASS)
-    {
-    case qnx:
-        snprintf(fstab, CF_BUFSIZE, "%s:%s \t %s %s\t%s 0 0", host, rmountpt, mountpt, fstype, opts);
-        break;
+#if defined(__QNX__) || defined(__QNXNTO__)
+    snprintf(fstab, CF_BUFSIZE, "%s:%s \t %s %s\t%s 0 0", host, rmountpt, mountpt, fstype, opts);
+#elif defined(_CRAY)
+    char fstype_upper[CF_BUFSIZE];
+    strlcpy(fstype_upper, fstype, CF_BUFSIZE);
+    ToUpperStrInplace(fstype_upper);
 
-    case crayos:
-    {
-        char fstype_upper[CF_BUFSIZE];
-        strlcpy(fstype_upper, fstype, CF_BUFSIZE);
-        ToUpperStrInplace(fstype_upper);
-
-        snprintf(fstab, CF_BUFSIZE, "%s:%s \t %s %s\t%s", host, rmountpt, mountpt, fstype_upper, opts);
-        break;
-    }
-    case hp:
-        snprintf(fstab, CF_BUFSIZE, "%s:%s %s \t %s \t %s 0 0", host, rmountpt, mountpt, fstype, opts);
-        break;
-    case aix:
-        snprintf(fstab, CF_BUFSIZE,
-                 "%s:\n\tdev\t= %s\n\ttype\t= %s\n\tvfs\t= %s\n\tnodename\t= %s\n\tmount\t= true\n\toptions\t= %s\n\taccount\t= false\n",
-                 mountpt, rmountpt, fstype, fstype, host, opts);
-        break;
-    case linuxx:
-        snprintf(fstab, CF_BUFSIZE, "%s:%s \t %s \t %s \t %s", host, rmountpt, mountpt, fstype, opts);
-        break;
-
-    case netbsd:
-    case openbsd:
-    case dragonfly:
-    case freebsd:
-        snprintf(fstab, CF_BUFSIZE, "%s:%s \t %s \t %s \t %s 0 0", host, rmountpt, mountpt, fstype, opts);
-        break;
-
-    case unix_sv:
-    case solaris:
-        snprintf(fstab, CF_BUFSIZE, "%s:%s - %s %s - yes %s", host, rmountpt, mountpt, fstype, opts);
-        break;
-
-    case cfnt:
-        snprintf(fstab, CF_BUFSIZE, "/bin/mount %s:%s %s", host, rmountpt, mountpt);
-        break;
-    case cfsco:
-        CfOut(cf_error, "", "Don't understand filesystem format on SCO, no data - please fix me");
-        break;
-
-    default:
-        free(opts);
-        return false;
-    }
+    snprintf(fstab, CF_BUFSIZE, "%s:%s \t %s %s\t%s", host, rmountpt, mountpt, fstype_upper, opts);
+    break;
+#elif defined(__hpux)
+    snprintf(fstab, CF_BUFSIZE, "%s:%s %s \t %s \t %s 0 0", host, rmountpt, mountpt, fstype, opts);
+#elif defined(_AIX)
+    snprintf(fstab, CF_BUFSIZE,
+             "%s:\n\tdev\t= %s\n\ttype\t= %s\n\tvfs\t= %s\n\tnodename\t= %s\n\tmount\t= true\n\toptions\t= %s\n\taccount\t= false\n",
+             mountpt, rmountpt, fstype, fstype, host, opts);
+#elif defined(__linux__)
+    snprintf(fstab, CF_BUFSIZE, "%s:%s \t %s \t %s \t %s", host, rmountpt, mountpt, fstype, opts);
+#elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__FreeBSD__)
+    snprintf(fstab, CF_BUFSIZE, "%s:%s \t %s \t %s \t %s 0 0", host, rmountpt, mountpt, fstype, opts);
+#elif defined(__sun) || defined(sco) || defined(__SCO_DS)
+    snprintf(fstab, CF_BUFSIZE, "%s:%s - %s %s - yes %s", host, rmountpt, mountpt, fstype, opts);
+#elif defined(__CYGWIN__)
+    snprintf(fstab, CF_BUFSIZE, "/bin/mount %s:%s %s", host, rmountpt, mountpt);
+#endif
 
     CfOut(cf_verbose, "", "Verifying %s in %s\n", mountpt, VFSTAB[VSYSTEMHARDCLASS]);
 
@@ -488,59 +438,52 @@ int VerifyNotInFstab(char *name, Attributes a, Promise *pp)
     {
         if (a.mount.editfstab)
         {
-            switch (VSYSTEMHARDCLASS)
+#if defined(_AIX)
+            snprintf(aixcomm, CF_BUFSIZE, "/usr/sbin/rmnfsmnt -f %s", mountpt);
+
+            if ((pfp = cf_popen(aixcomm, "r")) == NULL)
             {
-            case aix:
+                cfPS(cf_error, CF_FAIL, "", pp, a, "Failed to invoke /usr/sbin/rmnfsmnt to edit fstab");
+                return 0;
+            }
 
-                snprintf(aixcomm, CF_BUFSIZE, "/usr/sbin/rmnfsmnt -f %s", mountpt);
-
-                if ((pfp = cf_popen(aixcomm, "r")) == NULL)
+            while (!feof(pfp))
+            {
+                if (CfReadLine(line, CF_BUFSIZE, pfp) == -1)
                 {
-                    cfPS(cf_error, CF_FAIL, "", pp, a, "Failed to invoke /usr/sbin/rmnfsmnt to edit fstab");
+                    FatalError("Error in CfReadLine");
+                }
+
+                if (line[0] == '#')
+                {
+                    continue;
+                }
+
+                if (strstr(line, "busy"))
+                {
+                    cfPS(cf_inform, CF_INTERPT, "", pp, a, "The device under %s cannot be removed from %s\n",
+                         mountpt, VFSTAB[VSYSTEMHARDCLASS]);
                     return 0;
                 }
-
-                while (!feof(pfp))
-                {
-                    if (CfReadLine(line, CF_BUFSIZE, pfp) == -1)
-                    {
-                        FatalError("Error in CfReadLine");
-                    }
-
-                    if (line[0] == '#')
-                    {
-                        continue;
-                    }
-
-                    if (strstr(line, "busy"))
-                    {
-                        cfPS(cf_inform, CF_INTERPT, "", pp, a, "The device under %s cannot be removed from %s\n",
-                             mountpt, VFSTAB[VSYSTEMHARDCLASS]);
-                        return 0;
-                    }
-                }
-
-                cf_pclose(pfp);
-
-                return 0;       /* ignore internal editing for aix , always returns 0 changes */
-                break;
-
-            default:
-
-                snprintf(regex, CF_BUFSIZE, ".*[\\s]+%s[\\s]+.*", mountpt);
-
-                for (ip = FSTABLIST; ip != NULL; ip = ip->next)
-                {
-                    if (FullTextMatch(regex, ip->name))
-                    {
-                        cfPS(cf_inform, CF_CHG, "", pp, a, "Deleting file system mounted on %s.\n", host);
-                        // Check host name matches too?
-                        DeleteThisItem(&FSTABLIST, ip);
-                        FSTAB_EDITS++;
-                    }
-                }
-                break;
             }
+
+            cf_pclose(pfp);
+
+            return 0;       /* ignore internal editing for aix , always returns 0 changes */
+#else
+            snprintf(regex, CF_BUFSIZE, ".*[\\s]+%s[\\s]+.*", mountpt);
+
+            for (ip = FSTABLIST; ip != NULL; ip = ip->next)
+            {
+                if (FullTextMatch(regex, ip->name))
+                {
+                    cfPS(cf_inform, CF_CHG, "", pp, a, "Deleting file system mounted on %s.\n", host);
+                    // Check host name matches too?
+                    DeleteThisItem(&FSTABLIST, ip);
+                    FSTAB_EDITS++;
+                }
+            }
+#endif
         }
     }
 
@@ -681,30 +624,29 @@ void MountAll()
         CfOut(cf_verbose, "", " -> Attempting to mount all filesystems.\n");
     }
 
-    if (VSYSTEMHARDCLASS == cfnt)
-    {
-        /* This is a shell script. Make sure it hasn't been compromised. */
+#if defined(__CYGWIN__(
+    /* This is a shell script. Make sure it hasn't been compromised. */
 
-        if (cfstat("/etc/fstab", &sb) == -1)
+    if (cfstat("/etc/fstab", &sb) == -1)
+    {
+        if ((fd = creat("/etc/fstab", 0755)) > 0)
         {
-            if ((fd = creat("/etc/fstab", 0755)) > 0)
+            if (write(fd, "#!/bin/sh\n\n", 10) != 10)
             {
-                if (write(fd, "#!/bin/sh\n\n", 10) != 10)
-                {
-                    UnexpectedError("Failed to write to file '/etc/fstab'");
-                }
-                close(fd);
+                UnexpectedError("Failed to write to file '/etc/fstab'");
             }
-            else
+            close(fd);
+        }
+        else
+        {
+            if (sb.st_mode & (S_IWOTH | S_IWGRP))
             {
-                if (sb.st_mode & (S_IWOTH | S_IWGRP))
-                {
-                    CfOut(cf_error, "", "File /etc/fstab was insecure. Cannot mount filesystems.\n");
-                    return;
-                }
+                CfOut(cf_error, "", "File /etc/fstab was insecure. Cannot mount filesystems.\n");
+                return;
             }
         }
     }
+#endif
 
     SetTimeOut(RPCTIMEOUT);
 

--- a/cf-agent/verify_environments.c
+++ b/cf-agent/verify_environments.c
@@ -258,69 +258,57 @@ static void VerifyEnvironments(Attributes a, Promise *pp)
 
     virInitialize();
 
-    switch (VSYSTEMHARDCLASS)
+#if defined(__linux__)
+    switch (Str2Hypervisors(a.env.type))
     {
-    case linuxx:
-
-        switch (Str2Hypervisors(a.env.type))
-        {
-        case cfv_virt_xen:
-        case cfv_virt_kvm:
-        case cfv_virt_esx:
-        case cfv_virt_vbox:
-        case cfv_virt_test:
-            VerifyVirtDomain(hyper_uri, envtype, a, pp);
-            break;
-        case cfv_virt_xen_net:
-        case cfv_virt_kvm_net:
-        case cfv_virt_esx_net:
-        case cfv_virt_test_net:
-            VerifyVirtNetwork(hyper_uri, envtype, a, pp);
-            break;
-        case cfv_ec2:
-            break;
-        case cfv_eucalyptus:
-            break;
-        default:
-            break;
-        }
+    case cfv_virt_xen:
+    case cfv_virt_kvm:
+    case cfv_virt_esx:
+    case cfv_virt_vbox:
+    case cfv_virt_test:
+        VerifyVirtDomain(hyper_uri, envtype, a, pp);
         break;
-
-    case darwin:
-        switch (Str2Hypervisors(a.env.type))
-        {
-        case cfv_virt_vbox:
-        case cfv_virt_test:
-            VerifyVirtDomain(hyper_uri, envtype, a, pp);
-            break;
-        case cfv_virt_xen_net:
-        case cfv_virt_kvm_net:
-        case cfv_virt_esx_net:
-        case cfv_virt_test_net:
-            VerifyVirtNetwork(hyper_uri, envtype, a, pp);
-            break;
-        default:
-            break;
-        }
+    case cfv_virt_xen_net:
+    case cfv_virt_kvm_net:
+    case cfv_virt_esx_net:
+    case cfv_virt_test_net:
+        VerifyVirtNetwork(hyper_uri, envtype, a, pp);
         break;
-
-    case solaris:
-
-        switch (Str2Hypervisors(a.env.type))
-        {
-        case cfv_zone:
-            VerifyZone(a, pp);
-            break;
-        default:
-            break;
-        }
-
+    case cfv_ec2:
         break;
-
+    case cfv_eucalyptus:
+        break;
     default:
-        CfOut(cf_verbose, "", " -> Unable to resolve an environment supervisor/monitor for this platform, aborting");
         break;
     }
+#elif defined(__APPLE__)
+    switch (Str2Hypervisors(a.env.type))
+    {
+    case cfv_virt_vbox:
+    case cfv_virt_test:
+        VerifyVirtDomain(hyper_uri, envtype, a, pp);
+        break;
+    case cfv_virt_xen_net:
+    case cfv_virt_kvm_net:
+    case cfv_virt_esx_net:
+    case cfv_virt_test_net:
+        VerifyVirtNetwork(hyper_uri, envtype, a, pp);
+        break;
+    default:
+        break;
+    }
+#elif defined(__sun)
+    switch (Str2Hypervisors(a.env.type))
+    {
+    case cfv_zone:
+        VerifyZone(a, pp);
+        break;
+    default:
+        break;
+    }
+#else
+    CfOut(cf_verbose, "", " -> Unable to resolve an environment supervisor/monitor for this platform, aborting");
+#endif
 }
 
 /*****************************************************************************/

--- a/cf-monitord/mon_disk.c
+++ b/cf-monitord/mon_disk.c
@@ -51,14 +51,10 @@ void MonDiskGatherData(double *cf_this)
 
 /* Here would should have some detection based on OS type VSYSTEMHARDCLASS */
 
-    switch (VSYSTEMHARDCLASS)
-    {
-    default:
-        strcpy(accesslog, "/var/log/apache2/access_log");
-        strcpy(errorlog, "/var/log/apache2/error_log");
-        strcpy(syslog, "/var/log/syslog");
-        strcpy(messages, "/var/log/messages");
-    }
+    strcpy(accesslog, "/var/log/apache2/access_log");
+    strcpy(errorlog, "/var/log/apache2/error_log");
+    strcpy(syslog, "/var/log/syslog");
+    strcpy(messages, "/var/log/messages");
 
     cf_this[ob_webaccess] = GetFileGrowth(accesslog, ob_webaccess);
     CfOut(cf_verbose, "", "Webaccess = %.2lf%%\n", cf_this[ob_webaccess]);

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -457,15 +457,11 @@ int OpenReceiverChannel(void)
                 ThreadUnlock(cft_getaddr);
             }
 
-            if (VSYSTEMHARDCLASS == mingw || VSYSTEMHARDCLASS == openbsd || VSYSTEMHARDCLASS == freebsd
-                || VSYSTEMHARDCLASS == netbsd || VSYSTEMHARDCLASS == dragonfly)
-            {
-                continue;       /* *bsd doesn't map ipv6 addresses */
-            }
-            else
-            {
-                break;
-            }
+#if defined(__MINGW32__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+            continue;       /* *bsd doesn't map ipv6 addresses */
+#else
+            break;
+#endif
         }
 
         CfOut(cf_error, "bind", "Could not bind server address");

--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -304,10 +304,9 @@ void AddSlash(char *str)
 // add root slash on Unix systems
     if (strlen(str) == 0)
     {
-        if ((VSYSTEMHARDCLASS != mingw) && (VSYSTEMHARDCLASS != cfnt))
-        {
-            strcpy(str, "/");
-        }
+#if !defined(_WIN32)
+        strcpy(str, "/");
+#endif
         return;
     }
 

--- a/libpromises/files_properties.c
+++ b/libpromises/files_properties.c
@@ -101,10 +101,9 @@ int ConsiderFile(const char *nodename, char *path, Attributes attr, Promise *pp)
 
     if ((strcmp("[", nodename) == 0) && (strcmp("/usr/bin", path) == 0))
     {
-        if (VSYSTEMHARDCLASS == linuxx)
-        {
+#if defined(__linux__)
             return true;
-        }
+#endif
     }
 
     for (sp = nodename; *sp != '\0'; sp++)

--- a/libpromises/sysinfo.c
+++ b/libpromises/sysinfo.c
@@ -408,24 +408,21 @@ void GetNameInfo3()
     {
         snprintf(shortname, CF_MAXVARSIZE - 1, "%s", CanonifyName(components[i]));
 
-        if ((VSYSTEMHARDCLASS == mingw) || (VSYSTEMHARDCLASS == cfnt))
+#if defined(_WIN32)
+        // twin has own dir, and is named agent
+        if (i == 0)
         {
-            // twin has own dir, and is named agent
-            if (i == 0)
-            {
-                snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin-twin%ccf-agent.exe", CFWORKDIR, FILE_SEPARATOR,
-                         FILE_SEPARATOR);
-            }
-            else
-            {
-                snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin%c%s.exe", CFWORKDIR, FILE_SEPARATOR, FILE_SEPARATOR,
-                         components[i]);
-            }
+            snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin-twin%ccf-agent.exe", CFWORKDIR, FILE_SEPARATOR,
+                     FILE_SEPARATOR);
         }
         else
         {
-            snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin%c%s", CFWORKDIR, FILE_SEPARATOR, FILE_SEPARATOR, components[i]);
+            snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin%c%s.exe", CFWORKDIR, FILE_SEPARATOR, FILE_SEPARATOR,
+                     components[i]);
         }
+#else
+        snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin%c%s", CFWORKDIR, FILE_SEPARATOR, FILE_SEPARATOR, components[i]);
+#endif
 
         have_component[i] = false;
 
@@ -443,15 +440,12 @@ void GetNameInfo3()
     {
         snprintf(shortname, CF_MAXVARSIZE - 1, "%s", CanonifyName(components[0]));
 
-        if ((VSYSTEMHARDCLASS == mingw) || (VSYSTEMHARDCLASS == cfnt))
-        {
-            snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin%c%s.exe", CFWORKDIR, FILE_SEPARATOR, FILE_SEPARATOR,
-                     components[1]);
-        }
-        else
-        {
-            snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin%c%s", CFWORKDIR, FILE_SEPARATOR, FILE_SEPARATOR, components[1]);
-        }
+#if defined(_WIN32)
+        snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin%c%s.exe", CFWORKDIR, FILE_SEPARATOR, FILE_SEPARATOR,
+                 components[1]);
+#else
+        snprintf(name, CF_MAXVARSIZE - 1, "%s%cbin%c%s", CFWORKDIR, FILE_SEPARATOR, FILE_SEPARATOR, components[1]);
+#endif
 
         if (cfstat(name, &sb) != -1)
         {

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -472,11 +472,10 @@ void GetInterfacesInfo(AgentType ag)
         
         if (strstr(ifp->ifr_name, ":"))
         {
-            if (VSYSTEMHARDCLASS == linuxx)
-            {
-                CfOut(cf_verbose, "", "Skipping apparent virtual interface %d: %s\n", j + 1, ifp->ifr_name);
-                continue;
-            }
+#ifdef __linux__
+            CfOut(cf_verbose, "", "Skipping apparent virtual interface %d: %s\n", j + 1, ifp->ifr_name);
+            continue;
+#endif
         }
         else
         {
@@ -683,41 +682,28 @@ static void FindV6InterfacesInfo(void)
 
     CfOut(cf_verbose, "", "Trying to locate my IPv6 address\n");
 
-    switch (VSYSTEMHARDCLASS)
+#if defined(__CYGWIN__)
+    /* NT cannot do this */
+    return;
+#elif defined(__hpux)
+    if ((pp = cf_popen("/usr/sbin/ifconfig -a", "r")) == NULL)
     {
-    case cfnt:
-        /* NT cannot do this */
+        CfOut(cf_verbose, "", "Could not find interface info\n");
         return;
-
-    case hp:
-
-        if ((pp = cf_popen("/usr/sbin/ifconfig -a", "r")) == NULL)
-        {
-            CfOut(cf_verbose, "", "Could not find interface info\n");
-            return;
-        }
-
-        break;
-
-    case aix:
-
-        if ((pp = cf_popen("/etc/ifconfig -a", "r")) == NULL)
-        {
-            CfOut(cf_verbose, "", "Could not find interface info\n");
-            return;
-        }
-
-        break;
-
-    default:
-
-        if ((pp = cf_popen("/sbin/ifconfig -a", "r")) == NULL)
-        {
-            CfOut(cf_verbose, "", "Could not find interface info\n");
-            return;
-        }
-
     }
+#elif defined(_AIX)
+    if ((pp = cf_popen("/etc/ifconfig -a", "r")) == NULL)
+    {
+        CfOut(cf_verbose, "", "Could not find interface info\n");
+        return;
+    }
+#else
+    if ((pp = cf_popen("/sbin/ifconfig -a", "r")) == NULL)
+    {
+        CfOut(cf_verbose, "", "Could not find interface info\n");
+        return;
+    }
+#endif
 
 /* Don't know the output format of ifconfig on all these .. hope for the best*/
 


### PR DESCRIPTION
Instead of switching by operating system in runtime, #ifdef corresponding code.
