### PR TITLE
Fixes #2568. JoinSuffix should not be used here.

### DIFF
--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -28,6 +28,7 @@
 #include "files_names.h"
 #include "files_copy.h"
 #include "item_lib.h"
+#include "logging.h"
 #include "logging_old.h"
 #include "promises.h"
 #include "matching.h"
@@ -499,11 +500,20 @@ int LoadFileAsItemList(Item **liststart, const char *file, EditDefaults edits)
         if (join)
         {
             *(line + strlen(line) - 1) = '\0';
-            JoinSuffix(concat, line);
+
+            if (strlcat(concat, line, CF_BUFSIZE) >= CF_BUFSIZE)
+            {
+                Log(LOG_LEVEL_ERR, "Internal limit 3: Buffer ran out of space constructing string. Tried to add '%s' to '%s'",
+                    concat, line);
+            }
         }
         else
         {
-            JoinSuffix(concat, line);
+            if (strlcat(concat, line, CF_BUFSIZE) >= CF_BUFSIZE)
+            {
+                Log(LOG_LEVEL_ERR, "Internal limit 3: Buffer ran out of space constructing string. Tried to add '%s' to '%s'",
+                    concat, line);
+            }
 
             if (!feof(fp) || (strlen(concat) != 0))
             {


### PR DESCRIPTION
Fixes #2568
JoinSuffix should not be used because : 
1. this code has nothing to do with file paths
2. file path checking has a margin size of 128 to be taken of the max limit
