### PR TITLE
BSD: ignore default loopback interface

### DIFF
--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -358,6 +358,12 @@ static void GetMacAddress(EvalContext *ctx, AgentType ag, int fd, struct ifreq *
         snprintf(name, CF_MAXVARSIZE, "hardware_mac[interface_name]");
     }
 
+    // mac address on a loopback interface doesn't make sense
+    if (ifr->ifr_flags & IFF_LOOPBACK)
+    {
+      return;
+    }
+
 # if defined(SIOCGIFHWADDR) && defined(HAVE_STRUCT_IFREQ_IFR_HWADDR)
     char hw_mac[CF_MAXVARSIZE];
 
@@ -402,14 +408,6 @@ static void GetMacAddress(EvalContext *ctx, AgentType ag, int fd, struct ifreq *
                 sdl = (struct sockaddr_dl *)ifa->ifa_addr;
                 m = (char *) LLADDR(sdl);
                 
-                // Skip zeroed mac addresses (loopback interfaces, ...)
-                if (m[0] == 0 && m[1] == 0 
-                    && m[2] == 0 && m[3] == 0 
-                    && m[4] == 0 && m[5] == 0)
-                {
-                    continue;
-                }
-
                 snprintf(hw_mac, CF_MAXVARSIZE - 1, "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
                     (unsigned char) m[0],
                     (unsigned char) m[1],


### PR DESCRIPTION
lo0 is the default loopback interface on {Free,Open,Net}BSD, I think it makes sense to ignore it like lo on Linux.

Before:
/cf-promises -v|awk '/Hard classes/ {for (i=7;i<=NF;i++) {print $i}}'|grep net_iface
net_iface_em0
net_iface_gif0
net_iface_le0
net_iface_lo0

After:
cf-promises -v|awk '/Hard classes/ {for (i=7;i<=NF;i++) {print $i}}'|grep net_iface
net_iface_em0
net_iface_gif0
net_iface_le0
