### PR TITLE
Add context class for when paths exist

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -3132,6 +3132,7 @@ bundle common paths
                               };
 
   classes:
-    "_stdlib_has_path_$(all_paths)" expression => isvariable("$(all_paths)");
+    "_stdlib_has_path_$(all_paths)"    expression => isvariable("$(all_paths)");
+    "_stdlib_path_exists_$(all_paths)" expression => fileexists("$(all_paths)");
 
 }


### PR DESCRIPTION
Its useful to know not just when a path is defined, but when it actually exists.
