### PR TITLE
fixing a mem leak. Never free what you insert in a StringMap unless you xstrdup it.

### DIFF
--- a/cf-agent/tokyo_check.c
+++ b/cf-agent/tokyo_check.c
@@ -146,8 +146,6 @@ static int AddOffsetToMapUnlessExists(StringMap ** tree, uint64_t offset,
     {
         xasprintf(&val, "%zu", bucket_index);
         StringMapInsert(*tree, tmp, val);
-        free(tmp);
-        free(val);
     }
     else
     {
@@ -352,11 +350,7 @@ static int DBMetaPopulateRecordMap(DBMeta * dbmeta)
                 }
                 else
                 {
-                    StringMapInsert(dbmeta->record_map, key, "0");
-                    if (key)
-                    {
-                        free(key);
-                    }
+                    StringMapInsert(dbmeta->record_map, key, xstrdup("0"));
                 }
             }
             else


### PR DESCRIPTION
I totally misunderstood the way the API work.
Should be ported to the 3.5 branch.
