### PR TITLE
The joys of exotic unixes

### DIFF
--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -309,6 +309,7 @@ char *strsep(char **stringp, const char *delim);
 # include <sys/ioctl.h>
 # include <net/if.h>
 # include <netinet/in.h>
+# include <netinet/in_systm.h>
 # include <netinet/ip.h>
 # include <netinet/tcp.h>
 # include <arpa/inet.h>


### PR DESCRIPTION
In Linux and other Unixes this is implicitly included, however in
some more exotic Unixes we need to explicitly include it.
