### PR TITLE
Fix replace_or_add() when regex chars used

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -663,9 +663,10 @@ bundle edit_line replace_or_add(pattern,line)
 {
 vars:
   "cline" string => canonify("$(line)");
+  "eline" string => escape("$(line)");
 
 replace_patterns:
-  "^(?!$(line)$)$(pattern)$"
+  "^(?!$(eline)$)$(pattern)$"
           comment => "Replace a pattern here",
      replace_with => value("$(line)"),
           classes => always("replace_done_$(cline)");


### PR DESCRIPTION
replace_or_add(pattern, line) will currently break
if line incidentally contains special regular expression
characters. So $(line) should be escaped because it needs
to be matched literally.

For example, this fixes replace_or_add() when used in a crontab:

```
replace_or_add(".*myscript.*", "* * * * * /usr/bin/myscript $(arg1)")
```
