### PR TITLE
Change BufferNew Signature

### DIFF
--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -1226,17 +1226,8 @@ void ConvergeVarHashPromise(char *scope, const Promise *pp, int allow_redefine)
     a.classes = GetClassDefinitionConstraints(pp);
 
     enum cfdatatype existing_var = GetVariable(scope, pp->promiser, &retval);
-    Buffer *qualified_scope = NULL;
+    Buffer *qualified_scope = BufferNew();
     int result = 0;
-    result = BufferNew(&qualified_scope);
-    if (result < 0)
-    {
-        /*
-         * Extremely seldom, but we better take care of this.
-         */
-        UnexpectedError("Buffer initialization problems");
-        return;
-    }
     if (strcmp(pp->namespace, "default") == 0)
     {
         result = BufferSet(qualified_scope, scope, strlen(scope));
@@ -1312,18 +1303,8 @@ void ConvergeVarHashPromise(char *scope, const Promise *pp, int allow_redefine)
         }
         else
         {
-            Buffer *conv = NULL;
-            result = BufferNew(&conv);
-            if (result < 0)
-            {
-                /*
-                 * Even though there will be no problems with memory allocation, there
-                 * might be other problems.
-                 */
-                UnexpectedError("Problems initializating buffer");
-                BufferDestroy(&qualified_scope);
-                return;
-            }
+            Buffer *conv = BufferNew();
+
             if (strcmp(cp->lval, "int") == 0)
             {
                 result = BufferPrintf(conv, "%ld", Str2Int(cp->rval.item));

--- a/libutils/buffer.c
+++ b/libutils/buffer.c
@@ -42,23 +42,19 @@ void BufferSetGeneralMemoryCap(unsigned int cap)
     general_memory_cap = cap;
 }
 
-int BufferNew(Buffer **buffer)
+Buffer *BufferNew(void)
 {
-    if (!buffer)
-    {
-        return -1;
-    }
-    *buffer = (Buffer *)xmalloc(sizeof(Buffer));
-    (*buffer)->capacity = DEFAULT_BUFFER_SIZE;
-    (*buffer)->buffer = (char *)xmalloc((*buffer)->capacity);
-    (*buffer)->mode = BUFFER_BEHAVIOR_CSTRING;
-    (*buffer)->used = 0;
-    (*buffer)->beginning = 0;
-    (*buffer)->end = 0;
-    (*buffer)->memory_cap = general_memory_cap;
-    RefCountNew(&(*buffer)->ref_count);
-    RefCountAttach((*buffer)->ref_count, (*buffer));
-    return 0;
+    Buffer *buffer = (Buffer *)xmalloc(sizeof(Buffer));
+    buffer->capacity = DEFAULT_BUFFER_SIZE;
+    buffer->buffer = (char *)xmalloc(buffer->capacity);
+    buffer->mode = BUFFER_BEHAVIOR_CSTRING;
+    buffer->used = 0;
+    buffer->beginning = 0;
+    buffer->end = 0;
+    buffer->memory_cap = general_memory_cap;
+    RefCountNew(&(buffer->ref_count));
+    RefCountAttach(buffer->ref_count, buffer);
+    return buffer;
 }
 
 int BufferDestroy(Buffer **buffer)

--- a/libutils/buffer.h
+++ b/libutils/buffer.h
@@ -78,10 +78,10 @@ void BufferSetGeneralMemoryCap(unsigned int cap);
   @brief Buffer initialization routine.
   Initializes the internals of a buffer. By default it is initialized to emulate a C string, but that can be
   changed at run time if needed. The default size of the buffer is set to DEFAULT_BUFFER_SIZE (4096).
-  @param buffer Buffer to be initialized.
-  @return 0 if the initialization was successful, -1 otherwise.
+  @return Pointer to initialized Buffer if the initialization was successful,
+          otherwise terminate with message to stderr.
   */
-int BufferNew(Buffer **buffer);
+Buffer* BufferNew(void);
 /**
   @brief Destroys a buffer and frees the memory associated with it.
   @param buffer Buffer to be destroyed.

--- a/tests/unit/buffer_test.c
+++ b/tests/unit/buffer_test.c
@@ -8,8 +8,7 @@
 
 static void test_createBuffer(void **state)
 {
-    Buffer *buffer = NULL;
-    assert_int_equal(0, BufferNew(&buffer));
+    Buffer *buffer = BufferNew();
     assert_true(buffer != NULL);
     assert_true(buffer->buffer != NULL);
     assert_int_equal(buffer->mode, BUFFER_BEHAVIOR_CSTRING);
@@ -18,14 +17,12 @@ static void test_createBuffer(void **state)
     assert_int_equal(buffer->beginning, 0);
     assert_int_equal(buffer->end, 0);
     assert_true(buffer->ref_count != NULL);
-    assert_int_equal(buffer->ref_count->user_count, 1);
-    assert_int_equal(-1, BufferNew(NULL));
+    assert_int_equal(buffer->ref_count->user_count, 1);    
 }
 
 static void test_destroyBuffer(void **state)
 {
-    Buffer *buffer = NULL;
-    assert_int_equal(0, BufferNew(&buffer));
+    Buffer *buffer = BufferNew();
     assert_int_equal(0, BufferDestroy(&buffer));
     assert_true(buffer == NULL);
     assert_int_equal(0, BufferDestroy(NULL));
@@ -42,8 +39,7 @@ static void test_setBuffer(void **state)
     char element2[DEFAULT_MEMORY_CAP * 2];
     unsigned int element2size = 2 * DEFAULT_MEMORY_CAP;
 
-    Buffer *buffer = NULL;
-    assert_int_equal(0, BufferNew(&buffer));
+    Buffer *buffer = BufferNew();
     assert_true(buffer != NULL);
     // Smaller than the allocated buffer
     assert_int_equal(element0size, BufferSet(buffer, element0, element0size));
@@ -78,12 +74,9 @@ static void test_setBuffer(void **state)
     /*
      * Boundary checks, BUFFER_SIZE-1, BUFFER_SIZE and BUFFER_SIZE+1
      */
-    Buffer *bm1 = NULL;
-    assert_int_equal(0, BufferNew(&bm1));
-    Buffer *be = NULL;
-    assert_int_equal(0, BufferNew(&be));
-    Buffer *bp1 = NULL;
-    assert_int_equal(0, BufferNew(&bp1));
+    Buffer *bm1 = BufferNew();
+    Buffer *be = BufferNew();
+    Buffer *bp1 = BufferNew();
     char buffer_m1[DEFAULT_BUFFER_SIZE - 1];
     char buffer_0[DEFAULT_BUFFER_SIZE];
     char buffer_p1[DEFAULT_BUFFER_SIZE + 1];
@@ -132,8 +125,7 @@ static void test_zeroBuffer(void **state)
     unsigned int element0size = strlen(element0);
     const char *element0pointer = NULL;
 
-    Buffer *buffer = NULL;
-    assert_int_equal(0, BufferNew(&buffer));
+    Buffer *buffer = BufferNew();
     assert_int_equal(element0size, BufferSet(buffer, element0, element0size));
     element0pointer = buffer->buffer;
     assert_int_equal(element0size, buffer->used);
@@ -154,13 +146,11 @@ static void test_copyEqualBuffer(void **state)
     char element1[] = "element1";
     unsigned int element1size = strlen(element1);
 
-    Buffer *buffer0 = NULL;
-    Buffer *buffer1 = NULL;
-    Buffer *buffer2 = NULL;
+    Buffer *buffer0 = BufferNew();
+    Buffer *buffer1 = BufferNew();
+    Buffer *buffer2 = BufferNew();
 
     // Empty buffers, all empty buffers are the same
-    assert_int_equal(0, BufferNew(&buffer0));
-    assert_int_equal(0, BufferNew(&buffer1));
     assert_true(BufferEqual(buffer0, buffer0));
     assert_true(BufferEqual(buffer0, buffer1));
     assert_int_equal(0, BufferCopy(buffer0, &buffer2));
@@ -195,8 +185,7 @@ static void test_appendBuffer(void **state)
     char element3[DEFAULT_MEMORY_CAP * 2];
     unsigned int element3size = 2 * DEFAULT_MEMORY_CAP;
 
-    Buffer *buffer = NULL;
-    assert_int_equal(0, BufferNew(&buffer));
+    Buffer *buffer = BufferNew();
     assert_true(buffer != NULL);
     // Initialize the buffer with a small string
     assert_int_equal(element0size, BufferAppend(buffer, element0, element0size));
@@ -262,12 +251,9 @@ static void test_appendBuffer(void **state)
     /*
      * Boundary checks, BUFFER_SIZE-1, BUFFER_SIZE and BUFFER_SIZE+1
      */
-    Buffer *bm1 = NULL;
-    assert_int_equal(0, BufferNew(&bm1));
-    Buffer *be = NULL;
-    assert_int_equal(0, BufferNew(&be));
-    Buffer *bp1 = NULL;
-    assert_int_equal(0, BufferNew(&bp1));
+    Buffer *bm1 = BufferNew();
+    Buffer *be = BufferNew();
+    Buffer *bp1 = BufferNew();
     char buffer_m1[DEFAULT_BUFFER_SIZE - 1];
     char buffer_0[DEFAULT_BUFFER_SIZE];
     char buffer_p1[DEFAULT_BUFFER_SIZE + 1];
@@ -328,8 +314,7 @@ static void test_printf(void **state)
     char element3[DEFAULT_MEMORY_CAP * 2];
     unsigned int element3size = 2 * DEFAULT_MEMORY_CAP;
 
-    Buffer *buffer = NULL;
-    assert_int_equal(0, BufferNew(&buffer));
+    Buffer *buffer = BufferNew();
     assert_true(buffer != NULL);
     /*
      * Print the first char and compare the result
@@ -400,12 +385,9 @@ static void test_printf(void **state)
     /*
      * Boundary checks, BUFFER_SIZE-1, BUFFER_SIZE and BUFFER_SIZE+1
      */
-    Buffer *bm1 = NULL;
-    assert_int_equal(0, BufferNew(&bm1));
-    Buffer *be = NULL;
-    assert_int_equal(0, BufferNew(&be));
-    Buffer *bp1 = NULL;
-    assert_int_equal(0, BufferNew(&bp1));
+    Buffer *bm1 = BufferNew();
+    Buffer *be = BufferNew();
+    Buffer *bp1 = BufferNew();
     /*
      * The sizes are different for printf. If we have a size of X, then the string
      * is of length X-1, and so forth.
@@ -484,8 +466,7 @@ static void test_vprintf(void **state)
     char element3[DEFAULT_MEMORY_CAP * 2];
     unsigned int element3size = 2 * DEFAULT_MEMORY_CAP;
 
-    Buffer *buffer = NULL;
-    assert_int_equal(0, BufferNew(&buffer));
+    Buffer *buffer = BufferNew();
     assert_true(buffer != NULL);
     /*
      * Print the first char and compare the result
@@ -556,12 +537,9 @@ static void test_vprintf(void **state)
     /*
      * Boundary checks, BUFFER_SIZE-1, BUFFER_SIZE and BUFFER_SIZE+1
      */
-    Buffer *bm1 = NULL;
-    assert_int_equal(0, BufferNew(&bm1));
-    Buffer *be = NULL;
-    assert_int_equal(0, BufferNew(&be));
-    Buffer *bp1 = NULL;
-    assert_int_equal(0, BufferNew(&bp1));
+    Buffer *bm1 = BufferNew();
+    Buffer *be = BufferNew();
+    Buffer *bp1 = BufferNew();
     /*
      * The sizes are different for printf. If we have a size of X, then the string
      * is of length X-1, and so forth.


### PR DESCRIPTION
int BufferNew(Buffer *_buffer) -> Buffer_ BufferNew(void)

Since BufferNew uses xmalloc internally, checking its return value seems redundant.
Buffer initialization can be done in a single line now. Semantics similar to Map, Set and other data structures.
