### PR TITLE
Ensure common bundle convergence, acceptance test, Close #5222

### DIFF
--- a/tests/acceptance/00_basics/04_bundles/common-bundle-normal-ordering.cf
+++ b/tests/acceptance/00_basics/04_bundles/common-bundle-normal-ordering.cf
@@ -1,0 +1,39 @@
+# Tests that normal ordering (classes before vars) is adhered to in commmon
+# bundles, leading to correct resolution regardless of policy order.
+
+# This check tests that
+# 1. Common bundles are converged before other bundles.
+# 2. Common bundles promises follow normal ordering
+
+body common control
+{
+
+  bundlesequence  => { check };
+  version => "1.0";
+}
+
+bundle agent check
+{
+reports:
+  any::
+# this was the only way I found to trigger the issue. Classifying
+# on join seems to resolve the variable.
+    "$(this.promise_filename) $(g_stuff.two)";
+}
+
+# It is critical that the common bundle is declared after the agent bundles
+bundle common g_stuff
+{
+# promise type ordering here is critical
+    vars:
+        trigger::
+            "one"  string  => "Pas"; 
+
+        any::
+            "two" slist => { "$(one)s" };
+
+    classes:
+        "trigger" expression => "any";
+
+}
+


### PR DESCRIPTION
This ensures that common bundles are converged (variable resolution) before
other types of bundles, and that promise types within common bundles
are converged in normal order.
