### PR TITLE
Don't sleep in GracefulTerminate() if PID does not exist.

### DIFF
--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -30,7 +30,6 @@
 #include "cfstream.h"
 #include "string_lib.h"
 #include "pipes.h"
-#include "unix.h"
 #include "mutex.h"
 #include "logging.h"
 #include "exec_tools.h"
@@ -243,7 +242,7 @@ void LocalExec(const ExecConfig *config)
 
             if(PipeToPid(&pid_agent, pp))
             {
-                ProcessSignalTerminate(pid_agent);
+                GracefulTerminate(pid_agent);
             }
             else
             {

--- a/libpromises/unix.h
+++ b/libpromises/unix.h
@@ -31,6 +31,5 @@
 #include "assoc.h"
 
 void GetInterfacesInfo(EvalContext *ctx, AgentType ag);
-void ProcessSignalTerminate(pid_t pid);
 
 #endif


### PR DESCRIPTION
I got fed up waiting for cf-execd trying to kill() non-existent processes. Also got rid of similar function ProcessSignalTerminate().
