### PR TITLE
Add scope attribute to classes promise. RM #1941 

### DIFF
--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -977,13 +977,18 @@ ContextConstraint GetContextConstraints(const EvalContext *ctx, const Promise *p
     a.expression = NULL;
     a.persistent = PromiseGetConstraintAsInt(ctx, "persistence", pp);
 
+    {
+        const char *context_scope = ConstraintGetRvalValue(ctx, "scope", pp, RVAL_TYPE_SCALAR);
+        a.scope = ContextScopeFromString(context_scope);
+    }
+
     for (size_t i = 0; i < SeqLength(pp->conlist); i++)
     {
         Constraint *cp = SeqAt(pp->conlist, i);
 
         for (int k = 0; CF_CLASSBODY[k].lval != NULL; k++)
         {
-            if (strcmp(cp->lval, "persistence") == 0)
+            if (strcmp(cp->lval, "persistence") == 0 || strcmp(cp->lval, "scope") == 0)
             {
                 continue;
             }

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1342,6 +1342,7 @@ typedef struct
 typedef struct
 {
     Constraint *expression;
+    ContextScope scope;
     int nconstraints;
     int persistent;
 } ContextConstraint;

--- a/libpromises/env_context.c
+++ b/libpromises/env_context.c
@@ -433,6 +433,11 @@ void KeepClassContextPromise(EvalContext *ctx, Promise *pp)
                     EvalContextHeapPersistentSave(pp->promiser, PromiseGetNamespace(pp), a.context.persistent, CONTEXT_STATE_POLICY_RESET);
                     EvalContextHeapAddSoft(ctx, pp->promiser, PromiseGetNamespace(pp));
                 }
+                else if (a.context.scope == CONTEXT_SCOPE_BUNDLE)
+                {
+                    CfOut(OUTPUT_LEVEL_VERBOSE, "", " ?> defining explicit local bundle class %s\n", pp->promiser);
+                    EvalContextStackFrameAddSoft(ctx, pp->promiser);
+                }
                 else
                 {
                     CfOut(OUTPUT_LEVEL_VERBOSE, "", " ?> defining explicit global class %s\n", pp->promiser);
@@ -467,6 +472,11 @@ void KeepClassContextPromise(EvalContext *ctx, Promise *pp)
                     CfOut(OUTPUT_LEVEL_VERBOSE, "",
                           " ?> Warning: persistent classes are global in scope even in agent bundles\n");
                     EvalContextHeapPersistentSave(pp->promiser, PromiseGetNamespace(pp), a.context.persistent, CONTEXT_STATE_POLICY_RESET);
+                    EvalContextHeapAddSoft(ctx, pp->promiser, PromiseGetNamespace(pp));
+                }
+                else if (a.context.scope == CONTEXT_SCOPE_NAMESPACE)
+                {
+                    CfOut(OUTPUT_LEVEL_VERBOSE, "", " ?> defining explicit global class %s\n", pp->promiser);
                     EvalContextHeapAddSoft(ctx, pp->promiser, PromiseGetNamespace(pp));
                 }
                 else

--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -124,6 +124,7 @@ const BodySyntax CF_DEFAULTSBODY[] =
 
 const BodySyntax CF_CLASSBODY[] =
 {
+    {"scope", DATA_TYPE_OPTION, "namespace,bundle", "Scope of the class set by this promise" },
     {"and", DATA_TYPE_CONTEXT_LIST, CF_CLASSRANGE, "Combine class sources with AND"},
     {"dist", DATA_TYPE_REAL_LIST, CF_REALRANGE, "Generate a probabilistic class distribution (from strategies in cfengine 2)"},
     {"expression", DATA_TYPE_CONTEXT, CF_CLASSRANGE, "Evaluate string expression of classes in normal form"},

--- a/tests/acceptance/02_classes/01_basic/agent_class_scope.cf
+++ b/tests/acceptance/02_classes/01_basic/agent_class_scope.cf
@@ -1,0 +1,47 @@
+#######################################################
+#
+# Check that we can use scope attributes to promise global classes
+# from agent bundles
+#
+#######################################################
+
+body common control {
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+nova_edition::
+  host_licenses_paid => "5";
+}
+
+bundle agent init {
+vars:
+        "classes" slist => { "global_c", "local_c", "unglobal_c", "unlocal_c" };
+}
+
+bundle agent test {
+classes:
+        "global_c" expression => "any", scope => "namespace";
+        "unglobal_c" expression => "!any", scope => "namespace";
+        "local_c" expression => "any";
+        "unlocal_c" expression => "!any";
+reports:
+    DEBUG::
+        "$(init.classes) defined from test" ifvarclass => "${init.classes}";
+        "$(init.classes) not defined from test" ifvarclass => "!${init.classes}";
+}
+
+bundle agent check {
+classes:
+        global_c.!local_c.!unglobal_c.!unlocal_c::
+            "ok" expression => "any";
+
+reports:
+    DEBUG::
+        "$(init.classes) defined from check" ifvarclass => "${init.classes}";
+        "$(init.classes) not defined from check" ifvarclass => "!${init.classes}";
+
+    ok::
+        "${this.promise_filename} Pass";
+    !ok::
+        "${this.promise_filename} FAIL";
+}

--- a/tests/acceptance/02_classes/01_basic/common_class_scope.cf
+++ b/tests/acceptance/02_classes/01_basic/common_class_scope.cf
@@ -1,0 +1,47 @@
+#######################################################
+#
+# Check that we can use scope attributes to promise global classes
+# from common bundles
+#
+#######################################################
+
+body common control {
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+nova_edition::
+  host_licenses_paid => "5";
+}
+
+bundle agent init {
+vars:
+        "classes" slist => { "global_c", "local_c", "unglobal_c", "unlocal_c" };
+}
+
+bundle common test {
+classes:
+        "global_c" expression => "any";
+        "unglobal_c" expression => "!any";
+        "local_c" expression => "any", scope => "bundle";
+        "unlocal_c" expression => "!any", scope => "bundle";
+reports:
+    DEBUG::
+        "$(init.classes) defined from test" ifvarclass => "${init.classes}";
+        "$(init.classes) not defined from test" ifvarclass => "!${init.classes}";
+}
+
+bundle agent check {
+classes:
+        global_c.!local_c.!unglobal_c.!unlocal_c::
+            "ok" expression => "any";
+
+reports:
+    DEBUG::
+        "$(init.classes) defined from check" ifvarclass => "${init.classes}";
+        "$(init.classes) not defined from check" ifvarclass => "!${init.classes}";
+
+    ok::
+        "${this.promise_filename} Pass";
+    !ok::
+        "${this.promise_filename} FAIL";
+}


### PR DESCRIPTION
By setting scope => namespace, it's now possible to define a global class directly
from an agent bundle.

See discussion in RM #1941.
