### PR TITLE
Fix class definition for defined paths

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -3082,7 +3082,7 @@ bundle common paths
       "useradd"             string => "/usr/sbin/useradd";
 
 
-    all::
+    any::
       "ping" string => "/usr/bin/ping";
 
       "all_paths" slist => { 


### PR DESCRIPTION
The all context class is not an alias for any, this prevented the classes
that are supposed to be raised for each defined path from being defined
