### PR TITLE
Fix for 1804

### DIFF
--- a/libpromises/files_copy.c
+++ b/libpromises/files_copy.c
@@ -75,10 +75,21 @@ bool CopyRegularFileDisk(const char *source, const char *destination, bool make_
         unlink(destination);
         return false;
     }
+    /*
+     * We need to stat the file in order to get the right source permissions.
+     */
+    struct stat statbuf;
+
+    if (cfstat(source, &statbuf) == -1)
+    {
+        CfOut(cf_inform, "stat", "Can't copy %s!\n", source);
+        unlink(destination);
+        return false;
+    }
 
     unlink(destination);                /* To avoid link attacks */
 
-    if ((dd = open(destination, O_WRONLY | O_CREAT | O_TRUNC | O_EXCL | O_BINARY, 0600)) == -1)
+    if ((dd = open(destination, O_WRONLY | O_CREAT | O_TRUNC | O_EXCL | O_BINARY, statbuf.st_mode)) == -1)
     {
         close(sd);
         unlink(destination);

--- a/tests/acceptance/10_files/02_maintain/004.cf
+++ b/tests/acceptance/10_files/02_maintain/004.cf
@@ -47,7 +47,9 @@ body delete init_delete
 bundle agent test
 {
 vars:
-    "mode" int => "0600";
+    "mode" string => execresult(
+    "/usr/bin/stat --printf=%a $(g.source)",
+    "noshell");
 
 files:
         "$(G.testfile)"

--- a/tests/acceptance/10_files/02_maintain/005.cf
+++ b/tests/acceptance/10_files/02_maintain/005.cf
@@ -47,7 +47,9 @@ body delete init_delete
 bundle agent test
 {
 vars:
-    "mode" int => "0600";
+    "mode" string => execresult(
+    "/usr/bin/stat --printf=%a $(g.source)",
+    "noshell");
 
 files:
         "$(G.testfile)"

--- a/tests/acceptance/10_files/02_maintain/006.cf
+++ b/tests/acceptance/10_files/02_maintain/006.cf
@@ -47,7 +47,9 @@ body delete init_delete
 bundle agent test
 {
 vars:
-    "mode" int => "0600";
+    "mode" string => execresult(
+    "/usr/bin/stat --printf=%a $(g.source)",
+    "noshell");
 
 files:
         "$(G.testfile)"

--- a/tests/acceptance/10_files/02_maintain/007.cf
+++ b/tests/acceptance/10_files/02_maintain/007.cf
@@ -47,7 +47,9 @@ body delete init_delete
 bundle agent test
 {
 vars:
-    "mode" int => "0600";
+    "mode" string => execresult(
+    "/usr/bin/stat --printf=%a $(g.source)",
+    "noshell");
 
 files:
         "$(G.testfile)"


### PR DESCRIPTION
At creation time we were always assigning 0600 as mode to the new file.
This fix stats the source file first and assigns the same mode as the
original file.
Acceptance tests are updated too.
