### PR TITLE
Give a more precise error message when ACL cannot be set

### DIFF
--- a/cf-agent/acl_posix.c
+++ b/cf-agent/acl_posix.c
@@ -334,8 +334,8 @@ static int CheckPosixLinuxACEs(EvalContext *ctx, Rlist *aces, AclMethod method, 
             {
                 if ((retv = acl_set_file(file_path, acl_type, acl_new)) != 0)
                 {
-                    Log(LOG_LEVEL_ERR, "Error setting new %s ACL on file '%s' (are required ACEs present?)",
-                          acl_type_str, file_path);
+                    Log(LOG_LEVEL_ERR, "Error setting new %s ACL on file '%s' (acl_set_file: %s), are required ACEs present ?",
+                          acl_type_str, file_path, GetErrorStr());
                     acl_free((void *) acl_existing);
                     acl_free((void *) acl_tmp);
                     acl_free((void *) acl_new);


### PR DESCRIPTION
Hello,

I would like to improve error message when ACL cannot be set.

Sample policy:

```
body common control {
  bundlesequence => { "my_acl" };
}

bundle agent my_acl {
  files:
    "/foo"
      acl => template;
}

body acl template {
  acl_method => "overwrite";
  acl_type => "posix";
  acl_directory_inherit => "parent";
  aces => {
    "user:*:r(wwx),-r:allow",
      "group:*:+rw:allow",
      "mask:x:allow",
      "all:r"
  };
}
```

Create an immutable file (on a filesystem with ACL option, here ext4 on Debian Wheezy)
    #  touch /foo
    # chattr +i /foo 

Before the patch:

```
# cf-agent -lKIf ../policies/acl.cf 
Error setting new Access ACL on file '/foo' (are required ACEs present?)
Failed checking access ACL on /foo
Promise belongs to bundle 'my_acl' in file '../policies/acl.cf' near line 7
Error setting new Access ACL on file '/foo' (are required ACEs present?)
Failed checking access ACL on /foo
Promise belongs to bundle 'my_acl' in file '../policies/acl.cf' near line 7
```

After:

```
# cf-agent -lKIf ../policies/acl.cf 
Error setting new Access ACL on file '/foo' (acl_set_file: Operation not permitted), are required ACEs present ?
Failed checking access ACL on /foo
Promise belongs to bundle 'my_acl' in file '../policies/acl.cf' near line 7
Error setting new Access ACL on file '/foo' (acl_set_file: Operation not permitted), are required ACEs present ?
Failed checking access ACL on /foo
Promise belongs to bundle 'my_acl' in file '../policies/acl.cf' near line 7
```

**acl_set_file: Operation not permitted** message helps to find the error faster
