### PR TITLE
Harmonize uses of fgets()

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -184,7 +184,7 @@ Bundle *MakeTemporaryBundleFromTemplate(EvalContext *ctx, Policy *policy, Attrib
 
         for (;;)
         {
-            if (fgets(buffer, CF_BUFSIZE, fp) == NULL)
+            if (fgets(buffer, sizeof(buffer), fp) == NULL)
             {
                 if (ferror(fp))
                 {
@@ -1235,7 +1235,7 @@ static int InsertFileAtLocation(EvalContext *ctx, Item **start, Item *begin_ptr,
 
     for(;;)
     {
-        if (fgets(buf, CF_BUFSIZE, fin) == NULL)
+        if (fgets(buf, sizeof(buf), fin) == NULL)
         {
             if (ferror(fin)) {
                 if (errno == EISDIR)

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -533,7 +533,7 @@ static PackageItem *GetCachedPackageList(EvalContext *ctx, PackageManager *manag
     int linenumber = 0;
     for(;;)
     {
-        if (fgets(line, CF_BUFSIZE, fin) == NULL)
+        if (fgets(line, sizeof(line), fin) == NULL)
         {
             if (ferror(fin))
             {

--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -454,7 +454,7 @@ static void MailResult(const ExecConfig *config, const char *file)
     while (!feof(fp))
     {
         vbuff[0] = '\0';
-        if (fgets(vbuff, CF_BUFSIZE, fp) == NULL)
+        if (fgets(vbuff, sizeof(vbuff), fp) == NULL)
         {
             break;
         }
@@ -601,7 +601,7 @@ static void MailResult(const ExecConfig *config, const char *file)
     while (!feof(fp))
     {
         vbuff[0] = '\0';
-        if (fgets(vbuff, CF_BUFSIZE, fp) == NULL)
+        if (fgets(vbuff, sizeof(vbuff), fp) == NULL)
         {
             break;
         }

--- a/cf-monitord/mon_cpu.c
+++ b/cf-monitord/mon_cpu.c
@@ -59,7 +59,7 @@ void MonCPUGatherData(double *cf_this)
 
     while (!feof(fp))
     {
-        if (fgets(buf, CF_BUFSIZE - 1, fp) == NULL)
+        if (fgets(buf, sizeof(buf), fp) == NULL)
         {
             break;
         }

--- a/cf-monitord/mon_network_sniffer.c
+++ b/cf-monitord/mon_network_sniffer.c
@@ -113,7 +113,7 @@ void MonNetworkSnifferOpen(void)
             }
 
             /* Skip first banner */
-            if (fgets(tcpbuffer, CF_BUFSIZE - 1, TCPPIPE) == NULL)
+            if (fgets(tcpbuffer, sizeof(tcpbuffer), TCPPIPE) == NULL)
             {
                 UnexpectedError("Failed to read output from '%s'", CF_TCPDUMP_COMM);
                 cf_pclose(TCPPIPE);
@@ -164,7 +164,7 @@ static void Sniff(long iteration, double *cf_this)
             break;
         }
 
-        if (fgets(tcpbuffer, CF_BUFSIZE - 1, TCPPIPE) == NULL)
+        if (fgets(tcpbuffer, sizeof(tcpbuffer), TCPPIPE) == NULL)
         {
             UnexpectedError("Unable to read data from tcpdump; closing pipe");
             cf_pclose(TCPPIPE);

--- a/cf-monitord/mon_temp.c
+++ b/cf-monitord/mon_temp.c
@@ -133,7 +133,7 @@ static bool GetAcpi(double *cf_this)
             continue;
         }
 
-        if (fgets(buf, CF_BUFSIZE - 1, fp) == NULL)
+        if (fgets(buf, sizeof(buf), fp) == NULL)
         {
             CfOut(OUTPUT_LEVEL_ERROR, "", "Failed to read line from stream '%s'", path);
             fclose(fp);

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -409,7 +409,7 @@ static int HailServer(EvalContext *ctx, char *host)
 
             while (true)
             {
-                if (fgets(reply, 8, stdin) == NULL)
+                if (fgets(reply, sizeof(reply), stdin) == NULL)
                 {
                     FatalError(ctx, "EOF trying to read answer from terminal");
                 }

--- a/docs/tools/build-stdlib.c
+++ b/docs/tools/build-stdlib.c
@@ -49,7 +49,7 @@ while(!feof(fin))
    control[0] = '\0';
    data[0] = '\0';
    type[0] = '\0';
-   fgets(buffer,1023,fin);
+   fgets(buffer, sizeof(buffer),fin);
 
    if (strncmp(buffer,"##",2) == 0)
       {
@@ -141,7 +141,7 @@ if ((fp = fopen(file,"r")) == NULL)
 while(!feof(fp))
    {
    buffer[0] = '\0';
-   fgets(buffer,1023,fp);
+   fgets(buffer, sizeof(buffer),fp);
    fprintf(fout,"%s",buffer);
    }
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1541,7 +1541,7 @@ static FnCallResult FnCallGetFields(EvalContext *ctx, FnCall *fp, Rlist *finalar
     {
         char line[CF_BUFSIZE];
 
-        if (fgets(line, CF_BUFSIZE, fin) == NULL)
+        if (fgets(line, sizeof(line), fin) == NULL)
         {
             if (ferror(fin))
             {
@@ -1613,7 +1613,7 @@ static FnCallResult FnCallCountLinesMatching(EvalContext *ctx, FnCall *fp, Rlist
     for (;;)
     {
         char line[CF_BUFSIZE];
-        if (fgets(line, CF_BUFSIZE, fin) == NULL)
+        if (fgets(line, sizeof(line), fin) == NULL)
         {
             if (ferror(fin))
             {
@@ -3387,7 +3387,7 @@ static FnCallResult FnCallRegLine(EvalContext *ctx, FnCall *fp, Rlist *finalargs
         {
             char line[CF_BUFSIZE];
 
-            if (fgets(line, CF_BUFSIZE, fin) == NULL)
+            if (fgets(line, sizeof(line), fin) == NULL)
             {
                 if (ferror(fin))
                 {

--- a/libpromises/sysinfo.c
+++ b/libpromises/sysinfo.c
@@ -686,7 +686,7 @@ void Get3Environment(EvalContext *ctx, AgentType agent_type)
         name[0] = '\0';
         value[0] = '\0';
 
-        if (fgets(context, CF_BUFSIZE, fp) == NULL)
+        if (fgets(context, sizeof(context), fp) == NULL)
         {
             if (ferror(fp))
             {

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -758,7 +758,7 @@ static void FindV6InterfacesInfo(EvalContext *ctx)
 
     for(;;)
     {
-        if (fgets(buffer, CF_BUFSIZE, pp) == NULL)
+        if (fgets(buffer, sizeof(buffer), pp) == NULL)
         {
             if (ferror(pp))
             {

--- a/libpromises/verify_reports.c
+++ b/libpromises/verify_reports.c
@@ -154,7 +154,7 @@ static void PrintFile(EvalContext *ctx, Attributes a, Promise *pp)
 
     while ((lines < a.report.numlines))
     {
-        if (fgets(buffer, CF_BUFSIZE, fp) == NULL)
+        if (fgets(buffer, sizeof(buffer), fp) == NULL)
         {
             if (ferror(fp))
             {

--- a/libutils/proc_keyvalue.c
+++ b/libutils/proc_keyvalue.c
@@ -61,7 +61,7 @@ bool ParseKeyValue(FILE *fd, KeyValueCallback callback, void *param)
 {
     char buf[1024];
 
-    while (fgets(buf, 1024, fd))
+    while (fgets(buf, sizeof(buf), fd))
     {
         char *s = strchr(buf, ':');
 

--- a/tests/unit/avahi_config_test.c
+++ b/tests/unit/avahi_config_test.c
@@ -41,10 +41,10 @@ static void test_generateAvahiConfig(void)
 
     while (!feof(testfile) && !feof(optfile))
     {
-        memset(buffer1, 0, 256);
-        memset(buffer2, 0 ,256);
-        fgets(buffer1, 256, testfile);
-        fgets(buffer2, 256, optfile);
+        memset(buffer1, 0, sizeof(buffer1));
+        memset(buffer2, 0, sizeof(buffer2));
+        fgets(buffer1, sizeof(buffer1), testfile);
+        fgets(buffer2, sizeof(buffer2), optfile);
         assert_int_equal(strcmp(buffer1, buffer2), 0);
     }
 


### PR DESCRIPTION
fgets() already takes care of reading at most size-1 characters.

This patch corrects all

```
fgets(buf, CF_BUFSIZE - 1, fd);
fgets(buf, CF_BUFSIZE, fd);
```

to

```
fgets(buf, sizeof(buf), fd);
```

Such usage of fgets() was already used in sysinfo.c:1532

This improves readability, tracking the type of the buffer is no longer needed, and if its type change its size will follow.
