### PR TITLE
NULL-proof ScopeGet

### DIFF
--- a/libpromises/scope.c
+++ b/libpromises/scope.c
@@ -124,6 +124,11 @@ Scope *ScopeGet(const char *scope)
  * Not thread safe - returns pointer to global memory
  */
 {
+    if (!scope)
+    {
+        return NULL;
+    }
+
     const char *name = scope;
 
     if (strncmp(scope, "default:", strlen("default:")) == 0)  // CF_NS == ':'


### PR DESCRIPTION
This arised when function regarray was calling ScopeGet with a NULL pointer,
resulting in a segfault. We have as a rule agreed that this is an error on
the caller side, but since we are getting close to the release, I don't want
to risk additional segfaults due to careless callers. Either way, ScopeGet is
marked for deprecation.
