### PR TITLE
Fixes redmine #2988 otrs #1221. Get rid of special chars in debian6/7's /etc/issue

### DIFF
--- a/tests/acceptance/00_basics/01_compiler/800.cf
+++ b/tests/acceptance/00_basics/01_compiler/800.cf
@@ -1,0 +1,46 @@
+#######################################################
+#
+# Test whether parsing of /etc/issue works on Debian
+# (Acceptance test for redmine #2988)
+#
+#######################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };   
+  version => "1.0";
+}
+
+bundle agent init
+{
+}
+
+#######################################################
+
+bundle agent test
+{
+ vars:
+   debian::
+     "myflavor" string => execresult("/bin/grep Debian.*GNU /etc/issue | /usr/bin/cut -d' ' -f3 | cut -d. -f1", "useshell");
+
+}
+
+#######################################################
+
+bundle agent check
+{
+classes:
+    "ok" or => { 
+	    strcmp("$(sys.flavor)", "debian_$(test.myflavor)"),
+            "!debian" 
+    };
+
+reports:
+    DEBUG::
+	"Compared $(sys.flavor) to debian_$(test.myflavor)";
+    ok::
+	"$(this.promise_filename) Pass";
+    !ok::
+	"$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
- Reproduced the bug on debian 6 and 7 on 3.5.x and 3.4.x
- Added an acceptance test
- Code now only sanitizes the line where the version shows in /etc/issue
- Will close and replace pull #775
