### PR TITLE
edit_line bundle for editing $(sys.resolv) with options

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -249,6 +249,28 @@ insert_lines:
 
 ##
 
+bundle edit_line resolvconf_o(search,list,options)
+
+ # search is the search domains with space
+ # list is an slist of nameserver addresses
+ # options is an slist of variables to modify the resolver
+
+{
+delete_lines:
+
+  "search.*"     comment => "Reset search lines from resolver";
+  "nameserver.*" comment => "Reset nameservers in resolver";
+  "options.*"    comment => "Reset options in resolver";
+
+insert_lines:
+
+  "search $(search)"    comment => "Add search domains to resolver";
+  "nameserver $(list)"  comment => "Add name servers to resolver";
+  "options $(options)"  comment => "Add options to resolver";
+}
+
+##
+
 bundle edit_line manage_variable_values_ini(tab, sectionName)
 
  # Sets the RHS of configuration items in the file of the form


### PR DESCRIPTION
In my environment I need to modify certain internal resolver variables and the current resolvconf edit_line bundle only allows you to set the search and nameserver. I added a new edit_line bundle called resolvconf_o that also takes in an slist of 'options'. The end result is a file that will look something like this

$ cat /etc/resolv.conf
search exit2shell.com
nameserver 192.168.1.20
nameserver 192.168.2.20
nameserver 192.168.3.20
options timeout:1
options no_tld_query
