### PR TITLE
File cf_promises_validated was not created

### DIFF
--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -612,6 +612,10 @@ FilePathType FilePathGetType(const char *file_path)
 
 bool IsFileOutsideDefaultRepository(const char *f)
 {
+    if (strncmp(CFWORKDIR, f, strlen(CFWORKDIR)) == 0)
+    {
+       return false;
+    }
     return (*f == '.') || (IsAbsoluteFileName(f));
 }
 


### PR DESCRIPTION
due the fact that cf-agent/cf-promises use an absolute path \* promises.cf file. Debuged by Dennis Stam and me
