### PR TITLE
Increase polling interval to 10 ms from 10 us.

### DIFF
--- a/src/process_unix.c
+++ b/src/process_unix.c
@@ -27,7 +27,7 @@
 #include "process_unix_priv.h"
 #include "misc_lib.h"
 
-#define SLEEP_POLL_TIMEOUT_NS 10000
+#define SLEEP_POLL_TIMEOUT_NS 10000000
 
 /*
  * Wait until process specified by #pid is stopped due to SIGSTOP signal.


### PR DESCRIPTION
With 10us we poll (i.e. send signal(0)) way too frequently and on old kernels
we end up waiting minutes instead of 1 second. See nova redmine #3001.
