### PR TITLE
Change 'This promise has already been verified' message from verbose to ...

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -597,7 +597,7 @@ CfLock AcquireLock(EvalContext *ctx, char *operand, char *host, time_t now, Tran
     {
         if (IsItemIn(DONELIST, str_digest))
         {
-            Log(LOG_LEVEL_VERBOSE, "This promise has already been verified");
+            Log(LOG_LEVEL_DEBUG, "This promise has already been verified");
             return this;
         }
 


### PR DESCRIPTION
The agent today prints a ton of these types of messages.

2013-05-28T11:20:43-0700  verbose: This promise has already been verified

This makes no sense without context. However, adding stack path, producing

2013-05-28T11:20:43-0700  verbose: /main/methods/'any': promise already verified

also provides almost no value because this message is hit whenever a promise lock is found to be valid, i.e. when a promise does not need to be evaluated anymore. This happens a lot in an agent run and produces too much output to be useful.

This fix simply moves this message to log level debug.
