### PR TITLE
[3.4.x] Fixes #2943: in bundle edit_line, no kept reports on last line

### DIFF
--- a/src/item_lib.c
+++ b/src/item_lib.c
@@ -580,7 +580,7 @@ int MatchRegion(char *chunk, Item *start, Item *begin, Item *end)
         }
         else                    // if the region runs out before the end
         {
-            if (++sp <= chunk + strlen(chunk))
+            if (sp <= chunk + strlen(chunk))
             {
                 return false;
             }


### PR DESCRIPTION
Refs : https://cfengine.com/dev/issues/2943

On insert_lines, when a promise is kept considering the last line of the file, the reporting is invalid due to two successive pointer increase.
This pull request fixes this pb
