### PR TITLE
A defensive method for reducing the damage created by an incoherent TCDB 

### DIFF
--- a/libpromises/dbm_tokyocab.c
+++ b/libpromises/dbm_tokyocab.c
@@ -270,6 +270,16 @@ DBCursorPriv *DBPrivOpenCursor(DBPriv *db)
         return false;
     }
 
+    /*
+     * Be more defensive when it comes to Tokyo Cabinet.
+     * Ensure that the k/v store is optimized whenever a cursor is opened.
+     */
+    if (!tchdboptimize(db->hdb, -1, -1, -1, false))
+    {
+        CfOut(OUTPUT_LEVEL_ERROR, "", "!! tchdboptimize failed: %s",
+              ErrorMessage(db->hdb));
+    }
+
     DBCursorPriv *cursor = xcalloc(1, sizeof(DBCursorPriv));
     cursor->db = db;
 


### PR DESCRIPTION
Tokyo Cabinet has some serious design faults when it comes to handling the way updates of records are stored to the hard disk. This generally ends with a partially "incoherent" TCDB file.

Hopefully, TC provides an API call for "optimizing" and fixing these incoherences.

Because the cost for running this call could be high for general performance, we restrict its usage to every action of opening a new cursor.

A more conservative approach would be to call this optimization call each time we open a database or make a delete/write call.
