### PR TITLE
Add Idempotent Append and prepend to List

### DIFF
--- a/libutils/list.c
+++ b/libutils/list.c
@@ -32,6 +32,8 @@
 #define ChangeListState(list) \
     list->state++
 
+static int ListFindNode(List *list, void *payload);
+
 /*
  * Helper method to detach lists.
  */
@@ -225,6 +227,38 @@ int ListAppend(List *list, void *payload)
     list->last = node;
     list->node_count++;
     return 0;
+}
+
+int ListPrependIdemp(List *list, void *payload)
+{
+    if (!list || !payload || !(list->compare))
+    {
+        return -1;
+    }
+
+    int found = ListFindNode(list, payload);
+    if (!found)
+    {
+        ListPrepend(list, payload);
+    }
+
+    return found;
+}
+
+int ListAppendIdemp(List *list, void *payload)
+{
+    if (!list || !payload || !(list->compare))
+    {
+        return -1;
+    }
+
+    int found = ListFindNode(list, payload);
+    if (!found)
+    {
+        ListAppend(list, payload);
+    }
+
+    return found;
 }
 
 /*

--- a/libutils/list.h
+++ b/libutils/list.h
@@ -140,6 +140,17 @@ int ListCopy(List *origin, List **destination);
   @return 0 if prepended, -1 otherwise.
   */
 int ListPrepend(List *list, void *payload);
+
+/**
+  @brief Adds an element to the beginning of the list if the item doesn't already exist
+  The Compare function must be supplied while creating the list. Other properties are
+  exactly the same as ListPrepend.
+  @param list Linked list.
+  @param payload Data to be added.
+  @return 0 if prepended, 1 if the element already exists, -1 otherwise.
+  */
+int ListPrependIdemp(List *list, void *payload);
+
 /**
   @brief Adds an element to the end of the list.
   Notice that we do not copy the element, so if the original element is free'd there will be
@@ -154,6 +165,17 @@ int ListPrepend(List *list, void *payload);
   @return 0 if appended, -1 otherwise.
   */
 int ListAppend(List *list, void *payload);
+
+/**
+  @brief Adds an element to the end of the list if the item doesn't already exist
+  The Compare function must be supplied while creating the list. Other properties are
+  exactly the same as ListAppend.
+  @param list Linked list.
+  @param payload Data to be added.
+  @return 0 if appended, 1 if the element already exists, -1 otherwise.
+  */
+int ListAppendIdemp(List *list, void *payload);
+
 /**
   @brief Removes an element from the linked list.
   Removes the first element that matches the payload. It starts looking from the beginning of the list.


### PR DESCRIPTION
This is necessary to reduce the overuse of Rlist. There are a number of cases where Rlist is  used as a container to hold a list of unique items.

Please review and comment on:
1. Function naming
2. Making the Compare function mandatory for these functions to work
2. Tests

and anything else I might have missed.
