### PR TITLE
Include source information in JSON output.

### DIFF
--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -1520,6 +1520,10 @@ static JsonElement *BodyToJson(const Body *body)
 {
     JsonElement *json_body = JsonObjectCreate(10);
 
+    if (body->source_path)
+    {
+        JsonObjectAppendString(json_body, "sourcePath", body->source_path);
+    }
     JsonObjectAppendInteger(json_body, "line", body->offset.line);
 
     JsonObjectAppendString(json_body, "namespace", body->ns);


### PR DESCRIPTION
sourcePath was missing for bodies, and offset/offsetEnd doesn't reference location in the source file. Include the line within the source as well.

This works around the issue in https://cfengine.com/dev/issues/3054 - that should still be fixed though. It gives me what is needed for embedded documentation, although with only the beginning of the object in the JSON I have to then parse for the end of the bundle/body when quoting the code.
