### PR TITLE
Acceptance test for getvalues() - (Bug #1271)

### DIFF
--- a/tests/acceptance/01_vars/02_functions/getvalues_flattens-list-elements.cf
+++ b/tests/acceptance/01_vars/02_functions/getvalues_flattens-list-elements.cf
@@ -1,0 +1,72 @@
+#######################################################
+#
+# Test getvalues(), to be sure that If the array contains list elements on the
+# right hand side then all of the list elements are flattened into a single list
+# to make the return value a list. (Bug #1271)
+#
+#######################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+nova_edition::
+  host_licenses_paid => "5";
+}
+
+#######################################################
+
+bundle agent init
+{
+vars:
+    "results" slist => { "one", "two", "red", "blue" };
+
+files:
+    "$(G.testfile).expected"
+        create => "true",
+        edit_line => init_insert;
+}
+
+bundle edit_line init_insert
+{
+insert_lines:
+        "$(init.results)";
+}
+
+#######################################################
+
+bundle agent test
+{
+vars:
+    "sea[fish]" slist => { "one", "two" };
+    "sea[shark]" slist => { "red", "blue" };
+
+    secondpass::
+        "vals" slist => getvalues("sea");
+
+classes:
+    "secondpass" expression => "any";
+
+files:
+    secondpass::
+    "$(G.testfile).actual"
+        create => "true",
+        edit_line => test_insert;
+}
+
+bundle edit_line test_insert
+{
+insert_lines:
+    "$(test.vals)";
+}
+
+#######################################################
+
+bundle agent check
+{
+methods:
+        "any" usebundle => sorted_check_diff("$(G.testfile).actual",
+                                              "$(G.testfile).expected",
+                                              "$(this.promise_filename)");
+}


### PR DESCRIPTION
Adding an acceptance test for getvalues(), to be sure that if the array contains
list elements on the right hand side then all of the list elements are flattened
into a single list to make the return value a list.

Note: this issue was resolved in commit: eff95e357416a9936db4440fc1a79efe58df66cf
