### PR TITLE
add process name and pid in syslog message sent by RemoteSysLog

### DIFF
--- a/libpromises/syslog_client.c
+++ b/libpromises/syslog_client.c
@@ -96,10 +96,11 @@ void RemoteSysLog(int log_priority, const char *log_string)
         else
         {
             char timebuffer[26];
+            pid_t pid = getpid();
 
-            snprintf(message, rfc3164_len, "<%u>%.15s %s %s",
+            snprintf(message, rfc3164_len, "<%u>%.15s %s %s[%d]: %s",
                      pri, cf_strtimestamp_local(now, timebuffer) + 4,
-                     VFQNAME, log_string);
+                     VFQNAME, VPREFIX, pid, log_string);
             err = sendto(sd, message, strlen(message),
                          0, ap->ai_addr, ap->ai_addrlen);
             if (err == -1)

--- a/tests/unit/logging_test.c
+++ b/tests/unit/logging_test.c
@@ -6,6 +6,7 @@
 #include "syslog_client.h"
 
 char VFQNAME[CF_MAXVARSIZE];
+char VPREFIX[CF_MAXVARSIZE];
 
 static struct sockaddr *got_address;
 


### PR DESCRIPTION
RemoteSysLog is usefull when real syslog is not available. As explained in
rfc3164 (§5.3) we should provide process information as process name and pid.
This make filtering message much more easy.
