### PR TITLE
Minor bug fix and add new sys variables

### DIFF
--- a/libpromises/sysinfo.c
+++ b/libpromises/sysinfo.c
@@ -332,6 +332,9 @@ void DiscoverVersion(EvalContext *ctx)
 
         snprintf(workbuf, CF_BUFSIZE, "%s%clib%c%d.%d", CFWORKDIR, FILE_SEPARATOR, FILE_SEPARATOR, major, minor);
         ScopeNewSpecial(ctx, "sys", "libdir", workbuf, DATA_TYPE_STRING);
+
+        snprintf(workbuf, CF_BUFSIZE, "lib%c%d.%d", FILE_SEPARATOR, major, minor);
+        ScopeNewSpecial(ctx, "sys", "local_libdir", workbuf, DATA_TYPE_STRING);
     }
     else
     {


### PR DESCRIPTION
New variables in `sys`:
- based on `workdir`: `inputdir`, `libdir`, `masterdir`, `bindir`
- locate update and failsafe policies: `update` and `failsafe`

`libdir` is particularly convenient.

The bug fix is very minor and unlikely to matter either way, but it's tidier this way.
