### PR TITLE
Backport fixes to race conditions and file permissions in file editing.

### DIFF
--- a/src/acl.h
+++ b/src/acl.h
@@ -36,5 +36,6 @@
 #define CF_VALID_NPERMS_NTFS "drtxTwabBpcoD"
 
 void VerifyACL(char *file, Attributes a, Promise *pp);
+int CopyACLs(const char *src, const char *dst);
 
 #endif

--- a/src/acl_posix.c
+++ b/src/acl_posix.c
@@ -1094,6 +1094,68 @@ static int ParseModePosixLinux(char *mode, acl_permset_t perms)
     return true;
 }
 
+int CopyACLs(const char *src, const char *dst)
+{
+    acl_t acls;
+    struct stat statbuf;
+    int ret;
+
+    acls = acl_get_file(src, ACL_TYPE_ACCESS);
+    if (!acls)
+    {
+        if (errno == ENOTSUP)
+        {
+            return true;
+        }
+        else
+        {
+            Log(LOG_LEVEL_INFO, "Can't copy ACLs from '%s'. (acl_get_file: %s)", src, GetErrorStr());
+            return false;
+        }
+    }
+    ret = acl_set_file(dst, ACL_TYPE_ACCESS, acls);
+    acl_free(acls);
+    if (ret != 0)
+    {
+        if (errno == ENOTSUP)
+        {
+            return true;
+        }
+        else
+        {
+            Log(LOG_LEVEL_INFO, "Can't copy ACLs to '%s'. (acl_set_file: %s)", dst, GetErrorStr());
+            return false;
+        }
+    }
+
+    if (stat(src, &statbuf) != 0)
+    {
+        Log(LOG_LEVEL_INFO, "Can't copy ACLs from '%s'. (stat: %s)", src, GetErrorStr());
+        return false;
+    }
+    if (!S_ISDIR(statbuf.st_mode))
+    {
+        return true;
+    }
+
+    // For directory, copy default ACL too.
+    acls = acl_get_file(src, ACL_TYPE_DEFAULT);
+    if (!acls)
+    {
+        Log(LOG_LEVEL_INFO, "Can't copy ACLs from '%s'. (acl_get_file: %s)", src, GetErrorStr());
+        return false;
+    }
+    ret = acl_set_file(dst, ACL_TYPE_DEFAULT, acls);
+    acl_free(acls);
+    if (ret != 0)
+    {
+        Log(LOG_LEVEL_INFO, "Can't copy ACLs to '%s'. (acl_set_file: %s)", dst, GetErrorStr());
+        return false;
+    }
+
+    return true;
+}
+
 #else /* HAVE_LIBACL */
 
 int CheckPosixLinuxACL(char *file_path, Acl acl, Attributes a, Promise *pp)
@@ -1101,6 +1163,11 @@ int CheckPosixLinuxACL(char *file_path, Acl acl, Attributes a, Promise *pp)
     cfPS(cf_error, CF_FAIL, "", pp, a,
          "!! Posix ACLs are not supported on this Linux system - install the Posix acl library");
     PromiseRef(cf_error, pp);
+    return true;
+}
+
+int CopyACLs(const char *src, const char *dst)
+{
     return true;
 }
 

--- a/src/files_lib.h
+++ b/src/files_lib.h
@@ -34,5 +34,6 @@ int CompareToFile(Item *liststart, char *file, Attributes a, Promise *pp);
 ssize_t FileRead(const char *filename, char *buffer, size_t bufsize);
 ssize_t FileReadMax(char **output, char *filename, size_t size_max);
 bool FileWriteOver(char *filename, char *contents);
+bool CopyFilePermissionsDisk(const char *source, const char *destination);
 
 #endif

--- a/src/files_operators.c
+++ b/src/files_operators.c
@@ -31,6 +31,7 @@
 #include "promises.h"
 #include "dir.h"
 #include "dbm_api.h"
+#include "files_lib.h"
 #include "files_names.h"
 #include "files_interfaces.h"
 #include "vars.h"
@@ -2415,19 +2416,6 @@ int SaveAsFile(SaveCallbackFn callback, void *param, const char *file, Attribute
     char stamp[CF_BUFSIZE];
     time_t stamp_now;
 
-#ifdef WITH_SELINUX
-    int selinux_enabled = 0;
-    security_context_t scontext = NULL;
-
-    selinux_enabled = (is_selinux_enabled() > 0);
-
-    if (selinux_enabled)
-    {
-        /* get current security context */
-        getfilecon(file, &scontext);
-    }
-#endif
-
     stamp_now = time((time_t *) NULL);
 
     if (cfstat(file, &statbuf) == -1)
@@ -2455,11 +2443,34 @@ int SaveAsFile(SaveCallbackFn callback, void *param, const char *file, Attribute
         return false;
     }
 
-    if (cf_rename(file, backup) == -1)
+    if (!CopyFilePermissionsDisk(file, new))
     {
         cfPS(cf_error, CF_FAIL, "cf_rename", pp, a,
              " !! Can't rename %s to %s - so promised edits could not be moved into place\n", file, backup);
         return false;
+    }
+
+    unlink(backup);
+#ifndef __MINGW32__
+    if (link(file, backup) == -1)
+    {
+        CfOut(cf_verbose, "links", "Can't link '%s' to '%s' - falling back to copy.", file, backup);
+#else
+    /* No hardlinks on Windows, go straight to copying */
+    {
+#endif
+        if (!CopyRegularFileDisk((char*)file, backup, false))
+        {
+            cfPS(cf_error, CF_FAIL, "", pp, a,
+                 "!! Can't copy '%s' to '%s' - so promised edits could not be moved into place.", file, backup);
+            return false;
+        }
+        if (!CopyFilePermissionsDisk(file, backup))
+        {
+            cfPS(cf_error, CF_FAIL, "", pp, a,
+                 "!! Can't copy permissions '%s' to '%s' - so promised edits could not be moved into place.", file, backup);
+            return false;
+        }
     }
 
     if (a.edits.backup == cfa_rotate)
@@ -2487,19 +2498,6 @@ int SaveAsFile(SaveCallbackFn callback, void *param, const char *file, Attribute
              " !! Can't rename %s to %s - so promised edits could not be moved into place\n", new, file);
         return false;
     }
-
-    mask = umask(0);
-    cf_chmod(file, statbuf.st_mode);    /* Restore file permissions etc */
-    chown(file, statbuf.st_uid, statbuf.st_gid);
-    umask(mask);
-
-#ifdef WITH_SELINUX
-    if (selinux_enabled)
-    {
-        /* restore file context */
-        setfilecon(file, scontext);
-    }
-#endif
 
     return true;
 }
@@ -2614,4 +2612,67 @@ int LoadFileAsItemList(Item **liststart, const char *file, Attributes a, Promise
 
     fclose(fp);
     return (true);
+}
+
+bool CopyFilePermissionsDisk(const char *source, const char *destination)
+{
+    struct stat statbuf;
+
+    if (stat(source, &statbuf) == -1)
+    {
+        CfOut(cf_inform, "stat", "Can't copy permissions '%s'.", source);
+        return false;
+    }
+
+    if (chmod(destination, statbuf.st_mode) != 0)
+    {
+        CfOut(cf_inform, "chmod", "Can't copy permissions '%s'.", destination);
+        return false;
+    }
+
+    if (chown(destination, statbuf.st_uid, statbuf.st_gid) != 0)
+    {
+        CfOut(cf_inform, "chown", "Can't copy permissions '%s'.", destination);
+        return false;
+    }
+
+    if (!CopyACLs(source, destination))
+    {
+        return false;
+    }
+
+#ifdef WITH_SELINUX
+    int selinux_enabled = 0;
+    security_context_t scontext = NULL;
+
+    selinux_enabled = (is_selinux_enabled() > 0);
+
+    if (selinux_enabled)
+    {
+        /* get current security context */
+        if (getfilecon(source, &scontext) != 0)
+        {
+            if (errno != ENOTSUP && errno != ENODATA)
+            {
+                CfOut(cf_inform, "getfilecon", "Can't copy security context from '%s'.", source);
+                return false;
+            }
+        }
+        else
+        {
+            int ret = setfilecon(file, scontext);
+            freecon(scontext);
+            if (ret != 0)
+            {
+                if (errno != ENOTSUP)
+                {
+                    CfOut(cf_inform, "setfilecon", "Can't copy security context from '%s'.", destination);
+                    return false;
+                }
+            }
+        }
+    }
+#endif
+
+    return true;
 }


### PR DESCRIPTION
One squashed commit with the these three cherry-picks from master:

(cherry picked from commit a3f1a964ad5e079f8abc419bb9e0489aa8c62f7a)
(cherry picked from commit 908fb187191b41df44bdfb7d092a429cded06436)
(cherry picked from commit 76d895609ea7dee55502139acf52b1b141ca9b10)

as well as compile fixes (esp for Log() -> CfOut and cfPS).

Was hoping that this would make it easier to backport to 3.3.x as well, but that needs more work.

Needs testing.
