### PR TITLE
Fix solaris 9 unit test failure of policy_test

### DIFF
--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -996,8 +996,12 @@ void PolicyErrorWrite(Writer *writer, const PolicyError *error)
     SourceOffset offset = PolicyElementSourceOffset(error->type, error->subject);
     const char *path = PolicyElementSourceFile(error->type, error->subject);
 
+#ifdef HAVE_SNPRINTF
     // FIX: need to track columns in SourceOffset
     WriterWriteF(writer, "%s:%zu:%zu: error: %s\n", path, offset.line, (size_t)0, error->message);
+#else
+   WriterWriteF(writer, "%s:%ul:%ul: error: %s\n", path, (unsigned long)offset.line, (unsigned long)0, error->message);
+#endif
 }
 
 static char *PolicyErrorToString(const PolicyError *error)


### PR DESCRIPTION
%z format specifier is not supported in Solaris 9 which is not c99. The use of %zu in PolicyErrorWrite caused stack corruption and failure of 8 / 13 of the tests in policy_test. A platform test has been added which uses a suitable format specifier for solaris 9 and allows other platforms to be added if needed.
