### PR TITLE
Functions can now accept list arguments + unit test

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -972,13 +972,33 @@ gaitem:                IDSYNTAX
                            P.currentstring = NULL;
                        }
 
+                     | list
+                       {
+                           ParserDebug("\tP:%s:%s:%s:%s function %s, list arg = %s\n", P.block, P.blocktype, P.blockid, P.currentclasses ? P.currentclasses : "any", P.currentfnid[P.arg_nesting], P.lval);
+
+                           printf("FIXME list arg adding fo function not yet implemented\n");
+
+/*
+                           if (RlistLen(P.currentRlist) == 0)
+                           {
+                               RlistAppendScalar(&P.currentRlist, CF_NULL_VALUE);
+                           }
+                           P.rval = (Rval) { RlistCopy(P.currentRlist), RVAL_TYPE_LIST };
+                           RlistAppendScalar(&P.giveargs[P.arg_nesting],P.currentstring);
+                           RlistDestroy(P.currentRlist);
+                           P.currentRlist = NULL;
+                           P.references_body = false;
+                           */
+
+                       }
+
                      | usefunction
                        {
                            /* Careful about recursion */
                            ParserDebug("\tP:%s:%s:%s:%s function %s, nakedvar arg = %s\n", P.block, P.blocktype, P.blockid, P.currentclasses ? P.currentclasses : "any", P.currentfnid[P.arg_nesting], P.currentstring);
                            RlistAppendFnCall(&P.giveargs[P.arg_nesting],(void *)P.currentfncall[P.arg_nesting+1]);
                            RvalDestroy((Rval) { P.currentfncall[P.arg_nesting+1], RVAL_TYPE_FNCALL });
-                       };
+                       }
 
 %%
 

--- a/tests/unit/data/function_arg_allow_list_variable.cf
+++ b/tests/unit/data/function_arg_allow_list_variable.cf
@@ -1,0 +1,13 @@
+bundle agent foo(one)
+{
+reports:
+  cfengine3::
+   "$(one)";
+}
+
+bundle agent bar
+{
+methods:
+  "any"
+    usebundle => foo( { "1", "2" } );
+}

--- a/tests/unit/parser_test.c
+++ b/tests/unit/parser_test.c
@@ -164,6 +164,11 @@ void test_body_body_forget_cb_bundle(void)
     assert_false(LoadPolicy("body_body_forget_cb_bundle.cf"));
 }
 
+void test_function_arg_allow_list_variable(void)
+{
+    assert_true(LoadPolicy("function_arg_allow_list_variable.cf"));
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -202,7 +207,9 @@ int main()
 
         unit_test(test_promise_promiser_nonscalar),
 
-        unit_test(test_constraint_ifvarclass_invalid)
+        unit_test(test_constraint_ifvarclass_invalid),
+
+        unit_test(test_function_arg_allow_list_variable)
     };
 
     return run_tests(tests);


### PR DESCRIPTION
The parser accepts it, but we need code to add a list to a function argument, See FIXME statement
For example:
- "any" usebundle => test( { "bas", "andre", "jaap" } );
