### PR TITLE
single-quote command in "Checking policy" log because it contains double quotes

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -309,7 +309,7 @@ int CheckPromises(const GenericAgentConfig *config)
         strlcat(cmd, " -D bootstrap_mode", CF_BUFSIZE);
     }
 
-    Log(LOG_LEVEL_VERBOSE, "Checking policy with command \"%s\"", cmd);
+    Log(LOG_LEVEL_VERBOSE, "Checking policy with command '%s'", cmd);
 
     if (ShellCommandReturnsZero(cmd, true))
     {


### PR DESCRIPTION
Example of the problem this is fixing:

```
2013-05-16T11:05:49-0400  verbose: Checking policy with command ""/home/tzz/.cfagent/bin/cf-promises" -c "/policy.cf""
```
