### PR TITLE
Fix for the weird HPUX linker

### DIFF
--- a/libpromises/dbm_quick.c
+++ b/libpromises/dbm_quick.c
@@ -34,6 +34,15 @@
 #include "logging.h"
 #include "string_lib.h"
 
+/*
+ * The HPUX linker is interesting. It does not find the symbol "DEBUG", which is
+ * declared in cf3globals.c. So we define it here protected by an ifdef.
+ * It is ugly and it does not look great, but it fixes the problem.
+ */
+#ifdef CF_DBTEST
+int DEBUG = false;
+#endif
+
 #ifdef QDB
 # include <depot.h>
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -18,6 +18,7 @@ libstr_la_LIBADD = libtest.la
 check_LTLIBRARIES += libdb.la
 libdb_la_SOURCES = ../../libpromises/dbm_api.c ../../libpromises/dbm_quick.c ../../libpromises/dbm_tokyocab.c ../../libpromises/dbm_migration.c ../../libpromises/dbm_migration_lastseen.c ../../libpromises/dbm_migration_bundles.c ../../libutils/atexit.c
 libdb_la_LIBADD = libstr.la
+libdb_la_CFLAGS = -DCF_DBTEST
 
 check_PROGRAMS = \
 	arg_split_test \


### PR DESCRIPTION
This patch is not nice but it fixes the problem.
The issue appears because the HPUX linker tries to find
the symbol "DEBUG" in the libdb.a library. This library is
a static library of the old school, with tables for each
object file that provides symbols.
On that table there is no definition for the symbol in question,
therefore at linking time the process will fail. This commit
conditionally adds the symbol, but only when compiling the
unit test.
