### PR TITLE
Store proper PID in locks database by forking before taking a lock

### DIFF
--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -466,6 +466,28 @@ void StartServer(EvalContext *ctx, Policy *policy, GenericAgentConfig *config, E
     }
     assert(pp);
 
+#ifdef __MINGW32__
+
+    if (!NO_FORK)
+    {
+        CfOut(OUTPUT_LEVEL_VERBOSE, "", "Windows does not support starting processes in the background - starting in foreground");
+    }
+
+#else /* !__MINGW32__ */
+
+    if ((!NO_FORK) && (fork() != 0))
+    {
+        CfOut(OUTPUT_LEVEL_INFORM, "", "cf-execd starting %.24s\n", cf_ctime(&now));
+        _exit(0);
+    }
+
+    if (!NO_FORK)
+    {
+        ActAsDaemon(0);
+    }
+
+#endif /* !__MINGW32__ */
+
     Attributes dummyattr;
     CfLock thislock;
 
@@ -507,28 +529,6 @@ void StartServer(EvalContext *ctx, Policy *policy, GenericAgentConfig *config, E
         strcpy(CFLAST, thislock.last ? thislock.last : "");
         strcpy(CFLOG, thislock.log ? thislock.log : "");
     }
-
-#ifdef __MINGW32__
-
-    if (!NO_FORK)
-    {
-        CfOut(OUTPUT_LEVEL_VERBOSE, "", "Windows does not support starting processes in the background - starting in foreground");
-    }
-
-#else /* !__MINGW32__ */
-
-    if ((!NO_FORK) && (fork() != 0))
-    {
-        CfOut(OUTPUT_LEVEL_INFORM, "", "cf-execd starting %.24s\n", cf_ctime(&now));
-        _exit(0);
-    }
-
-    if (!NO_FORK)
-    {
-        ActAsDaemon(0);
-    }
-
-#endif /* !__MINGW32__ */
 
     WritePID("cf-execd.pid");
     signal(SIGINT, HandleSignalsForDaemon);

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -284,14 +284,6 @@ void StartServer(EvalContext *ctx, Policy *policy, GenericAgentConfig *config, c
     }
     assert(pp);
 
-    thislock = AcquireLock(pp->promiser, VUQNAME, CFSTARTTIME, dummyattr, pp, false);
-
-    if (thislock.lock == NULL)
-    {
-        PolicyDestroy(server_cfengine_policy);
-        return;
-    }
-
     CfOut(OUTPUT_LEVEL_INFORM, "", "cf-serverd starting %.24s\n", cf_ctime(&starttime));
 
     if (sd != -1)
@@ -319,6 +311,14 @@ void StartServer(EvalContext *ctx, Policy *policy, GenericAgentConfig *config, c
     }
 
 #endif /* !__MINGW32__ */
+
+    thislock = AcquireLock(pp->promiser, VUQNAME, CFSTARTTIME, dummyattr, pp, false);
+
+    if (thislock.lock == NULL)
+    {
+        PolicyDestroy(server_cfengine_policy);
+        return;
+    }
 
     WritePID("cf-serverd.pid");
 


### PR DESCRIPTION
Please test extensively. Not even compile-tested (don't have an environment to compile it ATM).
