### PR TITLE
Fixes Redmine #2553: different path for sys.crontab on redhat systems

### DIFF
--- a/src/sysinfo.c
+++ b/src/sysinfo.c
@@ -959,6 +959,10 @@ void OSClasses(void)
         {
             snprintf(vbuff, CF_BUFSIZE, "/var/spool/cron/tabs/%s", pw->pw_name);
         }
+        else if (IsDefinedClass("redhat", NULL))
+        {
+            snprintf(vbuff, CF_BUFSIZE, "/var/spool/cron/%s", pw->pw_name);
+        }
         else
         {
             snprintf(vbuff, CF_BUFSIZE, "/var/spool/cron/crontabs/%s", pw->pw_name);


### PR DESCRIPTION
This is a fix for https://cfengine.com/dev/issues/2553.
