### PR TITLE
Unsilent error when lsdir() is not able to read the directory

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1616,7 +1616,7 @@ static FnCallResult FnCallLsDir(FnCall *fp, Rlist *finalargs)
 
     if (dirh == NULL)
     {
-        CfOut(cf_verbose, "opendir", " !! Directory \"%s\" could not be accessed in lsdir()", dirname);
+        CfOut(cf_error, "opendir", " !! Directory \"%s\" could not be accessed in lsdir()", dirname);
         snprintf(retval, CF_SMALLBUF - 1, "0");
         return (FnCallResult) { FNCALL_SUCCESS, { xstrdup(retval), CF_SCALAR } };
     }


### PR DESCRIPTION
lsdir() does not report error opening the directory, except in verbose mode.

With the following policy:

```
body common control
{
bundlesequence => { "test" };
}

bundle agent test
{
vars:
  "test" slist => lsdir("/does/not/exist", "", "false");
}
```

All "cf-agent -Kf test.cf" outputs is:
Fatal CFEngine error: Validation:  !! Type mismatch -- rhs is a scalar, but lhs (slist) is not a scalar type

With this commit, the output is changed to:
 !! Directory "/does/not/exist" could not be accessed in lsdir()
 !!! System reports error for opendir: "No such file or directory"
 !! Directory "/does/not/exist" could not be accessed in lsdir()
 !!! System reports error for opendir: "No such file or directory"
Fatal CFEngine error: Validation:  !! Type mismatch -- rhs is a scalar, but lhs (slist) is not a scalar type
