### PR TITLE
Update masterfiles/libraries/cfengine_stdlib.cf

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -1095,6 +1095,17 @@ repaired_returncodes => { "$(code)" };
 promise_repaired => { "$(cl)" };
 }
 
+##
+
+body classes all_prefix(prefix)
+{
+promise_repaired => { "$(prefix)_repaired" };
+promise_kept => { "$(prefix)_kept" };
+repair_failed => { "$(prefix)_failed" };
+repair_denied => { "$(prefix)_denied" };
+repair_timeout => { "$(prefix)_timeout" };
+}
+
 ##-------------------------------------------------------
 ## Persistent classes
 ##-------------------------------------------------------


### PR DESCRIPTION
classes body all_prefix will define a class based all possible outcomes based on your prefix with the state appended (_failed, _repaired, etc).
