### PR TITLE
Make negative look-ahead only match exact lines

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -522,7 +522,7 @@ bundle edit_line maintain_key_values(v,sep)
   replace_patterns:
     # For convergence need to use negative lookahead on value:
     # "key sep (?!value).*"
-    "^($(keypat[$(index)]))(?!$(ve[$(index)])).*"
+    "^($(keypat[$(index)]))(?!$(ve[$(index)])$).*"
       comment => "Replace definition of $(index)",
       replace_with => value("$(match.1)$($(v)[$(index)])");
 


### PR DESCRIPTION
Fixes subtle problems like:

-GRUB_CMDLINE_LINUX_DEFAULT='console=ttyS0,115200n1 elevator=deadline'=ttyS0,115200n1 elevator=deadline'=ttyS0,115200n1 elevator=deadline'=ttyS0,115200n1 elevator=deadline'
-GRUB_CMDLINE_LINUX='console=tty0'=tty0'=tty0'=tty0'
+GRUB_CMDLINE_LINUX_DEFAULT='console=ttyS0,115200n1 elevator=deadline'
+GRUB_CMDLINE_LINUX='console=tty0'
