### PR TITLE
fix: avoid class name clash

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -404,6 +404,7 @@ vars:
   # Be careful if the index string contains funny chars
 
   "cindex[$(index)]" string => canonify("$(index)");
+  "cv"               string => canonify("$(v)");
 
 field_edits:
 
@@ -412,7 +413,7 @@ field_edits:
   "\s*$(index)\s*=.*"
 
      edit_field => col("=","2","$($(v)[$(index)])","set"),
-        classes => if_ok("$(cindex[$(index)])_in_file"),
+        classes => if_ok("$(cv)_$(cindex[$(index)])_in_file"),
         comment => "Match a line starting like key = something";
 
 insert_lines:
@@ -420,7 +421,7 @@ insert_lines:
   "$(index)=$($(v)[$(index)])",
 
          comment => "Insert a variable definition",
-      ifvarclass => "!$(cindex[$(index)])_in_file";
+      ifvarclass => "!$(cv)_$(cindex[$(index)])_in_file";
 }
 
 bundle edit_line set_config_values(v)


### PR DESCRIPTION
A new merge request asasked here:
https://github.com/cfengine/copbl/pull/25

The problem appended in this case:
if set_variable_values is used two time in a row in the same bundle
  and
    if the same key name is used

For example, in this case NM_CONTROLLED_in_file was defined for the first
file and the key was ignored for the second file.

"ifcfgeth0[BRIDGE]" string => "br0";
"ifcfgeth0[NM_CONTROLLED]" string => "no";

"ifcfgbr0[NM_CONTROLLED]" string => "no";

files:
    "/etc/sysconfig/network-scripts/ifcfg-eth0"
      edit_line => set_variable_values("app_srvkvm_set_up_bridge.ifcfgeth0");

files:
    "/etc/sysconfig/network-scripts/ifcfg-br0"
      edit_line => set_variable_values("app_srvkvm_set_up_bridge.ifcfgbr0");
