### PR TITLE
Fix yum package_method to be able to delete packages

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -1768,6 +1768,9 @@ package_list_arch_regex    => "[^.]+\.([^\s]+).*";
 package_installed_regex => ".*(installed|\s+@).*";
 package_name_convention => "$(name).$(arch)";
 
+# just give the package name to rpm to delete, otherwise it gets "name.*" (from package_name_convention above)
+package_delete_convention => "$(name)";
+
 # set it to "0" to avoid caching of list during upgrade
 package_list_update_command => "/usr/bin/yum --quiet check-update";
 package_list_update_ifelapsed => "240";


### PR DESCRIPTION
The package_method yum from cfengine_stdlib.cf doesn't delete packages properly, because the package_name_convention is "$(name).$(version)", so you get a message like this:

```
rudder> Checking if package (tree,*,*) is at the desired state (installed=1,matched=1)
rudder>  -> Package promises to refer to itself as "tree.*" to the manager
rudder> !! Package name contians '*' -- perhaps a missing attribute (name/version/arch) should be specified
rudder>  -> Package version seems to match criteria
rudder>  -> Schedule package for deletion
```

Which ends up causing something like this:

```
rudder> Running /bin/rpm -e --nodeps tree.*  in shell
rudder> Executing /bin/rpm -e --nodeps tree.* ...
rudder> Q:rpm -e --nodeps tree ...:error: package tree.* is not installed
rudder> Q:rpm -e --nodeps tree ...:
rudder> !! Command related to promiser "tree" returned code defined as promise failed (1)
rudder>  ?> defining promise result class rpm_package_install_failed_tree
rudder> Bulk package schedule execution failed somewhere - unknown outcome for tree.*
```

This patch fixes that.
