### PR TITLE
Snprintf() improvments

### DIFF
--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -320,11 +320,11 @@ static void GetMacAddress(EvalContext *ctx, AgentType ag, int fd, struct ifreq *
 
     if (ag != AGENT_TYPE_GENDOC)
     {
-        snprintf(name, CF_MAXVARSIZE, "hardware_mac[%s]", ifp->ifr_name);
+        snprintf(name, sizeof(name), "hardware_mac[%s]", ifp->ifr_name);
     }
     else
     {
-        snprintf(name, CF_MAXVARSIZE, "hardware_mac[interface_name]");
+        snprintf(name, sizeof(name), "hardware_mac[interface_name]");
     }
 
     // mac address on a loopback interface doesn't make sense
@@ -342,7 +342,7 @@ static void GetMacAddress(EvalContext *ctx, AgentType ag, int fd, struct ifreq *
         return;
     }
       
-    snprintf(hw_mac, CF_MAXVARSIZE - 1, "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
+    snprintf(hw_mac, sizeof(hw_mac), "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
              (unsigned char) ifr->ifr_hwaddr.sa_data[0],
              (unsigned char) ifr->ifr_hwaddr.sa_data[1],
              (unsigned char) ifr->ifr_hwaddr.sa_data[2],
@@ -354,7 +354,7 @@ static void GetMacAddress(EvalContext *ctx, AgentType ag, int fd, struct ifreq *
     RlistAppend(hardware, hw_mac, RVAL_TYPE_SCALAR);
     RlistAppend(interfaces, ifp->ifr_name, RVAL_TYPE_SCALAR);
 
-    snprintf(name, CF_MAXVARSIZE, "mac_%s", CanonifyName(hw_mac));
+    snprintf(name, sizeof(name), "mac_%s", CanonifyName(hw_mac));
     EvalContextHeapAddHard(ctx, name);
 
 # elif defined(HAVE_GETIFADDRS)
@@ -381,7 +381,7 @@ static void GetMacAddress(EvalContext *ctx, AgentType ag, int fd, struct ifreq *
                 sdl = (struct sockaddr_dl *)ifa->ifa_addr;
                 m = (char *) LLADDR(sdl);
                 
-                snprintf(hw_mac, CF_MAXVARSIZE - 1, "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
+                snprintf(hw_mac, sizeof(hw_mac), "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
                     (unsigned char) m[0],
                     (unsigned char) m[1],
                     (unsigned char) m[2],
@@ -393,7 +393,7 @@ static void GetMacAddress(EvalContext *ctx, AgentType ag, int fd, struct ifreq *
                 RlistAppend(hardware, hw_mac, RVAL_TYPE_SCALAR);
                 RlistAppend(interfaces, ifa->ifa_name, RVAL_TYPE_SCALAR);
 
-                snprintf(name, CF_MAXVARSIZE, "mac_%s", CanonifyName(hw_mac));
+                snprintf(name, sizeof(name), "mac_%s", CanonifyName(hw_mac));
                 EvalContextHeapAddHard(ctx, name);
             }
         }
@@ -417,11 +417,11 @@ void GetInterfaceFlags(EvalContext *ctx, AgentType ag, struct ifreq *ifr, Rlist 
 
     if (ag != AGENT_TYPE_GENDOC)
     {
-        snprintf(name, CF_MAXVARSIZE, "interface_flags[%s]", ifr->ifr_name);
+        snprintf(name, sizeof(name), "interface_flags[%s]", ifr->ifr_name);
     }
     else
     {
-        snprintf(name, CF_MAXVARSIZE, "interface_flags[interface_name]");
+        snprintf(name, sizeof(name), "interface_flags[interface_name]");
     }
 
     if (ifr->ifr_flags & IFF_UP) strcat(buffer, " up");
@@ -547,7 +547,7 @@ void GetInterfacesInfo(EvalContext *ctx, AgentType ag)
             }
         }
 
-        snprintf(workbuf, CF_BUFSIZE, "net_iface_%s", CanonifyName(ifp->ifr_name));
+        snprintf(workbuf, sizeof(workbuf), "net_iface_%s", CanonifyName(ifp->ifr_name));
 
         EvalContextHeapAddHard(ctx, workbuf);
 
@@ -627,7 +627,7 @@ void GetInterfacesInfo(EvalContext *ctx, AgentType ag)
                         if (*sp == '.')
                         {
                             *sp = '\0';
-                            snprintf(name, CF_MAXVARSIZE - 1, "ipv4_%d[%s]", i--, CanonifyName(VIPADDRESS));
+                            snprintf(name, sizeof(name), "ipv4_%d[%s]", i--, CanonifyName(VIPADDRESS));
                             ScopeNewSpecialScalar(ctx, "sys", name, ip, DATA_TYPE_STRING);
                         }
                     }
@@ -664,11 +664,11 @@ void GetInterfacesInfo(EvalContext *ctx, AgentType ag)
 
                 if (ag != AGENT_TYPE_GENDOC)
                 {
-                    snprintf(name, CF_MAXVARSIZE - 1, "ipv4[%s]", CanonifyName(ifp->ifr_name));
+                    snprintf(name, sizeof(name), "ipv4[%s]", CanonifyName(ifp->ifr_name));
                 }
                 else
                 {
-                    snprintf(name, CF_MAXVARSIZE - 1, "ipv4[interface_name]");
+                    snprintf(name, sizeof(name), "ipv4[interface_name]");
                 }
 
                 ScopeNewSpecialScalar(ctx, "sys", name, ip, DATA_TYPE_STRING);
@@ -683,11 +683,11 @@ void GetInterfacesInfo(EvalContext *ctx, AgentType ag)
 
                         if (ag != AGENT_TYPE_GENDOC)
                         {
-                            snprintf(name, CF_MAXVARSIZE - 1, "ipv4_%d[%s]", i--, CanonifyName(ifp->ifr_name));
+                            snprintf(name, sizeof(name), "ipv4_%d[%s]", i--, CanonifyName(ifp->ifr_name));
                         }
                         else
                         {
-                            snprintf(name, CF_MAXVARSIZE - 1, "ipv4_%d[interface_name]", i--);
+                            snprintf(name, sizeof(name), "ipv4_%d[interface_name]", i--);
                         }
 
                         ScopeNewSpecialScalar(ctx, "sys", name, ip, DATA_TYPE_STRING);


### PR DESCRIPTION
Hello,

I have found some improvements over uses of snprintf(), for example:

```
  snprintf(name, CF_MAXVARSIZE - 1, "ipv4[interface_name]");
```

Here - 1 is useless because snprintf() already takes care of '\0', printf(3):

```
The functions snprintf() and vsnprintf() write at most size bytes (including the terminating null byte ('\0')) to str.
```

Now we have

```
  snprintf(name, CF_MAXVARSIZE, "ipv4[interface_name]");
```

But I find annoying to scroll to track the type of 'name', so I suggest using sizeof():

```
snprintf(name, sizeof(name), "ipv4[interface_name]");
```

This way, we don't have to track the type of the buffer, and if it change, its size will automatically follow.

I applied these modifications on libpromises/unix.c to have a preview. Does these changes may also be applied more generally ?
