### PR TITLE
Backport fix for qualified array expansion from trunk

### DIFF
--- a/src/expand.c
+++ b/src/expand.c
@@ -322,7 +322,16 @@ static void MapIteratorsFromScalar(const char *scopeid, Rlist **scal, Rlist **it
 
                         if (strchr(var, CF_MAPPEDLIST))
                         {
-                            RewriteInnerVarStringAsLocalCopyName(sp);
+                            // Qualified outer var will eat the rewrite
+                            if (qualified)
+                            {
+                                // Skip parent scope and '$(.'
+                                RewriteInnerVarStringAsLocalCopyName(sp + strlen(absscope) + 3);
+                            }
+                            else
+                            {
+                                RewriteInnerVarStringAsLocalCopyName(sp);
+                            }
                         }
                     }
                 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -690,7 +690,7 @@ const char *ExtractInnerCf3VarString(const char *str, char *substr)
             else
             {
                 CfDebug("Illegal character found: '%c'\n", *sp);
-                CfDebug("Illegal character somewhere in variable \"%s\" or nested expansion", str);
+                CfDebug("Illegal character somewhere in variable \"%s\" or nested expansion\n", str);
             }
         }
 

--- a/tests/acceptance/01_vars/03_lists/012.cf
+++ b/tests/acceptance/01_vars/03_lists/012.cf
@@ -1,0 +1,90 @@
+#######################################################
+#
+# Iterations of non-local slists inside non-local (sclar) array
+#
+#######################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+nova_edition::
+  host_licenses_paid => "5";
+}
+
+#######################################################
+
+bundle agent init
+{
+vars:
+        "states" slist => { "actual", "expected" };
+
+        "actual" string => "";
+
+        "expected" string =>
+"
+XX
+XXX
+XXXX";
+
+files:
+        "$(G.testfile).$(states)"
+            create => "true",
+            edit_line => init_insert("$(init.$(states))"),
+            edit_defaults => init_empty;
+}
+
+bundle edit_line init_insert(str)
+{
+insert_lines:
+        "$(str)";
+}
+
+body edit_defaults init_empty
+{
+        empty_file_before_editing => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+files:
+        "$(G.testfile).actual"
+            edit_line => test_insert;
+
+}
+
+bundle agent otherbundle
+{
+vars:
+        "array[one]" string => "XX";
+        "array[two]" string => "XXX";
+        "array[three]" string => "XXXX";
+        "list" slist => { "one", "two", "three" };
+}
+
+bundle edit_line test_insert
+{
+insert_lines:
+        "$(otherbundle.array[$(otherbundle.list)])";
+}
+
+#######################################################
+
+bundle agent check
+{
+methods:
+        "any" usebundle => default_sort("$(G.testfile).actual", "$(G.testfile).actual.sorted");
+        "any" usebundle => default_sort("$(G.testfile).expected", "$(G.testfile).expected.sorted");
+        "any" usebundle => default_check_diff("$(G.testfile).actual.sorted",
+                                              "$(G.testfile).expected.sorted",
+                                              "$(this.promise_filename)");
+}
+
+body contain check_in_shell
+{
+useshell => "true";
+}
+


### PR DESCRIPTION
$(other.array[$(other.list)]) would expand to
$(other#array[$(other.list)]) in output due to issues mapping remote
lists to "this" scope. Fix skips the outer "." to properly map.

Fixes Issue #1998, Mantis #1128

Originally Pull #421
