### PR TITLE
Fixing compilation problems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -362,9 +362,11 @@ if test "x$with_libxml2" != xno; then
    fi
 
     CF3_WITH_LIBRARY(libxml2, [
-      AC_CHECK_LIB(xml2, xmlFirstElementChild, [], [if test "x$with_libxml2" != xcheck; then AC_MSG_ERROR(Cannot find libxml2); fi])
+      AC_CHECK_LIB(xml2, xmlFirstElementChild, AM_CONDITIONAL(HAVE_LIBXML2, true), [if test "x$with_libxml2" != xcheck; then AC_MSG_ERROR(Cannot find libxml2); fi])
       AC_CHECK_HEADERS([libxml/xmlwriter.h], [break], [if test "x$with_libxml2" != xcheck; then AC_MSG_ERROR(Cannot find libxml2); fi])
     ])
+else
+	AM_CONDITIONAL(HAVE_LIBXML2, false)
 fi
 
 dnl avahi

--- a/tests/acceptance/Makefile.am
+++ b/tests/acceptance/Makefile.am
@@ -1,16 +1,22 @@
 AM_CFLAGS = $(NOVA_CFLAGS) -I$(top_srcdir)/libpromises -I$(srcdir)/../../libutils
 
+if HAVE_LIBXML2
 noinst_PROGRAMS = mock-package-manager xml-c14nize
+else
+noinst_PROGRAMS = mock-package-manager
+endif
 
 mock_package_manager_SOURCES = mock-package-manager.c
-mock_package_manager_LDADD = ../../libpromises/libpromises.la
+mock_package_manager_LDADD = $(abs_top_builddir)/libpromises/libpromises.la
 
+if HAVE_LIBXML2
 xml_c14nize_SOURCES = xml-c14nize.c
 xml_c14nize_CPPFLAGS = $(LIBXML2_CPPFLAGS)
 xml_c14nize_CFLAGS = -I$(top_srcdir)/libpromises -I$(srcdir)/../../libutils \
     $(LIBXML2_CFLAGS)
-xml_c14nize_LDADD = ../../libutils/libutils.la \
+xml_c14nize_LDADD = $(abs_top_builddir)/libutils/libutils.la \
     $(LIBXML2_LIBS)
+endif
 
 EXTRA_DIST = default.cf.sub testall
 


### PR DESCRIPTION
xml-c14n should not be compiled if LIBXML2 is not present. This change
adds a new conditional HAVE_LIBXML2 that is used to detect the presence
of LIBXML2 and take the corresponding action.
