### PR TITLE
Redmine #2693: some 10_files tests check for unpromised gid numbers

### DIFF
--- a/tests/acceptance/10_files/01_create/007.cf
+++ b/tests/acceptance/10_files/01_create/007.cf
@@ -43,21 +43,14 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
-            perms => test_perms;
+            perms => test_perms($(mode));
 }
 
-body perms test_perms
+body perms test_perms(m)
 {
-mode => "$(test.mode)";
-linux::
-    owners => { "root", "sys" };
-    groups => { "root", "sys" };
-freebsd::
-    owners => { "root", "bin" };
-    groups => { "wheel", "sys" };
-!(linux|freebsd)::
-    owners => { "undefined-please-fix" };
-    groups => { "undefined-please-fix" };
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################

--- a/tests/acceptance/10_files/01_create/008.cf
+++ b/tests/acceptance/10_files/01_create/008.cf
@@ -44,24 +44,14 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
-            perms => test_perms;
+            perms => test_perms($(mode));
 }
 
-body perms test_perms
+body perms test_perms(m)
 {
-mode => "$(test.mode)";
-# In the POSIX model, one cannot create a file for another user, one can only
-# create a file as you, and then change owners.  This test file will be created
-# # by root, and thus the promise to be owned by root is kept.
-linux::
-    owners => { "sys", "root" };
-    groups => { "sys", "root" };
-freebsd::
-    owners => { "bin", "root" };
-    groups => { "sys", "wheel" };
-!(linux|freebsd)::
-    owners => { "undefined-please-fix" };
-    groups => { "undefined-please-fix" };
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################

--- a/tests/acceptance/10_files/02_maintain/001.cf
+++ b/tests/acceptance/10_files/02_maintain/001.cf
@@ -43,12 +43,20 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
+            perms => test_perms($(mode)),
             copy_from => test_copy;
 }
 
 body copy_from test_copy
 {
         source => "/etc/group";
+}
+
+body perms test_perms(m)
+{
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################

--- a/tests/acceptance/10_files/02_maintain/002.cf
+++ b/tests/acceptance/10_files/02_maintain/002.cf
@@ -43,6 +43,7 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
+            perms => test_perms($(mode)),
             copy_from => test_copy;
 }
 
@@ -50,6 +51,13 @@ body copy_from test_copy
 {
         source => "/etc/group";
         compare => "mtime";
+}
+
+body perms test_perms(m)
+{
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################

--- a/tests/acceptance/10_files/02_maintain/003.cf
+++ b/tests/acceptance/10_files/02_maintain/003.cf
@@ -43,6 +43,7 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
+            perms => test_perms($(mode)),
             copy_from => test_copy;
 }
 
@@ -50,6 +51,13 @@ body copy_from test_copy
 {
         source => "/etc/group";
         compare => "ctime";
+}
+
+body perms test_perms(m)
+{
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################

--- a/tests/acceptance/10_files/02_maintain/008.cf
+++ b/tests/acceptance/10_files/02_maintain/008.cf
@@ -43,6 +43,7 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
+            perms => test_perms($(mode)),
             copy_from => test_copy;
 }
 
@@ -50,6 +51,13 @@ body copy_from test_copy
 {
         source => "/etc/group";
         compare => "exists";
+}
+
+body perms test_perms(m)
+{
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################

--- a/tests/acceptance/10_files/02_maintain/009.cf
+++ b/tests/acceptance/10_files/02_maintain/009.cf
@@ -39,9 +39,13 @@ files:
 
 bundle agent test
 {
+vars:
+    "mode" int => "0600";
+
 files:
     "$(G.testdir)/copy_file"
       comment => "Copy the file behind the link.",
+      perms => test_perms($(mode)),
       copy_from => cp_2_file("$(G.testdir)/linkdir/link");
 }
 
@@ -58,12 +62,19 @@ body copy_from cp_2_file(x) {
   copylink_patterns => { ".*" };
 }
 
+body perms test_perms(m) {
+  mode => "$(m)";
+  owners => { "0" };
+  groups => { "0" };
+}
+
+
 #######################################################
 
 bundle agent check
 {
 vars:
-        "expect" string => "600 1 0 0 0";
+        "expect" string => "$(test.mode) 1 0 0 0";
 
         "result" string => execresult(
             "/usr/bin/perl -le '$(g.command)'", "noshell");

--- a/tests/acceptance/10_files/02_maintain/101.cf
+++ b/tests/acceptance/10_files/02_maintain/101.cf
@@ -43,12 +43,20 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
+            perms => test_perms($(mode)),
             link_from => test_link;
 }
 
 body link_from test_link
 {
         source => "/etc/group";
+}
+
+body perms test_perms(m)
+{
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################

--- a/tests/acceptance/10_files/02_maintain/102.cf
+++ b/tests/acceptance/10_files/02_maintain/102.cf
@@ -43,6 +43,7 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
+            perms => test_perms($(mode)),
             link_from => test_link;
 }
 
@@ -50,6 +51,13 @@ body link_from test_link
 {
         source => "/etc/group";
         link_type => "hardlink";
+}
+
+body perms test_perms(m)
+{
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################

--- a/tests/acceptance/10_files/02_maintain/103.cf
+++ b/tests/acceptance/10_files/02_maintain/103.cf
@@ -43,6 +43,7 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
+            perms => test_perms($(mode)),
             link_from => test_link;
 }
 
@@ -50,6 +51,13 @@ body link_from test_link
 {
         source => "/etc/group";
         link_type => "symlink";
+}
+
+body perms test_perms(m)
+{
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################

--- a/tests/acceptance/10_files/02_maintain/104.cf
+++ b/tests/acceptance/10_files/02_maintain/104.cf
@@ -43,6 +43,7 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
+            perms => test_perms($(mode)),
             link_from => test_link;
 }
 
@@ -50,6 +51,13 @@ body link_from test_link
 {
         source => "/etc/group";
         link_type => "relative";
+}
+
+body perms test_perms(m)
+{
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################

--- a/tests/acceptance/10_files/02_maintain/105.cf
+++ b/tests/acceptance/10_files/02_maintain/105.cf
@@ -46,6 +46,7 @@ vars:
 files:
         "$(G.testfile)"
             create => "true",
+            perms => test_perms($(test.mode)),
             link_from => test_link;
 }
 
@@ -53,6 +54,13 @@ body link_from test_link
 {
         link_type => "absolute";
         source => "$(G.testfile).SOURCE";
+}
+
+body perms test_perms(m)
+{
+        mode => "$(m)";
+        owners => { "0" };
+        groups => { "0" };
 }
 
 #######################################################


### PR DESCRIPTION
Some platforms, such as HP-UX, do not have root's primary group as gid 0. Certain tests expect a string showing mode, nlinks, uid, gid, and size to show a uid and gid of zero for the test file, but without promising the GID the file defaults to root's primary group. On HP-UX this is 3 (sys), causing the test to fail.

The tests have been updated to promise the same mode, uid, and gid that are expected in the "expect" string for the test file that is checked by the printf statement.
