### PR TITLE
rename uniq() to unique() everywhere

### DIFF
--- a/docs/reference/functions/uniq_notes.texinfo
+++ b/docs/reference/functions/uniq_notes.texinfo
@@ -1,3 +1,0 @@
-
-Extracts a sublist of unique elements (determined by a string
-comparison) from a list variable specified in arg1.

--- a/docs/reference/functions/unique_example.texinfo
+++ b/docs/reference/functions/unique_example.texinfo
@@ -14,12 +14,12 @@ bundle agent test
                       };
 
       "test_str" string => join(",", "test");
-      "test_uniq" slist => uniq("test");
-      "uniq_str" string => join(",", "test_uniq");
+      "test_unique" slist => unique("test");
+      "unique_str" string => join(",", "test_unique");
 
   reports:
       "The test list is $(test_str)";
-      "The unique elements of the test list: $(uniq_str)";
+      "The unique elements of the test list: $(unique_str)";
 }
 
 @end verbatim

--- a/docs/reference/functions/unique_notes.texinfo
+++ b/docs/reference/functions/unique_notes.texinfo
@@ -1,0 +1,3 @@
+
+Extracts a sublist of unique elements (determined by a string
+comparison) from a list variable specified in arg1.  Similar to the standard Unix uniq utility.

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -2648,7 +2648,7 @@ static FnCallResult FnCallLength(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
 
 /*********************************************************************/
 
-static FnCallResult FnCallUniq(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
+static FnCallResult FnCallUnique(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
 {
     const char *name = RlistScalarValue(finalargs);
 
@@ -5748,7 +5748,7 @@ FnCallArg USEMODULE_ARGS[] =
     {NULL, DATA_TYPE_NONE, NULL}
 };
 
-FnCallArg UNIQ_ARGS[] =
+FnCallArg UNIQUE_ARGS[] =
 {
     {CF_IDRANGE, DATA_TYPE_STRING, "CFEngine list identifier"},
     {NULL, DATA_TYPE_NONE, NULL}
@@ -5932,7 +5932,7 @@ const FnCallType CF_FNCALL_TYPES[] =
     FnCallTypeNew("sublist", DATA_TYPE_STRING_LIST, SUBLIST_ARGS, &FnCallSublist, "Returns arg3 element from either the head or the tail (according to arg2) of list arg1.", false, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("sum", DATA_TYPE_REAL, SUM_ARGS, &FnCallSum, "Return the sum of a list of reals", false, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("translatepath", DATA_TYPE_STRING, TRANSLATEPATH_ARGS, &FnCallTranslatePath, "Translate path separators from Unix style to the host's native", false, FNCALL_CATEGORY_FILES, SYNTAX_STATUS_NORMAL),
-    FnCallTypeNew("uniq", DATA_TYPE_STRING_LIST, UNIQ_ARGS, &FnCallUniq, "Returns all the unique elements of list arg1", false, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
+    FnCallTypeNew("unique", DATA_TYPE_STRING_LIST, UNIQUE_ARGS, &FnCallUnique, "Returns all the unique elements of list arg1", false, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("usemodule", DATA_TYPE_CONTEXT, USEMODULE_ARGS, &FnCallUseModule, "Execute cfengine module script and set class if successful", false, FNCALL_CATEGORY_UTILS, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("userexists", DATA_TYPE_CONTEXT, USEREXISTS_ARGS, &FnCallUserExists, "True if user name or numerical id exists on this host", false, FNCALL_CATEGORY_SYSTEM, SYNTAX_STATUS_NORMAL),
     FnCallTypeNewNull()

--- a/tests/acceptance/01_vars/02_functions/difference_intersection.cf
+++ b/tests/acceptance/01_vars/02_functions/difference_intersection.cf
@@ -31,7 +31,7 @@ bundle agent test
       "list1" slist => { "a", "b", "c", "d", "e" };
       "list2" slist => { "a", "b", "c", "d", "e" };
 
-      "uniq_$(list1)" slist => uniq("init.$(list1)");
+      "unique_$(list1)" slist => unique("init.$(list1)");
       "difference_$(list1)_$(list2)" slist => difference("init.$(list1)",
                                                          "init.$(list2)");
 
@@ -52,7 +52,7 @@ bundle agent check
 
       "check_$(call)_$(list1)_$(list2)" string => join(",", "test.$(call)_$(list1)_$(list2)");
 
-      "joined_$(list1)" string => join(",", "test.uniq_$(list1)");
+      "joined_$(list1)" string => join(",", "test.unique_$(list1)");
 
       # the difference of any list with itself is empty
       "verify_difference_$(list1)_$(list1)" string => "";

--- a/tests/acceptance/01_vars/02_functions/unique.cf
+++ b/tests/acceptance/01_vars/02_functions/unique.cf
@@ -1,6 +1,6 @@
 #######################################################
 #
-# Test uniq()
+# Test unique()
 #
 #######################################################
 
@@ -18,7 +18,7 @@ bundle agent init
   vars:
       "results" slist => {
                            "starting list = 1,2,3,one,two,three,long string,four,fix,six,one,two,three",
-                           "uniq list = 1,2,3,one,two,three,long string,four,fix,six",
+                           "unique list = 1,2,3,one,two,three,long string,four,fix,six",
       };
 
   files:
@@ -54,8 +54,8 @@ bundle agent test
                       };
       "test_str" string => join(",", "test");
 
-      "test_uniq" slist => uniq("test");
-      "uniq_str" string => join(",", "test_uniq");
+      "test_unique" slist => unique("test");
+      "unique_str" string => join(",", "test_unique");
 
   files:
       "$(G.testfile).actual"
@@ -67,7 +67,7 @@ bundle edit_line test_insert
 {
   insert_lines:
       "starting list = $(test.test_str)";
-      "uniq list = $(test.uniq_str)";
+      "unique list = $(test.unique_str)";
 }
 
 #######################################################


### PR DESCRIPTION
Docs to be moved to new format in a later commit.
