### PR TITLE
Handle specific Debian path for sshd service

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -2898,12 +2898,6 @@ vars:
   "stopcommand[sendmail]"    string => "/etc/init.d/sendmail stop";
   "pattern[sendmail]"        string => ".*sendmail.*";
 
-  "startcommand[ssh]"   string => "/etc/init.d/sshd start";
-  "restartcommand[ssh]" string => "/etc/init.d/sshd restart";
-  "reloadcommand[ssh]"  string => "/etc/init.d/sshd reload";
-  "stopcommand[ssh]"    string => "/etc/init.d/sshd stop";
-  "pattern[ssh]"        string => ".*sshd.*";
-
   "startcommand[tomcat5]"   string => "/etc/init.d/tomcat5 start";
   "restartcommand[tomcat5]" string => "/etc/init.d/tomcat5 restart";
   "reloadcommand[tomcat5]"  string => "/etc/init.d/tomcat5 reload";
@@ -2941,6 +2935,12 @@ vars:
   "reloadcommand[www]"  string => "/etc/init.d/apache2 reload";
   "stopcommand[www]"    string => "/etc/init.d/apache2 stop";
   "pattern[www]"        string => ".*apache2.*";
+
+  "startcommand[ssh]"   string => "/etc/init.d/sshd start";
+  "restartcommand[ssh]" string => "/etc/init.d/sshd restart";
+  "reloadcommand[ssh]"  string => "/etc/init.d/sshd reload";
+  "stopcommand[ssh]"    string => "/etc/init.d/sshd stop";
+  "pattern[ssh]"        string => ".*sshd.*";
 
 
  redhat::
@@ -3281,6 +3281,12 @@ vars:
   "stopcommand[yum-updatesd]"    string => "/etc/init.d/yum-updatesd stop";
   "pattern[yum-updatesd]"        string => ".*yum-updatesd.*";
 
+  "startcommand[ssh]"   string => "/etc/init.d/sshd start";
+  "restartcommand[ssh]" string => "/etc/init.d/sshd restart";
+  "reloadcommand[ssh]"  string => "/etc/init.d/sshd reload";
+  "stopcommand[ssh]"    string => "/etc/init.d/sshd stop";
+  "pattern[ssh]"        string => ".*sshd.*";
+
  debian|ubuntu::
 
   "startcommand[atd]"   string => "/etc/init.d/atd start";
@@ -3372,6 +3378,12 @@ vars:
   "reloadcommand[www]"  string => "/etc/init.d/apache2 reload";
   "stopcommand[www]"    string => "/etc/init.d/apache2 stop";
   "pattern[www]"        string => ".*apache2.*";
+
+  "startcommand[ssh]"   string => "/etc/init.d/ssh start";
+  "restartcommand[ssh]" string => "/etc/init.d/ssh restart";
+  "reloadcommand[ssh]"  string => "/etc/init.d/ssh reload";
+  "stopcommand[ssh]"    string => "/etc/init.d/ssh stop";
+  "pattern[ssh]"        string => ".*sshd.*";
 
 
  # METHODS that implement these ............................................


### PR DESCRIPTION
A better solution may be to use "free" policy for vars under any::, so they can be redefined later, to take into account various distributions's specificities, and avoid duplicated lines.

What do you think ?
