### PR TITLE
Fix restarting of standard_services with invalid class characters

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -2991,7 +2991,7 @@ processes:
    "$(startcommand[$(service)])" -> { "@(stakeholders[$(service)])" },
 
             comment => "Execute command to restart the $(service) service",
-         ifvarclass => "restart_$(service)";
+         ifvarclass => canonify("restart_$(service)");
 }
 
 


### PR DESCRIPTION
Closes https://cfengine.com/dev/issues/2404
