### PR TITLE
Add --full-check flag to cf-promises

### DIFF
--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -63,6 +63,7 @@ static const struct option OPTIONS[] =
     {"analysis", no_argument, 0, 'a'},
     {"reports", no_argument, 0, 'r'},
     {"parse-tree", no_argument, 0, 'p'},
+    {"full-check", no_argument, 0, 'c'},
     {NULL, 0, 0, '\0'}
 };
 
@@ -82,7 +83,7 @@ static const char *HINTS[] =
     "Perform additional analysis of configuration",
     "Generate reports about configuration and insert into CFDB",
     "Print a parse tree for the policy file in JSON format",
-    "Use the GCC brief-format for output",
+    "Ensure full policy integrity checks",
     NULL
 };
 
@@ -133,10 +134,14 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
     int c;
     GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_COMMON);
 
-    while ((c = getopt_long(argc, argv, "advnIf:D:N:VSrxMb:pg:h", OPTIONS, &optindex)) != EOF)
+    while ((c = getopt_long(argc, argv, "advnIf:D:N:VSrxMb:pcg:h", OPTIONS, &optindex)) != EOF)
     {
         switch ((char) c)
         {
+        case 'c':
+            config->check_runnable = true;
+            break;
+
         case 'f':
 
             if (optarg && (strlen(optarg) < 5))

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -34,7 +34,8 @@ typedef struct
     Rlist *bundlesequence;
     char *input_file;
     bool check_not_writable_by_others;
-    bool tty_interactive; //agent is running interactively, via tty/terminal interface
+    bool check_runnable;
+    bool tty_interactive; // agent is running interactively, via tty/terminal interface
 
     // change to evaluation behavior from the policy itself
     bool ignore_missing_bundles;

--- a/libpromises/syntax.h
+++ b/libpromises/syntax.h
@@ -49,8 +49,4 @@ void SyntaxPrintAsJson(Writer *writer);
 /* print a parse tree of the given policy (bundles, bodies) */
 void PolicyPrintAsJson(Writer *writer, const char *filename, Seq *bundles, Seq *bodies);
 
-/* print language elements using official formatting */
-void BodyPrettyPrint(Writer *writer, Body *body);
-void BundlePrettyPrint(Writer *writer, Bundle *bundle);
-
 #endif


### PR DESCRIPTION
Previously, cf-promises did full validation checks requiring a
runnable policy (with body common control) as input. It also did
certain checks to see that bundle/body references were accounted for.

Now, cf-promises will validate a partial policy file if this is given.
If it is given a runnable policy file, it will additionally validate
the integrity as before.

To enforce integrity checks, use the new --full-check flag. This is
also being used by other agents when running cf-promises for validation.

The new lighter partial checks makes it possible to use cf-promises as
a tool operating on incomplete policies.
