### PR TITLE
exec_tools: don't bork daemons when no verbosity level

### DIFF
--- a/src/exec_tools.c
+++ b/src/exec_tools.c
@@ -163,6 +163,18 @@ void ActAsDaemon(int preserve, const ReportContext *report_context)
 # endif
 #endif
 
+    if (!report_context)
+    {
+        for (fd = STDERR_FILENO + 1; fd < maxfd; ++fd)
+        {
+            if (fd != preserve)
+            {
+                close(fd);
+            }
+        }
+        return;
+    }
+
     // build an array of file descriptors we need to preserve
     for (size_t i = 0; i < REPORT_OUTPUT_TYPE_MAX; i++)
     {


### PR DESCRIPTION
This is an emergency fix, that lets "cf-serverd" run again!

At commit 4ddf558fc88047ad a loop was introduced, that scanned the
report context to find file descriptors we shouldn't close.

But, when no "-I", "-v", or "-d" options are given, the daemon would
have report_context == NULL !

So, we'd better skip the whole loop and use the shorter loop, like
before that commit.

Note that this bug had prevented cf-serverd from running at all!
