### PR TITLE
Adding a check to insure that test will fail if libxml2 is not installed.

### DIFF
--- a/tests/acceptance/xml-c14nize.c
+++ b/tests/acceptance/xml-c14nize.c
@@ -8,6 +8,7 @@
 
 static bool xmlC14nizeFile(const char *filename)
 {
+#ifdef HAVE_LIBXML2
     xmlDocPtr doc = xmlParseFile(filename);
 
     if (doc == NULL)
@@ -38,6 +39,10 @@ static bool xmlC14nizeFile(const char *filename)
 
     xmlFreeDoc(doc);
     return true;
+#else
+    fprintf(stderr, " !! Cannot use xml_check_diff (xml-c14nize) on XML files without LIBXML2\n");
+    return false;
+#endif
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
....
