### PR TITLE
cf-execd use : as class separator when launching cf-agent, it should use...

### DIFF
--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -107,7 +107,7 @@ static void ConstructFailsafeCommand(bool scheduled_run, char *buffer)
              "\"%s/%s\" -f failsafe.cf "
              "&& \"%s/%s\" -Dfrom_cfexecd%s",
              CFWORKDIR, twin_exists ? TwinFilename() : AgentFilename(),
-             CFWORKDIR, AgentFilename(), scheduled_run ? ":scheduled_run" : "");
+             CFWORKDIR, AgentFilename(), scheduled_run ? ",scheduled_run" : "");
 }
 
 #ifndef __MINGW32__


### PR DESCRIPTION
From cf-agent -h : 
--define      , -D value - Define a list of comma separated classes to be defined at the start of execution

The current behaviour defines "from_cfexecd_scheduled_run" as a class.
The new behaviour will define "from_cfexecd" and "scheduled_run" as classes.
