### PR TITLE
fixes segfault when no process_result is provided redmine core #3224

### DIFF
--- a/libpromises/env_context.c
+++ b/libpromises/env_context.c
@@ -487,6 +487,10 @@ static bool EvalWithTokenFromList(const char *expr, StringSet *token_set)
 
 bool EvalProcessResult(const char *process_result, StringSet *proc_attr)
 {
+    if (process_result == NULL || !strcmp(process_result, ""))
+    {
+        return false;
+    }
     return EvalWithTokenFromList(process_result, proc_attr);
 }
 


### PR DESCRIPTION
I suggest this pull request as a fix for #3224
