### PR TITLE
Fix a crash happening rarely when exiting serverd

### DIFF
--- a/src/dbm_api.c
+++ b/src/dbm_api.c
@@ -254,6 +254,8 @@ void CloseAllDBExit()
                 };
                 nanosleep(&sleeptime, NULL);
                 count++;
+
+                pthread_mutex_lock(&db_handles[i].lock);
             }
             /* Keep mutex locked. */
         }


### PR DESCRIPTION
The reason was that even though we were keeping mutexes locked, a thread that
had already opened the database wouldn't be stopped from reading or writing to
it. But all DB-related structures would have been freed by us, so it would
crash.
