### PR TITLE
Redmine 2573; prevent HP-UX type-punned pointer warning in FD_SET()

### DIFF
--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -115,7 +115,14 @@ static bool IsReadReady(int fd, int timeout_sec)
 {
     fd_set  rset;
     FD_ZERO(&rset);
+#if defined(__hpux) && defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+// Avoid spurious HP-UX GCC type-pun warning on FD_SET() macro
+#endif
     FD_SET(fd, &rset);
+#if defined(__hpux) && defined(__GNUC__)
+#pragma GCC diagnostic warning "-Wstrict-aliasing"
+#endif
 
     struct timeval tv = {
         .tv_sec = timeout_sec,


### PR DESCRIPTION
Related to Redmine #1802 and pull request 287.

While the HP-UX "fd_set" type is defined in /usr/include/sys/_fd_macros.h as a struct of an array of "long" values in accordance with the XPG4 standard's requirements, the macros for the FD operations "pretend it is an array of int32_t's so the binary layout is the same for both Narrow and Wide processes," as described in fd_macros.h. In the FD_SET, FD_CLR, and FD_ISSET macros at line 101, the result is cast to an "_fd_mask *" type, which is defined as int32_t at _fd_macros.h:82.

This conflict between the "long fds_bits[]" array in the XPG4-compliant fd_set structure, and the cast to an int32_t - not long - pointer in the macros, causes a type-pun warning if GCC -Wstrict-aliasing is enabled. The warning is merely a side effect of HP-UX working as designed, so it can be ignored.
