### PR TITLE
tchdboptimize() should not be necessary to avoid corruption...

### DIFF
--- a/libpromises/dbm_tokyocab.c
+++ b/libpromises/dbm_tokyocab.c
@@ -117,12 +117,6 @@ static bool OpenTokyoDatabase(const char *filename, TCHDB **hdb)
         return false;
     }
 
-    if (!tchdboptimize(*hdb, -1, -1, -1, false))
-    {
-        tchdbclose(*hdb);
-        return false;
-    }
-
     return true;
 }
 


### PR DESCRIPTION
... now that we have proper signal handling.

I put this here because the performance impact does not seem negligible as thought when tchdboptimize() was committed. I have not managed to reproduce any corruption in intense kill-respawn tests, I'll test even more today together with @awsiv and post the results.
