### PR TITLE
Internal data coherence checks + removal of keys from lastseen and fs

### DIFF
--- a/cf-agent/agent-diagnostics.c
+++ b/cf-agent/agent-diagnostics.c
@@ -32,6 +32,7 @@
 #include "dbm_api.h"
 #include "dbm_priv.h"
 #include "tokyo_check.h"
+#include "lastseen.h"
 
 #include <assert.h>
 
@@ -146,13 +147,21 @@ static AgentDiagnosticsResult AgentDiagnosticsCheckDB(const char *workdir, dbid 
     {
         int ret = CheckTokyoDBCoherence(dbpath);
         free(dbpath);
-        if(ret)
+        if (ret)
         {
             return AgentDiagnosticsResultNew(false, xstrdup("Internal DB coherence problem"));
-        } 
+        }
         else
         {
+            if (id == dbid_lastseen)
+            {
+                if (IsLastSeenCoherent() == false)
+                {
+                    return AgentDiagnosticsResultNew(false, xstrdup("Lastseen DB data coherence problem"));
+                }
+            }
             return AgentDiagnosticsResultNew(true, xstrdup("OK"));
+            
         }
     }
 }
@@ -213,7 +222,7 @@ const AgentDiagnosticCheck *AgentDiagnosticsAllChecks(void)
         { "Check file stats DB", &AgentDiagnosticsCheckDBFileStats },
         { "Check locks DB", &AgentDiagnosticsCheckDBLocks },
         { "Check performance DB", &AgentDiagnosticsCheckDBPerformance },
-
+        { "Check lastseen DB", &AgentDiagnosticsCheckDBLastSeen },
         { NULL, NULL }
     };
 

--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -450,6 +450,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
         case 'x':
             {
                 const char *workdir = GetWorkDir();
+                strcpy(CFWORKDIR, workdir);
                 Writer *out = FileWriter(stdout);
                 WriterWriteF(out, "self-diagnostics for agent using workdir '%s'\n", workdir);
 

--- a/cf-key/cf-key-functions.c
+++ b/cf-key/cf-key-functions.c
@@ -167,44 +167,93 @@ void ShowLastSeenHosts()
 
     printf("Total Entries: %d\n", count);
 }
-
-
-int RemoveKeys(const char *host)
+/**
+ * @brief detects whether input is a host/ip name or a key digest
+ *
+ * @param[in] key digest (SHA/MD5 format) or free host name string
+ *            (character '=' is optional but recommended)
+ * @retval true if a key digest, false otherwise
+ */
+static bool IsDigestOrHost(const char *input)
 {
-    char digest[CF_BUFSIZE];
-    char ipaddr[CF_MAX_IP_LEN];
-
-    if (Hostname2IPString(ipaddr, host, sizeof(ipaddr)) == -1)
+    if (strncmp(input, "SHA=", 3) == 0)
     {
-        Log(LOG_LEVEL_ERR, 
-            "ERROR, could not resolve '%s', not removing", host);
-        return 255;
+        return true;
     }
-
-    Address2Hostkey(ipaddr, digest);
-    RemoveHostFromLastSeen(digest);
-
-    int removed_by_ip = RemovePublicKey(ipaddr);
-    int removed_by_digest = RemovePublicKey(digest);
-
-    if ((removed_by_ip == -1) || (removed_by_digest == -1))
+    else if (strncmp(input, "MD5=", 3) == 0)
     {
-        Log(LOG_LEVEL_ERR, "Unable to remove keys for the host '%s'", host);
-        return 255;
-    }
-    else if (removed_by_ip + removed_by_digest == 0)
-    {
-        Log(LOG_LEVEL_ERR, "No keys for host '%s' were found", host);
-        return 1;
+        return true;
     }
     else
     {
-        Log(LOG_LEVEL_INFO, "Removed %d key(s) for host '%s'",
-              removed_by_ip + removed_by_digest, host);
-        return 0;
+        return false;
     }
 }
 
+/**
+ * @brief removes all traces of entry 'input' from lastseen and filesystem
+ *
+ * @param[in] key digest (SHA/MD5 format) or free host name string
+ * @retval 0 if entry was deleted, >0 otherwise
+ */
+int RemoveKeys(const char *input)
+{
+    char equivalent[CF_BUFSIZE];
+    bool is_digest;
+
+    if (IsLastSeenCoherent() == true)
+    {
+        is_digest = IsDigestOrHost(input);
+        equivalent[0] = '\0';
+        if (is_digest == true)
+        {
+            Log(LOG_LEVEL_VERBOSE, "Removing digest '%s' from lastseen database\n", input);
+            if (DeleteDigestFromLastSeen(input, equivalent) == false)
+            {
+                Log(LOG_LEVEL_ERR, "Unable to remove digest from lastseen database.");
+                return 252;
+            }
+        }
+        else
+        {
+            Log(LOG_LEVEL_VERBOSE, "Removing host '%s' from lastseen database\n", input);
+            if (DeleteIpFromLastSeen(input, equivalent) == false)
+            {
+                Log(LOG_LEVEL_ERR, "Unable to remove host from lastseen database.");
+                return 253;
+            }
+        }
+
+        Log(LOG_LEVEL_INFO, "Removed corresponding entries from lastseen database.");
+
+        int removed_input      = RemovePublicKey(input);
+        int removed_equivalent = RemovePublicKey(equivalent);
+
+        if ((removed_input == -1) || (removed_equivalent == -1))
+        {
+            Log(LOG_LEVEL_ERR, "Unable to remove keys for the entry %s", input);
+            return 255;
+        }
+        else if (removed_input + removed_equivalent == 0)
+        {
+            Log(LOG_LEVEL_ERR, "No key file(s) for entry %s were found on the filesytem", input);
+            return 1;
+        }
+        else
+        {
+            Log(LOG_LEVEL_INFO, "Removed %d corresponding key file(s) from filesystem.",
+                  removed_input + removed_equivalent);
+            return 0;
+        }
+
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Lastseen database is incoherent. Will not proceed to remove entries from it.");
+        return 254;
+    }
+    return -1;
+}
 
 void KeepKeyPromises(const char *public_key_file, const char *private_key_file)
 {

--- a/libpromises/item_lib.c
+++ b/libpromises/item_lib.c
@@ -30,7 +30,6 @@
 #include "misc_lib.h"
 
 /*******************************************************************/
-
 void PrintItemList(const Item *list, Writer *w)
 {
     WriterWriteChar(w, '{');
@@ -151,6 +150,27 @@ bool IsItemIn(const Item *list, const char *item)
 
     return false;
 }
+
+/*********************************************************************/
+
+bool ListsCompare(const Item *list1, const Item *list2)
+{
+    if (ListLen(list1) != ListLen(list2))
+    {
+        return false;
+    }
+
+    for (const Item *ptr = list1; ptr != NULL; ptr = ptr->next)
+    {
+        if (IsItemIn(list2, ptr->name) == false)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 
 /*********************************************************************/
 

--- a/libpromises/item_lib.h
+++ b/libpromises/item_lib.h
@@ -48,7 +48,6 @@ typedef enum
     ITEM_MATCH_TYPE_LITERAL_SOMEWHERE_NOT,
     ITEM_MATCH_TYPE_REGEX_COMPLETE_NOT
 } ItemMatchType;
-
 void PrintItemList(const Item *list, Writer *w);
 void PrependFullItem(Item **liststart, const char *itemstring, const char *classes, int counter, time_t t);
 Item *ReturnItemIn(Item *list, const char *item);
@@ -76,6 +75,7 @@ int DeleteItemNotContaining(Item **list, const char *string);
 int ListLen(const Item *list);
 int ByteSizeList(const Item *list);
 bool IsItemIn(const Item *list, const char *item);
+bool ListsCompare(const Item *list1, const Item *list2);
 int IsMatchItemIn(Item *list, const char *item);
 Item *ConcatLists(Item *list1, Item *list2);
 void CopyList(Item **dest, const Item *source);

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -28,6 +28,7 @@
 #include "conversion.h"
 #include "files_hashes.h"
 #include "locks.h"
+#include "item_lib.h"
 
 void UpdateLastSawHost(const char *hostkey, const char *address,
                        bool incoming, time_t timestamp);
@@ -133,52 +134,6 @@ void UpdateLastSawHost(const char *hostkey, const char *address,
 
     CloseDB(db);
 }
-
-/*****************************************************************************/
-
-bool RemoveHostFromLastSeen(const char *hostkey)
-{
-    DBHandle *db;
-    if (!OpenDB(&db, dbid_lastseen))
-    {
-        Log(LOG_LEVEL_ERR, "Unable to open lastseen database");
-        return false;
-    }
-
-    /* Lookup corresponding address entry */
-
-    char hostkey_key[CF_BUFSIZE];
-    snprintf(hostkey_key, CF_BUFSIZE, "k%s", hostkey);
-    char address[CF_BUFSIZE];
-
-    if (ReadDB(db, hostkey_key, &address, sizeof(address)) == true)
-    {
-        /* Remove address entry */
-        char address_key[CF_BUFSIZE];
-        snprintf(address_key, CF_BUFSIZE, "a%s", address);
-
-        DeleteDB(db, address_key);
-    }
-
-    /* Remove quality-of-connection entries */
-
-    char quality_key[CF_BUFSIZE];
-
-    snprintf(quality_key, CF_BUFSIZE, "qi%s", hostkey);
-    DeleteDB(db, quality_key);
-
-    snprintf(quality_key, CF_BUFSIZE, "qo%s", hostkey);
-    DeleteDB(db, quality_key);
-
-    /* Remove main entry */
-
-    DeleteDB(db, hostkey_key);
-
-    CloseDB(db);
-
-    return true;
-}
-
 /*****************************************************************************/
 
 static bool Address2HostkeyInDB(DBHandle *db, const char *address, char *result)
@@ -250,7 +205,227 @@ bool Address2Hostkey(const char *address, char *result)
 }
 
 /*****************************************************************************/
+bool IsLastSeenCoherent(void)
+{
+    DBHandle *db;
+    DBCursor *cursor;
+    bool res = true;
 
+    if (!OpenDB(&db, dbid_lastseen))
+    {
+        Log(LOG_LEVEL_ERR, "Unable to open lastseen database");
+        return false;
+    }
+
+    if (!NewDBCursor(db, &cursor))
+    {
+        Log(LOG_LEVEL_ERR, "Unable to create lastseen database cursor");
+        CloseDB(db);
+        return false;
+    }
+
+    char *key;
+    void *value;
+    int ksize, vsize;
+
+    Item *qkeys=NULL;
+    Item *akeys=NULL;
+    Item *kkeys=NULL;
+    Item *ahosts=NULL;
+    Item *khosts=NULL;
+
+    char val[CF_BUFSIZE];
+    while (NextDB(cursor, &key, &ksize, &value, &vsize))
+    {
+        if (key[0] != 'k' && key[0] != 'q' && key[0] != 'a' )
+        {
+            continue;
+        }
+
+        if (key[0] == 'q' )
+        {
+            if (strncmp(key,"qiSHA=",5)==0 || strncmp(key,"qoSHA=",5)==0 ||
+                strncmp(key,"qiMD5=",5)==0 || strncmp(key,"qoMD5=",5)==0)
+            {
+                if (IsItemIn(qkeys, key+2)==false)
+                {
+                    PrependItem(&qkeys, key+2, NULL);
+                }
+            }
+        }
+
+        if (key[0] == 'k' )
+        {
+            if (strncmp(key, "kSHA=", 4)==0 || strncmp(key, "kMD5=", 4)==0)
+            {
+                if (IsItemIn(kkeys, key+1)==false)
+                {
+                    PrependItem(&kkeys, key+1, NULL);
+                }
+                if (ReadDB(db, key, &val, vsize))
+                {
+                    if (IsItemIn(khosts, val)==false)
+                    {
+                        PrependItem(&khosts, val, NULL);
+                    }
+                }
+            }
+        }
+
+        if (key[0] == 'a' )
+        {
+            if (IsItemIn(ahosts, key+1)==false)
+            {
+                PrependItem(&ahosts, key+1, NULL);
+            }
+            if (ReadDB(db, key, &val, vsize))
+            {
+                if (IsItemIn(akeys, val)==false)
+                {
+                    PrependItem(&akeys, val, NULL);
+                }
+            }
+        }
+    }
+
+    DeleteDBCursor(cursor);
+    CloseDB(db);
+
+    if (ListsCompare(ahosts, khosts) == false)
+    {
+        res = false;
+        goto clean;
+    }
+    if (ListsCompare(akeys, kkeys) == false)
+    {
+        res = false;
+        goto clean;
+    }
+
+clean:
+    DeleteItemList(qkeys);
+    DeleteItemList(akeys);
+    DeleteItemList(kkeys);
+    DeleteItemList(ahosts);
+    DeleteItemList(khosts);
+
+    return res;
+}
+/*****************************************************************************/
+bool DeleteIpFromLastSeen(const char *ip, char *digest)
+{
+    DBHandle *db;
+    bool res = false;
+
+    if (!OpenDB(&db, dbid_lastseen))
+    {
+        Log(LOG_LEVEL_ERR, "Unable to open lastseen database");
+        return false;
+    }
+
+    char bufkey[CF_BUFSIZE + 1];
+    char bufhost[CF_BUFSIZE + 1];
+
+    strcpy(bufhost, "a");
+    strlcat(bufhost, ip, CF_BUFSIZE);
+
+    char key[CF_BUFSIZE];
+    if (ReadDB(db, bufhost, &key, sizeof(key)) == true)
+    {
+        strcpy(bufkey, "k");
+        strlcat(bufkey, key, CF_BUFSIZE);
+        if (HasKeyDB(db, bufkey, strlen(bufkey) + 1) == false)
+        {
+            res = false;
+            goto clean;
+        }
+        else
+        {
+            if (digest != NULL)
+            {
+                strcpy(digest, bufkey);
+            }
+            DeleteDB(db, bufkey);
+            DeleteDB(db, bufhost);
+            res = true;
+        }
+    }
+    else
+    {
+        res = false;
+        goto clean;
+    }
+
+    strcpy(bufkey, "qi");
+    strlcat(bufkey, key, CF_BUFSIZE);
+    DeleteDB(db, bufkey);
+
+    strcpy(bufkey, "qo");
+    strlcat(bufkey, key, CF_BUFSIZE);
+    DeleteDB(db, bufkey);
+
+clean:
+    CloseDB(db);
+    return res;
+}
+/*****************************************************************************/
+bool DeleteDigestFromLastSeen(const char *key, char *ip)
+{
+    DBHandle *db;
+    bool res = false;
+
+    if (!OpenDB(&db, dbid_lastseen))
+    {
+        Log(LOG_LEVEL_ERR, "Unable to open lastseen database");
+        return false;
+    }
+    char bufkey[CF_BUFSIZE + 1];
+    char bufhost[CF_BUFSIZE + 1];
+
+    strcpy(bufkey, "k");
+    strlcat(bufkey, key, CF_BUFSIZE);
+
+    char host[CF_BUFSIZE];
+    if (ReadDB(db, bufkey, &host, sizeof(host)) == true)
+    {
+        strcpy(bufhost, "a");
+        strlcat(bufhost, host, CF_BUFSIZE);
+        if (HasKeyDB(db, bufhost, strlen(bufhost) + 1) == false)
+        {
+            res = false;
+            goto clean;
+        }
+        else
+        {
+            if (ip != NULL)
+            {
+                strcpy(ip, host);
+            }
+            DeleteDB(db, bufhost);
+            DeleteDB(db, bufkey);
+            res = true;
+        }
+    }
+    else
+    {
+        res = false;
+        goto clean;
+    }
+
+    strcpy(bufkey, "qi");
+    strlcat(bufkey, key, CF_BUFSIZE);
+    DeleteDB(db, bufkey);
+
+    strcpy(bufkey, "qo");
+    strlcat(bufkey, key, CF_BUFSIZE);
+    DeleteDB(db, bufkey);
+
+clean:
+    CloseDB(db);
+    return res;
+}
+
+/*****************************************************************************/
 bool ScanLastSeenQuality(LastSeenQualityCallback callback, void *ctx)
 {
     DBHandle *db;
@@ -354,3 +529,4 @@ int LastSeenHostKeyCount(void)
 
     return count;
 }
+

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -40,7 +40,9 @@ typedef enum
 bool Address2Hostkey(const char *address, char *hostkey);
 
 void LastSaw(const char *ipaddress, unsigned char digest[EVP_MAX_MD_SIZE + 1], LastSeenRole role);
-bool RemoveHostFromLastSeen(const char *hostkey);
+
+bool DeleteIpFromLastSeen(const char *ip, char *digest);
+bool DeleteDigestFromLastSeen(const char *key, char *ip);
 
 /*
  * Return false in order to stop iteration
@@ -51,5 +53,6 @@ typedef bool (*LastSeenQualityCallback)(const char *hostkey, const char *address
 
 bool ScanLastSeenQuality(LastSeenQualityCallback callback, void *ctx);
 int LastSeenHostKeyCount(void);
+bool IsLastSeenCoherent(void);
 
 #endif

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -146,11 +146,11 @@ file_writer_test_LDFLAGS =
 db_test_SOURCES = db_test.c
 db_test_LDADD = libdb.la
 
-lastseen_test_SOURCES = lastseen_test.c ../../libpromises/lastseen.c ../../libutils/statistics.c
-lastseen_test_LDADD = libdb.la
+lastseen_test_SOURCES = lastseen_test.c ../../libpromises/item_lib.c  ../../libpromises/lastseen.c ../../libutils/statistics.c
+lastseen_test_LDADD = libdb.la ../../libpromises/libpromises.la
 
-lastseen_migration_test_SOURCES = lastseen_migration_test.c ../../libpromises/lastseen.c ../../libutils/statistics.c
-lastseen_migration_test_LDADD = libdb.la
+lastseen_migration_test_SOURCES = lastseen_migration_test.c ../../libpromises/lastseen.c ../../libutils/statistics.c ../../libpromises/item_lib.c 
+lastseen_migration_test_LDADD = libdb.la ../../libpromises/libpromises.la
 
 dbm_migration_bundles_test_SOURCES = dbm_migration_bundles_test.c
 dbm_migration_bundles_test_LDADD = libdb.la

--- a/tests/unit/item_test.c
+++ b/tests/unit/item_test.c
@@ -75,6 +75,31 @@ static void test_list_select_last_matching_not_found(void)
     DeleteItemList(list);
 }
 
+static void test_list_compare(void)
+{
+    Item *list1 = NULL, *list2 = NULL;
+    bool result;
+
+    result = ListsCompare(list1, list2);
+    assert_true(result);
+
+    AppendItem(&list1, "abc", NULL);
+    AppendItem(&list1, "def", NULL);
+
+    result = ListsCompare(list1, list2);
+    assert_false(result);
+
+    AppendItem(&list2, "def", NULL);
+    AppendItem(&list2, "abc", NULL);
+
+    result = ListsCompare(list1, list2);
+
+    assert_true(result);
+
+    DeleteItemList(list1);
+    DeleteItemList(list2);
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -84,7 +109,8 @@ int main()
         unit_test(test_list_len),
         unit_test(test_list_select_last_matching_finds_first),
         unit_test(test_list_select_last_matching_finds_last),
-        unit_test(test_list_select_last_matching_not_found)
+        unit_test(test_list_select_last_matching_not_found),
+        unit_test(test_list_compare)
     };
 
     return run_tests(tests);

--- a/tests/unit/lastseen_test.c
+++ b/tests/unit/lastseen_test.c
@@ -2,6 +2,7 @@
 #include "dbm_api.h"
 #include "test.h"
 #include "lastseen.h"
+#include "item_lib.h"
 
 #include <setjmp.h>
 #include <cmockery.h>
@@ -142,7 +143,9 @@ static void test_remove(void)
     UpdateLastSawHost("SHA-12345", "127.0.0.64", true, 555);
     UpdateLastSawHost("SHA-12345", "127.0.0.64", false, 556);
 
-    RemoveHostFromLastSeen("SHA-12345");
+    //RemoveHostFromLastSeen("SHA-12345");
+    int res;
+    res = DeleteDigestFromLastSeen("SHA-12345", NULL);
 
     DBHandle *db;
     OpenDB(&db, dbid_lastseen);
@@ -154,6 +157,29 @@ static void test_remove(void)
 
     CloseDB(db);
 }
+
+static void test_remove_ip(void)
+{
+    setup();
+
+    UpdateLastSawHost("SHA-12345", "127.0.0.64", true, 555);
+    UpdateLastSawHost("SHA-12345", "127.0.0.64", false, 556);
+
+    int res;
+    char digest[CF_BUFSIZE];
+    res = DeleteIpFromLastSeen("127.0.0.64", digest);
+
+    DBHandle *db;
+    OpenDB(&db, dbid_lastseen);
+
+    assert_int_equal(HasKeyDB(db, "qiSHA-12345", strlen("qiSHA-12345") + 1), false);
+    assert_int_equal(HasKeyDB(db, "qoSHA-12345", strlen("qoSHA-12345") + 1), false);
+    assert_int_equal(HasKeyDB(db, "kSHA-12345", strlen("kSHA-12345") + 1), false);
+    assert_int_equal(HasKeyDB(db, "a127.0.0.64", strlen("a127.0.0.64") + 1), false);
+
+    CloseDB(db);
+}
+
 
 int main()
 {
@@ -167,6 +193,7 @@ int main()
             unit_test(test_reverse_conflict),
             unit_test(test_reverse_missing_forward),
             unit_test(test_remove),
+            unit_test(test_remove_ip),
         };
 
     PRINT_TEST_BANNER();


### PR DESCRIPTION
- A helping function that I needed from item_lib.c
- Lastseen DB coherence is redmine #2463
- Key removal is redmine #2025
- Key removal is started only if the lastseen data coherence is good
- DNS resolution for deleting hosts is gone (host is ideally an IP address)
- Discussed previously in pull #694
