### PR TITLE
Redmine #2704: fix canonify issue with negative signed chars

### DIFF
--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -407,7 +407,7 @@ void CanonifyNameInPlace(char *s)
 {
     for (; *s != '\0'; s++)
     {
-        if ((!isalnum((int)*s)) || (*s == '.'))
+        if ((!isalnum((int)(unsigned char)*s)) || (*s == '.'))
         {
             *s = '_';
         }


### PR DESCRIPTION
On HP-UX 11.11, the "isalnum()" call expects a range of values from -1 to 255. However the range of a signed char is -127 to 127, and when an out-of-range negative number is passed to isalnum() on this platform, the results in the case of the Yen symbol in acceptance test 01_vars/02_functions/007.cf, with a signed char value of -91, isalnum() returns "2" which is taken to mean that the Yen symbol is alphanumeric.

By casting to "unsigned char" before the cast to "int" for the call, the "-91" value is converted to a valid character set value of 165, which is properly handled by isalnum() and thus allows the test to pass.
