### PR TITLE
Redmine #2702: add missing uid/gid name mapping for hpux & aix

### DIFF
--- a/tests/acceptance/01_vars/02_functions/001.cf
+++ b/tests/acceptance/01_vars/02_functions/001.cf
@@ -30,7 +30,7 @@ vars:
     !darwin::
         "uid_bin" int => getuid("bin");
 
-    (linux.!SuSE.!redhat.!gentoo)|solaris::
+    (linux.!SuSE.!redhat.!gentoo)|solaris|hpux|aix::
         "num_root" int => "0";
         "num_daemon" int => "1";
         "num_bin" int => "2";
@@ -46,7 +46,7 @@ vars:
         "num_root" int => "0";
         "num_daemon" int => "1";
 
-    !freebsd.!linux.!solaris.!darwin.!openbsd::
+    !linux.!solaris.!hpux.!aix.!freebsd.!openbsd.!darwin::
         "num_root" string => "fixme";
         "num_daemon" string => "fixme";
         "num_bin" string => "fixme";

--- a/tests/acceptance/01_vars/02_functions/002.cf
+++ b/tests/acceptance/01_vars/02_functions/002.cf
@@ -24,20 +24,24 @@ vars:
 bundle agent test
 {
 vars:
-  linux|freebsd|solaris|openbsd::
+  linux|freebsd|solaris|openbsd|hpux::
     "gid_daemon" int => getgid("daemon");
     "gid_sys" int => getgid("sys");
   darwin::
     "gid_daemon" int => getgid("daemon");
-  !linux.!freebsd.!solaris.!darwin.!openbsd::
+  aix::
+    "gid_sys" int => getgid("sys");
+  !linux.!freebsd.!solaris.!darwin.!openbsd.!hpux.!aix::
     "gid_daemon" string => "fixme";
     "gid_sys" string => "fixme";
 
-  linux|solaris::
+  linux|solaris|hpux::
     "gid_0" int => getgid("root");
   freebsd|darwin|openbsd::
     "gid_0" int => getgid("wheel");
-  !linux.!freebsd.!solaris.!darwin.!openbsd::
+  aix::
+    "gid_0" int => getgid("system");
+  !linux.!freebsd.!solaris.!darwin.!openbsd.!hpux.!aix::
     "gid_0" string => "fixme";
 
   SuSE|redhat|gentoo::
@@ -46,12 +50,14 @@ vars:
     "num_daemon" int => "1";
   solaris::
     "num_daemon" int => "12";
-  !linux.!freebsd.!solaris.!darwin.!openbsd::
+  hpux::
+    "num_daemon" int => "5";
+  !linux.!freebsd.!solaris.!darwin.!openbsd.!hpux.!aix::
     "num_daemon" string => "fixme";
 
-  linux|freebsd|solaris|openbsd::
+  linux|freebsd|solaris|openbsd|hpux|aix::
     "num_sys" int => "3";
-  !linux.!freebsd.!solaris.!darwin.!openbsd::
+  !linux.!freebsd.!solaris.!darwin.!openbsd.!hpux.!aix::
     "num_sys" string => "fixme";
 }
 


### PR DESCRIPTION
Tests 01_vars/02_functions/001.cf and 002.cf fail on HP-UX and AIX because the hard classes don't cover the uid and gid mappings for those platforms. This commit adds the necessary information to allow the tests to pass on those two platforms.

HP-UX information was gathered from and tested on my own HP-UX system, and for AIX see the following links for sample passwd and group files:

http://pic.dhe.ibm.com/infocenter/aix/v6r1/index.jsp?topic=%2Fcom.ibm.aix.security%2Fdoc%2Fsecurity%2Fpasswords_etc_passwd_file.htm

http://www.rootunix.org/AIX/migrate.txt

Note that the "daemon" group does not exist on AIX, so it was handled in the same way as "sys" for Darwin.
