### PR TITLE
Fix a memory leak in BundleDestroy() and BodyDestroy()

### DIFF
--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -1164,6 +1164,7 @@ static void BundleDestroy(Bundle *bundle)
     {
         free(bundle->name);
         free(bundle->type);
+        free(bundle->ns);
 
         RlistDestroy(bundle->args);
         SeqDestroy(bundle->promise_types);
@@ -1177,6 +1178,7 @@ static void BodyDestroy(Body *body)
     {
         free(body->name);
         free(body->type);
+        free(body->ns);
 
         RlistDestroy(body->args);
         SeqDestroy(body->conlist);


### PR DESCRIPTION
bundle->ns and body->ns are xstrdup'ed in PolicyAppendBody() and PolicyAppendBundle(), but never freed.

Hope this will help https://cfengine.com/dev/issues/2471 a little bit. More to come :)
