### PR TITLE
Call tchdboptimize only in 1% of the OpenTokyoDatabase() calls

### DIFF
--- a/libpromises/dbm_tokyocab.c
+++ b/libpromises/dbm_tokyocab.c
@@ -117,10 +117,13 @@ static bool OpenTokyoDatabase(const char *filename, TCHDB **hdb)
         return false;
     }
 
-    if (!tchdboptimize(*hdb, -1, -1, -1, false))
+    if (rand() % 100 < 1)                              /* corresponds to 1% */
     {
-        tchdbclose(*hdb);
-        return false;
+        if (!tchdboptimize(*hdb, -1, -1, -1, false))
+        {
+            tchdbclose(*hdb);
+            return false;
+        }
     }
 
     return true;


### PR DESCRIPTION
Even though we call non-reentrant rand() from multiple thread contexts,
there is no harm done even if bad random numbers are returned.

Adopted from Jeffali's fix at dcdba697.
