### PR TITLE
Fix for redmine #2626. Array keys are not constrained to 126 characters

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1202,18 +1202,9 @@ static FnCallResult FnCallGetIndices(EvalContext *ctx, FnCall *fp, Rlist *finala
 
         if (strncmp(match, assoc->lval, strlen(match)) == 0)
         {
-            char *sp;
 
             index[0] = '\0';
-            sscanf(assoc->lval + strlen(match), "%127[^\n]", index);
-            if ((sp = strchr(index, ']')))
-            {
-                *sp = '\0';
-            }
-            else
-            {
-                index[strlen(index) - 1] = '\0';
-            }
+            strlcpy(index, ExtractFirstReference("([^\\]\\[\n]+)", assoc->lval + strlen(match)), CF_MAXVARSIZE);
 
             if (strlen(index) > 0)
             {


### PR DESCRIPTION
Changing scanf with regexp matching. It's more precise and with less headache.

The main reason though is to use the global CF_MAXVARSIZE as the maximal size of a key and not the 127 limit.
