### PR TITLE
Fix regression with path style and add createrepo paths for redhat and debian

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -3109,7 +3109,7 @@ bundle common paths
 
     any::
       "all_paths"     slist => getindices("path");
-      "$(all_paths)" string => "$(all_paths)";
+      "$(all_paths)" string => "$(path[$(all_paths)])";
 
   classes:
     "_stdlib_has_path_$(all_paths)"


### PR DESCRIPTION
A sketch wants to use the createrepo path, and while adding it I found we weren't supporting the old path style properly.

Test Output

```
% cf-agent -KIf ./t.cf           
R: [short path style] createrepo has a path defined as $(paths.createrepo): /usr/bin/createrepo
R: [array path style] createrepo has a path defined as $(paths.path[createrepo]): /usr/bin/createrepo
R: /usr/bin/createrepo exists on this system
R: I passed the path check for createrepo woohoo!
```

Test Policy

```

body common control {

bundlesequence => {
"main",
};

inputs => {
"cfengine_stdlib.cf",
};
}

bundle agent main {
classes:
    "$(paths.all_paths)_passed_path_check"
      expression => regcmp("$(paths.$(paths.all_paths))", "$(paths.path[$(paths.all_paths)])"),
      comment    => "I really wish this worked, would be nice to ensure all paths defined match.";

    "createrepo_passed_path_check"
      expression => regcmp("$(paths.createrepo)", "$(paths.path[createrepo])"),
      comment => "We can test for them individually, this is brittle in case one of the paths isnt defined.";

reports:
 _stdlib_has_path_createrepo::
    "[short path style] createrepo has a path defined as $(const.dollar)(paths.createrepo): $(paths.createrepo)";
    "[array path style] createrepo has a path defined as $(const.dollar)(paths.path[createrepo]): $(paths.path[createrepo])";

 _stdlib_path_exists_createrepo::
    "$(paths.path[createrepo]) exists on this system";

 !_stdlib_has_path_createrepo::
    "createrepo is not defined for this system";
    "Since $(paths.createrepo) is not defined for this system, I didnt bother checking if it actually exists";

  createrepo_passed_path_check::
    "I passed the path check for createrepo woohoo!";

}
```
