### PR TITLE
Get rid of skewed 'efficiency' calculation.

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -211,12 +211,6 @@ static const char *HINTS[15] =
     NULL
 };
 
-#ifndef HAVE_NOVA
-void NoteEfficiency(ARG_UNUSED double e)
-{
-}
-#endif
-
 /*******************************************************************/
 
 int main(int argc, char *argv[])
@@ -644,22 +638,8 @@ static void ThisAgentInit(void)
 
 static void KeepPromises(EvalContext *ctx, Policy *policy, GenericAgentConfig *config)
 {
-    double efficiency, model;
-
     KeepControlPromises(ctx, policy);
     KeepPromiseBundles(ctx, policy, config);
-
-// TOPICS counts the number of currently defined promises
-// OCCUR counts the number of objects touched while verifying config
-
-    efficiency = 100.0 * CF_OCCUR / (double) (CF_OCCUR + CF_TOPICS);
-    model = 100.0 * (1.0 - CF_TOPICS / (double)(PR_KEPT + PR_NOTKEPT + PR_REPAIRED));
-    
-    NoteEfficiency(efficiency);
-
-    CfOut(OUTPUT_LEVEL_VERBOSE, "", " -> Checked %d objects with %d promises, i.e. model efficiency %.2lf%%", CF_OCCUR, CF_TOPICS, efficiency);
-    CfOut(OUTPUT_LEVEL_VERBOSE, "", " -> The %d declared promise patterns actually expanded into %d individual promises, i.e. declaration efficiency %.2lf%%", (int) CF_TOPICS, PR_KEPT + PR_NOTKEPT + PR_REPAIRED, model);
-
 }
 
 /*******************************************************************/
@@ -1228,11 +1208,6 @@ int ScheduleAgentOperations(EvalContext *ctx, Bundle *bp)
             for (size_t ppi = 0; ppi < SeqLength(sp->promises); ppi++)
             {
                 Promise *pp = SeqAt(sp->promises, ppi);
-
-                if (pass == 1)  // Count the number of promises modelled for efficiency
-                {
-                    CF_TOPICS++;
-                }
 
                 ExpandPromise(ctx, pp, KeepAgentPromise, NULL);
 

--- a/cf-agent/verify_environments.c
+++ b/cf-agent/verify_environments.c
@@ -134,8 +134,6 @@ void VerifyEnvironmentsPromise(EvalContext *ctx, Promise *pp)
             return;
         }
 
-        CF_OCCUR++;
-
         PromiseBanner(pp);
         ScopeNewSpecialScalar(ctx, "this", "promiser", pp->promiser, DATA_TYPE_STRING);
 

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -210,8 +210,6 @@ static void VerifyFilePromise(EvalContext *ctx, char *path, Promise *pp)
         return;
     }
 
-    CF_OCCUR++;
-
     LoadSetuid(a);
 
     if (lstat(path, &oslb) == -1)       /* Careful if the object is a link */

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -422,8 +422,6 @@ static bool PackageListInstalledFromCommand(EvalContext *ctx, PackageItem **inst
             return false;
         }
 
-        CF_OCCUR++;
-
         if (a.packages.package_multiline_start)
         {
             if (FullTextMatch(a.packages.package_multiline_start, buf))

--- a/cf-agent/verify_processes.c
+++ b/cf-agent/verify_processes.c
@@ -327,8 +327,6 @@ static int FindPidMatches(Item *procdata, Item **killlist, Attributes a, const c
 
     for (Item *ip = matched; ip != NULL; ip = ip->next)
     {
-        CF_OCCUR++;
-
         if (a.transaction.action == cfa_warn)
         {
             CfOut(OUTPUT_LEVEL_ERROR, "", " !! Matched: %s\n", ip->name);

--- a/cf-agent/verify_storage.c
+++ b/cf-agent/verify_storage.c
@@ -90,8 +90,6 @@ void VerifyStoragePromise(EvalContext *ctx, char *path, Promise *pp)
 
     a = GetStorageAttributes(ctx, pp);
 
-    CF_OCCUR++;
-
 #ifdef __MINGW32__
     if (!a.havemount)
     {

--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -89,8 +89,6 @@ extern int LICENSES;
 extern int AM_NOVA;
 extern char EXPIRY[CF_SMALLBUF];
 extern char LICENSE_COMPANY[CF_SMALLBUF];
-extern int CF_TOPICS;
-extern int CF_OCCUR;
 extern HashMethod CF_DEFAULT_DIGEST;
 extern int CF_DEFAULT_DIGEST_LEN;
 

--- a/libpromises/cf3globals.c
+++ b/libpromises/cf3globals.c
@@ -54,11 +54,6 @@ int AM_PHP_MODULE = false;
 char EXPIRY[CF_SMALLBUF] = { 0 };
 char LICENSE_COMPANY[CF_SMALLBUF] = { 0 };
 
-// These are used to measure graph complexity in know/agent
-
-int CF_TOPICS = 0;              // objects
-int CF_OCCUR = 0;               // objects
-
 Item *PROCESSTABLE = NULL;
 Item *ROTATED = NULL;
 Item *DONELIST = NULL;


### PR DESCRIPTION
In case similar metric is needed later, we can calculate it by
querying state of EvalContext and traversiong Policy, not by
counting it on-the-go.
