### PR TITLE
rewrote promise_type logic

### DIFF
--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -210,17 +210,25 @@ promise_type   [a-zA-Z_]+:
                       }
 
 {class}               {
-                          P.line_pos += strlen(yytext);
+                          char *tmp = NULL;
+                        
+                          tmp = xmalloc(yyleng + 1);
+
+                          P.line_pos += yyleng;
                           ParserDebug("\tL:class %s %d\n", yytext, P.line_pos);
+
+                          tmp = xstrdup(yytext);
+                          tmp[yyleng-2] = '\0';
 
                           if (P.currentclasses != NULL)
                           {
                               free(P.currentclasses);
                           }
 
-                          yytext[strlen(yytext)-2] = '\0';
-                          ValidateClassSyntax(yytext);
-                          P.currentclasses = xstrdup(yytext);
+                          ValidateClassSyntax(tmp);
+                          P.currentclasses = xstrdup(tmp);
+
+                          free(tmp);
                           return CLASS;
                       }
 

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -293,8 +293,8 @@ statements:            /* empty */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-statement:             promise_type
-                     | classpromises;
+statement:             promise_type 
+                     | promise_type classpromises
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -412,7 +412,7 @@ classpromises:         classpromise                     /* BUNDLE ONLY */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 classpromise:          class
-                     | promises;
+                     | promises
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -446,7 +446,12 @@ promise_type:          PROMISE_TYPE             /* BUNDLE ONLY */
                                    P.currentstype = NULL;
                                }
                            }
-                       };
+                       }
+                     | error 
+                       {
+                          yyclearin;
+                          ParseError("Expected promise type, got:%s", yytext);
+                       }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/tests/unit/data/bundle_body_wrong_promise_type_token.cf
+++ b/tests/unit/data/bundle_body_wrong_promise_type_token.cf
@@ -1,0 +1,4 @@
+bundle agent foo
+{
+
+invalid::

--- a/tests/unit/parser_test.c
+++ b/tests/unit/parser_test.c
@@ -57,6 +57,11 @@ void test_bundle_invalid_promise_type(void **state)
     assert_true(LoadPolicy("bundle_invalid_promise_type.cf"));
 }
 
+void test_bundle_body_wrong_promise_type_token(void **state)
+{
+    assert_false(LoadPolicy("bundle_body_wrong_promise_type_token.cf"));
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -71,6 +76,7 @@ int main()
         unit_test(test_body_invalid_type),
         unit_test(test_constraint_ifvarclass_invalid),
         unit_test(test_bundle_invalid_promise_type),
+        unit_test(test_bundle_body_wrong_promise_type_token),
     };
 
     return run_tests(tests);


### PR DESCRIPTION
reduce the shift/reduce error by 3 and is now logical correct + unit test for promise type unknown token
