### PR TITLE
Redmine#2278: added linux mint and mint_<version> hard-classes

### DIFF
--- a/libpromises/sysinfo.c
+++ b/libpromises/sysinfo.c
@@ -1828,6 +1828,13 @@ static int Linux_Debian_Version(EvalContext *ctx)
             EvalContextHeapAddHard(ctx, buffer);
         }
     }
+    else if (strcmp(os, "Linux") == 0)
+    {
+        sscanf(buffer, "%*s %*s %s", version);
+        snprintf(buffer, CF_MAXVARSIZE, "mint_%s", version);
+        SetFlavour(ctx, buffer);
+        EvalContextHeapAddHard(ctx, "mint");
+    }
 
     return 0;
 }


### PR DESCRIPTION
added linux mint and mint_<version> hard-classes to libpromises/sysinfo.c
