### PR TITLE
ifelse() function

### DIFF
--- a/docs/reference/functions/ifelse_example.texinfo
+++ b/docs/reference/functions/ifelse_example.texinfo
@@ -1,0 +1,40 @@
+
+@verbatim
+
+body common control
+
+{
+bundlesequence  => { "example" };
+}
+
+###########################################################
+
+bundle agent example
+
+{     
+  classes:
+      "myclass" expression => "any";
+      "myclass2" expression => "any";
+      "secondpass" expression => "any";
+  vars:
+      # result: { "1", "single string parameter", "hardclass OK", "bundle class OK", "5 parameters OK" }
+
+      # we need to use the secondpass class because on the first pass,
+      # myclass and myclass2 are not defined yet
+
+    secondpass::
+      "mylist" slist => {
+                          ifelse(1),
+                          ifelse("single string parameter"),
+                          ifelse("cfengine", "hardclass OK", "hardclass broken"),
+                          ifelse("myclass.myclass2", "bundle class OK", "bundle class broken"),
+                          ifelse("this is not true", "5 parameters broken",
+                                 "this is also not true", "5 parameters broken 2",
+                                 "5 parameters OK"),
+                        };
+
+  reports:
+      "ifelse result list: $(mylist)";
+}
+
+@end verbatim

--- a/docs/reference/functions/ifelse_notes.texinfo
+++ b/docs/reference/functions/ifelse_notes.texinfo
@@ -1,0 +1,18 @@
+
+The @code{ifelse} function is like a multi-level if-else statement.  It
+must have an odd number of arguments (from 1 to N).  The last argument
+is the default value, like the @code{else} clause in standard
+programming languages.  Every pair of arguments before the last one are
+evaluated as a pair.  If the first one evaluates true (as if you had
+used it in a class @code{expression}, so it can be more than just a
+class name) then the second one is returned.
+
+As an example, if @code{ifelse} were called with arguments (@var{a1},
+@var{a2}, @var{b1}, @var{b2}, and @var{c}), the behavior expressed as
+pseudo-code is:
+
+@verbatim
+if a1 then return a2
+else-if b1 then return b2
+else return c
+@end verbatim

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -630,6 +630,51 @@ static FnCallResult FnCallClassMatch(EvalContext *ctx, FnCall *fp, Rlist *finala
 
 /*********************************************************************/
 
+static FnCallResult FnCallIfElse(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
+{
+    Rlist *arg = NULL;
+    int argcount = 0;
+    char id[CF_BUFSIZE];
+
+    snprintf(id, CF_BUFSIZE, "built-in FnCall ifelse-arg");
+
+    /* We need to check all the arguments, ArgTemplate does not check varadic functions */
+    for (arg = finalargs; arg; arg = arg->next)
+    {
+        SyntaxTypeMatch err = CheckConstraintTypeMatch(id, (Rval) {arg->item, arg->type}, DATA_TYPE_STRING, "", 1);
+        if (err != SYNTAX_TYPE_MATCH_OK && err != SYNTAX_TYPE_MATCH_ERROR_UNEXPANDED)
+        {
+            FatalError(ctx, "in %s: %s", id, SyntaxTypeMatchToString(err));
+        }
+        argcount++;
+    }
+
+    /* Require an odd number of arguments. We will always return something. */
+    if (argcount%2 != 1)
+    {
+        FatalError(ctx, "in built-in FnCall ifelse: even number of arguments");
+    }
+
+    for (arg = finalargs;        /* Start with arg set to finalargs. */
+         arg && arg->next;       /* We must have arg and arg->next to proceed. */
+         arg = arg->next->next)  /* arg steps forward *twice* every time. */
+    {
+        /* Similar to classmatch(), we evaluate the first of the two
+         * arguments as a class. */
+        if (IsDefinedClass(ctx, RlistScalarValue(arg), PromiseGetNamespace(fp->caller)))
+        {
+            /* If the evaluation returned true in the current context,
+             * return the second of the two arguments. */
+            return (FnCallResult) { FNCALL_SUCCESS, { xstrdup(RlistScalarValue(arg->next)), RVAL_TYPE_SCALAR } };
+        }
+    }
+
+    /* If we get here, we've reached the last argument (arg->next is NULL). */
+    return (FnCallResult) { FNCALL_SUCCESS, { xstrdup(RlistScalarValue(arg)), RVAL_TYPE_SCALAR } };
+}
+
+/*********************************************************************/
+
 static FnCallResult FnCallCountClassesMatching(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
 {
     char buffer[CF_BUFSIZE], *string = RlistScalarValue(finalargs);
@@ -4406,6 +4451,11 @@ FnCallArg HOSTSWITHCLASS_ARGS[] =
     {NULL, DATA_TYPE_NONE, NULL}
 };
 
+FnCallArg IFELSE_ARGS[] =
+{
+    {NULL, DATA_TYPE_NONE, NULL}
+};
+
 FnCallArg IPRANGE_ARGS[] =
 {
     {CF_ANYSTRING, DATA_TYPE_STRING, "IP address range syntax"},
@@ -4857,6 +4907,7 @@ const FnCallType CF_FNCALL_TYPES[] =
      "Extract the list of hosts with the given class set from the hub database (commercial extension)"},
     {"hubknowledge", DATA_TYPE_STRING, HUB_KNOWLEDGE_ARGS, &FnCallHubKnowledge,
      "Read global knowledge from the hub host by id (commercial extension)"},
+    {"ifelse", DATA_TYPE_STRING, IFELSE_ARGS, &FnCallIfElse, "Do If-ElseIf-ElseIf-...-Else evaluation of arguments", true},
     {"iprange", DATA_TYPE_CONTEXT, IPRANGE_ARGS, &FnCallIPRange,
      "True if the current host lies in the range of IP addresses specified"},
     {"irange", DATA_TYPE_INT_RANGE, IRANGE_ARGS, &FnCallIRange, "Define a range of integer values for cfengine internal use"},

--- a/tests/acceptance/01_vars/02_functions/ifelse.cf
+++ b/tests/acceptance/01_vars/02_functions/ifelse.cf
@@ -1,0 +1,86 @@
+#######################################################
+#
+# Test ifelse()
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+    nova_edition::
+      host_licenses_paid => "5";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "results" slist => { 1, "single string parameter",
+                           "hardclass OK", "bundle class OK",
+                           "5 parameters OK"
+     };
+
+  files:
+      "$(G.testfile).expected"
+      create => "true",
+      edit_defaults => empty,
+      edit_line => init_insert;
+}
+
+body edit_defaults empty
+{
+      empty_file_before_editing => "true";
+      edit_backup => "false";
+}
+
+bundle edit_line init_insert
+{
+  insert_lines:
+      "$(init.results)";
+}
+
+#######################################################
+
+bundle agent test
+{
+  classes:
+      "myclass" expression => "any";
+      "myclass2" expression => "any";
+      "secondpass" expression => "any";
+  vars:
+    secondpass::
+      "vals" slist => {
+                        ifelse(1),
+                        ifelse("single string parameter"),
+                        ifelse("cfengine", "hardclass OK", "hardclass broken"),
+                        ifelse("myclass.myclass2", "bundle class OK", "bundle class broken"),
+                        ifelse("this is not true", "5 parameters broken",
+                               "this is also not true", "5 parameters broken 2",
+                               "5 parameters OK"),
+      };
+
+  files:
+      "$(G.testfile).actual"
+      create => "true",
+      edit_defaults => empty,
+      edit_line => test_insert;
+}
+
+bundle edit_line test_insert
+{
+  insert_lines:
+      "$(test.vals)";
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => sorted_check_diff("$(G.testfile).actual",
+                                           "$(G.testfile).expected",
+                                           "$(this.promise_filename)");
+}


### PR DESCRIPTION
Proposed example usage (note that any odd number of arguments are allowed, similar to the Oracle DECODE() function for instance):

```
body common control
{
      bundlesequence => { run };
}

bundle agent run
{
  vars:
      "a" string => concat(
                            # ifelse(), # fatal error
                            # ifelse("x", "y"), # fatal error
                            ifelse("any.cfengine", "1", "0"),
                            ifelse(3),
                            ifelse("!any", 2, 3),
                            ifelse("undefined.any", 5, "missing||!cfengine", 6, 7)
      );

  reports:
      "a = $(a)";
}
```

Output:

```
R: a = 1337
```

If this is OK syntax-wise I will write acceptance tests.
