### PR TITLE
new function: packagesmatching

### DIFF
--- a/tests/acceptance/01_vars/02_functions/packagesmatching.cf
+++ b/tests/acceptance/01_vars/02_functions/packagesmatching.cf
@@ -1,0 +1,80 @@
+#######################################################
+#
+# Test packagesmatching()
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  packages:
+      "cfe-no-such-package"
+      package_policy => "add",
+      package_method => mock;
+}
+
+body package_method mock
+{
+      package_changes => "individual";
+
+      package_list_command => "$(G.printf) 'bfoobar-1-besm6'";
+      package_list_name_regex => "^([^-]+)";
+      package_list_version_regex => "^[^-]+-([^-]+)";
+      package_list_arch_regex => "^[^-]+-[^-]+-([\S]+)";
+
+      package_installed_regex => ".*";
+
+      package_add_command => "$(G.false)";
+      package_update_command => "$(G.false)";
+      package_delete_command => "$(G.false)";
+      package_verify_command => "$(G.false)";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "all_packages" data => packagesmatching(".*", ".*", ".*", ".*");
+      "all_string" string => storejson(all_packages);
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "expected" string => '[
+  {
+    "name": "bfoobar",
+    "version": "1",
+    "arch": "besm6",
+    "method": "printf"
+  }
+]';
+
+  classes:
+    any::
+      "ok" expression => strcmp($(test.all_string), $(expected));
+
+  reports:
+    DEBUG::
+      "package count check '$(test.all_string)' != '$(expected)'"
+      ifvarclass => "!ok";
+
+      "package count check '$(test.all_string)' == '$(expected)'"
+      ifvarclass => "ok";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Very similar to `classesmatching`.

Takes a regex.  Returns the matching lines from the package cache in format "package,version,arch,manager".  I will write docs if it's accepted.

Issues:
- I don't know how to trigger the package discovery from policy
- (probably related) can't get the acceptance test to work

Advice and help welcome.
