### PR TITLE
Redmine#2595 - missing CfOut references in unit tests

### DIFF
--- a/tests/unit/csv_writer_test.c
+++ b/tests/unit/csv_writer_test.c
@@ -1,3 +1,4 @@
+#include "cf3.defs.h"
 #include "test.h"
 
 #include "csv_writer.h"
@@ -112,6 +113,12 @@ void __ProgrammingError(const char *file, int lineno, const char *format, ...)
 }
 
 void FatalError(char *s, ...)
+{
+    fail();
+    exit(42);
+}
+
+void CfOut(OutputLevel level, const char *errstr, const char *fmt, ...)
 {
     fail();
     exit(42);

--- a/tests/unit/file_writer_test.c
+++ b/tests/unit/file_writer_test.c
@@ -1,3 +1,4 @@
+#include "cf3.defs.h"
 #include "test.h"
 
 #include "alloc.h"
@@ -107,6 +108,12 @@ void __ProgrammingError(const char *file, int lineno, const char *format, ...)
 }
 
 void FatalError(char *s, ...)
+{
+    fail();
+    exit(42);
+}
+
+void CfOut(OutputLevel level, const char *errstr, const char *fmt, ...)
 {
     fail();
     exit(42);

--- a/tests/unit/process_terminate_unix_test.c
+++ b/tests/unit/process_terminate_unix_test.c
@@ -1,3 +1,4 @@
+#include "cf3.defs.h"
 #include "platform.h"
 #include "compiler.h"
 #include "test.h"
@@ -357,4 +358,10 @@ int main()
     };
 
     return run_tests(tests);
+}
+
+void CfOut(OutputLevel level, const char *errstr, const char *fmt, ...)
+{
+    fail();
+    exit(42);
 }

--- a/tests/unit/sort_test.c
+++ b/tests/unit/sort_test.c
@@ -148,3 +148,8 @@ void FatalError(char *s, ...)
     exit(42);
 }
 
+void CfOut(OutputLevel level, const char *errstr, const char *fmt, ...)
+{
+    fail();
+    exit(42);
+}

--- a/tests/unit/xml_writer_test.c
+++ b/tests/unit/xml_writer_test.c
@@ -88,3 +88,9 @@ void FatalError(char *s, ...)
     fail();
     exit(42);
 }
+
+void CfOut(OutputLevel level, const char *errstr, const char *fmt, ...)
+{
+    fail();
+    exit(42);
+}


### PR DESCRIPTION
During a build on HP-UX 11.11 with GCC, the following error appeared for various files:

```
 CCLD   csv_writer_test
/usr/ccs/bin/ld: Unsatisfied symbols:
   CfOut (first referenced in ./.libs/libtest.a(patches.o)) (code)
collect2: error: ld returned 1 exit status
gmake[3]: *** [csv_writer_test] Error 1
gmake[2]: *** [check-am] Error 2
gmake[1]: *** [check-recursive] Error 1
gmake: *** [check-recursive] Error 1
$
```

Following the example of the other unit test C code, a dummy CfOut function was added to each file affected by this problem. In order to obtain the OutputLevel definition for CfOut's first argument, the "cf3.defs.h" file was included where not already present.
