### PR TITLE
Bug #2057 - Messages from edit_xml operations do not show the xpath

### DIFF
--- a/cf-agent/files_editxml.c
+++ b/cf-agent/files_editxml.c
@@ -403,7 +403,7 @@ static void KeepEditXmlPromise(Promise *pp)
 
 static bool VerifyXPathBuild(Attributes a, Promise *pp)
 {
-    xmlDocPtr doc;
+    xmlDocPtr doc = NULL;
     CfLock thislock;
     char lockname[CF_BUFSIZE], rawxpath[CF_BUFSIZE] = { 0 };
 
@@ -421,13 +421,13 @@ static bool VerifyXPathBuild(Attributes a, Promise *pp)
     if (!SanityCheckXPathBuild(a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised XPath build (%s) breaks its own promises", rawxpath);
+             " !! The promised XPath build: \"%s\", breaks its own promises", rawxpath);
         return false;
     }
 
     if ((doc = pp->edcontext->xmldoc) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a, " !! Unable to load XML document");
+        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! Unable to load XML document");
         return false;
     }
 
@@ -461,8 +461,8 @@ static bool VerifyXPathBuild(Attributes a, Promise *pp)
 
 static void VerifyTreeDeletions(Attributes a, Promise *pp)
 {
-    xmlDocPtr doc;
-    xmlNodePtr docnode;
+    xmlDocPtr doc = NULL;
+    xmlNodePtr docnode = NULL;
     CfLock thislock;
     char lockname[CF_BUFSIZE];
 
@@ -471,7 +471,7 @@ static void VerifyTreeDeletions(Attributes a, Promise *pp)
     if (!SanityCheckTreeDeletions(a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised tree deletion (%s) is inconsistent", pp->promiser);
+             " !! The promised tree deletion:\n\"%s\"\nis inconsistent", pp->promiser);
         return;
     }
 
@@ -488,6 +488,9 @@ static void VerifyTreeDeletions(Attributes a, Promise *pp)
 
     if (!XmlSelectNode(a.xml.select_xpath, doc, &docnode, a, pp))
     {
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+            " !! The promised XPath pattern: \"%s\", was NOT successful when selecting an edit node, in XML document(%s)",
+             a.xml.select_xpath, pp->this_server);
         return;
     }
 
@@ -511,8 +514,8 @@ static void VerifyTreeDeletions(Attributes a, Promise *pp)
 
 static void VerifyTreeInsertions(Attributes a, Promise *pp)
 {
-    xmlDocPtr doc;
-    xmlNodePtr docnode;
+    xmlDocPtr doc = NULL;
+    xmlNodePtr docnode = NULL;
     CfLock thislock;
     char lockname[CF_BUFSIZE];
 
@@ -521,7 +524,7 @@ static void VerifyTreeInsertions(Attributes a, Promise *pp)
     if (!SanityCheckTreeInsertions(a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised tree insertion (%s) breaks its own promises", pp->promiser);
+             " !! The promised tree insertion:\n\"%s\"\nbreaks its own promises", pp->promiser);
         return;
     }
 
@@ -532,13 +535,16 @@ static void VerifyTreeInsertions(Attributes a, Promise *pp)
 
     if ((doc = pp->edcontext->xmldoc) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a, " !! Unable to load XML document");
+        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! Unable to load XML document");
         return;
     }
 
     //if file is not empty: select an edit node, for tree insertion
     if (a.xml.haveselectxpath && !XmlSelectNode(a.xml.select_xpath, doc, &docnode, a, pp))
     {
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+            " !! The promised XPath pattern: \"%s\", was NOT successful when selecting an edit node, in XML document(%s)",
+             a.xml.select_xpath, pp->this_server);
         return;
     }
 
@@ -551,7 +557,7 @@ static void VerifyTreeInsertions(Attributes a, Promise *pp)
     }
 
     //insert tree into empty file or selected node
-    if (!a.xml.haveselectxpath && !xmlDocGetRootElement(doc))
+    if (!a.xml.haveselectxpath)
     {
         if (InsertTreeInFile(pp->promiser, doc, docnode, a, pp))
         {
@@ -570,8 +576,8 @@ static void VerifyTreeInsertions(Attributes a, Promise *pp)
 
 static void VerifyAttributeDeletions(Attributes a, Promise *pp)
 {
-    xmlDocPtr doc = pp->edcontext->xmldoc;
-    xmlNodePtr docnode;
+    xmlDocPtr doc = NULL;
+    xmlNodePtr docnode = NULL;
     CfLock thislock;
     char lockname[CF_BUFSIZE];
 
@@ -580,7 +586,7 @@ static void VerifyAttributeDeletions(Attributes a, Promise *pp)
     if (!SanityCheckAttributeDeletions(a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised attribute deletion (%s) is inconsistent", pp->promiser);
+             " !! The promised attribute deletion: \"%s\", is inconsistent", pp->promiser);
         return;
     }
 
@@ -589,14 +595,17 @@ static void VerifyAttributeDeletions(Attributes a, Promise *pp)
         return;
     }
 
-    if (doc == NULL)
+    if ((doc = pp->edcontext->xmldoc) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a, " !! Unable to load XML document");
+        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! Unable to load XML document");
         return;
     }
 
     if (!XmlSelectNode(a.xml.select_xpath, doc, &docnode, a, pp))
     {
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+            " !! The promised XPath pattern: \"%s\", was NOT successful when selecting an edit node, in XML document(%s)",
+             a.xml.select_xpath, pp->this_server);
         return;
     }
 
@@ -620,8 +629,8 @@ static void VerifyAttributeDeletions(Attributes a, Promise *pp)
 
 static void VerifyAttributeSet(Attributes a, Promise *pp)
 {
-    xmlDocPtr doc = pp->edcontext->xmldoc;
-    xmlNodePtr docnode;
+    xmlDocPtr doc = NULL;
+    xmlNodePtr docnode = NULL;
     CfLock thislock;
     char lockname[CF_BUFSIZE];
 
@@ -630,7 +639,7 @@ static void VerifyAttributeSet(Attributes a, Promise *pp)
     if (!SanityCheckAttributeSet(a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised attribute set (%s) breaks its own promises", pp->promiser);
+             " !! The promised attribute set: \"%s\", breaks its own promises", pp->promiser);
         return;
     }
 
@@ -639,14 +648,17 @@ static void VerifyAttributeSet(Attributes a, Promise *pp)
         return;
     }
 
-    if (doc == NULL)
+    if ((doc = pp->edcontext->xmldoc) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a, " !! Unable to load XML document");
+        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! Unable to load XML document");
         return;
     }
 
     if (!XmlSelectNode(a.xml.select_xpath, doc, &docnode, a, pp))
     {
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+            " !! The promised XPath pattern: \"%s\", was NOT successful when selecting an edit node, in XML document(%s)",
+             a.xml.select_xpath, pp->this_server);
         return;
     }
 
@@ -680,7 +692,7 @@ static void VerifyTextDeletions(Attributes a, Promise *pp)
     if (!SanityCheckTextDeletions(a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised text deletion (%s) is inconsistent", pp->promiser);
+             " !! The promised text deletion:\n\"%s\"\nis inconsistent", pp->promiser);
         return;
     }
 
@@ -697,6 +709,9 @@ static void VerifyTextDeletions(Attributes a, Promise *pp)
 
     if (!XmlSelectNode(a.xml.select_xpath, doc, &docnode, a, pp))
     {
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+            " !! The promised XPath pattern: \"%s\", was NOT successful when selecting an edit node, in XML document(%s)",
+             a.xml.select_xpath, pp->this_server);
         return;
     }
 
@@ -730,7 +745,7 @@ static void VerifyTextSet(Attributes a, Promise *pp)
     if (!SanityCheckTextSet(a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised text set (%s) breaks its own promises", pp->promiser);
+             " !! The promised text set:\n\"%s\"\nbreaks its own promises", pp->promiser);
         return;
     }
 
@@ -747,6 +762,9 @@ static void VerifyTextSet(Attributes a, Promise *pp)
 
     if (!XmlSelectNode(a.xml.select_xpath, doc, &docnode, a, pp))
     {
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+            " !! The promised XPath pattern: \"%s\", was NOT successful when selecting an edit node, in XML document(%s)",
+             a.xml.select_xpath, pp->this_server);
         return;
     }
 
@@ -780,7 +798,7 @@ static void VerifyTextInsertions(Attributes a, Promise *pp)
     if (!SanityCheckTextInsertions(a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised text insertion (%s) breaks its own promises", pp->promiser);
+             " !! The promised text insertion:\n\"%s\"\nbreaks its own promises", pp->promiser);
         return;
     }
 
@@ -797,6 +815,9 @@ static void VerifyTextInsertions(Attributes a, Promise *pp)
 
     if (!XmlSelectNode(a.xml.select_xpath, doc, &docnode, a, pp))
     {
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+            " !! The promised XPath pattern: \"%s\", was NOT successful when selecting an edit node, in XML document(%s)",
+             a.xml.select_xpath, pp->this_server);
         return;
     }
 
@@ -841,19 +862,19 @@ static bool XmlSelectNode(char *rawxpath, xmlDocPtr doc, xmlNodePtr *docnode, At
     if (!XPathVerifyConvergence(rawxpath, a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! select_xpath expression (%s) is not convergent", a.xml.select_xpath);
+             " !! select_xpath expression: \"%s\", is NOT convergent", rawxpath);
         return false;
     }
 
     if ((xpathExpr = CharToXmlChar(rawxpath)) == NULL)
     {
-        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! Unable to create new XPath expression");
+        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! Unable to create new XPath expression: \"%s\"", rawxpath);
         return false;
     }
 
     if ((xpathCtx = xmlXPathNewContext(doc)) == NULL)
     {
-        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! Unable to create new XPath context");
+        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! Unable to create new XPath context: \"%s\"", rawxpath);
         return false;
     }
 
@@ -874,8 +895,8 @@ static bool XmlSelectNode(char *rawxpath, xmlDocPtr doc, xmlNodePtr *docnode, At
     if (size > 1)
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! Current select_xpath expression \"%s\" returns (%d) edit nodes, please modify to select a unique edit node",
-             xpathExpr, size);
+             " !! Current select_xpath expression: \"%s\", returns (%d) edit nodes in XML document(%s), please modify expression to select a unique edit node",
+             xpathExpr, size, pp->this_server);
         valid = false;
     }
 
@@ -894,7 +915,7 @@ static bool XmlSelectNode(char *rawxpath, xmlDocPtr doc, xmlNodePtr *docnode, At
         if (cur == NULL)
         {
             cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-                 " !! The promised XPath pattern (%s) was not found when selecting edit node in %s",
+                 " !! The promised XPath pattern: \"%s\", was NOT found when selecting an edit node, in XML document(%s)",
                  xpathExpr, pp->this_server);
             valid = false;
         }
@@ -919,32 +940,33 @@ static bool BuildXPathInFile(char rawxpath[CF_BUFSIZE], xmlDocPtr doc, Attribute
 
     if (xmlDocGetRootElement(doc))
     {
-        cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised xmldoc (%s) already exists and contains a root element %s",
-             pp->promiser, pp->this_server);
+        cfPS(cf_verbose, CF_NOP, "", pp, a, " !! The promised XML document (%s) already exists and contains a root element (promise kept)",
+             pp->this_server);
         return false;
     }
 
     //set rootnode
     if ((docnode = XPathHeadExtractNode(copyxpath, a, pp)) == NULL)
     {
-        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! Unable to extract node from XPath (%s) in server %s",
+        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! Unable to extract root node from XPath (%s), to be inserted into an empty XML document (%s)",
              rawxpath, pp->this_server);
         return false;
     }
 
     if (docnode == NULL || (docnode->name) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a, " !! The extracted node to be inserted is empty");
+        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! The extracted root node, from XPath (%s), to be inserted into an empty XML document (%s), is empty",
+             rawxpath, pp->this_server);
         return false;
     }
 
     //insert the content into new XML document, beginning from root node
-    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Building XPath \"%s\" in %s", rawxpath, pp->this_server);
+    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Building XPath: \"%s\", into an empty XML document (%s)",
+         rawxpath, pp->this_server);
     if (xmlDocSetRootElement(doc, docnode) != NULL)
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised XPath (%s) was not built successfully in %s",
+             " !! The promised XPath \"%s\", was NOT built successfully into an empty XML document (%s)",
              rawxpath, pp->this_server);
         return false;
     }
@@ -993,7 +1015,8 @@ static bool BuildXPathInNode(char rawxpath[CF_BUFSIZE], xmlDocPtr doc, Attribute
     }
 
     //insert the new tree into selected node in XML document
-    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Building XPath \"%s\" in %s", rawxpath, pp->this_server);
+    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Building XPath: \"%s\", in XML document (%s)",
+         rawxpath, pp->this_server);
     if (docnode != NULL)
     {
         xmlAddChild(docnode, tail);
@@ -1018,50 +1041,65 @@ static bool InsertTreeInFile(char *rawtree, xmlDocPtr doc, xmlNodePtr docnode, A
     //for parsing subtree from memory
     if ((buf = CharToXmlChar(rawtree)) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Tree to be inserted was not successfully loaded into an XML buffer");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Tree to be inserted:\n\"%s\"\ninto an empty XML document (%s), was NOT successfully loaded into an XML buffer",
+             rawtree, pp->this_server);
         return false;
     }
 
     //parse the subtree
     if (xmlParseBalancedChunkMemory(doc, NULL, NULL, 0, buf, &treenode) != 0)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Tree to be inserted was not parsed successfully");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Tree to be inserted:\n\"%s\"\ninto an empty XML document (%s), was NOT parsed successfully",
+             rawtree, pp->this_server);
         return false;
     }
 
     if (treenode == NULL || (treenode->name) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! The promised tree to be inserted is empty");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! The promised tree to be inserted:\n\"%s\"\ninto an empty XML document (%s), is empty",
+             rawtree, pp->this_server);
         return false;
     }
 
     //verify treenode does not already exist inside docnode
     if ((rootnode = xmlDocGetRootElement(doc)) != NULL)
     {
-        cfPS(cf_verbose, CF_NOP, "", pp, a, " !! The promised xmldoc exists and contains a root element in %s (promise kept)",
-             pp->this_server);
+        if (!XmlNodesCompare(treenode, rootnode, a, pp))
+        {
+            cfPS(cf_error, CF_INTERPT, "", pp, a,
+                 " !! The promised tree:\n\"%s\"\nis to be inserted into an empty XML document (%s),"
+                 " however XML document is NOT empty and tree to be inserted does NOT match existing content."
+                 " If you would like to insert into a non-empty XML document, please specify select_xpath expression",
+                 rawtree, pp->this_server);
+        }
+        else
+        {
+            cfPS(cf_verbose, CF_NOP, "", pp, a, " !! The promised XML document (%s) already exists and contains a root element (promise kept)",
+                 pp->this_server);
+        }
+
         return false;
     }
 
     if (a.transaction.action == cfa_warn)
     {
         cfPS(cf_error, CF_WARN, "", pp, a,
-             " -> Need to create the promised xmldoc \"%s\" in %s - but only a warning was promised",
-             pp->promiser, pp->this_server);
+             " -> Need to insert the promised tree:\n\"%s\"\ninto an empty XML document (%s) - but only a warning was promised",
+             rawtree, pp->this_server);
         return true;
     }
 
     //insert the content into new XML document
-    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Inserting tree \"%s\" in %s", pp->promiser,
-          pp->this_server);
+    cfPS(cf_verbose, CF_CHG, "", pp, a, "\n -> Inserting tree:\n\"%s\"\ninto an empty XML document (%s)",
+         rawtree, pp->this_server);
     if (xmlDocSetRootElement(doc, treenode) != NULL)
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised tree (%s) was not inserted successfully in %s",
-             pp->promiser, pp->this_server);
+             " !! The promised tree:\n\"%s\"\nwas NOT inserted successfully, into an empty XML document (%s)",
+             rawtree, pp->this_server);
         return false;
     }
 
@@ -1069,8 +1107,8 @@ static bool InsertTreeInFile(char *rawtree, xmlDocPtr doc, xmlNodePtr docnode, A
     if (((rootnode = xmlDocGetRootElement(doc)) == NULL) || !XmlNodesCompare(treenode, rootnode, a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised tree (%s) was not inserted successfully in %s",
-             pp->promiser, pp->this_server);
+             " !! The promised tree:\n\"%s\"\nwas NOT inserted successfully, into an empty XML document (%s)",
+             rawtree, pp->this_server);
         return false;
     }
 
@@ -1088,38 +1126,40 @@ static bool DeleteTreeInNode(char *rawtree, xmlDocPtr doc, xmlNodePtr docnode, A
     //for parsing subtree from memory
     if ((buf = CharToXmlChar(rawtree)) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Tree to be deleted was not successfully loaded into an XML buffer");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Tree to be deleted:\n\"%s\"\nat XPath (%s) in XML document (%s), was NOT successfully loaded into an XML buffer",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     //parse the subtree
     if (xmlParseBalancedChunkMemory(doc, NULL, NULL, 0, buf, &treenode) != 0)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Tree to be deleted was not parsed successfully");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Tree to be deleted:\n\"%s\"\nat XPath (%s) in XML document (%s), was NOT parsed successfully",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     //verify treenode exists inside docnode
     if ((deletetree = XmlVerifyNodeInNodeSubset(treenode, docnode, a, pp)) == NULL)
     {
-        cfPS(cf_verbose, CF_NOP, "", pp, a, " !! The promised tree to be deleted: \n\n(%s) \n\ndoes not exists in %s (promise kept)",
-             pp->promiser, pp->this_server);
+        cfPS(cf_verbose, CF_NOP, "", pp, a, " !! The promised tree to be deleted:\n\"%s\"\ndoes NOT exist, at XPath (%s) in XML document (%s) (promise kept)",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     if (a.transaction.action == cfa_warn)
     {
         cfPS(cf_error, CF_WARN, "", pp, a,
-             " -> Need to delete the promised tree \"%s\" from %s - but only a warning was promised",
-             pp->promiser, pp->this_server);
+             " -> Need to delete the promised tree:\n\"%s\"\nat XPath (%s) in XML document (%s) - but only a warning was promised",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return true;
     }
 
     //remove the subtree from XML document
-    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Deleting tree \"%s\" in %s", pp->promiser,
-          pp->this_server);
+    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Deleting tree:\n\"%s\"\nat XPath (%s) in XML document (%s)",
+         rawtree, a.xml.select_xpath, pp->this_server);
     xmlUnlinkNode(deletetree);
     xmlFreeNode(deletetree);
 
@@ -1127,8 +1167,8 @@ static bool DeleteTreeInNode(char *rawtree, xmlDocPtr doc, xmlNodePtr docnode, A
     if (XmlVerifyNodeInNodeSubset(treenode, docnode, a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised tree to be deleted(%s) was not successfully deleted, in %s",
-             pp->promiser, pp->this_server);
+             " !! The promised tree to be deleted:\n\"%s\"\nwas NOT successfully deleted, at XPath (%s) in XML document (%s)",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1145,49 +1185,52 @@ static bool InsertTreeInNode(char *rawtree, xmlDocPtr doc, xmlNodePtr docnode, A
     //for parsing subtree from memory
     if ((buf = CharToXmlChar(rawtree)) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Tree to be inserted was not successfully loaded into an XML buffer");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Tree to be inserted:\n\"%s\"\nat XPath (%s) in XML document (%s), was NOT successfully loaded into an XML buffer",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     //parse the subtree
     if (xmlParseBalancedChunkMemory(doc, NULL, NULL, 0, buf, &treenode) != 0)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Tree to be inserted was not parsed successfully");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Tree to be inserted:\n\"%s\"\nat XPath (%s) in XML document (%s), was NOT parsed successfully",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     if (treenode == NULL || (treenode->name) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a, " !! The promised tree to be inserted is empty");
+        cfPS(cf_error, CF_INTERPT, "", pp, a, " !! The promised tree to be inserted:\n\"%s\"\nat XPath (%s) in XML document (%s), is empty",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     //verify treenode does not already exist inside docnode
     if (XmlVerifyNodeInNodeSubset(treenode, docnode, a, pp))
     {
-        cfPS(cf_verbose, CF_NOP, "", pp, a, " !! The promised tree to be inserted: \n\n(%s) \n\nexists in %s (promise kept)",
-             pp->promiser, pp->this_server);
+        cfPS(cf_verbose, CF_NOP, "", pp, a, " !! The promised tree to be inserted:\n\"%s\"\nalready exists, at XPath (%s) in XML document (%s) (promise kept)",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     if (a.transaction.action == cfa_warn)
     {
         cfPS(cf_error, CF_WARN, "", pp, a,
-             " -> Need to insert the promised tree \"%s\" to %s - but only a warning was promised",
-             pp->promiser, pp->this_server);
+             " -> Need to insert the promised tree:\n\"%s\"\nat XPath (%s) in XML document (%s) - but only a warning was promised",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return true;
     }
 
     //insert the subtree into XML document
-    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Inserting tree \"%s\" in %s", pp->promiser,
-          pp->this_server);
+    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Inserting tree:\n\"%s\"\nat XPath (%s) in XML document (%s)\n",
+         rawtree, a.xml.select_xpath, pp->this_server);
     if (!xmlAddChild(docnode, treenode))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised tree (%s) was not inserted successfully in %s",
-             pp->promiser, pp->this_server);
+             " !! The promised tree:\n\"%s\"\nwas NOT inserted successfully, at XPath (%s) in XML document (%s)",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1195,8 +1238,8 @@ static bool InsertTreeInNode(char *rawtree, xmlDocPtr doc, xmlNodePtr docnode, A
     if (!XmlVerifyNodeInNodeSubset(treenode, docnode, a, pp))
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised tree (%s) was not inserted successfully in %s",
-             pp->promiser, pp->this_server);
+             " !! The promised tree:\n\"%s\"\nwas NOT inserted successfully, at XPath (%s) in XML document (%s)",
+             rawtree, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1212,8 +1255,9 @@ static bool DeleteAttributeInNode(char *rawname, xmlDocPtr doc, xmlNodePtr docno
 
     if ((name = CharToXmlChar(rawname)) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Name of attribute to be deleted was not successfully loaded into an XML buffer");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Name of attribute to be deleted: \"%s\", at XPath (%s) in XML document (%s), was NOT successfully loaded into an XML buffer",
+             rawname, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1221,26 +1265,27 @@ static bool DeleteAttributeInNode(char *rawname, xmlDocPtr doc, xmlNodePtr docno
     if ((attr = xmlHasProp(docnode, name)) == NULL)
     {
         cfPS(cf_verbose, CF_NOP, "", pp, a,
-             " !! The promised attribute to be deleted (%s) does not exists in %s (promise kept)",
-             pp->promiser, pp->this_server);
+             " !! The promised attribute to be deleted: \"%s\", does NOT exist, at XPath (%s) in XML document (%s) (promise kept)",
+             rawname, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     if (a.transaction.action == cfa_warn)
     {
         cfPS(cf_error, CF_WARN, "", pp, a,
-             " -> Need to delete the promised attribute \"%s\" from %s - but only a warning was promised",
-             pp->promiser, pp->this_server);
+             " -> Need to delete the promised attribute: \"%s\", at XPath (%s) in XML document (%s) - but only a warning was promised",
+             rawname, a.xml.select_xpath, pp->this_server);
         return true;
     }
 
     //delete attribute from docnode
-    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Deleting attribute \"%s\" in %s", pp->promiser,
-          pp->this_server);
+    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Deleting attribute: \"%s\", at XPath (%s) in XML document (%s)",
+             rawname, a.xml.select_xpath, pp->this_server);
     if ((xmlRemoveProp(attr)) == -1)
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised attribute to be deleted was not deleted successfully.");
+             " !! The promised attribute to be deleted: \"%s\", was NOT deleted successfully, at XPath (%s) in XML document (%s).",
+             rawname, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1248,8 +1293,8 @@ static bool DeleteAttributeInNode(char *rawname, xmlDocPtr doc, xmlNodePtr docno
     if ((attr = xmlHasProp(docnode, name)) != NULL)
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised attribute to be deleted (%s) was not deleted from edit node in %s",
-             pp->promiser, pp->this_server);
+             " !! The promised attribute to be deleted: \"%s\", was NOT deleted successfully, at XPath (%s) in XML document (%s)",
+             rawname, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1266,15 +1311,17 @@ static bool SetAttributeInNode(char *rawname, char *rawvalue, xmlDocPtr doc, xml
 
     if ((name = CharToXmlChar(rawname)) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Name of attribute to be set was not successfully loaded into an XML buffer");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Name of attribute to be set: \"%s\", at XPath (%s) in XML document (%s), was NOT successfully loaded into an XML buffer",
+             rawname, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     if ((value = CharToXmlChar(rawvalue)) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Value of attribute to be set was not successfully loaded into an XML buffer");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Value of attribute to be set: \"%s\", at XPath (%s) in XML document (%s), was NOT successfully loaded into an XML buffer",
+             rawvalue, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1282,26 +1329,27 @@ static bool SetAttributeInNode(char *rawname, char *rawvalue, xmlDocPtr doc, xml
     if ((attr = XmlVerifyAttributeInNode(name, value, docnode, a, pp)) != NULL)
     {
         cfPS(cf_verbose, CF_NOP, "", pp, a,
-             " !! The promised attribute to be set (%s) with value (%s) exists in %s (promise kept)",
-             pp->promiser, a.xml.attribute_value, pp->this_server);
+             " !! The promised attribute to be set, with name: \"%s\" and value: \"%s\", already exists, at XPath (%s) in XML document (%s) (promise kept)",
+             rawname, rawvalue, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     if (a.transaction.action == cfa_warn)
     {
         cfPS(cf_error, CF_WARN, "", pp, a,
-             " -> Need to set the promised attribute \"%s\" to %s - but only a warning was promised",
-             pp->promiser, pp->this_server);
+             " -> Need to set the promised attribute, with name: \"%s\" and value: \"%s\", at XPath (%s) in XML document (%s) - but only a warning was promised",
+             rawname, rawvalue, a.xml.select_xpath, pp->this_server);
         return true;
     }
 
     //set attribute in docnode
-    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Setting attribute \"%s\" in %s", pp->promiser,
-          pp->this_server);
+    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Setting attribute with name: \"%s\" and value: \"%s\", at XPath (%s) in XML document (%s)",
+         rawname, rawvalue, a.xml.select_xpath, pp->this_server);
     if ((attr = xmlSetProp(docnode, name, value)) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Attribute was not successfully set in XML document");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! The promised attribute to be set, with name: \"%s\" and value: \"%s\", was NOT successfully set, at XPath (%s) in XML document (%s)",
+             rawname, rawvalue, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1309,8 +1357,8 @@ static bool SetAttributeInNode(char *rawname, char *rawvalue, xmlDocPtr doc, xml
     if ((attr = XmlVerifyAttributeInNode(name, value, docnode, a, pp)) == NULL)
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised attribute (%s) with value (%s) was not set in %s",
-             pp->promiser, a.xml.attribute_value, pp->this_server);
+             " !! The promised attribute to be set, with name: \"%s\" and value: \"%s\", was NOT successfully set, at XPath (%s) in XML document (%s)",
+             rawname, rawvalue, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1326,8 +1374,9 @@ static bool DeleteTextInNode(char *rawtext, xmlDocPtr doc, xmlNodePtr docnode, A
 
     if ((text = CharToXmlChar(rawtext)) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Text to be deleted was not successfully loaded into an XML buffer");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Text to be deleted:\n\"%s\"\nat XPath (%s) in XML document (%s), was NOT successfully loaded into an XML buffer",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1335,22 +1384,22 @@ static bool DeleteTextInNode(char *rawtext, xmlDocPtr doc, xmlNodePtr docnode, A
     if (XmlVerifyTextInNodeSubstring(text, docnode, a, pp) == NULL)
     {
         cfPS(cf_verbose, CF_NOP, "", pp, a,
-             " !! The promised text to be deleted (%s) does not exist in %s (promise kept)",
-             pp->promiser, pp->this_server);
+             " !! The promised text to be deleted:\n\"%s\"\ndoes NOT exist, at XPath (%s) in XML document (%s) (promise kept)",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     if (a.transaction.action == cfa_warn)
     {
         cfPS(cf_error, CF_WARN, "", pp, a,
-             " -> Need to delete the promised text \"%s\" to %s - but only a warning was promised",
-             pp->promiser, pp->this_server);
+             " -> Need to delete the promised text:\n\"%s\"\nat XPath (%s) in XML document (%s) - but only a warning was promised",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return true;
     }
 
     //delete text from docnode
-    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Deleting text \"%s\" in %s", pp->promiser,
-          pp->this_server);
+    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Deleting text:\n\"%s\"\nat XPath (%s) in XML document (%s)",
+         rawtext, a.xml.select_xpath, pp->this_server);
 
     //node contains text
     if (xmlNodeIsText(docnode->children))
@@ -1374,8 +1423,8 @@ static bool DeleteTextInNode(char *rawtext, xmlDocPtr doc, xmlNodePtr docnode, A
     if (XmlVerifyTextInNodeSubstring(text, docnode, a, pp) != NULL)
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised text (%s) was not deleted successfully from %s",
-             pp->promiser, pp->this_server);
+             " !! The promised text:\n\"%s\"\nwas NOT deleted successfully, at XPath (%s) in XML document (%s)",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1391,8 +1440,9 @@ static bool SetTextInNode(char *rawtext, xmlDocPtr doc, xmlNodePtr docnode, Attr
 
     if ((text = CharToXmlChar(rawtext)) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Text to be set was not successfully loaded into an XML buffer");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Text to be set:\n\"%s\"\nat XPath (%s) in XML document (%s), was NOT successfully loaded into an XML buffer",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1400,22 +1450,22 @@ static bool SetTextInNode(char *rawtext, xmlDocPtr doc, xmlNodePtr docnode, Attr
     if (XmlVerifyTextInNodeExact(text, docnode, a, pp) != NULL)
     {
         cfPS(cf_verbose, CF_NOP, "", pp, a,
-             " !! The promised text to be set (%s) exists in %s (promise kept)",
-             pp->promiser, pp->this_server);
+             " !! The promised text to be set:\n\"%s\"\nalready exists, at XPath (%s) in XML document (%s) (promise kept)",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     if (a.transaction.action == cfa_warn)
     {
         cfPS(cf_error, CF_WARN, "", pp, a,
-             " -> Need to set the promised text \"%s\" to %s - but only a warning was promised",
-             pp->promiser, pp->this_server);
+             " -> Need to set the promised text:\n\"%s\"\nat XPath (%s) in XML document (%s) - but only a warning was promised",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return true;
     }
 
     //set text in docnode
-    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Setting text \"%s\" in %s", pp->promiser,
-          pp->this_server);
+    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Setting text:\n\"%s\"\nat XPath (%s) in XML document (%s)",
+         rawtext, a.xml.select_xpath, pp->this_server);
 
     //node already contains text
     if (xmlNodeIsText(docnode->children))
@@ -1439,8 +1489,8 @@ static bool SetTextInNode(char *rawtext, xmlDocPtr doc, xmlNodePtr docnode, Attr
     if (XmlVerifyTextInNodeExact(text, docnode, a, pp) == NULL)
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised text (%s) was not set successfully in %s",
-             pp->promiser, pp->this_server);
+             " !! The promised text:\n\"%s\"\nwas NOT set successfully, at XPath (%s) in XML document (%s)",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1456,8 +1506,9 @@ static bool InsertTextInNode(char *rawtext, xmlDocPtr doc, xmlNodePtr docnode, A
 
     if ((text = CharToXmlChar(rawtext)) == NULL)
     {
-        cfPS(cf_verbose, CF_INTERPT, "", pp, a,
-             " !! Text to be inserted was not successfully loaded into an XML buffer");
+        cfPS(cf_error, CF_INTERPT, "", pp, a,
+             " !! Text to be inserted:\n\"%s\"\nat XPath (%s) in XML document (%s), was NOT successfully loaded into an XML buffer",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1465,22 +1516,22 @@ static bool InsertTextInNode(char *rawtext, xmlDocPtr doc, xmlNodePtr docnode, A
     if (XmlVerifyTextInNodeSubstring(text, docnode, a, pp) != NULL)
     {
         cfPS(cf_verbose, CF_NOP, "", pp, a,
-             " !! The promised text to be inserted (%s) exists in %s (promise kept)",
-             pp->promiser, pp->this_server);
+             " !! The promised text to be inserted:\n\"%s\"\nalready exists, at XPath (%s) in XML document (%s) (promise kept)",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
     if (a.transaction.action == cfa_warn)
     {
         cfPS(cf_error, CF_WARN, "", pp, a,
-             " -> Need to insert the promised text \"%s\" to %s - but only a warning was promised",
-             pp->promiser, pp->this_server);
+             " -> Need to insert the promised text:\n\"%s\"\nat XPath (%s) in XML document (%s) - but only a warning was promised",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return true;
     }
 
     //insert text into docnode
-    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Inserting text \"%s\" in %s", pp->promiser,
-          pp->this_server);
+    cfPS(cf_verbose, CF_CHG, "", pp, a, " -> Inserting text:\n\"%s\"\nat XPath (%s) in XML document (%s)",
+         rawtext, a.xml.select_xpath, pp->this_server);
 
     //node already contains text
     if (xmlNodeIsText(docnode->children))
@@ -1505,8 +1556,8 @@ static bool InsertTextInNode(char *rawtext, xmlDocPtr doc, xmlNodePtr docnode, A
     if (XmlVerifyTextInNodeSubstring(text, docnode, a, pp) == NULL)
     {
         cfPS(cf_error, CF_INTERPT, "", pp, a,
-             " !! The promised text (%s) was not inserted successfully in %s",
-             pp->promiser, pp->this_server);
+             " !! The promised text:\n\"%s\"\nwas NOT inserted successfully, at XPath (%s) in XML document (%s)",
+             rawtext, a.xml.select_xpath, pp->this_server);
         return false;
     }
 
@@ -1577,10 +1628,10 @@ static bool SanityCheckTreeInsertions(Attributes a, Promise *pp)
               " !! Tree insertion into an empty file, using select_xpath, does not make sense");
         return false;
     }
-    else if ((!a.xml.haveselectxpath &&  (a.xml.havebuildxpath || xmlDocGetRootElement(pp->edcontext->xmldoc))))
+    else if ((!a.xml.haveselectxpath &&  a.xml.havebuildxpath))
     {
-        CfOut(cf_error, "Tree insertion requires select_xpath to be specified, unless inserting into an empty file",
-              " !! ");
+        CfOut(cf_error, "",
+              "!! Tree insertion requires select_xpath to be specified, unless inserting into an empty file");
         return false;
     }
 


### PR DESCRIPTION
Improved error messages for edit_xml promises:
- include more useful information in error messages, such as select_xpath and name of XML document being edited
- verify cfPS() parameters, such as cf_error or cf_verbose
- improve general appearance of messages, such as punctuation and whitespace

Correct SanityCheckTreeInsertions() so that there are not error messages on multiple passes, when inserting a tree into an initially empty file.
