### PR TITLE
Show method name in result messages; remove spurious if statement

### DIFF
--- a/cf-agent/verify_methods.c
+++ b/cf-agent/verify_methods.c
@@ -135,15 +135,15 @@ int VerifyMethod(EvalContext *ctx, char *attrname, Attributes a, Promise *pp)
         switch (retval)
         {
         case PROMISE_RESULT_FAIL:
-            cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_FAIL, pp, a, "Method failed in some repairs or aborted");
+            cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_FAIL, pp, a, "Method \"%s\" failed in some repairs or aborted", bp->name);
             break;
 
         case PROMISE_RESULT_CHANGE:
-            cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_CHANGE, pp, a, "Method invoked repairs");
+            cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_CHANGE, pp, a, "Method \"%s\" invoked repairs", bp->name);
             break;
 
         default:
-            cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a, "Method verified");
+            cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a, "Method \"%s\" verified", bp->name);
             break;
 
         }
@@ -161,15 +161,8 @@ int VerifyMethod(EvalContext *ctx, char *attrname, Attributes a, Promise *pp)
             Log(LOG_LEVEL_ERR,
                   "A variable seems to have been used for the name of the method. In this case, the promiser also needs to contain the unique name of the method");
         }
-        if (bp && (bp->name))
-        {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a, "Method \"%s\" was used but was not defined!\n", bp->name);
-        }
-        else
-        {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a,
-                 "A method attempted to use a bundle \"%s\" that was apparently not defined!\n", method_name);
-        }
+        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a,
+             "A method attempted to use a bundle \"%s\" that was apparently not defined!\n", method_name);
     }
 
     


### PR DESCRIPTION
See Redmine 2070 - https://cfengine.com/dev/issues/2070

Added method name to messages generated about results of method invocations.

Removed an "if(bp)" true clause in the "else" clause of another "if(bp)" statement.
