### PR TITLE
Properly cast time_t values while printing.

### DIFF
--- a/libpromises/sysinfo.c
+++ b/libpromises/sysinfo.c
@@ -409,9 +409,9 @@ void GetNameInfo3(EvalContext *ctx, AgentType agent_type)
     }
     else
     {
-        snprintf(workbuf, CF_BUFSIZE, "%jd", tloc);
+        snprintf(workbuf, CF_BUFSIZE, "%jd", (intmax_t) tloc);
         ScopeNewSpecial(ctx, "sys", "systime", workbuf, DATA_TYPE_INT);
-        snprintf(workbuf, CF_BUFSIZE, "%jd", tloc / SECONDS_PER_DAY);
+        snprintf(workbuf, CF_BUFSIZE, "%jd", (intmax_t) tloc / SECONDS_PER_DAY);
         ScopeNewSpecial(ctx, "sys", "sysday", workbuf, DATA_TYPE_INT);
         i = GetUptimeMinutes(tloc);
         if (i != -1)


### PR DESCRIPTION
On RHEL 4, 32 bit,

$ cat /etc/issue
Red Hat Enterprise Linux AS release 4 (Nahant Update 7)
Kernel \r on an \m

The following produces:
# include <stdio.h>
# include <time.h>
# include <stdint.h>

int main(void)
{
    time_t now = time(NULL);
    printf("now = %jd\n", now);
    printf("now = %jd\n", (intmax_t)now);
    return 0;
}

This Output:
now = -4612898194263019405
now = 1374253171
