### PR TITLE
platform.h instead of system headers for HPUX

### DIFF
--- a/tests/unit/ipaddress_test.c
+++ b/tests/unit/ipaddress_test.c
@@ -1,9 +1,7 @@
 #include "test.h"
 
 #include <string.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netinet/ip.h>
+#include "platform.h"
 #include "buffer.h"
 #include "ip_address.c"
 #include "ip_address.h"


### PR DESCRIPTION
This way all the logic for deciding which headers need to be called is
kept inside platform.h.
