### PR TITLE
Fix a memory leak in VLog()

### DIFF
--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -206,6 +206,7 @@ void VLog(LogLevel level, const char *fmt, va_list ap)
     {
         LogToSystemLog(msg, level);
     }
+    free(msg);
 }
 
 void Log(LogLevel level, const char *fmt, ...)


### PR DESCRIPTION
Save many bytes, because VLog() is called by CfOut()
