### PR TITLE
Use portable PRIuMAX/PRIdMAX/PRIoMAX to print [u]intmax_t (Mantis #1677)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -477,6 +477,18 @@ AC_CHECK_FUNCS(sysinfo setsid sysconf)
 AC_CHECK_FUNCS(getzoneid getzonenamebyid)
 AC_CHECK_FUNCS(fpathconf)
 
+AC_MSG_CHECKING([for PRIuMAX/PRIdMAX macros])
+AC_EGREP_CPP([primacros_found],
+  AC_INCLUDES_DEFAULT
+  [#include <inttypes.h>
+  #if defined(PRIuMAX) && defined(PRIdMAX)
+    primacros_found
+  #endif
+  ],
+  [AC_MSG_RESULT(yes)],
+  [AC_MSG_RESULT(no)
+   AC_MSG_RESULT(Unable to find out how to print intmax_t/uintmax_t types)])
+
 HW_FUNC_VSNPRINTF
 HW_FUNC_SNPRINTF
 HW_FUNC_VASPRINTF

--- a/src/cf.defs.h
+++ b/src/cf.defs.h
@@ -88,6 +88,10 @@ struct utsname
 # include <stdint.h>
 #endif
 
+#ifdef HAVE_INTTYPES_H
+# include <inttypes.h>
+#endif
+
 #ifdef HAVE_SYS_SYSTEMINFO_H
 # include <sys/systeminfo.h>
 #endif

--- a/src/client_code.c
+++ b/src/client_code.c
@@ -353,8 +353,8 @@ int cf_remote_stat(char *file, struct stat *buf, char *stattype, Attributes attr
         CfDebug("Mode = %ld,%ld\n", d2, d3);
 
         CfDebug
-            ("OK: type=%d\n mode=%o\n lmode=%o\n uid=%d\n gid=%d\n size=%ld\n atime=%jd\n mtime=%jd ino=%d nlnk=%d, dev=%jd\n",
-             cfst.cf_type, cfst.cf_mode, cfst.cf_lmode, cfst.cf_uid, cfst.cf_gid, (long) cfst.cf_size,
+            ("OK: type=%d\n mode=%" PRIoMAX "\n lmode=%" PRIoMAX "\n uid=%" PRIuMAX "\n gid=%" PRIuMAX "\n size=%ld\n atime=%" PRIdMAX "\n mtime=%" PRIdMAX " ino=%d nlnk=%d, dev=%" PRIdMAX "\n",
+             cfst.cf_type, (uintmax_t)cfst.cf_mode, (uintmax_t)cfst.cf_lmode, (uintmax_t)cfst.cf_uid, (uintmax_t)cfst.cf_gid, (long) cfst.cf_size,
              (intmax_t) cfst.cf_atime, (intmax_t) cfst.cf_mtime, cfst.cf_ino, cfst.cf_nlink, (intmax_t) cfst.cf_dev);
 
         memset(recvbuffer, 0, CF_BUFSIZE);

--- a/src/files_operators.c
+++ b/src/files_operators.c
@@ -573,7 +573,7 @@ int MoveObstruction(char *from, Attributes attr, Promise *pp)
 
             if (attr.copy.backup == cfa_timestamp || attr.edits.backup == cfa_timestamp)
             {
-                sprintf(stamp, "_%jd_%s", (intmax_t) CFSTARTTIME, CanonifyName(cf_ctime(&now_stamp)));
+                snprintf(stamp, CF_BUFSIZE, "_%jd_%s", (intmax_t) CFSTARTTIME, CanonifyName(cf_ctime(&now_stamp)));
                 strcat(saved, stamp);
             }
 
@@ -607,7 +607,7 @@ int MoveObstruction(char *from, Attributes attr, Promise *pp)
             saved[0] = '\0';
             strcpy(saved, from);
 
-            sprintf(stamp, "_%jd_%s", (intmax_t) CFSTARTTIME, CanonifyName(cf_ctime(&now_stamp)));
+            snprintf(stamp, CF_BUFSIZE, "_%jd_%s", (intmax_t) CFSTARTTIME, CanonifyName(cf_ctime(&now_stamp)));
             strcat(saved, stamp);
             strcat(saved, CF_SAVED);
             strcat(saved, ".dir");
@@ -1470,7 +1470,7 @@ int MakeParentDirectory(char *parentandchild, int force)
             }
             else if (cfstat(currentpath, &statbuf) == -1)
             {
-                CfDebug("cfengine: Making directory %s, mode %o\n", currentpath, DEFAULTMODE);
+                CfDebug("cfengine: Making directory %s, mode %" PRIoMAX "\n", currentpath, (uintmax_t)DEFAULTMODE);
 
                 if (!DONTDO)
                 {
@@ -1846,7 +1846,7 @@ static int Unix_VerifyOwner(char *file, Promise *pp, Attributes attr, struct sta
     uid_t uid = CF_SAME_OWNER;
     gid_t gid = CF_SAME_GROUP;
 
-    CfDebug("Unix_VerifyOwner: %jd\n", (uintmax_t) sb->st_uid);
+    CfDebug("VerifyOwner: %" PRIdMAX "\n", (uintmax_t) sb->st_uid);
 
     for (ulp = attr.perms.owners; ulp != NULL; ulp = ulp->next)
     {
@@ -1920,12 +1920,12 @@ static int Unix_VerifyOwner(char *file, Promise *pp, Attributes attr, struct sta
             {
                 if (uid != CF_SAME_OWNER)
                 {
-                    CfDebug("(Change owner to uid %d if possible)\n", uid);
+                    CfDebug("(Change owner to uid %" PRIuMAX " if possible)\n", (uintmax_t)uid);
                 }
 
                 if (gid != CF_SAME_GROUP)
                 {
-                    CfDebug("Change group to gid %d if possible)\n", gid);
+                    CfDebug("Change group to gid %" PRIuMAX " if possible)\n", (uintmax_t)gid);
                 }
             }
 
@@ -2173,7 +2173,7 @@ static void Unix_VerifyFileAttributes(char *file, struct stat *dstat, Attributes
         newperm |= attr.perms.plus;
         newperm &= ~(attr.perms.minus);
 
-        CfDebug("Unix_VerifyFileAttributes(%s -> %o)\n", file, newperm);
+        CfDebug("VerifyFileAttributes(%s -> %" PRIoMAX ")\n", file, (uintmax_t)newperm);
 
         /* directories must have x set if r set, regardless  */
 
@@ -2245,12 +2245,12 @@ static void Unix_VerifyFileAttributes(char *file, struct stat *dstat, Attributes
 
     if ((newperm & 07777) == (dstat->st_mode & 07777))  /* file okay */
     {
-        CfDebug("File okay, newperm = %o, stat = %o\n", (newperm & 07777), (dstat->st_mode & 07777));
+        CfDebug("File okay, newperm = %" PRIoMAX ", stat = %" PRIoMAX "\n", (uintmax_t)(newperm & 07777), (uintmax_t)(dstat->st_mode & 07777));
         cfPS(cf_verbose, CF_NOP, "", pp, attr, " -> File permissions on %s as promised\n", file);
     }
     else
     {
-        CfDebug("Trying to fix mode...newperm = %o, stat = %o\n", (newperm & 07777), (dstat->st_mode & 07777));
+        CfDebug("Trying to fix mode...newperm = %" PRIoMAX ", stat = %" PRIoMAX "\n", (uintmax_t)(newperm & 07777), (uintmax_t)(dstat->st_mode & 07777));
 
         switch (attr.transaction.action)
         {
@@ -2356,7 +2356,7 @@ static void Unix_VerifyCopiedFileAttributes(char *file, struct stat *dstat, stru
 
 // If we get here, there is both a src and dest file
 
-    CfDebug("VerifyCopiedFile(%s,+%o,-%o)\n", file, attr.perms.plus, attr.perms.minus);
+    CfDebug("VerifyCopiedFile(%s,+%" PRIoMAX ",-%" PRIoMAX ")\n", file, (uintmax_t)attr.perms.plus, (uintmax_t)attr.perms.minus);
 
     save_uid = (attr.perms.owners)->uid;
     save_gid = (attr.perms.groups)->gid;

--- a/src/files_properties.c
+++ b/src/files_properties.c
@@ -151,7 +151,7 @@ int ConsiderFile(const char *nodename, char *path, Attributes attr, Promise *pp)
 
 void SetSearchDevice(struct stat *sb, Promise *pp)
 {
-    CfDebug("Registering root device as %jd\n", (intmax_t) sb->st_dev);
+    CfDebug("Registering root device as %" PRIdMAX "\n", (intmax_t) sb->st_dev);
     pp->rootdevice = sb->st_dev;
 }
 

--- a/src/files_select.c
+++ b/src/files_select.c
@@ -305,12 +305,12 @@ static int SelectOwnerMatch(char *path, struct stat *lstatptr, Rlist *crit)
     Rlist *rp;
     char ownerName[CF_BUFSIZE];
     int gotOwner;
-    char buffer[CF_SMALLBUF];
 
     InitAlphaList(&leafattrib);
 
 #ifndef MINGW                   // no uids on Windows
-    sprintf(buffer, "%jd", (uintmax_t) lstatptr->st_uid);
+    char buffer[CF_SMALLBUF];
+    snprintf(buffer, CF_BUFSIZE, "%jd", (uintmax_t) lstatptr->st_uid);
     PrependAlphaList(&leafattrib, buffer);
 #endif /* MINGW */
 
@@ -565,7 +565,7 @@ static int SelectGroupMatch(struct stat *lstatptr, Rlist *crit)
 
     InitAlphaList(&leafattrib);
 
-    sprintf(buffer, "%jd", (uintmax_t) lstatptr->st_gid);
+    snprintf(buffer, CF_SMALLBUF, "%jd", (uintmax_t) lstatptr->st_gid);
     PrependAlphaList(&leafattrib, buffer);
 
     if ((gr = getgrgid(lstatptr->st_gid)) != NULL)

--- a/src/generic_agent.c
+++ b/src/generic_agent.c
@@ -1841,7 +1841,7 @@ void WritePID(char *filename)
         return;
     }
 
-    fprintf(fp, "%d\n", getpid());
+    fprintf(fp, "%" PRIuMAX "\n", (uintmax_t)getpid());
 
     fclose(fp);
 }

--- a/src/logging.c
+++ b/src/logging.c
@@ -478,7 +478,8 @@ void PromiseLog(char *s)
         return;
     }
 
-    fprintf(fout, "%jd,%jd: %s\n", (intmax_t) CFSTARTTIME, (intmax_t) now, s);
+    fprintf(fout, "%" PRIdMAX ",%" PRIdMAX ": %s\n", (intmax_t)CFSTARTTIME, (intmax_t)now, s);
+
     fclose(fout);
 }
 

--- a/src/modes.c
+++ b/src/modes.c
@@ -221,7 +221,7 @@ int ParseModeString(char *modestring, mode_t *plusmask, mode_t *minusmask)
                 CfOut(cf_inform, "", "Symbolic and numeric form for modes mixed");
             }
 
-            CfDebug("[PLUS=%o][MINUS=%o]\n", *plusmask, *minusmask);
+            CfDebug("[PLUS=%" PRIoMAX "][MINUS=%" PRIoMAX "]\n", (uintmax_t)*plusmask, (uintmax_t)*minusmask);
             return true;
 
         default:

--- a/src/pipes.c
+++ b/src/pipes.c
@@ -358,7 +358,7 @@ static FILE *Unix_cf_popensetuid(char *command, char *type, uid_t uid, gid_t gid
     pid_t pid;
     FILE *pp = NULL;
 
-    CfDebug("Unix_cf_popensetuid(%s,%s,%d,%d)\n", command, type, uid, gid);
+    CfDebug("cf_popensetuid(%s,%s,%" PRIuMAX ",%" PRIuMAX ")\n", command, type, (uintmax_t)uid, (uintmax_t)gid);
 
     if ((*type != 'r' && *type != 'w') || (type[1] != '\0'))
     {
@@ -645,7 +645,7 @@ static FILE *Unix_cf_popen_shsetuid(char *command, char *type, uid_t uid, gid_t 
     pid_t pid;
     FILE *pp = NULL;
 
-    CfDebug("Unix_cf_popen_shsetuid(%s,%s,%d,%d)\n", command, type, uid, gid);
+    CfDebug("cf_popen_shsetuid(%s,%s,%" PRIuMAX ",%" PRIuMAX ")\n", command, type, (uintmax_t)uid, (uintmax_t)gid);
 
     if ((*type != 'r' && *type != 'w') || (type[1] != '\0'))
     {
@@ -796,7 +796,7 @@ int cf_pwait(pid_t pid)
 {
     int status;
 
-    CfDebug("cf_pwait - Waiting for process %d\n", pid);
+    CfDebug("cf_pwait - Waiting for process %" PRIdMAX "\n", (intmax_t)pid);
 
 # ifdef HAVE_WAITPID
 
@@ -941,7 +941,7 @@ static int Unix_cf_pclose_def(FILE *pfp, Attributes a, Promise *pp)
         return -1;
     }
 
-    CfDebug("Unix_cf_pclose_def - Waiting for process %d\n", pid);
+    CfDebug("cf_pclose_def - Waiting for process %" PRIdMAX "\n", (intmax_t)pid);
 
 # ifdef HAVE_WAITPID
 

--- a/src/processes_select.c
+++ b/src/processes_select.c
@@ -238,8 +238,8 @@ static int SelectProcTimeCounterRangeMatch(char *name1, char *name2, time_t min,
         }
         else
         {
-            CfDebug("Selection filter REJECTED counter range %s/%s = %s in [%ld,%ld] (= %ld secs)\n", name1, name2,
-                    line[i], min, max, value);
+            CfDebug("Selection filter REJECTED counter range %s/%s = %s in [%" PRIdMAX ",%" PRIdMAX "] (= %" PRIdMAX " secs)\n", name1, name2,
+                    line[i], (intmax_t)min, (intmax_t)max, (intmax_t)value);
             return false;
         }
     }

--- a/src/storage_tools.c
+++ b/src/storage_tools.c
@@ -137,7 +137,7 @@ static off_t Unix_GetDiskUsage(char *file, enum cfsizes type)
 
     capacity = (double) (avail) / (double) (avail + used) * 100;
 
-    CfDebug("GetDiskUsage(%s) = %jd/%jd\n", file, (intmax_t) avail, (intmax_t) capacity);
+    CfDebug("GetDiskUsage(%s) = %" PRIdMAX "/%" PRIdMAX "\n", file, (intmax_t) avail, (intmax_t) capacity);
 
     if (type == cfabs)
     {


### PR DESCRIPTION
%jd is not supported in Solaris 8, and hence was causing segfault. This fix is backported from master: f6ba42d5b2988be1f94ee4e55baa174fd7906362

Original Commit Message:

Not all standard C libraries support %jd/%ju/%jo (though C99 ones should). Hence
check for macros and use them for the functions which are not C99
compliant. snprintf and derivatives are C99-compliant in CFEngine (in case
standard library does not provide for C99-compliant implementation,
pub/snprintf.c is used instead). Note that blindly using PRIdMAX in all the
cases is not possible, as e.g. on Windows it expands into I64d, which is not
accepted by pub/snprintf.c implementation.

Cherry-picked from: f6ba42d5b2988be1f94ee4e55baa174fd7906362

Conflicts:

```
src/client_code.c
src/files_operators.c
src/files_select.c
src/generic_agent.c
src/logging.c
src/modes.c
src/pipes.c
src/platform.h
src/processes_select.c
src/server.c
```
