### PR TITLE
Added forgotten nanosleep() declaration

### DIFF
--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -409,6 +409,9 @@ int lstat(const char *file_name, struct stat *buf);
 #if !HAVE_DECL_SLEEP
 unsigned int sleep(unsigned int seconds);
 #endif
+#if !HAVE_DECL_NANOSLEEP
+int nanosleep(const struct timespec *req, struct timespec *rem);
+#endif
 #if !HAVE_DECL_CHOWN
 int chown(const char *path, uid_t owner, gid_t group);
 #endif


### PR DESCRIPTION
Replacement function already existed in libcompat.
