### PR TITLE
Redmine#1735: classesmatching() function

### DIFF
--- a/docs/reference/functions/classesmatching_example.texinfo
+++ b/docs/reference/functions/classesmatching_example.texinfo
@@ -1,0 +1,20 @@
+
+@verbatim
+
+body common control
+{
+      bundlesequence => { run };
+}
+
+bundle agent run
+{
+  vars:
+      "all" slist => classesmatching(".*");
+      "c" slist => classesmatching("cfengine");
+  reports:
+      "All classes = $(all)";
+      "Classes matching 'cfengine' = $(c)";
+}
+
+
+@end verbatim

--- a/docs/reference/functions/classesmatching_notes.texinfo
+++ b/docs/reference/functions/classesmatching_notes.texinfo
@@ -1,0 +1,9 @@
+
+The regular expression is matched against the current list of defined
+classes (hard, then soft, then local to the current bundle).  This
+regular expression does not need to be anchored.
+
+@xref{Anchored vs. unanchored regular expressions}.
+
+This function replaces the @code{allclasses.txt} static file available
+in older versions of CFEngine.

--- a/libpromises/env_context.c
+++ b/libpromises/env_context.c
@@ -1465,6 +1465,44 @@ size_t EvalContextStackFrameMatchCountSoft(const EvalContext *ctx, const char *c
     return StringSetMatchCount(frame->data.bundle.contexts, context_regex);
 }
 
+StringSet *StringSetAddAllMatchingIterator(StringSet* base, StringSetIterator it, const char *filter_regex)
+{
+    const char *element = NULL;
+    while ((element = SetIteratorNext(&it)))
+    {
+        if (StringMatch(filter_regex, element))
+        {
+            StringSetAdd(base, xstrdup(element));
+        }
+    }
+    return base;
+}
+
+StringSet *StringSetAddAllMatching(StringSet* base, const StringSet* filtered, const char *filter_regex)
+{
+    return StringSetAddAllMatchingIterator(base, StringSetIteratorInit((StringSet*)filtered), filter_regex);
+}
+
+StringSet *EvalContextHeapAddMatchingSoft(const EvalContext *ctx, StringSet* base, const char *context_regex)
+{
+    return StringSetAddAllMatching(base, ctx->heap_soft, context_regex);
+}
+
+StringSet *EvalContextHeapAddMatchingHard(const EvalContext *ctx, StringSet* base, const char *context_regex)
+{
+    return StringSetAddAllMatching(base, ctx->heap_hard, context_regex);
+}
+
+StringSet *EvalContextStackFrameAddMatchingSoft(const EvalContext *ctx, StringSet* base, const char *context_regex)
+{
+    if (SeqLength(ctx->stack) == 0)
+    {
+        return base;
+    }
+
+    return StringSetAddAllMatchingIterator(base, EvalContextStackFrameIteratorSoft(ctx), context_regex);
+}
+
 StringSetIterator EvalContextHeapIteratorSoft(const EvalContext *ctx)
 {
     return StringSetIteratorInit(ctx->heap_soft);

--- a/libpromises/env_context.h
+++ b/libpromises/env_context.h
@@ -115,6 +115,10 @@ size_t EvalContextHeapMatchCountSoft(const EvalContext *ctx, const char *context
 size_t EvalContextHeapMatchCountHard(const EvalContext *ctx, const char *context_regex);
 size_t EvalContextStackFrameMatchCountSoft(const EvalContext *ctx, const char *context_regex);
 
+StringSet* EvalContextHeapAddMatchingSoft(const EvalContext *ctx, StringSet* base, const char *context_regex);
+StringSet* EvalContextHeapAddMatchingHard(const EvalContext *ctx, StringSet* base, const char *context_regex);
+StringSet* EvalContextStackFrameAddMatchingSoft(const EvalContext *ctx, StringSet* base, const char *context_regex);
+
 StringSetIterator EvalContextHeapIteratorSoft(const EvalContext *ctx);
 StringSetIterator EvalContextHeapIteratorHard(const EvalContext *ctx);
 StringSetIterator EvalContextHeapIteratorNegated(const EvalContext *ctx);

--- a/tests/acceptance/02_classes/02_functions/classesmatching.cf
+++ b/tests/acceptance/02_classes/02_functions/classesmatching.cf
@@ -1,0 +1,73 @@
+#######################################################
+#
+# Test classesmatching()
+#
+#######################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+nova_edition::
+  host_licenses_paid => "5";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "known" slist => { "cfengine", "cfengine_3", "agent", "any", $(dow), $(dow) };
+      "known_str" string => join(" ", "known");
+
+    Monday::
+      "dow" string => "Monday";
+    Tuesday::
+      "dow" string => "Tuesday";
+    Wednesday::
+      "dow" string => "Wednesday";
+    Thursday::
+      "dow" string => "Thursday";
+    Friday::
+      "dow" string => "Friday";
+    Saturday::
+      "dow" string => "Saturday";
+    Sunday::
+      "dow" string => "Sunday";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "matched" slist => { classesmatching("^cfengine$"), # static string
+                           # range of multiples
+                           classesmatching("^cfengine_[0-9]$"),
+                           # alternation/capture of single
+                           classesmatching("^a(g)ent$"),
+                           # range of single
+                           classesmatching("^a[n]y$"),
+                           # alternation of multiples
+                           classesmatching("^(Mon|Tue|Wednes|Thurs|Fri|Satur|Sun)day$"),
+                           # interpolation
+                           classesmatching("^$(init.dow)$"),
+      };
+      "matched_str" string => join(" ", "matched");
+}
+
+#######################################################
+
+bundle agent check
+{
+classes:
+        "ok" expression => strcmp($(init.known_str), $(test.matched_str));
+reports:
+    ok::
+        "$(this.promise_filename) Pass";
+    !ok::
+        "$(this.promise_filename) FAIL";
+    DEBUG.!ok::
+        "$(this.promise_filename) expected '$(init.known_str)', got '$(test.matched_str)'";
+}


### PR DESCRIPTION
This adds a `classesmatching` function, e.g.:

```
body common control
{
      bundlesequence => { run };
}

bundle agent run
{
  vars:
      "c" slist => classesmatching(".*");
  reports:
    cfengine::
      "Classes matching = $(c)";
}
```

produces all the defined classes:

```
...
R: Classes matching = cfengine_3_5
R: Classes matching = net_iface_eth0
...
```

Please review the code and once it's considered OK, I will add an acceptance test.
