### PR TITLE
Fixing parsing of lists passed through use_module redmine #2239

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -5038,7 +5038,7 @@ void ModuleProtocol(EvalContext *ctx, char *command, char *line, int print, cons
         {
             Rlist *list = NULL;
 
-            list = RlistParseString(content, NULL);
+            list = RlistParseString(content);
             Log(LOG_LEVEL_VERBOSE, "Defined variable '%s' in context '%s' with value '%s'", name, context, content);
 
             EvalContextVariablePut(ctx, (VarRef) { NULL, context, name }, (Rval) { list, RVAL_TYPE_LIST }, DATA_TYPE_STRING_LIST);

--- a/libpromises/rlist.h
+++ b/libpromises/rlist.h
@@ -58,7 +58,7 @@ char *RlistScalarValue(const Rlist *rlist);
 FnCall *RlistFnCallValue(const Rlist *rlist);
 Rlist *RlistRlistValue(const Rlist *rlist);
 Rlist *RlistParseShown(char *string);
-Rlist *RlistParseString(char *string, int *n);
+Rlist *RlistParseString(char *string);
 bool RlistIsStringIn(const Rlist *list, const char *s);
 bool RlistIsIntIn(const Rlist *list, int i);
 Rlist *RlistKeyIn(Rlist *list, const char *key);

--- a/tests/unit/rlist_test.c
+++ b/tests/unit/rlist_test.c
@@ -207,37 +207,74 @@ static struct ParseRoulette
     2, "{\"\",\"\"}"},
     {
     3, "{\"\",\"\",\"\"}"},
-        /*Single escaped */
+        /*Simple mixed kind of quotations */
     {
-    1, "{\"\\\"\"}"},
+    1, "{\"'\"}"},
+    {
+    1, "{'\"'}"},
     {
     1, "{\",\"}"},
     {
+    1, "{','}"},
+    {
     1, "{\"\\\\\"}"},
+    {
+    1, "{'\\\\'}"},
     {
     1, "{\"}\"}"},
     {
+    1, "{'}'}"},
+    {
     1, "{\"{\"}"},
     {
+    1, "{'{'}"},
+    {
     1, "{\"'\"}"},
-        /*Couple double-escaped */
     {
-    1, "{\"\\\",\"}"},          /*   [",]    */
+    1, "{'\"'}"},
     {
-    1, "{\",\\\"\"}"},          /*   [,"]    */
+    1, "{'\\\",'}"},          /*   [",]    */
+    {
+    1, "{\"\\',\"}"},          /*   [",]    */
+
+    {
+    1, "{',\\\"'}"},          /*   [,"]    */
+    {
+    1, "{\",\\'\"}"},          /*   [,"]    */
+
     {
     1, "{\",,\"}"},             /*   [\\]    */
     {
+    1, "{',,'}"},             /*   [\\]    */
+
+    {
     1, "{\"\\\\\\\\\"}"},       /*   [\\]    */
     {
-    1, "{\"\\\\\\\"\"}"},       /*   [\"]    */
+    1, "{'\\\\\\\\'}"},       /*   [\\]    */
+
     {
-    1, "{\"\\\"\\\\\"}"},       /*   ["\]    */
+    1, "{'\\\\\\\"'}"},       /*   [\"]    */
+    {
+    1, "{\"\\\\\\'\"}"},       /*   [\"]    */
+
+    {
+    1, "{'\\\"\\\\'}"},       /*   ["\]    */
+    {
+    1, "{\"\\'\\\\\"}"},       /*   ["\]    */
+
         /*Very long */
     {
     1, "{\"AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA\"}"},
     {
-    2, "{\"Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA\"  ,  \"Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\\\\bbbbbbbbbbbbbbbbbbbbbbbb\\\\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\\\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbB\" }"},
+    1, "{'AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA'}"},
+
+    {
+    2, "{\"Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa''aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA\"  ,  \"Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\\\\bbbbbbbbbbbbbbbbbbbbbbbb\\\\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb''bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbB\" }"},
+    {
+    2, "{'Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA'  ,  'Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\\\\bbbbbbbbbbbbbbbbbbbbbbbb\\\\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\\\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbB' }"},
+    {
+    2, "{\"Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa''aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA\"  ,  'Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\\\\bbbbbbbbbbbbbbbbbbbbbbbb\\\\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\\\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbB' }"},
+  
         /*Inner space (inside elements) */
     {
     1, "{\" \"}"},
@@ -266,9 +303,19 @@ static struct ParseRoulette
     2, "{    \"a\",    \"b\"}       "},
         /*Normal */
     {
-    4, "   { \" ab,c,d\\\\ \" ,  \" e,f\\\"g \" ,\"hi\\\\jk\", \"l''m \" }   "},
+    4, "   { \" ab,c,d\\\\ \" ,  ' e,f\\\"g ' ,\"hi\\\\jk\", \"l''m \" }   "},
     {
-    21, "   { \"A\\\"\\\\    \", \"    \\\\\",   \"}B\",   \"\\\\\\\\\"  ,   \"   \\\\C\\\"\"  ,   \"\\\",\"  ,   \",\\\"D\"  ,   \"   ,,    \", \"E\\\\\\\\F\", \"\", \"{\",   \"   G    '\"  ,   \"\\\\\\\"\", \" \\\"  H \\\\    \", \",   ,\"  ,   \"I\", \"  \",   \"\\\"    J  \",   \"\\\",\", \",\\\"\", \",\"  }   "},
+    21, "   { 'A\\\"\\\\    ', \"    \\\\\",   \"}B\",   \"\\\\\\\\\"  ,   \"   \\\\C\\'\"  ,   \"\\',\"  ,   ',\\\"D'  ,   \"   ,,    \", \"E\\\\\\\\F\", \"\", \"{\",   \"   G    '\"  ,   \"\\\\\\'\", ' \\\"  H \\\\    ', \",   ,\"  ,   \"I\", \"  \",   \"\\'    J  \",   '\\\",', \",\\'\", \",\"  }   "},
+    {
+    3,  "{   \"   aaa    \",    \"    bbbb       \"  ,   \"   cc    \"          }    "},
+    {
+    3,  "  {   \"   a'a    \",    \"    b''b       \"  ,   \"   c'c   \"          }    "},
+    {
+    3,  "  {   '   a\"a    ',    '    b\"\"b       '  ,   '   c\"c   '          }    "},
+    {
+    3,  "  {   '   a\"a    ',    \"    b''b       \"  ,   '   c\"c   '          }    "},
+    {
+    3,  "  {   '   a,\"a } { ',    \"  } b','b       \"  ,   ' {, c\"c } '          }    "},
     {
     -1, (char *)NULL}
 };
@@ -279,13 +326,20 @@ static char *PFR[] = {
     " ",
     "a",
     "\"",
+    "'",
     "\"\"",
+    "''",
+    "'\"",
+    "\"'",
     /* trim right failure */
     "{",
     "{ ",
     "{a",
     "{\"",
+    "{'",
     "{\"\"",
+    "{''",
+    "{\"'",
     /* parse failure */
     /* un-even number of quotation marks */
     "{\"\"\"}",
@@ -295,11 +349,34 @@ static char *PFR[] = {
     "{\"\",\"\"\"}",
     "{\"\"\"\",\"}",
     "{\"\",\"\",\"}",
+    "{'''}",
+    "{'','}",
+    "{''''}",
+    "{'''''}",
+    "{'','''}",
+    "{'''','}",
+    "{\"}",
+    "{'}",
+    "{'','','}",
+    "{\"\"'}",
+    "{\"\",'}",
+    "{\"'\"'}",
+    "{\"\"'\"\"}",
+    "{\"\",'\"\"}",
+    "{'\"\"\",\"}",
+    "{'',\"\",'}",
+
     /* Misplaced commas*/
     "{\"a\",}",
     "{,\"a\"}",
     "{,,\"a\"}",
     "{\"a\",,\"b\"}",
+    "{'a',}",
+    "{,'a'}",
+    "{,,'a'}",
+    "{'a',,'b'}",
+    "{\"a\",,'b'}",
+    "{'a',,\"b\"}",
     " {,}",
     " {,,}",
     " {,,,}",
@@ -312,6 +389,20 @@ static char *PFR[] = {
     " {\"\",\"\",}",
     " {\"\",\"\",,}",
     " {   \"\"  ,  \"\" ,  , }",
+    " {,''}",
+    " {'',}",
+    " {,'',}",
+    " {'',,}",
+    " {'',,,}",
+    " {,,'',,}",
+    " {'','',}",
+    " {'','',,}",
+    " {   ''  ,  '' ,  , }",
+    " {'',\"\",}",
+    " {\"\",'',,}",
+    " {   ''  ,  \"\" ,  , }",
+    " {   \"\"  ,  '' ,  , }",
+
     /*Ignore space's oddities */
     "\" {\"\"}",
     "{ {\"\"}",
@@ -332,7 +423,41 @@ static char *PFR[] = {
     "{a\"\"}b",
     "{\"\"a\"\"}",
     "{\"\",\"\"a\"\"}",
-    /*Incomplete */
+    "' {''}",
+    "{ {''}",
+    "{''}'",
+    "{''}\\",
+    "{''} } ",
+    "a{''}",
+    " a {''}",
+    "{a''}",
+    "{ a ''}",
+    "{''}a",
+    "{''}  a ",
+    "{''a}",
+    "{'' a }",
+    "a{''}b",
+    "{a''b}",
+    "a{''b}",
+    "{a''}b",
+    "{''a''}",
+    "{'',''a''}",
+    "{''a\"\"}",
+    "{\"\"a''}",
+    "{\"\",''a''}",
+    "{'',\"\"a''}",
+    "{'',''a\"\"}",
+    "{\"\",''a\"\"}",
+    /* Bad type of quotation inside an element */
+    "{'aa'aa'}",
+    "{\"aa\"aa\"}",
+    "{'aa\"''}",
+    "{'aa\"\"''}",
+    "{\"aa'\"\"}",
+    "{\"aa''\"\"}",
+    "{'aa\"'', 'aa\"\"'',\"aa'\"\"}",
+    "{\"aa\"aa\", 'aa\"'', 'aa\"\"''}",
+    "{ \"aa\"aa\"   ,'aa\"\"'',\"aa''\"\"   }",
     NULL
 };
 
@@ -343,7 +468,7 @@ static void test_new_parser_success()
     int i = 0;
     while (PR[i].nfields != -1)
     {
-        list = RlistParseString(PR[i].str, NULL);
+        list = RlistParseString(PR[i].str);
         assert_int_equal(PR[i].nfields, RlistLen(list));
         if (list != NULL)
         {
@@ -359,7 +484,7 @@ static void test_new_parser_failure()
     Rlist *list = NULL;
     while (PFR[i] != NULL)
     {
-        list = RlistParseString(PFR[i], NULL);
+        list = RlistParseString(PFR[i]);
         assert_true(RlistLast(list) == NULL);
         if(list) RlistDestroy(list);
         i++;


### PR DESCRIPTION
This fixes #2239 and #2853.
- Cfengine should respect quote interchangeability
- Cfegine does not have any escaping characters
- +100 unit tests in rlist_test.c
