### PR TITLE
Fixes Redmine #1855: don't close file descriptors we use

### DIFF
--- a/src/cf-execd.c
+++ b/src/cf-execd.c
@@ -459,7 +459,7 @@ void StartServer(Policy *policy, ExecConfig *config, const ReportContext *report
 
     if (!NO_FORK)
     {
-        ActAsDaemon(0);
+        ActAsDaemon(0, report_context);
     }
 
 #endif /* NOT MINGW */

--- a/src/cf-serverd-functions.c
+++ b/src/cf-serverd-functions.c
@@ -272,7 +272,7 @@ void StartServer(Policy *policy, GenericAgentConfig config, const ReportContext 
 
     if (!NO_FORK)
     {
-        ActAsDaemon(sd);
+        ActAsDaemon(sd, report_context);
     }
 
 #endif /* NOT MINGW */

--- a/src/env_monitor.c
+++ b/src/env_monitor.c
@@ -261,7 +261,7 @@ void MonitorStartServer(const Policy *policy, const ReportContext *report_contex
 
     if (!NO_FORK)
     {
-        ActAsDaemon(0);
+        ActAsDaemon(0, report_context);
     }
 
 #endif /* NOT MINGW */

--- a/src/prototypes3.h
+++ b/src/prototypes3.h
@@ -258,7 +258,7 @@ void ModuleProtocol(char *command, char *line, int print, const char *namespace)
 int IsExecutable(const char *file);
 int ShellCommandReturnsZero(const char *comm, int useshell);
 int GetExecOutput(char *command, char *buffer, int useshell);
-void ActAsDaemon(int preserve);
+void ActAsDaemon(int preserve, const ReportContext *report_context);
 char *ShEscapeCommand(char *s);
 char **ArgSplitCommand(const char *comm);
 void ArgFree(char **args);

--- a/src/writer.c
+++ b/src/writer.c
@@ -256,3 +256,13 @@ FILE *FileWriterDetach(Writer *writer)
     free(writer);
     return file;
 }
+
+int WriterFD(Writer *writer)
+{
+    if (writer->type != WT_FILE)
+    {
+        return 0;
+    }
+    FILE *file = writer->file;
+    return fileno(file);
+}

--- a/src/writer.h
+++ b/src/writer.h
@@ -59,4 +59,7 @@ char *StringWriterClose(Writer *writer);
 /* Returns the open file and destroys itself */
 FILE *FileWriterDetach(Writer *writer);
 
+/* Returns the open file descriptor for a FileWriter, otherwise 0 */
+int WriterFD(Writer *writer);
+
 #endif


### PR DESCRIPTION
I've been studying the Redmine #1855 bug, which causes promise analysis strings (mostly HTML, sometimes TEXT) to be output to syslog at random times.

I've included a full explanation on https://cfengine.com/dev/issues/1855, but basically this patch gets the file descriptors used to write the HTML/TEXT promise analysis strings to files (actually, /dev/null usually) and makes sure the ActAsDaemon function doesn't close them. I believe that closing them, then writing to them, is what's causing this issue.

I apologize if this patch doesn't match CFEngine coding style or best practices - I did my best to match what was around in the file. Also, if I'm screwing up in my logic here, please let me know. Basically just tell me how you feel about this and I'll rework it if necessary.
