### PR TITLE
Change mode for cron files to 600

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -701,7 +701,7 @@ files:
     comment => "A user's regular batch jobs are added to this file",
      create => "true",
   edit_line => append_if_no_line("$(mins) $(hours) * * * $(commands)"),
-      perms => mo("644","$(user)"),
+      perms => mo("600","$(user)"),
     classes => if_repaired("changed_crontab");
 
 processes:


### PR DESCRIPTION
Hi,
I edited the cfengine_stdlib.cf about the permissions on cronjobs.

Use 600 mode for crontab files in cronjob function to avoid this error on Ubuntu:
" (root) INSECURE MODE (mode 0600 expected) (crontabs/root)"

Using another mode than 600 makes the crontab to be ignored.

Regards

Remi Debay
