### PR TITLE
new lib bundle: feature.cf

### DIFF
--- a/masterfiles/lib/3.5/feature.cf
+++ b/masterfiles/lib/3.5/feature.cf
@@ -1,0 +1,85 @@
+bundle agent feature
+# @brief Finds feature_set_X and feature_unset_X classes and sets/unsets X persistently
+#
+# Finds all classes named `feature_unset_X` and clear class X.
+#
+# Finds all classes named `feature_set_DURATION_X` and sets class X
+# persistently for DURATION.  DURATION can be any digits followed by
+# `k`, `m`, or `g`.
+#
+# In inform mode (`-I`) it will report what it does.
+#
+# **Example:**
+# Set class `xyz` for 10 minutes, class `qpr` for 100 minutes, and
+# `ijk` for 90m minutes.  Unset class `abc`.
+# `cf-agent -I -f ./feature.cf -b feature -Dfeature_set_10_xyz,feature_set_100_qpr,feature_set_90m_ijk,feature_unset_abc`
+{
+  classes:
+      "parsed_$(on)" expression => regextract("feature_set_([0-9]+[kmgKMG]?)_(.*)",
+                                              $(on),
+                                              "extract_$(on)");
+
+      "parsed_$(off)" expression => regextract("feature_unset_(.*)",
+                                               $(off),
+                                               "extract_$(off)");
+
+      "$(extract_$(on)[2])" expression => "parsed_$(on)",
+      persistence => "$(extract_$(on)[1])";
+
+  vars:
+      "on" slist => classesmatching("feature_set_.*");
+      "off" slist => classesmatching("feature_unset_.*");
+
+      "_$(off)" string => "off", classes => feature_cancel("$(extract_$(off)[1])");
+
+  reports:
+    inform_mode::
+      "$(this.bundle): $(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
+      ifvarclass => "parsed_$(on)";
+
+      "$(this.bundle): $(off) => UNSET class '$(extract_$(off)[1])'"
+      ifvarclass => "parsed_$(off)";
+
+      "$(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "$(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+
+      "$(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "$(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+}
+
+bundle agent feature_test
+# @brief Finds feature_set_X and feature_unset_X classes and reports X
+#
+# Note that this bundle is intended to be used exactly like `feature`
+# and just show what's defined or undefined.
+#
+# **Example:**
+# Check classes `xyz`, `qpr`, `ijk`, and `abc`.
+# `cf-agent -I -f ./feature.cf -b feature_test -Dfeature_set_10_xyz,feature_set_100_qpr,feature_set_90m_ijk,feature_unset_abc`
+{
+  classes:
+      "parsed_$(on)" expression => regextract("feature_set_([0-9]+[kmgKMG]?)_(.*)",
+                                              $(on),
+                                              "extract_$(on)");
+
+      "parsed_$(off)" expression => regextract("feature_unset_(.*)",
+                                               $(off),
+                                               "extract_$(off)");
+
+  vars:
+      "on" slist => classesmatching("feature_set_.*");
+      "off" slist => classesmatching("feature_unset_.*");
+
+  reports:
+      "$(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "$(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+
+      "$(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "$(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+}
+
+body classes feature_cancel(x)
+{
+      cancel_kept => { "$(x)" };
+      cancel_repaired => { "$(x)" };
+}

--- a/masterfiles/lib/3.6/feature.cf
+++ b/masterfiles/lib/3.6/feature.cf
@@ -1,0 +1,85 @@
+bundle agent feature
+# @brief Finds feature_set_X and feature_unset_X classes and sets/unsets X persistently
+#
+# Finds all classes named `feature_unset_X` and clear class X.
+#
+# Finds all classes named `feature_set_DURATION_X` and sets class X
+# persistently for DURATION.  DURATION can be any digits followed by
+# `k`, `m`, or `g`.
+#
+# In inform mode (`-I`) it will report what it does.
+#
+# **Example:**
+# Set class `xyz` for 10 minutes, class `qpr` for 100 minutes, and
+# `ijk` for 90m minutes.  Unset class `abc`.
+# `cf-agent -I -f ./feature.cf -b feature -Dfeature_set_10_xyz,feature_set_100_qpr,feature_set_90m_ijk,feature_unset_abc`
+{
+  classes:
+      "parsed_$(on)" expression => regextract("feature_set_([0-9]+[kmgKMG]?)_(.*)",
+                                              $(on),
+                                              "extract_$(on)");
+
+      "parsed_$(off)" expression => regextract("feature_unset_(.*)",
+                                               $(off),
+                                               "extract_$(off)");
+
+      "$(extract_$(on)[2])" expression => "parsed_$(on)",
+      persistence => "$(extract_$(on)[1])";
+
+  vars:
+      "on" slist => classesmatching("feature_set_.*");
+      "off" slist => classesmatching("feature_unset_.*");
+
+      "_$(off)" string => "off", classes => feature_cancel("$(extract_$(off)[1])");
+
+  reports:
+    inform_mode::
+      "$(this.bundle): $(on) => SET class '$(extract_$(on)[2]) for '$(extract_$(on)[1])'"
+      ifvarclass => "parsed_$(on)";
+
+      "$(this.bundle): $(off) => UNSET class '$(extract_$(off)[1])'"
+      ifvarclass => "parsed_$(off)";
+
+      "$(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "$(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+
+      "$(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "$(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+}
+
+bundle agent feature_test
+# @brief Finds feature_set_X and feature_unset_X classes and reports X
+#
+# Note that this bundle is intended to be used exactly like `feature`
+# and just show what's defined or undefined.
+#
+# **Example:**
+# Check classes `xyz`, `qpr`, `ijk`, and `abc`.
+# `cf-agent -I -f ./feature.cf -b feature_test -Dfeature_set_10_xyz,feature_set_100_qpr,feature_set_90m_ijk,feature_unset_abc`
+{
+  classes:
+      "parsed_$(on)" expression => regextract("feature_set_([0-9]+[kmgKMG]?)_(.*)",
+                                              $(on),
+                                              "extract_$(on)");
+
+      "parsed_$(off)" expression => regextract("feature_unset_(.*)",
+                                               $(off),
+                                               "extract_$(off)");
+
+  vars:
+      "on" slist => classesmatching("feature_set_.*");
+      "off" slist => classesmatching("feature_unset_.*");
+
+  reports:
+      "$(this.bundle): have $(extract_$(on)[2])" ifvarclass => "$(extract_$(on)[2])";
+      "$(this.bundle): have no $(extract_$(on)[2])" ifvarclass => "!$(extract_$(on)[2])";
+
+      "$(this.bundle): have $(extract_$(off)[1])" ifvarclass => "$(extract_$(off)[1])";
+      "$(this.bundle): have no $(extract_$(off)[1])" ifvarclass => "!$(extract_$(off)[1])";
+}
+
+body classes feature_cancel(x)
+{
+      cancel_kept => { "$(x)" };
+      cancel_repaired => { "$(x)" };
+}


### PR DESCRIPTION
Please see `persistent_disable_DAEMON` and `clear_persistent_disable_DAEMON` for prior work in this direction.  Also the `abortclasses` facility is related as a on/off toggle.

This bundle will let us (in the core) and our users set and unset features easily.  The usage is documented inline, but basically this lets you define a bunch of `feature_set_DURATION_X` and `feature_unset_X` classes at any time, then call the `feature` bundle, and those classes will instruct the bundle to automatically set `X` for `DURATION` minutes or to unset `X`.  The `classesmatching` function is used for this.

In other words, it's a general mechanism for toggling arbitrary **features** on or off.  For instance you may want to instantly set or unset the knowledge that a machine is disabled, or that it's in a change window, or that it's being moved, or that it's being tested.

The included `feature_test` bundle lets us verify what's on and off; and also lets us test the signaling classes mentioned above.  Again, see the inline documentation for usage.
