### PR TITLE
Changing lsdir to consistently return an slist

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1702,7 +1702,7 @@ static FnCallResult FnCallLsDir(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
     if (dirh == NULL)
     {
         Log(LOG_LEVEL_ERR, "Directory '%s' could not be accessed in lsdir(), (opendir: %s)", dirname, GetErrorStr());
-        RlistPrependScalar(&newlist, "cf_null");
+        RlistPrependScalar(&newlist, CF_NULL_VALUE);
         return (FnCallResult) { FNCALL_SUCCESS, { newlist, RVAL_TYPE_LIST } };
     }
 
@@ -1727,7 +1727,7 @@ static FnCallResult FnCallLsDir(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
 
     if (newlist == NULL)
     {
-        RlistPrependScalar(&newlist, "cf_null");
+        RlistPrependScalar(&newlist, CF_NULL_VALUE);
     }
 
     return (FnCallResult) { FNCALL_SUCCESS, { newlist, RVAL_TYPE_LIST } };


### PR DESCRIPTION
If a directory is passed to lsdir which does not exist, it will return
the mismatched type scalar, as compared to its normal return and the
dictated return type in its function definition entry of slist.  This
causes all evaluation to stop in the event of a missing directory due
to mismatched assignment in a var designated as slist.
