### PR TITLE
Fix wrong log message when a promise is ignored due to 'ifvarclass' not ...

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1414,7 +1414,7 @@ static void KeepAgentPromise(EvalContext *ctx, Promise *pp, ARG_UNUSED void *par
         }
         else
         {
-            Log(LOG_LEVEL_VERBOSE, "Skipping next promise '%s', as context '%s' is not relevant", pp->promiser, pp->classes);
+            Log(LOG_LEVEL_VERBOSE, "Skipping next promise '%s', as var-context '%s' is not relevant", pp->promiser, sp);
         }
         return;
     }


### PR DESCRIPTION
...matching

See https://cfengine.com/dev/issues/3254

I have targeted this Pull Request on the master branch, as requested in previous discussions about Pull Requests. However, it is my opinion that this should get backported to the 3.5.x branch to be released in 3.5.2.
