### PR TITLE
add by_owner process_select body

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -2764,6 +2764,16 @@ process_result => "stime";
 
 ##
 
+body process_select by_owner(u)
+# Takes user as parameter and matches it against the given username
+# and the given username's uid in case only uid is visible in process list.
+{
+  process_owner => { "$(u)", canonify(getuid("$(u)")) };
+  process_result => "process_owner";
+}
+
+##
+
 body process_count any_count(cl)
 
 {


### PR DESCRIPTION
I'd assume this is common enough to warrant existence in the cobpl.
There's also workaround in it to match processes even if the username is too long, and uid is shown in ps list.

ref: https://cfengine.com/dev/issues/3002
