### PR TITLE
Add support for new and old openssl API

### DIFF
--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -257,7 +257,12 @@ static int RemoveKeys(const char *host)
 static void KeepKeyPromises(void)
 {
     unsigned long err;
+#ifdef OPENSSL_NO_DEPRECATED
+    RSA *pair = RSA_new();
+    BIGNUM *rsa_bignum = BN_new();
+#else
     RSA *pair;
+#endif
     FILE *fp;
     struct stat statbuf;
     int fd;
@@ -283,9 +288,15 @@ static void KeepKeyPromises(void)
 
     printf("Making a key pair for cfengine, please wait, this could take a minute...\n");
 
+#ifdef OPENSSL_NO_DEPRECATED
+    BN_set_word(rsa_bignum, 35);
+
+    if (!RSA_generate_key_ex(pair, 2048, rsa_bignum, NULL))
+#else
     pair = RSA_generate_key(2048, 35, NULL, NULL);
 
     if (pair == NULL)
+#endif
     {
         err = ERR_get_error();
         CfOut(cf_error, "", "Unable to generate key: %s\n", ERR_reason_error_string(err));

--- a/configure.ac
+++ b/configure.ac
@@ -286,7 +286,8 @@ if test x"$with_openssl" = xno ; then
 fi
 
 CF3_WITH_LIBRARY(openssl, [
-   AC_CHECK_LIB(crypto, RSA_generate_key, [], [AC_MSG_ERROR(Cannot find OpenSSL)])
+   AC_CHECK_LIB(crypto, RSA_generate_key_ex, [], [])
+   AC_CHECK_LIB(crypto, RSA_generate_key, [], [])
    AC_CHECK_HEADERS([openssl/opensslv.h], [], [AC_MSG_ERROR(Cannot find OpenSSL)])
 
    AC_MSG_CHECKING(for OpenSSL version)
@@ -298,6 +299,15 @@ CF3_WITH_LIBRARY(openssl, [
    #This OpenSSL is too old
    #endif
    ]])],[AC_MSG_RESULT(OK)],[AC_MSG_ERROR(This release of CFEngine requires OpenSSL >= 0.9.7)])
+
+   if test "x$ac_cv_lib_crypto_RSA_generate_key_ex" = "xyes" ; then
+      AC_DEFINE(OPENSSL_NO_DEPRECATED, 1, [Define if non deprecated API is available.])
+   fi
+
+   if test "x$ac_cv_lib_crypto_RSA_generate_key_ex" = "xno" && \
+      test "x$ac_cv_lib_crypto_RSA_generate_key" = "xno" ; then
+      AC_MSG_ERROR(Cannot find OpenSSL)
+   fi
 ])
 
 dnl PCRE


### PR DESCRIPTION
RSA_generate_key is marked as deprecated and as been remplaced by
RSA_generate_key_ex.
Some distributors, like Android, do not support deprecated openssl.
This patch add support for RSA_generate_key_ex. If both are available,
RSA_generate_key_ex (newer) is chosen.
