### PR TITLE
Allow empty lists at the language level.

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -532,6 +532,10 @@ rval:                  IDSYNTAX
                        }
                      | list
                        {
+                           if (RlistLen(P.currentRlist) == 0)
+                           {
+                               RlistAppendScalar(&P.currentRlist, CF_NULL_VALUE);
+                           }
                            P.rval = (Rval) { RlistCopy(P.currentRlist), RVAL_TYPE_LIST };
                            RlistDestroy(P.currentRlist);
                            P.currentRlist = NULL;
@@ -545,9 +549,8 @@ rval:                  IDSYNTAX
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-list:                  '{'
-                       litems
-                       '}';
+list:                  '{' '}'
+                     | '{' litems '}';
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tests/acceptance/00_basics/01_compiler/103.cf
+++ b/tests/acceptance/00_basics/01_compiler/103.cf
@@ -1,0 +1,28 @@
+######################################################
+#
+#  Issue 375 setup (precursor to actual tickle of bug)
+#
+#####################################################
+body common control
+{
+  inputs => { @(g.inputs) };
+  bundlesequence  => { check };
+  version => "1.0";
+nova_edition::
+  host_licenses_paid => "5";
+}
+
+bundle common g
+{
+vars:
+  "inputs" slist => { };
+}
+
+bundle agent check
+{
+reports:
+    DEBUG::
+        "This test should pass as a precursor to a bunch of related failures";
+    any::
+        "$(this.promise_filename) Pass";
+}


### PR DESCRIPTION
Translates empty lists { } => { "cf_null" } in the parser.
Arguably a hack, but much simpler than removing cf_null itself.
