### PR TITLE
Add body control option wildcard_inputs that accepts input wildcards against $(sys.workdir)/inputs only.

### DIFF
--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -223,6 +223,7 @@ const ConstraintSyntax CFG_CONTROLBODY[] =
     ConstraintSyntaxNewBool("ignore_missing_bundles", "If any bundles in the bundlesequence do not exist, ignore and continue. Default value: false", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBool("ignore_missing_inputs", "If any input files do not exist, ignore and continue. Default value: false", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewStringList("inputs", ".*", "List of additional filenames to parse for promises", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewStringList("wildcard_inputs", ".*", "List of additional filenames to parse for promises.  Wildcards are accepted but the filenames must be non-absolute.", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("version", "", "Scalar version string for this configuration", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewInt("lastseenexpireafter", CF_VALRANGE, "Number of minutes after which last-seen entries are purged. Default value: one week", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("output_prefix", "", "The string prefix for standard output", SYNTAX_STATUS_NORMAL),


### PR DESCRIPTION
Usage example:

```
body common control
{
      bundlesequence => { run};
      inputs => {};
      wildcard_inputs => { "api*.cf", "/x*.cf" };
}

bundle agent run
{
  reports:
      "Hi!";
}
```

Issues:
- requires `inputs` to be given as well, see `InputFiles` function
- requires `<glob.h>` which is standard but may be missing on older systems, so an autoconf rule for it would be really nice
