### PR TITLE
Fix double free on current_line. RM #2418

### DIFF
--- a/libpromises/parser.c
+++ b/libpromises/parser.c
@@ -38,6 +38,7 @@ static void ParserStateReset(ParserState *p)
     p->policy = NULL;
 
     free(p->current_line);
+    p->current_line = NULL;
     p->line_no = 1;
     p->line_pos = 1;
     p->list_nesting = 0;


### PR DESCRIPTION
Fixes segfault from double free on P->current_line.
