### PR TITLE
Redmine#1193: Fix CheckIdentifierNotPurelyNumerical so it does not use IntFromString

### DIFF
--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -131,10 +131,13 @@ static bool CheckIdentifierNotPurelyNumerical(const char *identifier)
          *check != '\0' && check - identifier < CF_BUFSIZE;
          check++)
     {
-        if (!isdigit(*check)) return 1;
+        if (!isdigit(*check))
+        {
+            return false;
+        }
     }
 
-    return 0;
+    return true;
 }
 
 static bool VarsParseTreeCheck(const Promise *pp, Seq *errors)


### PR DESCRIPTION
Fixes https://cfengine.com/dev/issues/1193
