### PR TITLE
Avoid invalidating package cache when only verifying

### DIFF
--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -1801,8 +1801,11 @@ static int ExecuteSchedule(EvalContext *ctx, PackageManager *schedule, PackageAc
         free(command_string);
     }
 
-/* We have performed some operation on packages, our cache is invalid */
-    InvalidateSoftwareCache();
+/* We have performed some modification operation on packages, our cache is invalid */
+    if (!verify)
+    {
+        InvalidateSoftwareCache();
+    }
 
     return retval;
 }


### PR DESCRIPTION
For most cases, package_policy => verify shouldn't be expected to invalidate CFEngine's package cache.

May need a per-package-method flag, as some package managers might
conceivably add or remove packages as part of a verify operation.

https://cfengine.com/dev/issues/2276
