### PR TITLE
Remove VINPUTLIST

### DIFF
--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -639,9 +639,9 @@ typedef enum
     RELOAD_FULL
 } Reload;
 
-static Reload CheckNewPromises(const char *input_file, const ReportContext *report_context)
+static Reload CheckNewPromises(const char *input_file, const Rlist *input_files, const ReportContext *report_context)
 {
-    if (NewPromiseProposals(input_file))
+    if (NewPromiseProposals(input_file, input_files))
     {
         CfOut(cf_verbose, "", " -> New promises detected...\n");
 
@@ -682,7 +682,7 @@ static bool ScheduleRun(Policy **policy, GenericAgentConfig *config, ExecConfig 
      * FIXME: this logic duplicates the one from cf-serverd.c. Unify ASAP.
      */
 
-    if (CheckNewPromises(config->input_file, report_context) == RELOAD_FULL)
+    if (CheckNewPromises(config->input_file, InputFiles(*policy), report_context) == RELOAD_FULL)
     {
         /* Full reload */
 
@@ -706,7 +706,6 @@ static bool ScheduleRun(Policy **policy, GenericAgentConfig *config, ExecConfig 
         POLICY_SERVER[0] = '\0';
 
         VNEGHEAP = NULL;
-        VINPUTLIST = NULL;
 
         PolicyDestroy(*policy);
         *policy = NULL;

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -541,7 +541,7 @@ void CheckFileChanges(Policy **policy, GenericAgentConfig *config, const ReportC
 
     CfDebug("Checking file updates on %s\n", config->input_file);
 
-    if (NewPromiseProposals(config->input_file))
+    if (NewPromiseProposals(config->input_file, InputFiles(*policy)))
     {
         CfOut(cf_verbose, "", " -> New promises detected...\n");
 
@@ -599,8 +599,6 @@ void CheckFileChanges(Policy **policy, GenericAgentConfig *config, const ReportC
             SV.attackerlist = NULL;
             SV.nonattackerlist = NULL;
             SV.multiconnlist = NULL;
-
-            VINPUTLIST = NULL;
 
             PolicyDestroy(*policy);
             *policy = NULL;

--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -135,7 +135,6 @@ extern Item *EDIT_ANCHORS;
 extern Scope *VSCOPE;
 extern Audit *AUDITPTR;
 extern Audit *VAUDIT;
-extern Rlist *VINPUTLIST;
 extern Rlist *BODYPARTS;
 extern Rlist *SUBBUNDLES;
 extern Rlist *SINGLE_COPY_LIST;

--- a/libpromises/cf3globals.c
+++ b/libpromises/cf3globals.c
@@ -104,7 +104,6 @@ double METER_REPAIRED[meter_endmark];
 /*****************************************************************************/
 
 Scope *VSCOPE = NULL;
-Rlist *VINPUTLIST = NULL;
 Rlist *BODYPARTS = NULL;
 Rlist *SUBBUNDLES = NULL;
 Rlist *ACCESSLIST = NULL;

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -290,31 +290,6 @@ selection:             id                         /* BODY ONLY */
                                }
                            }
                            
-                           if (strcmp(P.blockid,"control") == 0 && strcmp(P.blocktype,"common") == 0)
-                           {
-                               if (strcmp(P.lval,"inputs") == 0)
-                               {
-                                   if (IsDefinedClass(P.currentclasses, CurrentNameSpace(P.policy)))
-                                   {
-                                       if (VINPUTLIST == NULL)
-                                       {
-                                           if (P.rval.rtype == CF_LIST)
-                                           {
-                                               VINPUTLIST = P.rval.item;
-                                           }
-                                           else
-                                           {
-                                               yyerror("inputs promise must have a list as rvalue");
-                                           }
-                                       }
-                                       else
-                                       {
-                                           yyerror("Redefinition of input list (broken promise)");
-                                       }
-                                   }
-                               }
-                           }
-
                            P.rval = (Rval) { NULL, '\0' };
                        }
                        ';' ;

--- a/libpromises/constraints.h
+++ b/libpromises/constraints.h
@@ -51,6 +51,24 @@ void ConstraintDestroy(Constraint *cp);
 Constraint *ConstraintAppendToPromise(Promise *promise, const char *lval, Rval rval, const char *classes, bool references_body);
 Constraint *ConstraintAppendToBody(Body *body, const char *lval, Rval rval, const char *classes, bool references_body);
 
+/**
+ * @brief A sequence of constraints matching the l-value.
+ * @param body Body to query
+ * @param lval l-value to match
+ * @return Sequence of pointers to the constraints. Destroying it does not alter the DOM.
+ */
+Seq *ConstraintGetFromBody(Body *body, const char *lval);
+
+const char *ConstraintContext(const Constraint *cp);
+
+/**
+ * @brief Returns the first effective constraint from a list of candidates, depending on evaluation state.
+ * @param constraints The list of potential candidates
+ * @return The effective constraint, or NULL if none are found.
+ */
+Constraint *EffectiveConstraint(Seq *constraints);
+
+
 Constraint *GetConstraint(const Promise *promise, const char *lval);
 void EditScalarConstraint(Seq *conlist, const char *lval, const char *rval);
 void *GetConstraintValue(const char *lval, const Promise *promise, char type);

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -43,12 +43,21 @@ void ManPage(const char *component, const struct option options[], const char *h
 void PrintVersionBanner(const char *component);
 int CheckPromises(AgentType ag, const char *input_file, const ReportContext *report_context);
 Policy *ReadPromises(AgentType ag, char *agents, GenericAgentConfig *config, const ReportContext *report_context);
-int NewPromiseProposals(const char *input_file);
+int NewPromiseProposals(const char *input_file, const Rlist *input_files);
 void CompilationReport(Policy *policy, char *fname);
 void HashVariables(Policy *policy, const char *name, const ReportContext *report_context);
 void HashControls(const Policy *policy);
 void CloseLog(void);
 Seq *ControlBodyConstraints(const Policy *policy, AgentType agent);
+
+/**
+ * @brief Conventience function for getting the effective list of input_files from common body control.
+ * @param policy Policy where inputs are specified
+ * @return Pointer to the Rlist in the DOM
+ */
+const Rlist *InputFiles(Policy *policy);
+
+
 void SetFacility(const char *retval);
 Bundle *GetBundle(const Policy *policy, const char *name, const char *agent);
 SubType *GetSubTypeForBundle(char *type, Bundle *bp);

--- a/libpromises/parser.c
+++ b/libpromises/parser.c
@@ -51,10 +51,10 @@ static void ParserStateReset()
     P.blocktype[0] = '\0';
 }
 
-Policy *ParserParseFile(Policy *policy, const char *path)
+Policy *ParserParseFile(const char *path)
 {
     ParserStateReset();
-    P.policy = policy;
+    P.policy = PolicyNew();
 
     strncpy(P.filename, path, CF_MAXVARSIZE);
 

--- a/libpromises/parser.h
+++ b/libpromises/parser.h
@@ -27,6 +27,6 @@
 
 #include "policy.h"
 
-Policy *ParserParseFile(Policy *policy, const char *path);
+Policy *ParserParseFile(const char *path);
 
 #endif

--- a/libpromises/policy.h
+++ b/libpromises/policy.h
@@ -36,7 +36,12 @@ struct Policy_
 };
 
 Policy *PolicyNew(void);
+int PolicyCompare(const void *a, const void *b);
 void PolicyDestroy(Policy *policy);
+
+Policy *PolicyMerge(Policy *a, Policy *b);
+
+Body *PolicyGetBody(Policy *policy, const char *ns, const char *type, const char *name);
 
 Policy *PolicyFromPromise(const Promise *promise);
 char *BundleQualifiedName(const Bundle *bundle);
@@ -61,6 +66,7 @@ PolicyError *PolicyErrorNew(PolicyElementType type, const void *subject, const c
 void PolicyErrorDestroy(PolicyError *error);
 void PolicyErrorWrite(Writer *writer, const PolicyError *error);
 bool PolicyCheck(const Policy *policy, Seq *errors);
+
 void PolicySetNameSpace(Policy *policy, char *namespace);
 char *CurrentNameSpace(Policy *policy);
 
@@ -68,11 +74,17 @@ Bundle *AppendBundle(Policy *policy, const char *name, const char *type, Rlist *
 Body *AppendBody(Policy *policy, const char *name, const char *type, Rlist *args, const char *source_path);
 SubType *AppendSubType(Bundle *bundle, char *typename);
 Promise *AppendPromise(SubType *type, char *promiser, Rval promisee, char *classes, char *bundle, char *bundletype, char *namespace);
-void DeleteBodies(Body *bp);
+
+
+const char *NamespaceFromConstraint(const Constraint *cp);
+
+
+// TODO: legacy
 void DeletePromise(Promise *pp);
 void DeletePromises(Promise *pp);
-
 Bundle *GetBundle(const Policy *policy, const char *name, const char *agent);
 SubType *GetSubTypeForBundle(char *type, Bundle *bp);
+
+
 
 #endif

--- a/libutils/hash_map_priv.h
+++ b/libutils/hash_map_priv.h
@@ -33,7 +33,7 @@ typedef struct BucketListItem_
     struct BucketListItem_ *next;
 } BucketListItem;
 
-typedef unsigned (*MapHashFn) (const void *p, unsigned int max);
+typedef unsigned int (*MapHashFn) (const void *p, unsigned int max);
 
 typedef struct
 {

--- a/libutils/sequence.c
+++ b/libutils/sequence.c
@@ -92,6 +92,14 @@ void SeqAppend(Seq *seq, void *item)
     ++(seq->length);
 }
 
+void SeqAppendSeq(Seq *seq, const Seq *items)
+{
+    for (size_t i = 0; i < SeqLength(items); i++)
+    {
+        SeqAppend(seq, SeqAt(items, i));
+    }
+}
+
 void SeqRemoveRange(Seq *seq, size_t start, size_t end)
 {
     assert(seq);

--- a/libutils/sequence.h
+++ b/libutils/sequence.h
@@ -82,6 +82,13 @@ typedef int (*SeqItemComparator) (const void *, const void *, void *user_data);
 void SeqAppend(Seq *seq, void *item);
 
 /**
+ * @brief Append a sequence to this sequence. Only copies pointers.
+ * @param seq Sequence to append to
+ * @param items Sequence to copy pointers from.
+ */
+void SeqAppendSeq(Seq *seq, const Seq *items);
+
+/**
   @brief Linearly searches through the sequence and return the first item considered equal to the specified key.
   @param seq [in] The Sequence to search.
   @param key [in] The item to compare against.

--- a/tests/unit/policy_test.c
+++ b/tests/unit/policy_test.c
@@ -7,8 +7,7 @@ static Seq *LoadAndCheck(const char *filename)
     char path[1024];
     sprintf(path, "%s/%s", TESTDATADIR, filename);
 
-    Policy *p = PolicyNew();
-    ParserParseFile(p, path);
+    Policy *p = ParserParseFile(path);
 
     Seq *errs = SeqNew(10, PolicyErrorDestroy);
     PolicyCheck(p, errs);


### PR DESCRIPTION
Previously, VINPUTLIST contained the list of inputs read from body common control
during parsing.

Now we have:
  Policy *PolicyParseFile(const char *path)
And:
  Policy *PolicyMerge(Policy *a, Policy *b)

Allowing Policy object to be treated as stand-alone collections of bundles and bodies,
and allowing them to be 'linked' (merged) together later for evaluation.

This passes all the tests, but is a high risk commit, but one I think is necessary to get out there to progress.
