### PR TITLE
typo in doc: sys.hardware instead of harware

### DIFF
--- a/docs/reference/vars/sys_hardware_mac[interface_name].texinfo
+++ b/docs/reference/vars/sys_hardware_mac[interface_name].texinfo
@@ -10,6 +10,6 @@ reports:
 
   linux::
 
-    "Tell me $(harware_mac[eth0])";
+    "Tell me $(sys.hardware_mac[eth0])";
 @end verbatim
 


### PR DESCRIPTION
Nothing really serious, but the example is buggy.
