### PR TITLE
Get rid of StartJoin

### DIFF
--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -561,6 +561,21 @@ static void PublishEnvironment(Item *classes)
 
 /*********************************************************************/
 
+static void AddOpenPortsClasses(const char *name, const Item *value, Item **classlist)
+{
+    Writer *w = StringWriter();
+    WriterWriteF(w, "@%s=", name);
+    PrintItemList(value, w);
+    if (StringWriterLength(w) <= 1500)
+    {
+        AppendItem(classlist, StringWriterClose(w), NULL);
+    }
+    else
+    {
+        WriterClose(w);
+    }
+}
+
 static void ArmClasses(Averages av, char *timekey)
 {
     double sigma;
@@ -657,50 +672,11 @@ static void ArmClasses(Averages av, char *timekey)
 
     // Report on the open ports, in various ways
 
-    ldt_buff[0] = '\0';
-    PrintItemList(ldt_buff,CF_BUFSIZE,ALL_INCOMING);
-
-    if (strlen(ldt_buff) < 1500)
-    {
-        snprintf(buff,CF_BUFSIZE,"@listening_ports=%s",ldt_buff);
-        AppendItem(&classlist,buff,NULL);
-    }
-
-    ldt_buff[0] = '\0';
-    PrintItemList(ldt_buff,CF_BUFSIZE,MON_UDP6);
-
-    if (strlen(ldt_buff) < 1500)
-    {
-        snprintf(buff,CF_BUFSIZE,"@listening_udp6_ports=%s",ldt_buff);
-        AppendItem(&classlist,buff,NULL);
-    }
-
-    ldt_buff[0] = '\0';
-    PrintItemList(ldt_buff,CF_BUFSIZE,MON_UDP4);
-
-    if (strlen(ldt_buff) < 1500)
-    {
-        snprintf(buff,CF_BUFSIZE,"@listening_udp4_ports=%s",ldt_buff);
-        AppendItem(&classlist,buff,NULL);
-    }
-
-    ldt_buff[0] = '\0';
-    PrintItemList(ldt_buff,CF_BUFSIZE,MON_TCP6);
-
-    if (strlen(ldt_buff) < 1500)
-    {
-        snprintf(buff,CF_BUFSIZE,"@listening_tcp6_ports=%s",ldt_buff);
-        AppendItem(&classlist,buff,NULL);
-    }
-
-    ldt_buff[0] = '\0';
-    PrintItemList(ldt_buff,CF_BUFSIZE,MON_TCP4);
-
-    if (strlen(ldt_buff) < 1500)
-    {
-        snprintf(buff,CF_BUFSIZE,"@listening_tcp4_ports=%s",ldt_buff);
-        AppendItem(&classlist,buff,NULL);
-    }
+    AddOpenPortsClasses("listening_ports", ALL_INCOMING, &classlist);
+    AddOpenPortsClasses("listening_udp6_ports", MON_UDP6, &classlist);
+    AddOpenPortsClasses("listening_udp4_ports", MON_UDP4, &classlist);
+    AddOpenPortsClasses("listening_tcp6_ports", MON_TCP6, &classlist);
+    AddOpenPortsClasses("listening_tcp4_ports", MON_TCP4, &classlist);
 
     // Port addresses
 

--- a/libpromises/cfstream.c
+++ b/libpromises/cfstream.c
@@ -251,12 +251,13 @@ void cfPS(EvalContext *ctx, OutputLevel level, char status, char *errstr, const 
                 break;
 
             case RVAL_TYPE_LIST:
-                
-                snprintf(output, CF_BUFSIZE - 1, "I: The promise was made to (stakeholders): ");
-                RlistPrint(output+strlen(output), CF_BUFSIZE, (Rlist *)pp->promisee.item);
-                AppendItem(&mess, output, NULL);
+            {
+                Writer *w = StringWriter();
+                WriterWriteF(w, "I: The promise was made to (stakeholders): ");
+                RlistWrite(w, pp->promisee.item);
+                AppendItem(&mess, StringWriterClose(w), NULL);
                 break;
-
+            }
             default:
                 break;
             }

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -53,39 +53,6 @@ char *MapAddress(char *unspec_address)
     }
 }
 
-/***************************************************************************/
-
-char *EscapeQuotes(const char *s, char *out, int outSz)
-{
-    char *spt;
-    const char *spf;
-    int i = 0;
-
-    memset(out, 0, outSz);
-
-    for (spf = s, spt = out; (i < outSz - 2) && (*spf != '\0'); spf++, spt++, i++)
-    {
-        switch (*spf)
-        {
-        case '\'':
-        case '\"':
-            *spt++ = '\\';
-            *spt = *spf;
-            i += 3;
-            break;
-
-        default:
-            *spt = *spf;
-            i++;
-            break;
-        }
-    }
-
-    return out;
-}
-
-/***************************************************************************/
-
 int FindTypeInArray(const char **haystack, const char *needle, int default_value, int null_value)
 {
     if (needle == NULL)

--- a/libpromises/conversion.h
+++ b/libpromises/conversion.h
@@ -71,7 +71,6 @@ int IsRealNumber(const char *s);
 // Misc.
 char *Rlist2String(Rlist *list, char *sep); // TODO: Yet another Rlist serialization scheme.. Found 5 so far.
 DataType BodySyntaxGetDataType(const BodySyntax *body_syntax, const char *lval);
-char *EscapeQuotes(const char *s, char *out, int outSz);
 char *MapAddress(char *addr);
 const char *CommandArg0(const char *execstr);
 void CommandPrefix(char *execstr, char *comm);

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -1382,12 +1382,18 @@ void ConvergeVarHashPromise(EvalContext *ctx, char *scope, const Promise *pp, in
 
                 case RVAL_TYPE_LIST:
                     {
-                        char valbuf[CF_BUFSIZE];
                         CfOut(OUTPUT_LEVEL_VERBOSE, "", " !! Redefinition of a constant list \"%s\".", pp->promiser);
-                        RlistPrint(valbuf, CF_BUFSIZE, retval.item);
-                        CfOut(OUTPUT_LEVEL_VERBOSE, "", "Old value: %s", valbuf);
-                        RlistPrint(valbuf, CF_BUFSIZE, rval.item);
-                        CfOut(OUTPUT_LEVEL_VERBOSE, "", " New value: %s", valbuf);
+                        Writer *w = StringWriter();
+                        RlistWrite(w, retval.item);
+                        char *oldstr = StringWriterClose(w);
+                        CfOut(OUTPUT_LEVEL_VERBOSE, "", "Old value: %s", oldstr);
+                        free(oldstr);
+
+                        w = StringWriter();
+                        RlistWrite(w, rval.item);
+                        char *newstr = StringWriterClose(w);
+                        CfOut(OUTPUT_LEVEL_VERBOSE, "", " New value: %s", newstr);
+                        free(newstr);
                         PromiseRef(OUTPUT_LEVEL_VERBOSE, pp);
                     }
                     break;

--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -198,16 +198,6 @@ char *JoinSuffix(char *path, char *leaf)
     return path;
 }
 
-/*********************************************************************/
-
-int StartJoin(char *path, char *leaf, int bufsize)
-{
-    memset(path, 0, bufsize);
-    return JoinMargin(path, leaf, NULL, bufsize, CF_BUFFERMARGIN);
-}
-
-/*********************************************************************/
-
 int Join(char *path, const char *leaf, int bufsize)
 {
     return JoinMargin(path, leaf, NULL, bufsize, CF_BUFFERMARGIN);

--- a/libpromises/files_names.h
+++ b/libpromises/files_names.h
@@ -33,7 +33,6 @@ int IsDir(char *path);
 char *JoinPath(char *path, const char *leaf);
 char *JoinSuffix(char *path, char *leaf);
 int JoinMargin(char *path, const char *leaf, char **nextFree, int bufsize, int margin);
-int StartJoin(char *path, char *leaf, int bufsize);
 int Join(char *path, const char *leaf, int bufsize);
 int JoinSilent(char *path, const char *leaf, int bufsize);
 int EndJoin(char *path, char *leaf, int bufsize);

--- a/libpromises/item_lib.c
+++ b/libpromises/item_lib.c
@@ -33,43 +33,23 @@
 
 /*******************************************************************/
 
-int PrintItemList(char *buffer, int bufsize, const Item *list)
+void PrintItemList(const Item *list, Writer *w)
 {
-    StartJoin(buffer, "{", bufsize);
+    WriterWriteChar(w, '{');
 
     for (const Item *ip = list; ip != NULL; ip = ip->next)
     {
-        if (!JoinSilent(buffer, "'", bufsize))
+        if (ip != list)
         {
-            EndJoin(buffer, "'}", bufsize);
-            return false;
+            WriterWriteChar(w, ',');
         }
 
-        if (!Join(buffer,ip->name,bufsize))
-        {
-            EndJoin(buffer, "'}", bufsize);
-            return false;
-        }
-
-        if (!JoinSilent(buffer, "'", bufsize))
-        {
-            EndJoin(buffer, "'}", bufsize);
-            return false;
-        }
-
-        if (ip->next != NULL)
-        {
-            if (!JoinSilent(buffer, ",", bufsize))
-            {
-                EndJoin(buffer, "}", bufsize);
-                return false;
-            }
-        }
+        WriterWriteChar(w, '\'');
+        WriterWrite(w, ip->name);
+        WriterWriteChar(w, '\'');
     }
 
-    EndJoin(buffer, "}", bufsize);
-
-    return true;
+    WriterWriteChar(w, '}');
 }
 
 /*********************************************************************/

--- a/libpromises/item_lib.h
+++ b/libpromises/item_lib.h
@@ -26,6 +26,7 @@
 #define CFENGINE_ITEM_LIB_H
 
 #include "cf3.defs.h"
+#include "writer.h"
 
 struct Item_
 {
@@ -48,7 +49,7 @@ typedef enum
     ITEM_MATCH_TYPE_REGEX_COMPLETE_NOT
 } ItemMatchType;
 
-int PrintItemList(char *buffer, int bufsize, const Item *list);
+void PrintItemList(const Item *list, Writer *w);
 void PrependFullItem(Item **liststart, const char *itemstring, const char *classes, int counter, time_t t);
 Item *ReturnItemIn(Item *list, const char *item);
 Item *ReturnItemInClass(Item *list, const char *item, const char *classes);

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -1275,6 +1275,35 @@ SubType *BundleGetSubType(Bundle *bp, const char *name)
 
 /****************************************************************************/
 
+static char *EscapeQuotes(const char *s, char *out, int outSz)
+{
+    char *spt;
+    const char *spf;
+    int i = 0;
+
+    memset(out, 0, outSz);
+
+    for (spf = s, spt = out; (i < outSz - 2) && (*spf != '\0'); spf++, spt++, i++)
+    {
+        switch (*spf)
+        {
+        case '\'':
+        case '\"':
+            *spt++ = '\\';
+            *spt = *spf;
+            i += 3;
+            break;
+
+        default:
+            *spt = *spf;
+            i++;
+            break;
+        }
+    }
+
+    return out;
+}
+
 static JsonElement *AttributeValueToJson(Rval rval, bool symbolic_reference)
 {
     JsonElement *json_attribute = JsonObjectCreate(10);

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -452,7 +452,6 @@ void PromiseRef(OutputLevel level, const Promise *pp)
 {
     char *v;
     Rval retval;
-    char buffer[CF_BUFSIZE];
 
     if (pp == NULL)
     {
@@ -490,9 +489,14 @@ void PromiseRef(OutputLevel level, const Promise *pp)
            CfOut(level, "", "This was a promise to: %s\n", (char *)(pp->promisee.item));
            break;
        case RVAL_TYPE_LIST:
-           RlistPrint(buffer, CF_BUFSIZE, (Rlist *)pp->promisee.item);
-           CfOut(level, "", "This was a promise to: %s",buffer);
+       {
+           Writer *w = StringWriter();
+           RlistWrite(w, pp->promisee.item);
+           char *p = StringWriterClose(w);
+           CfOut(level, "", "This was a promise to: %s", p);
+           free(p);
            break;
+       }
        default:
            break;
     }

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -660,243 +660,6 @@ Rlist *RlistParseShown(char *string)
     return newlist;
 }
 
-/*******************************************************************/
-
-void RlistShow(FILE *fp, const Rlist *list)
-{
-    fprintf(fp, " {");
-
-    for (const Rlist *rp = list; rp != NULL; rp = rp->next)
-    {
-        fprintf(fp, "\'");
-        RvalShow(fp, (Rval) {rp->item, rp->type});
-        fprintf(fp, "\'");
-
-        if (rp->next != NULL)
-        {
-            fprintf(fp, ",");
-        }
-    }
-    fprintf(fp, "}");
-}
-
-/*******************************************************************/
-
-int RlistPrint(char *buffer, int bufsize, const Rlist *list)
-{
-    StartJoin(buffer, "{", bufsize);
-
-    for (const Rlist *rp = list; rp != NULL; rp = rp->next)
-    {
-        if (!JoinSilent(buffer, "'", bufsize))
-        {
-            EndJoin(buffer, "'}", bufsize);
-            return false;
-        }
-
-        if (!RvalPrint(buffer, bufsize, (Rval) {rp->item, rp->type}))
-        {
-            EndJoin(buffer, "'}", bufsize);
-            return false;
-        }
-
-        if (!JoinSilent(buffer, "'", bufsize))
-        {
-            EndJoin(buffer, "'}", bufsize);
-            return false;
-        }
-
-        if (rp->next != NULL)
-        {
-            if (!JoinSilent(buffer, ",", bufsize))
-            {
-                EndJoin(buffer, "}", bufsize);
-                return false;
-            }
-        }
-    }
-
-    EndJoin(buffer, "}", bufsize);
-
-    return true;
-}
-
-/*******************************************************************/
-
-static int PrintFnCall(char *buffer, int bufsize, const FnCall *fp)
-{
-    Rlist *rp;
-    char work[CF_MAXVARSIZE];
-
-    snprintf(buffer, bufsize, "%s(", fp->name);
-
-    for (rp = fp->args; rp != NULL; rp = rp->next)
-    {
-        switch (rp->type)
-        {
-        case RVAL_TYPE_SCALAR:
-            Join(buffer, (char *) rp->item, bufsize);
-            break;
-
-        case RVAL_TYPE_FNCALL:
-            PrintFnCall(work, CF_MAXVARSIZE, (FnCall *) rp->item);
-            Join(buffer, work, bufsize);
-            break;
-
-        default:
-            break;
-        }
-
-        if (rp->next != NULL)
-        {
-            strcat(buffer, ",");
-        }
-    }
-
-    strcat(buffer, ")");
-
-    return strlen(buffer);
-}
-
-int RvalPrint(char *buffer, int bufsize, Rval rval)
-{
-    if (rval.item == NULL)
-    {
-        return 0;
-    }
-
-    switch (rval.type)
-    {
-    case RVAL_TYPE_SCALAR:
-        return JoinSilent(buffer, (const char *) rval.item, bufsize);
-    case RVAL_TYPE_LIST:
-        return RlistPrint(buffer, bufsize, (Rlist *) rval.item);
-    case RVAL_TYPE_FNCALL:
-        return PrintFnCall(buffer, bufsize, (FnCall *) rval.item);
-    default:
-        return 0;
-    }
-}
-
-/*******************************************************************/
-
-static JsonElement *FnCallToJson(const FnCall *fp)
-{
-    assert(fp);
-
-    JsonElement *object = JsonObjectCreate(3);
-
-    JsonObjectAppendString(object, "name", fp->name);
-    JsonObjectAppendString(object, "type", "function-call");
-
-    JsonElement *argsArray = JsonArrayCreate(5);
-
-    for (Rlist *rp = fp->args; rp != NULL; rp = rp->next)
-    {
-        switch (rp->type)
-        {
-        case RVAL_TYPE_SCALAR:
-            JsonArrayAppendString(argsArray, (const char *) rp->item);
-            break;
-
-        case RVAL_TYPE_FNCALL:
-            JsonArrayAppendObject(argsArray, FnCallToJson((FnCall *) rp->item));
-            break;
-
-        default:
-            assert(false && "Unknown argument type");
-            break;
-        }
-    }
-    JsonObjectAppendArray(object, "arguments", argsArray);
-
-    return object;
-}
-
-static JsonElement *RlistToJson(Rlist *list)
-{
-    JsonElement *array = JsonArrayCreate(RlistLen(list));
-
-    for (Rlist *rp = list; rp; rp = rp->next)
-    {
-        switch (rp->type)
-        {
-        case RVAL_TYPE_SCALAR:
-            JsonArrayAppendString(array, (const char *) rp->item);
-            break;
-
-        case RVAL_TYPE_LIST:
-            JsonArrayAppendArray(array, RlistToJson((Rlist *) rp->item));
-            break;
-
-        case RVAL_TYPE_FNCALL:
-            JsonArrayAppendObject(array, FnCallToJson((FnCall *) rp->item));
-            break;
-
-        default:
-            assert(false && "Unsupported item type in rlist");
-            break;
-        }
-    }
-
-    return array;
-}
-
-JsonElement *RvalToJson(Rval rval)
-{
-    assert(rval.item);
-
-    switch (rval.type)
-    {
-    case RVAL_TYPE_SCALAR:
-        return JsonStringCreate((const char *) rval.item);
-    case RVAL_TYPE_LIST:
-        return RlistToJson((Rlist *) rval.item);
-    case RVAL_TYPE_FNCALL:
-        return FnCallToJson((FnCall *) rval.item);
-    default:
-        assert(false && "Invalid rval type");
-        return JsonStringCreate("");
-    }
-}
-
-/*******************************************************************/
-
-void RvalShow(FILE *fp, Rval rval)
-{
-    char buf[CF_BUFSIZE];
-
-    if (rval.item == NULL)
-    {
-        return;
-    }
-
-    switch (rval.type)
-    {
-    case RVAL_TYPE_SCALAR:
-        EscapeQuotes((const char *) rval.item, buf, sizeof(buf));
-        fprintf(fp, "%s", buf);
-        break;
-
-    case RVAL_TYPE_LIST:
-        RlistShow(fp, (Rlist *) rval.item);
-        break;
-
-    case RVAL_TYPE_FNCALL:
-        FnCallShow(fp, (FnCall *) rval.item);
-        break;
-
-    case RVAL_TYPE_NOPROMISEE:
-        fprintf(fp, "(no-one)");
-        break;
-
-    default:
-        break;
-    }
-}
-
-/*******************************************************************/
-
 void RvalDestroy(Rval rval)
 {
     Rlist *clist, *next = NULL;
@@ -1098,6 +861,56 @@ void RlistPopStack(Rlist **liststart, void **item, size_t size)
 
 /*******************************************************************/
 
+/*
+ * Copies from <from> to <to>, reading up to <len> characters from <from>,
+ * stopping at first <sep>.
+ *
+ * \<sep> is not counted as the separator, but copied to <to> as <sep>.
+ * Any other escape sequences are not supported.
+ */
+static int SubStrnCopyChr(char *to, const char *from, int len, char sep)
+{
+    char *sto = to;
+    int count = 0;
+
+    memset(to, 0, len);
+
+    if (from == NULL)
+    {
+        return 0;
+    }
+
+    if (from && (strlen(from) == 0))
+    {
+        return 0;
+    }
+
+    for (const char *sp = from; *sp != '\0'; sp++)
+    {
+        if (count > len - 1)
+        {
+            break;
+        }
+
+        if ((*sp == '\\') && (*(sp + 1) == sep))
+        {
+            *sto++ = *++sp;
+        }
+        else if (*sp == sep)
+        {
+            break;
+        }
+        else
+        {
+            *sto++ = *sp;
+        }
+
+        count++;
+    }
+
+    return count;
+}
+
 Rlist *RlistFromSplitString(const char *string, char sep)
  /* Splits a string containing a separator like "," 
     into a linked list of separate items, supports
@@ -1197,86 +1010,6 @@ Rlist *RlistLast(Rlist *start)
     return rp;
 }
 
-/*******************************************************************/
-
-void RlistWrite(Writer *writer, const Rlist *list)
-{
-    WriterWrite(writer, " {");
-
-    for (const Rlist *rp = list; rp != NULL; rp = rp->next)
-    {
-        WriterWriteChar(writer, '\'');
-        RvalWrite(writer, (Rval) {rp->item, rp->type});
-        WriterWriteChar(writer, '\'');
-
-        if (rp->next != NULL)
-        {
-            WriterWriteChar(writer, ',');
-        }
-    }
-
-    WriterWriteChar(writer, '}');
-}
-
-static void FnCallPrint(Writer *writer, const FnCall *call)
-{
-    for (const Rlist *rp = call->args; rp != NULL; rp = rp->next)
-    {
-        switch (rp->type)
-        {
-        case RVAL_TYPE_SCALAR:
-            WriterWriteF(writer, "%s,", (const char *) rp->item);
-            break;
-
-        case RVAL_TYPE_FNCALL:
-            FnCallPrint(writer, (FnCall *) rp->item);
-            break;
-
-        default:
-            WriterWrite(writer, "(** Unknown argument **)\n");
-            break;
-        }
-    }
-}
-
-void RvalWrite(Writer *writer, Rval rval)
-{
-    if (rval.item == NULL)
-    {
-        return;
-    }
-
-    switch (rval.type)
-    {
-    case RVAL_TYPE_SCALAR:
-    {
-        size_t buffer_size = (strlen((const char *) rval.item) * 2) + 1;
-        char *buffer = xcalloc(buffer_size, sizeof(char));
-
-        EscapeQuotes((const char *) rval.item, buffer, buffer_size);
-        WriterWrite(writer, buffer);
-        free(buffer);
-    }
-        break;
-
-    case RVAL_TYPE_LIST:
-        RlistWrite(writer, (Rlist *) rval.item);
-        break;
-
-    case RVAL_TYPE_FNCALL:
-        FnCallPrint(writer, (FnCall *) rval.item);
-        break;
-
-    case RVAL_TYPE_NOPROMISEE:
-        WriterWrite(writer, "(no-one)");
-        break;
-
-    case RVAL_TYPE_ASSOC:
-        // TODO: do something here, but not handled previously
-        break;
-    }
-}
-
 void RlistFilter(Rlist **list, bool (*KeepPredicate)(void *, void *), void *predicate_user_data, void (*DestroyItem)(void *))
 {
     assert(KeepPredicate);
@@ -1313,5 +1046,202 @@ void RlistFilter(Rlist **list, bool (*KeepPredicate)(void *, void *), void *pred
             prev = rp;
             rp = rp->next;
         }
+    }
+}
+
+/* Human-readable serialization */
+
+static void FnCallPrint(Writer *writer, const FnCall *call)
+{
+    WriterWrite(writer, call->name);
+    WriterWriteChar(writer, '(');
+
+    for (const Rlist *rp = call->args; rp != NULL; rp = rp->next)
+    {
+        switch (rp->type)
+        {
+        case RVAL_TYPE_SCALAR:
+            WriterWrite(writer, RlistScalarValue(rp));
+            break;
+
+        case RVAL_TYPE_FNCALL:
+            FnCallPrint(writer, RlistFnCallValue(rp));
+            break;
+
+        default:
+            WriterWrite(writer, "(** Unknown argument **)\n");
+            break;
+        }
+
+        if (rp->next != NULL)
+        {
+            WriterWriteChar(writer, ',');
+        }
+    }
+
+    WriterWriteChar(writer, ')');
+}
+
+void RlistWrite(Writer *writer, const Rlist *list)
+{
+    WriterWrite(writer, " {");
+
+    for (const Rlist *rp = list; rp != NULL; rp = rp->next)
+    {
+        WriterWriteChar(writer, '\'');
+        RvalWrite(writer, (Rval) {rp->item, rp->type});
+        WriterWriteChar(writer, '\'');
+
+        if (rp->next != NULL)
+        {
+            WriterWriteChar(writer, ',');
+        }
+    }
+
+    WriterWriteChar(writer, '}');
+}
+
+/* Note: only single quotes are escaped, as they are used in RlistWrite to
+   delimit strings. If double quotes would be escaped, they would be mangled by
+   RlistParseShown */
+
+static void ScalarWrite(Writer *w, const char *s)
+{
+    for (; *s; s++)
+    {
+        if (*s == '\'')
+        {
+            WriterWriteChar(w, '\\');
+        }
+        WriterWriteChar(w, *s);
+    }
+}
+
+void RvalWrite(Writer *writer, Rval rval)
+{
+    if (rval.item == NULL)
+    {
+        return;
+    }
+
+    switch (rval.type)
+    {
+    case RVAL_TYPE_SCALAR:
+        ScalarWrite(writer, RvalScalarValue(rval));
+        break;
+
+    case RVAL_TYPE_LIST:
+        RlistWrite(writer, RvalRlistValue(rval));
+        break;
+
+    case RVAL_TYPE_FNCALL:
+        FnCallPrint(writer, RvalFnCallValue(rval));
+        break;
+
+    case RVAL_TYPE_NOPROMISEE:
+        WriterWrite(writer, "(no-one)");
+        break;
+
+    case RVAL_TYPE_ASSOC:
+        // TODO: do something here, but not handled previously
+        break;
+    }
+}
+
+/* Human-readable serialization to FILE* */
+
+void RlistShow(FILE *fp, const Rlist *list)
+{
+    Writer *w = FileWriter(fp);
+    RlistWrite(w, list);
+    FileWriterDetach(w);
+}
+
+void RvalShow(FILE *fp, Rval rval)
+{
+    Writer *w = FileWriter(fp);
+    RvalWrite(w, rval);
+    FileWriterDetach(w);
+}
+
+/* JSON serialization */
+
+static JsonElement *FnCallToJson(const FnCall *fp)
+{
+    assert(fp);
+
+    JsonElement *object = JsonObjectCreate(3);
+
+    JsonObjectAppendString(object, "name", fp->name);
+    JsonObjectAppendString(object, "type", "function-call");
+
+    JsonElement *argsArray = JsonArrayCreate(5);
+
+    for (Rlist *rp = fp->args; rp != NULL; rp = rp->next)
+    {
+        switch (rp->type)
+        {
+        case RVAL_TYPE_SCALAR:
+            JsonArrayAppendString(argsArray, RlistScalarValue(rp));
+            break;
+
+        case RVAL_TYPE_FNCALL:
+            JsonArrayAppendObject(argsArray, FnCallToJson(RlistFnCallValue(rp)));
+            break;
+
+        default:
+            assert(false && "Unknown argument type");
+            break;
+        }
+    }
+    JsonObjectAppendArray(object, "arguments", argsArray);
+
+    return object;
+}
+
+static JsonElement *RlistToJson(Rlist *list)
+{
+    JsonElement *array = JsonArrayCreate(RlistLen(list));
+
+    for (Rlist *rp = list; rp; rp = rp->next)
+    {
+        switch (rp->type)
+        {
+        case RVAL_TYPE_SCALAR:
+            JsonArrayAppendString(array, RlistScalarValue(rp));
+            break;
+
+        case RVAL_TYPE_LIST:
+            JsonArrayAppendArray(array, RlistToJson(RlistRlistValue(rp)));
+            break;
+
+        case RVAL_TYPE_FNCALL:
+            JsonArrayAppendObject(array, FnCallToJson(RlistFnCallValue(rp)));
+            break;
+
+        default:
+            assert(false && "Unsupported item type in rlist");
+            break;
+        }
+    }
+
+    return array;
+}
+
+JsonElement *RvalToJson(Rval rval)
+{
+    assert(rval.item);
+
+    switch (rval.type)
+    {
+    case RVAL_TYPE_SCALAR:
+        return JsonStringCreate(RvalScalarValue(rval));
+    case RVAL_TYPE_LIST:
+        return RlistToJson(RvalRlistValue(rval));
+    case RVAL_TYPE_FNCALL:
+        return FnCallToJson(RvalFnCallValue(rval));
+    default:
+        assert(false && "Invalid rval type");
+        return JsonStringCreate("");
     }
 }

--- a/libpromises/rlist.h
+++ b/libpromises/rlist.h
@@ -42,11 +42,12 @@ FnCall *RvalFnCallValue(Rval rval);
 Rlist *RvalRlistValue(Rval rval);
 Rval RvalCopy(Rval rval);
 void RvalDestroy(Rval rval);
-int RvalPrint(char *buffer, int bufsize, Rval rval);
 JsonElement *RvalToJson(Rval rval);
 void RvalShow(FILE *fp, Rval rval);
 void RvalWrite(Writer *writer, Rval rval);
 
+void RlistPrintToWriter(const Rlist *list, Writer *w);
+void RvalPrintToWriter(Rval rval, Writer *w);
 
 Rlist *RlistCopy(const Rlist *list);
 void RlistDestroy(Rlist *list);
@@ -81,7 +82,6 @@ Rlist *RlistFromSplitString(const char *string, char sep);
 Rlist *RlistFromSplitRegex(const char *string, const char *regex, int max, int purge);
 void RlistShow(FILE *fp, const Rlist *list);
 void RlistWrite(Writer *writer, const Rlist *list);
-int RlistPrint(char *buffer, int bufsize, const Rlist *list);
 Rlist *RlistLast(Rlist *start);
 void RlistFilter(Rlist **list, bool (*KeepPredicate)(void *item, void *predicate_data), void *predicate_user_data, void (*DestroyItem)(void *item));
 

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -473,49 +473,6 @@ bool IsStrCaseIn(const char *str, const char **strs)
     return false;
 }
 
-int SubStrnCopyChr(char *to, const char *from, int len, char sep)
-{
-    char *sto = to;
-    int count = 0;
-
-    memset(to, 0, len);
-
-    if (from == NULL)
-    {
-        return 0;
-    }
-
-    if (from && (strlen(from) == 0))
-    {
-        return 0;
-    }
-
-    for (const char *sp = from; *sp != '\0'; sp++)
-    {
-        if (count > len - 1)
-        {
-            break;
-        }
-
-        if ((*sp == '\\') && (*(sp + 1) == sep))
-        {
-            *sto++ = *++sp;
-        }
-        else if (*sp == sep)
-        {
-            break;
-        }
-        else
-        {
-            *sto++ = *sp;
-        }
-
-        count++;
-    }
-
-    return count;
-}
-
 int CountChar(const char *string, char sep)
 {
     int count = 0;

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -64,7 +64,6 @@ bool IsStrCaseIn(const char *str, const char **strs);
 char **String2StringArray(char *str, char separator);
 void FreeStringArray(char **strs);
 
-int SubStrnCopyChr(char *to, const char *from, int len, char sep);
 int CountChar(const char *string, char sp);
 void ReplaceChar(char *in, char *out, int outSz, char from, char to);
 void ReplaceTrailingChar(char *str, char from, char to);

--- a/tests/unit/rlist_test.c
+++ b/tests/unit/rlist_test.c
@@ -284,27 +284,12 @@ int EndJoin(char *path, char *leaf, int bufsize)
     fail();
 }
 
-char *EscapeQuotes(const char *s, char *out, int outSz)
-{
-    fail();
-}
-
 void FnCallDestroy(FnCall *fp)
 {
     fail();
 }
 
-int PrintFnCall(char *buffer, int bufsize, const FnCall *fp)
-{
-    fail();
-}
-
 int SubStrnCopyChr(char *to, const char *from, int len, char sep)
-{
-    fail();
-}
-
-int StartJoin(char *path, char *leaf, int bufsize)
 {
     fail();
 }


### PR DESCRIPTION
StartJoin was used to generate JSON and serialized representation of
Rlist. Writer and JsonElement-based implementations were added instead of
relying on static-size buffers.
