### PR TITLE
Fixing an evident compilation failure

### DIFF
--- a/tests/unit/logging_test.c
+++ b/tests/unit/logging_test.c
@@ -30,7 +30,7 @@ ssize_t __xnet_sendto(int sockfd, const void *buf, size_t len, int flags, const 
  * We might be naives by thinking that size_t, socklen_t and such are the same size as int.
  * Given that we are not using them here, we can live with that assumption.
  */
-int sendto(int s, const void *buf, int len, int flags, void sockaddr *dest_addr, int addrlen)
+int sendto(int s, const void *buf, int len, int flags, const void *dest_addr, int addrlen)
 {
     got_address = xmemdup(dest_addr, sizeof(struct sockaddr_in));
     return len;


### PR DESCRIPTION
In logging_test.c we mock "sendto" to avoid sending data. In HPUX the compiler
is a little bit more strict than anticipated so it was complaining about the
type of the signature. It is interesting that this worked all over the place
and no other compiler complained even though it is evidently a failure.
