### PR TITLE
Fix for acceptance tests.

### DIFF
--- a/tests/acceptance/10_files/02_maintain/004.cf
+++ b/tests/acceptance/10_files/02_maintain/004.cf
@@ -48,7 +48,7 @@ bundle agent test
 {
 vars:
     "mode" string => execresult(
-    "/usr/bin/stat --printf=%a $(g.source)",
+    "/usr/bin/perl -le 'printf \"%o\", (stat(\"$(g.source)\"))[2]&07777'",
     "noshell");
 
 files:

--- a/tests/acceptance/10_files/02_maintain/005.cf
+++ b/tests/acceptance/10_files/02_maintain/005.cf
@@ -48,7 +48,7 @@ bundle agent test
 {
 vars:
     "mode" string => execresult(
-    "/usr/bin/stat --printf=%a $(g.source)",
+	"/usr/bin/perl -le 'printf \"%o\", (stat(\"$(g.source)\"))[2]&07777'",
     "noshell");
 
 files:

--- a/tests/acceptance/10_files/02_maintain/006.cf
+++ b/tests/acceptance/10_files/02_maintain/006.cf
@@ -48,7 +48,7 @@ bundle agent test
 {
 vars:
     "mode" string => execresult(
-    "/usr/bin/stat --printf=%a $(g.source)",
+	"/usr/bin/perl -le 'printf \"%o\", (stat(\"$(g.source)\"))[2]&07777'",
     "noshell");
 
 files:

--- a/tests/acceptance/10_files/02_maintain/007.cf
+++ b/tests/acceptance/10_files/02_maintain/007.cf
@@ -48,7 +48,7 @@ bundle agent test
 {
 vars:
     "mode" string => execresult(
-    "/usr/bin/stat --printf=%a $(g.source)",
+	"/usr/bin/perl -le 'printf \"%o\", (stat(\"$(g.source)\"))[2]&07777'",
     "noshell");
 
 files:


### PR DESCRIPTION
It turns out that using printf and stat is not such a good idea, since
their behavior change from platform to platform.
This commit changes the mode test to a little perl script.
