### PR TITLE
Zeroing the buffer

### DIFF
--- a/libutils/buffer.c
+++ b/libutils/buffer.c
@@ -766,6 +766,7 @@ void BufferZero(Buffer *buffer)
         RefCountAttach(buffer->ref_count, buffer);
     }
     buffer->used = 0;
+	buffer->buffer[0] = '\0';
 }
 
 unsigned int BufferSize(Buffer *buffer)

--- a/tests/unit/buffer_test.c
+++ b/tests/unit/buffer_test.c
@@ -147,6 +147,8 @@ static void test_zeroBuffer(void **state)
     assert_int_equal(DEFAULT_BUFFER_SIZE, buffer->capacity);
     assert_int_equal(0, buffer->used);
     assert_int_equal(0, BufferSize(buffer));
+	const char *data = BufferData(buffer);
+	assert_string_equal(data, "");
     assert_true(element0pointer == buffer->buffer);
     BufferZero(NULL);
     assert_int_equal(0, BufferDestroy(&buffer));


### PR DESCRIPTION
The previous behavior was just to mark the size as zero, but it was
found that is better to add a '\0' at the beginning to make this
clearer.
