### PR TITLE
Fix test to look masterfiles in ABS_TOP_SRCDIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,10 @@ AM_MAINTAINER_MODE([enable])
 
 AC_DEFINE(BUILD_YEAR, esyscmd([date +%Y | tr -d '\n']), "Software build year")
 
+AC_DEFINE_UNQUOTED(ABS_TOP_SRCDIR,
+"`cd -- "$srcdir"; pwd`",
+[Absolute path of source tree])
+
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
 AC_CONFIG_HEADERS([libutils/config.h])

--- a/tests/unit/generic_agent_test.c
+++ b/tests/unit/generic_agent_test.c
@@ -9,7 +9,8 @@ void test_load_masterfiles(void)
     EvalContext *ctx = EvalContextNew();
     GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_COMMON);
 
-    GenericAgentConfigSetInputFile(config, GetWorkDir(), "../../masterfiles/promises.cf");
+    GenericAgentConfigSetInputFile(config, NULL,
+                                   ABS_TOP_SRCDIR "/masterfiles/promises.cf");
 
     Policy *masterfiles = GenericAgentLoadPolicy(ctx, config);
     assert_true(masterfiles);


### PR DESCRIPTION
ABS_TOP_SRCDIR is now a compile time define as you suggested, although I'm not sure it's right to reveal the build path in the distributed binaries.
