### PR TITLE
cfengine_stdlib typo breaks documentation generation

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -393,7 +393,8 @@ bundle edit_line set_variable_values_ini(tab, sectionName)
 
 }
 
-bundle edit_line set_quoted_values(v) {
+bundle edit_line set_quoted_values(v) 
+{
 # Sets the RHS of variables in shell-like files
 #   that is:
 #      LHS="RHS"
@@ -1492,7 +1493,8 @@ body depth_search include_base
 include_basedir => "true";
 }
 
-body depth_search recurse_with_base(d) {
+body depth_search recurse_with_base(d) 
+{
 	depth => "$(d)";
 	xdev  => "true";
 	include_basedir => "true";


### PR DESCRIPTION
cannot create documentation for cfengine stdlib with those two misplaced parenthesis
