### PR TITLE
Look at NI instead of PRI in ps output on Linux

### DIFF
--- a/libpromises/classes.c
+++ b/libpromises/classes.c
@@ -74,7 +74,7 @@ const char *VPSOPTS[PLATFORM_CONTEXT_MAX] =
     "",
     "-ef",                      /* hpux */
     "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args",  /* aix */
-    "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,pri,rss,nlwp,stime,time,args",        /* linux */
+    "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",        /* linux */
     "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,pri,rss,nlwp,stime,time,args",        /* solaris */
     "auxw",                     /* freebsd */
     "auxw",                     /* netbsd */


### PR DESCRIPTION
The PRI field is the Linux kernel scheduling priority which is
different from the niceness of a process (which is what a system
adminitrator and policy-writer is likely to want to select upon). This
value is almost always larger than 20, so it isn't selectable if the
defined range per the documentation is -20,+20 anyway.
