### PR TITLE
Redmine#2316: check abortclasses every time a new bundle frame is pushed

### DIFF
--- a/libpromises/env_context.c
+++ b/libpromises/env_context.c
@@ -1110,6 +1110,15 @@ void EvalContextStackPushBundleFrame(EvalContext *ctx, const Bundle *owner, cons
 {
     assert(!LastStackFrame(ctx, 0) || LastStackFrame(ctx, 0)->type == STACK_FRAME_TYPE_PROMISE_ITERATION);
 
+    for (const Item *ip = ctx->heap_abort; ip != NULL; ip = ip->next)
+    {
+        if (IsDefinedClass(ctx, ip->name, NULL))
+        {
+            Log(LOG_LEVEL_ERR, "cf-agent aborted on defined class '%s' defined before bundle frame", ip->name);
+            exit(1);
+        }
+    }
+
     EvalContextStackPushFrame(ctx, StackFrameNewBundle(owner, inherits_previous));
     if (!ScopeGet(owner->ns, owner->name))
     {


### PR DESCRIPTION
See https://cfengine.com/dev/issues/2316 for details.

I'm not sure if this is the right place for the check, but it seems to work for classes defined with `-D` and from common bundles, which didn't work before.

Acceptance tests and documentation will be provided if the fix is acceptable.
