### PR TITLE
Add GetInterfaceFlags() to get NIC flags

### DIFF
--- a/docs/reference/vars/sys_interface_flags[interface_name].texinfo
+++ b/docs/reference/vars/sys_interface_flags[interface_name].texinfo
@@ -1,0 +1,31 @@
+
+@i{History}: Was introduced in XXXX, Nova XXXX (2013)
+
+Contains a space separated list of the flags of the named interface. e.g.
+
+@verbatim
+
+  reports:
+
+    cfengine::
+
+    "eth0 flags: $(sys.interface_flags[eth0])";
+@end verbatim
+
+@verbatim
+
+R: eth0 flags: up broadcast running multicast
+@end verbatim
+
+The following device flags are supported: 
+-up
+-broadcast
+-debug
+-loopback
+-pointopoint
+-notrailers
+-running
+-noarp
+-promisc
+-allmulti
+-multicast

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -437,6 +437,49 @@ static void GetMacAddress(EvalContext *ctx, AgentType ag, int fd, struct ifreq *
 
 /******************************************************************/
 
+void GetInterfaceFlags(EvalContext *ctx, AgentType ag, struct ifreq *ifr, Rlist **flags)
+{
+    char name[CF_MAXVARSIZE];
+    char buffer[CF_BUFSIZE] = "";
+    char *fp = NULL;
+
+    if (ag != AGENT_TYPE_GENDOC)
+    {
+        snprintf(name, CF_MAXVARSIZE, "interface_flags[%s]", ifr->ifr_name);
+    }
+    else
+    {
+        snprintf(name, CF_MAXVARSIZE, "interface_flags[interface_name]");
+    }
+
+    if (ifr->ifr_flags & IFF_UP) strcat(buffer, " up");
+    if (ifr->ifr_flags & IFF_BROADCAST) strcat(buffer, " broadcast");
+    if (ifr->ifr_flags & IFF_DEBUG) strcat(buffer, " debug");
+    if (ifr->ifr_flags & IFF_LOOPBACK) strcat(buffer, " loopback");
+    if (ifr->ifr_flags & IFF_POINTOPOINT) strcat(buffer, " pointopoint");
+
+#ifdef IFF_NOTRAILERS
+    if (ifr->ifr_flags & IFF_NOTRAILERS) strcat(buffer, " notrailers");
+#endif
+
+    if (ifr->ifr_flags & IFF_RUNNING) strcat(buffer, " running");
+    if (ifr->ifr_flags & IFF_NOARP) strcat(buffer, " noarp");
+    if (ifr->ifr_flags & IFF_PROMISC) strcat(buffer, " promisc");
+    if (ifr->ifr_flags & IFF_ALLMULTI) strcat(buffer, " allmulti");
+    if (ifr->ifr_flags & IFF_MULTICAST) strcat(buffer, " multicast");
+
+    // If a least 1 flag is found
+    if (strlen(buffer) > 1)
+    {
+      // Skip leading space
+      fp = buffer + 1;
+      ScopeNewSpecialScalar(ctx, "sys", name, fp, DATA_TYPE_STRING);
+      RlistAppend(flags, fp, RVAL_TYPE_SCALAR);
+    }
+}
+
+/******************************************************************/
+
 void GetInterfacesInfo(EvalContext *ctx, AgentType ag)
 {
     int fd, len, i, j, first_address = false, ipdefault = false;
@@ -448,7 +491,7 @@ void GetInterfacesInfo(EvalContext *ctx, AgentType ag)
     char ip[CF_MAXVARSIZE];
     char name[CF_MAXVARSIZE];
     char last_name[CF_BUFSIZE];
-    Rlist *interfaces = NULL, *hardware = NULL, *ips = NULL;
+    Rlist *interfaces = NULL, *hardware = NULL, *flags = NULL, *ips = NULL;
 
     CfDebug("GetInterfacesInfo()\n");
 
@@ -550,6 +593,10 @@ void GetInterfacesInfo(EvalContext *ctx, AgentType ag)
             {
                 CfOut(OUTPUT_LEVEL_ERROR, "ioctl", "No such network device");
                 continue;
+            }
+            else
+            {
+              GetInterfaceFlags(ctx, ag, &ifr, &flags);
             }
 
             if ((ifr.ifr_flags & IFF_UP) && (!(ifr.ifr_flags & IFF_LOOPBACK)))
@@ -691,10 +738,12 @@ void GetInterfacesInfo(EvalContext *ctx, AgentType ag)
 
     ScopeNewSpecialList(ctx, "sys", "interfaces", interfaces, DATA_TYPE_STRING_LIST);
     ScopeNewSpecialList(ctx, "sys", "hardware_addresses", hardware, DATA_TYPE_STRING_LIST);
+    ScopeNewSpecialList(ctx, "sys", "hardware_flags", flags, DATA_TYPE_STRING_LIST);
     ScopeNewSpecialList(ctx, "sys", "ip_addresses", ips, DATA_TYPE_STRING_LIST);
 
     RlistDestroy(interfaces);
     RlistDestroy(hardware);
+    RlistDestroy(flags);
     RlistDestroy(ips);
 
     FindV6InterfacesInfo(ctx);

--- a/libpromises/unix.h
+++ b/libpromises/unix.h
@@ -31,6 +31,7 @@
 #include "assoc.h"
 
 void GetInterfacesInfo(EvalContext *ctx, AgentType ag);
+void GetInterfaceFlags(EvalContext *ctx, AgentType ag, struct ifreq *ifr, Rlist **hw_flags);
 void ProcessSignalTerminate(pid_t pid);
 
 #endif


### PR DESCRIPTION
Here is my first try to get interfaces flag in sys.interface_flags[device]

Tried with the following bundle:

```
body common control {
  bundlesequence => { "foo" };
  inputs  =>  { "cfengine_stdlib.cf" };
}

bundle agent foo {

  vars:
    "if"          slist   =>  { "@(sys.interfaces)"};

  reports:
    "interface: $(if) flags: $(sys.interface_flags[$(if)])";
}
```

Tested on a CentOS 6.4:

```
# ip link show|grep "^[0-9]"
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 16436 qdisc noqueue state UNKNOWN 
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
3: eth1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
4: eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
5: eth3: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
```

Adding IPs to get them found by CFEngine:

```
# ip addr add 10.0.1.1 dev eth1
# ip addr add 10.0.2.1 dev eth2
# ip addr add 10.0.3.1 dev eth3
```

Changing some flags:

```
# ip link  set eth1 arp off
# ip link  set eth2 multicast off
# ip link  set eth3 promisc on
# ip link show|grep "^[0-9]"
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 16436 qdisc noqueue state UNKNOWN 
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
3: eth1: <BROADCAST,MULTICAST,NOARP> mtu 1500 qdisc noop state DOWN qlen 1000
4: eth2: <BROADCAST> mtu 1500 qdisc noop state DOWN qlen 1000
5: eth3: <BROADCAST,MULTICAST,PROMISC> mtu 1500 qdisc noop state DOWN qlen 1000
```

Running the bundle:

```
# ./cf-agent/cf-agent -KIf ~/.cfagent/inputs/test.cf 
Running full policy integrity checks
R: interface: eth0 flags: up_broadcast_running_multicast
R: interface: eth1 flags: broadcast_noarp_multicast
R: interface: eth2 flags: broadcast
R: interface: eth3 flags: broadcast_promisc_multicast
```

Feedback is welcome :) (can't test on FreeBSD right now, because of a bug I've just found while testing this feature)
