### PR TITLE
add service debian ssh commands

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -3355,6 +3355,12 @@ vars:
   "stopcommand[saned]"    string => "/etc/init.d/saned stop";
   "pattern[saned]"        string => ".*saned.*";
 
+  "startcommand[ssh]"   string => "/etc/init.d/ssh start";
+  "restartcommand[ssh]" string => "/etc/init.d/ssh restart";
+  "reloadcommand[ssh]"  string => "/etc/init.d/ssh reload";
+  "stopcommand[ssh]"    string => "/etc/init.d/ssh stop";
+  "pattern[ssh]"        string => ".*sshd.*";
+
   "startcommand[udev]"   string => "/etc/init.d/udev start";
   "restartcommand[udev]" string => "/etc/init.d/udev restart";
   "reloadcommand[udev]"  string => "/etc/init.d/udev reload";


### PR DESCRIPTION
standard_services ssh did not work on debian/ubuntu systems because they use "ssh" instead of "sshd".

This patch adds a debian|ubuntu specific promise.
