### PR TITLE
redefine StringMapSize

### DIFF
--- a/libutils/map.h
+++ b/libutils/map.h
@@ -110,7 +110,7 @@ void MapDestroy(Map *map);
     ValueType Prefix##MapGet(const Prefix##Map *map, const KeyType key); \
     bool Prefix##MapRemove(const Prefix##Map *map, const KeyType key);  \
     void Prefix##MapClear(Prefix##Map *map);                            \
-    size_t Prefix##MapSet(Prefix##Map *map);                            \
+    size_t Prefix##MapSize(const Prefix##Map *map);                            \
     void Prefix##MapDestroy(Prefix##Map *map);                          \
 
 #define TYPED_MAP_DEFINE(Prefix, KeyType, ValueType, hash_fn, equal_fn, \

--- a/tests/unit/map_test.c
+++ b/tests/unit/map_test.c
@@ -16,6 +16,7 @@ static unsigned int ConstHash(const void *key, unsigned int max)
 static void test_new_destroy(void)
 {
     Map *map = MapNew(NULL, NULL, NULL, NULL);
+    assert_int_equal(MapSize(map), 0);
     MapDestroy(map);
 }
 
@@ -26,10 +27,14 @@ static void test_insert(void)
     assert_false(StringMapHasKey(map, "one"));
     StringMapInsert(map, xstrdup("one"), xstrdup("first"));
     assert_true(StringMapHasKey(map, "one"));
+    assert_int_equal(StringMapSize(map), 1);
+    StringMapInsert(map, xstrdup("one"), xstrdup("duplicate"));
+    assert_int_equal(StringMapSize(map), 1);
 
     assert_false(StringMapHasKey(map, "two"));
     StringMapInsert(map, xstrdup("two"), xstrdup("second"));
     assert_true(StringMapHasKey(map, "two"));
+    assert_int_equal(StringMapSize(map), 2);
 
     assert_false(StringMapHasKey(map, "third"));
     StringMapInsert(map, xstrdup("third"), xstrdup("first"));
@@ -37,6 +42,7 @@ static void test_insert(void)
 
     StringMapInsert(map, xstrdup("third"), xstrdup("stuff"));
     assert_true(StringMapHasKey(map, "third"));
+    assert_int_equal(StringMapSize(map), 3);
 
     StringMapDestroy(map);
 }
@@ -133,6 +139,7 @@ static void test_iterate(void)
         assert_true(StringMapHasKey(map, s));
         free(s);
     }
+    size_t size = StringMapSize(map);
 
     MapIterator it = MapIteratorInit(map->impl);
     MapKeyValue *item = NULL;
@@ -148,6 +155,7 @@ static void test_iterate(void)
         count++;
     }
     assert_int_equal(count, 10000);
+    assert_int_equal(count, size);
     assert_int_equal(sum_len, 10000*9999/2);
 
     StringMapDestroy(map);


### PR DESCRIPTION
- fix a definition problem with StringMapSize
- add test cases for it
