### PR TITLE
Fixing acl acceptance tests

### DIFF
--- a/tests/acceptance/10_files/12_acl/acl.cf.sub
+++ b/tests/acceptance/10_files/12_acl/acl.cf.sub
@@ -263,7 +263,7 @@ bundle agent test_check(testname, file)
 {
   vars:
     linux::
-      "cmd" string => execresult("/bin/getfacl $(file)", "noshell");
+      "cmd" string => execresult("/usr/bin/getfacl $(file)", "noshell");
     windows::
       "cmd" string => execresult("C:\windows\system32\cmd.exe /C cacls $(file)", "noshell");
 


### PR DESCRIPTION
getfacl is installed in /usr/bin not in /bin.
