### PR TITLE
Edit the example policy to include cfengine_stdlib

### DIFF
--- a/examples/unit_change_detect.cf
+++ b/examples/unit_change_detect.cf
@@ -30,6 +30,13 @@ body common control
 
 {
 bundlesequence  => { "testbundle"  };
+
+# This section may be removed if you are incorporating this policy into your main policy
+
+inputs => {
+  "libraries/cfengine_stdlib.cf",
+};
+
 }
 
 ########################################################
@@ -47,8 +54,4 @@ files:
 
 #########################################################
 
-# This section may be removed if you are incorporating this policy into your main policy
-inputs => {
 
-  "libraries/cfengine_stdlib.cf",
-};


### PR DESCRIPTION
The documentation has been changed to reflect the addition of an inputs section containing an include for cfengine_stdlib with instructions to remove it if the example is incorporated into the master policy. Correct misplacement of inputs section so that it's inside the control body.
