### PR TITLE
Fix cscope target

### DIFF
--- a/cf-monitord/Makefile.am
+++ b/cf-monitord/Makefile.am
@@ -31,7 +31,7 @@ cf_monitord_SOURCES = \
 
 if !HAVE_NOVA
 cf_monitord_SOURCES += \
-	cf-monitord-enterprise-stubs.c cf-monitord-enterpsise-stubs.h
+	cf-monitord-enterprise-stubs.c cf-monitord-enterprise-stubs.h
 endif
 
 CLEANFILES = *.gcno *.gcda

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -120,10 +120,10 @@ if HAVE_AVAHI_COMMON
 findhub_test_SOURCES = findhub_test.c ../../cf-agent/findhub.c ../../cf-agent/load_avahi.c
 
 if HAVE_NOVA
-avahi_config_test_SOURCES = avahi_config_test.c ../../cf-serverd/server.c ../../cf-serverd/enterprise_stubs_serverd.c ../../cf-serverd/server_transform.c
+avahi_config_test_SOURCES = avahi_config_test.c ../../cf-serverd/server.c ../../cf-serverd/cf-serverd-enterprise-stubs.c ../../cf-serverd/server_transform.c
 avahi_config_test_LDADD = libtest.la ../../nova/libcfserverd/libcfserverd.la
 else
-avahi_config_test_SOURCES = avahi_config_test.c ../../cf-serverd/server.c ../../cf-serverd/enterprise_stubs_serverd.c ../../cf-serverd/server_transform.c
+avahi_config_test_SOURCES = avahi_config_test.c ../../cf-serverd/server.c ../../cf-serverd/cf-serverd-enterprise-stubs.c ../../cf-serverd/server_transform.c
 avahi_config_test_LDADD = ../../libpromises/libpromises.la libtest.la
 endif
 


### PR DESCRIPTION
At the moment, the cscope target fails to build:

```
$ make cscope
Making cscopelist in libcompat
Making cscopelist in libutils
Making cscopelist in libpromises
Making cscopelist in cf-agent
Making cscopelist in cf-execd
Making cscopelist in cf-gendoc
Making cscopelist in cf-key
Making cscopelist in cf-monitord
make[1]: *** No rule to make target `cf-monitord-enterpsise-stubs.h', needed by `cscopelist-am'.  Stop.
make: *** [cscopelist-recursive] Error 1
```
