### PR TITLE
Rewrote bundle statement logic 

### DIFF
--- a/tests/unit/data/bundle_body_promiser_wrong_constraint_token.cf
+++ b/tests/unit/data/bundle_body_promiser_wrong_constraint_token.cf
@@ -1,0 +1,8 @@
+bundle agent foo
+{
+
+  vars:
+      "a" string  => "foo",
+          "comment" => "bar"; 
+
+}

--- a/tests/unit/parser_test.c
+++ b/tests/unit/parser_test.c
@@ -87,6 +87,11 @@ void test_bundle_body_promise_missing_arrow(void **state)
     assert_false(LoadPolicy("bundle_body_promise_missing_arrow.cf"));
 }
 
+void test_bundle_body_promiser_wrong_constraint_token(void **state)
+{
+    assert_false(LoadPolicy("bundle_body_promiser_wrong_constraint_token.cf"));
+}
+
 void test_bundle_body_promiser_unknown_constraint_id(void **state)
 {
     /* 
@@ -148,6 +153,7 @@ int main()
         unit_test(test_bundle_body_promiser_statement_missing_assign),
         unit_test(test_bundle_body_promise_missing_arrow),
         unit_test(test_bundle_body_promiser_unknown_constraint_id),
+        unit_test(test_bundle_body_promiser_wrong_constraint_token),
         unit_test(test_bundle_body_promiser_forgot_colon),
         unit_test(test_bundle_body_promisee_no_colon_allowed),
 


### PR DESCRIPTION
Reduce shift/reduce error by 1. we have now better error reporting for wrong bundle statement and added  constraint token test.
