### PR TITLE
Remove old svn tag and update with relevant core version

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -39,8 +39,7 @@
 # the online docs
 #
 
-# Subversion : $Rev$
-# For Cfengine Core: 3.1.0
+# For Cfengine Core: 3.4.3
 
 ###################################################
 # If you find Cfengine useful, please consider    #


### PR DESCRIPTION
Subversion is no longer used and the current stdlib won't work with
3.1.0.
