### PR TITLE
Redmine #2691: test does not specify group names for some platforms

### DIFF
--- a/tests/acceptance/10_files/02_maintain/205.cf
+++ b/tests/acceptance/10_files/02_maintain/205.cf
@@ -86,11 +86,8 @@ files:
 body perms test_perms(m)
 {
 mode => "$(m)";
-owners => { "root" };
-linux::
-    groups => { "root" };
-freebsd::
-    groups => { "wheel" };
+owners => { "0" };
+groups => { "0" };
 }
 
 


### PR DESCRIPTION
The 10_files/02_maintain/205.cf test has a test_perms body which sets the owner and group of the test file to the "root" user and a group name for gid 0, then the rest of the test run compares the UID and GID numbers looking for "0" for both to verify the test. The group names are defined for either linux or freebsd, but no other platforms.

In the absence of a specification, the file created by the test takes the default group of the process owner, which for root is "sys" GID 3 on HP-UX 11.11, causing the test to show "0 3" instead of "0 0" and thus failing.

This commit uses UID and GID 0 instead of group names which vary from platform to platform. With this update, the test now passes on HP-UX:

```
mphp1# ./testall --agent=/var/cfengine/bin/cf-agent 10_files/02_maintain/205.cf
======================================================================
Testsuite started at May 21:19:06
----------------------------------------------------------------------
Total tests: 1

./10_files/02_maintain/205.cf Pass

======================================================================
Testsuite finished at May 21:19:24 (18 seconds)

Passed tests: 1
Failed tests: 0
Failed to crash tests: 0
Skipped tests: 0
mphp1# uname -a
HP-UX mphp1 B.11.11 U 9000/785 2007997283 unlimited-user license
mphp1#
```
