### PR TITLE
Added check if promiser/promisee contraints forgot a ',' 

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -272,7 +272,7 @@ bundlebody:            body_begin
                                P.currentbundle->offset.end = P.offsets.current;
                            }
                            CfDebug("End promise bundle\n\n");
-                       };
+                       }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -368,12 +368,14 @@ promise_line:          promise ';'
 
 promise:               promisee
                      | promiser_statement
+                     /*
                      | promiser error
                        {
                           yyclearin;
                           INSTALL_SKIP=true;
                           ParseError("Expected ';' or promise attribute, got:%s", yytext);
                        }
+                     */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -434,12 +436,13 @@ promiser_statement:    promiser
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 promisee_constraints:  /* empty */
-                     | ',' constraints
+                     | ',' constraint_decl
+
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 promiser_constraints:  /* empty */
-                     | constraints
+                     | constraint_decl
                        {
                            CfDebug("End full promise with promisee %s\n\n",P.promiser);
 
@@ -460,7 +463,16 @@ promiser_constraints:  /* empty */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-constraints:           constraint               /* BUNDLE ONLY */
+constraint_decl:       constraints
+                     | constraints error
+                       {
+                          yyclearin;
+                          ParseError("Expected ',' check previous statement, got:%s", yytext);
+                       }
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+constraints:           constraint                           /* BUNDLE ONLY */
                      | constraints ',' constraint
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -509,7 +521,8 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
                            {
                                RvalDestroy(P.rval);
                            }
-                       };
+                       }
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 constraint_id:         IDSYNTAX                        /* BUNDLE ONLY */

--- a/tests/unit/data/bundle_body_promisee_forgot_colon.cf
+++ b/tests/unit/data/bundle_body_promisee_forgot_colon.cf
@@ -1,0 +1,11 @@
+bundle agent foo
+{
+
+vars:
+
+    debian::
+        "foo" -> "bar",
+            handle  => "foo"
+            comment => "test";
+}
+

--- a/tests/unit/data/bundle_body_promiser_forgot_colon.cf
+++ b/tests/unit/data/bundle_body_promiser_forgot_colon.cf
@@ -1,0 +1,10 @@
+bundle agent foo
+{
+
+vars:
+
+        "foo" string => "bar",
+            handle  => "foo"            
+            comment => "test";
+}
+

--- a/tests/unit/parser_test.c
+++ b/tests/unit/parser_test.c
@@ -95,6 +95,16 @@ void test_bundle_body_promiser_unknown_constraint_id(void **state)
     assert_true(LoadPolicy("bundle_body_promiser_unknown_constraint_id.cf"));
 }
 
+void test_bundle_body_promiser_forgot_colon(void **state)
+{
+    assert_false(LoadPolicy("bundle_body_promiser_forgot_colon.cf"));
+}
+
+void test_bundle_body_promisee_forgot_colon(void **state)
+{
+    assert_false(LoadPolicy("bundle_body_promisee_forgot_colon.cf"));
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -116,6 +126,8 @@ int main()
         unit_test(test_bundle_body_promiser_statement_missing_assign),
         unit_test(test_bundle_body_promise_missing_arrow),
         unit_test(test_bundle_body_promiser_unknown_constraint_id),
+        unit_test(test_bundle_body_promiser_forgot_colon),
+        unit_test(test_bundle_body_promisee_forgot_colon),
     };
 
     return run_tests(tests);


### PR DESCRIPTION
- 2 unit checks one for promisee contraints and for promiser contraints
