### PR TITLE
Add package_method enabeling additional repository during install

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -1861,6 +1861,43 @@ body package_method yum_rpm
 
 ##
 
+body package_method yum_rpm_enable_repo(repoid)
+
+# based on yum_rpm with addition to enable a repository for the install
+# Sometimes repositories are configured but disabled by default. For example
+# this pacakge_method could be used when installing a package that exists in
+# the EPEL, which normally you do not want to install packages from.
+{
+  package_changes => "bulk";
+  package_list_command => "/bin/rpm -qa --qf '%{name} %{version}-%{release} %{arch}\n'";
+  package_patch_list_command => "/usr/bin/yum --quiet check-update";
+
+  package_list_name_regex    => "^(\S+?)\s\S+?\s\S+$";
+  package_list_version_regex => "^\S+?\s(\S+?)\s\S+$";
+  package_list_arch_regex    => "^\S+?\s\S+?\s(\S+)$";
+
+  package_installed_regex => ".*";
+  package_name_convention => "$(name)";
+
+  # set it to "0" to avoid caching of list during upgrade
+  package_list_update_command => "/usr/bin/yum --quiet check-update";
+  package_list_update_ifelapsed => "240";
+
+  package_patch_installed_regex => "^\s.*";
+  package_patch_name_regex    => "([^.]+).*";
+  package_patch_version_regex => "[^\s]\s+([^\s]+).*";
+  package_patch_arch_regex    => "[^.]+\.([^\s]+).*";
+
+  package_add_command    => "/usr/bin/yum --enablerepo=$(repoid) -y install";
+  package_update_command => "/usr/bin/yum --enablerepo=$(repoid) -y update";
+  package_patch_command => "/usr/bin/yum -y update";
+  package_delete_command => "/bin/rpm -e --nodeps --allmatches";
+  package_verify_command => "/bin/rpm -V";
+}
+
+##
+
+
 body package_method rpm_filebased(path)
 
 # Contributed by Aleksey Tsalolikhin. Written on 29-Feb-2012.


### PR DESCRIPTION
Sometimes repositories are disabled by default. This package_method
allows you to selectively enable a repository during a promise to
install or update a package.
