### PR TITLE
Check validity of constraints' lvalues during PolicyCheckPartial().

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -918,10 +918,8 @@ static SyntaxTypeMatch CheckSelection(const char *type, const char *name, const 
 
 static SyntaxTypeMatch CheckConstraint(const char *type, const char *lval, Rval rval, SubTypeSyntax ss)
 {
-    int lmatch = false;
-    int i, l, allowed = false;
+    int l;
     const BodySyntax *bs;
-    char output[CF_BUFSIZE];
 
     CfDebug("CheckConstraint(%s,%s,", type, lval);
 
@@ -948,75 +946,19 @@ static SyntaxTypeMatch CheckConstraint(const char *type, const char *lval, Rval 
                 {
                     /* If we get here we have found the lval and it is valid
                        for this subtype */
-
-                    lmatch = true;
                     CfDebug("Matched syntatically correct bundle (lval,rval) item = (%s) to its rval\n", lval);
 
-                    if (bs[l].dtype == DATA_TYPE_BODY)
+                    /* For bodies and bundles definitions can be elsewhere, so
+                       they are checked in PolicyCheckRunnable(). */
+                    if (bs[l].dtype != DATA_TYPE_BODY &&
+                        bs[l].dtype != DATA_TYPE_BUNDLE)
                     {
-                        CfDebug("Constraint syntax ok, but definition of body is elsewhere %s=%c\n", lval, rval.type);
-                        return SYNTAX_TYPE_MATCH_OK;
-                    }
-                    else if (bs[l].dtype == DATA_TYPE_BUNDLE)
-                    {
-                        CfDebug("Constraint syntax ok, but definition of relevant bundle is elsewhere %s=%c\n", lval,
-                                rval.type);
-                        return SYNTAX_TYPE_MATCH_OK;
-                    }
-                    else
-                    {
-                        return CheckConstraintTypeMatch(lval, rval, bs[l].dtype, (char *) (bs[l].range), 0);
+                        return CheckConstraintTypeMatch(lval, rval, bs[l].dtype,
+                                                        (char *) bs[l].range, 0);
                     }
                 }
             }
         }
-    }
-
-/* Now check the functional modules - extra level of indirection
-   Note that we only check body attributes relative to promise type.
-   We can enter any promise types in any bundle, but only recognized
-   types will be dealt with. */
-
-    for (i = 0; CF_COMMON_BODIES[i].lval != NULL; i++)
-    {
-        CfDebug("CMP-common # %s,%s\n", lval, CF_COMMON_BODIES[i].lval);
-
-        if (strcmp(lval, CF_COMMON_BODIES[i].lval) == 0)
-        {
-            CfDebug("Found a match for lval %s in the common constraint attributes\n", lval);
-            return SYNTAX_TYPE_MATCH_OK;
-        }
-    }
-
-    for (i = 0; CF_COMMON_EDITBODIES[i].lval != NULL; i++)
-    {
-        CfDebug("CMP-common # %s,%s\n", lval, CF_COMMON_EDITBODIES[i].lval);
-
-        if (strcmp(lval, CF_COMMON_EDITBODIES[i].lval) == 0)
-        {
-            CfDebug("Found a match for lval %s in the common edit_line constraint attributes\n", lval);
-            return SYNTAX_TYPE_MATCH_OK;
-        }
-    }
-
-    for (i = 0; CF_COMMON_XMLBODIES[i].lval != NULL; i++)
-    {
-        CfDebug("CMP-common # %s,%s\n", lval, CF_COMMON_XMLBODIES[i].lval);
-
-        if (strcmp(lval, CF_COMMON_XMLBODIES[i].lval) == 0)
-        {
-            CfDebug("Found a match for lval %s in the common edit_xml constraint attributes\n", lval);
-            return SYNTAX_TYPE_MATCH_OK;
-        }
-    }
-
-
-// Now check if it is in the common list...
-
-    if (!lmatch || !allowed)
-    {
-        snprintf(output, CF_BUFSIZE, "Constraint lvalue \'%s\' is not allowed in bundle category \'%s\'", lval, type);
-        yyerror(output);
     }
 
     return SYNTAX_TYPE_MATCH_OK;

--- a/tests/acceptance/00_basics/01_compiler/710.x.cf
+++ b/tests/acceptance/00_basics/01_compiler/710.x.cf
@@ -39,7 +39,7 @@ classes:
         "ok" not => fileexists("$(G.testdir)/shouldnotexist");
 reports:
     DEBUG::
-        "Expected to crash - illegal body contstraint name";
+        "This test should fail";
     ok::
         "$(this.promise_filename) Pass";
     !ok::

--- a/tests/unit/data/constraint_lval_invalid.cf
+++ b/tests/unit/data/constraint_lval_invalid.cf
@@ -1,0 +1,7 @@
+bundle agent test
+{
+files:
+  "$(G.testdir)/shouldnotexist"
+     create => "true",
+     nonexistant_attribute => "abc";
+}

--- a/tests/unit/policy_test.c
+++ b/tests/unit/policy_test.c
@@ -213,6 +213,15 @@ static void test_util_bundle_qualified_name(void **state)
     free(b);
 }
 
+static void test_constraint_lval_invalid(void **state)
+{
+    Seq *errs = LoadAndCheck("constraint_lval_invalid.cf");
+    assert_int_equal(1, errs->length);
+
+    SeqDestroy(errs);
+}
+
+
 int main()
 {
     const UnitTest tests[] =
@@ -227,7 +236,9 @@ int main()
 
         unit_test(test_policy_json_to_from),
 
-        unit_test(test_util_bundle_qualified_name)
+        unit_test(test_util_bundle_qualified_name),
+
+        unit_test(test_constraint_lval_invalid)
     };
 
     return run_tests(tests);


### PR DESCRIPTION
The same check existed in the parser so I removed it. Validity of constraints
is now checked in ConstraintCheckSyntax(), copied from ConstraintGetSyntax()
which now expects syntax is already checked.

Also fixed a segfault, so changed the relevant acceptance test to not expect
crash, but just failure.
