### PR TITLE
Redmine #2675: /bin/bash is not available on all supported plaforms

### DIFF
--- a/tests/acceptance/08_commands/01_modules/003.cf.script
+++ b/tests/acceptance/08_commands/01_modules/003.cf.script
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 echo =myvar[dot.dash-test]=42


### PR DESCRIPTION
The test script test/acceptance/08_commands/01_modules/003.cf.script uses a /bin/bash shebang, and the Bash shell is not available on stock HP-UX systems among others, preventing the test from running properly. This commit changes bash to sh to conform with all the other test scripts.
