### PR TITLE
Adding getifaddrs() fallback to collect MAC addresses on BSD systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -400,6 +400,9 @@ AC_CHECK_HEADERS(sys/mount.h, [], [], [AC_INCLUDES_DEFAULT
 #endif
 ])
 
+# Required on BSD to get struct sockaddr_dl (for retrieving MAC addresses from getifaddrs())
+AC_CHECK_HEADERS(net/if_dl.h)
+
 AC_CHECK_HEADERS(utime.h)
 AC_CHECK_HEADERS(time.h)
 AC_CHECK_HEADERS(sys/time.h)
@@ -639,6 +642,8 @@ AC_CHECK_FUNCS(socket)
 AC_CHECK_FUNCS(setsockopt)
 AC_CHECK_FUNCS(getaddrinfo)
 AC_CHECK_FUNCS(gethostent)
+
+AC_CHECK_FUNCS(getifaddrs)
 
 AC_CHECK_FUNC(lchown, AC_DEFINE(HAVE_LCHOWN, 1, [Whether to use lchown(3) to change ownerships]))
 


### PR DESCRIPTION
Hello,

I have found that MAC addresses were not detected on FreeBSD, only "mac_unknown" class is reported by cf-promises:

```
# cf-promises -v | hcgrep mac_
mac_unknown
```

Similar behavior happens on OpenBSD and NetBSD.

It's because these systems lack the SIOCGIFHWADDR ioctl, used by GetMacAddress().

Hopefully, getifaddrs() can help (and is available on Linux too), so I wrote support for a getifaddrs() fallback, in case of missing SIOCGIFHWADDR ioctl.

My tests were done on FreeBSD-8.2/9.0, checks for OpenBSD-5.2 and NetBSD-6.0.1 are in progress, but before I would like to have your opinion on this fallback.
