### PR TITLE
The two strings at absolute address 0 are not equal...

### DIFF
--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -125,14 +125,14 @@ int StringSafeCompare(const char *a, const char *b)
 
 bool StringSafeEqual(const char *a, const char *b)
 {
-    if (a == b)
-    {
-        return true;
-    }
-
     if ((a == NULL) || (b == NULL))
     {
         return false;
+    }
+
+    if (a == b)
+    {
+        return true;
     }
 
     return strcmp(a, b) == 0;


### PR DESCRIPTION
I suggest this modification in order to mitigate the risk of having to compare(NULL, NULL)
