### PR TITLE
Consistent use of CfReadLine

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -307,7 +307,7 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a, Promise *pp)
 
         for (;;)
         {
-            ssize_t res = CfReadLine(line, CF_BUFSIZE - 1, pfp);
+            ssize_t res = CfReadLine(line, CF_BUFSIZE, pfp);
 
             if (res == 0)
             {

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -2221,7 +2221,7 @@ int ExecPackageCommand(EvalContext *ctx, char *command, int verify, int setCmdCl
 
     for (;;)
     {
-        ssize_t res = CfReadLine(line, CF_BUFSIZE - 1, pfp);
+        ssize_t res = CfReadLine(line, CF_BUFSIZE, pfp);
 
         if (res == 0)
         {

--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -474,7 +474,7 @@ int LoadFileAsItemList(Item **liststart, const char *file, EditDefaults edits)
 
     for (;;)
     {
-        ssize_t res = CfReadLine(line, CF_BUFSIZE - 1, fp);
+        ssize_t res = CfReadLine(line, CF_BUFSIZE, fp);
         if (res == 0)
         {
             break;

--- a/tests/unit/files_interfaces_test.c
+++ b/tests/unit/files_interfaces_test.c
@@ -57,7 +57,7 @@ static void test_cfreadline_valid(void)
     fin = fopen(FILE_NAME, "r");
 
     //test with non-empty file and valid file pointer
-    read = CfReadLine(output, CF_BUFSIZE - 1, fin);
+    read = CfReadLine(output, CF_BUFSIZE, fin);
     assert_true(read > 0);
     assert_string_equal(output, FILE_LINE);
 
@@ -77,7 +77,7 @@ static void test_cfreadline_corrupted(void)
     fin = fopen(FILE_NAME, "r");
 
     //test with non-empty file and valid file pointer
-    read = CfReadLine(output, CF_BUFSIZE - 1, fin);
+    read = CfReadLine(output, CF_BUFSIZE, fin);
     assert_true(read > 0);
     assert_string_not_equal(output, FILE_LINE);
 


### PR DESCRIPTION
In CfReadLine(), fgets() already takes care of reading at most size-1 characters.
