### PR TITLE
Redmine #2691: missing group name spec for some platforms in test

### DIFF
--- a/tests/acceptance/10_files/02_maintain/205.cf
+++ b/tests/acceptance/10_files/02_maintain/205.cf
@@ -87,10 +87,15 @@ body perms test_perms(m)
 {
 mode => "$(m)";
 owners => { "root" };
-linux::
+linux|hpux|solaris::
     groups => { "root" };
-freebsd::
+freebsd|netbsd|openbsd|darwin::
     groups => { "wheel" };
+aix::
+    groups => { "system" };
+cray::
+    groups => { "sys" };
+# Still need unix_sv, sco, qnx, dragonfly, vmware
 }
 
 


### PR DESCRIPTION
The **10_files/02_maintain/205.cf** test has a test_perms body which sets the owner and group of the test file to the "root" user and a group name for gid 0, then the rest of the test run compares the UID and GID numbers looking for "0" for both to verify the test. The group names are defined for either linux or freebsd, but no other platforms.

In the absence of a specification, the file created by the test takes the default group of the process owner, which for root is "sys" GID 3 on HP-UX 11.11, causing the test to show "0 3" instead of "0 0" and thus failing.

This commit adds correct GID 0 group names for hpux, solaris, netbsd, openbsd, darwin, aix, and cray platforms.

The "sys" group for Cray:
   http://docs.cray.com/books/S-2311-22/html-S-2311-22/z1055890212.html

The "system" group for AIX:
   http://publib.boulder.ibm.com/tividd/td/user_admin/GC32-0661-01/en_US/HTML/admusref34.htm

I was unable to find documentation for unix_sv, sco, qnx, dragonfly, or vmware platforms.

With this update, the test now passes on HP-UX:

```
mphp1# ./testall --agent=/var/cfengine/bin/cf-agent 10_files/02_maintain/205.cf
======================================================================
Testsuite started at May 21:19:06
----------------------------------------------------------------------
Total tests: 1

./10_files/02_maintain/205.cf Pass

======================================================================
Testsuite finished at May 21:19:24 (18 seconds)

Passed tests: 1
Failed tests: 0
Failed to crash tests: 0
Skipped tests: 0
mphp1# uname -a
HP-UX mphp1 B.11.11 U 9000/785 2007997283 unlimited-user license
mphp1#
```
