### PR TITLE
Add ^context=xyz specifier to set the bundle for the module variables

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -194,6 +194,9 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a, Promise *pp)
     char cmdOutBuf[CF_BUFSIZE];
     int cmdOutBufPos = 0;
     int lineOutLen;
+    char module_context[CF_BUFSIZE];
+
+    module_context[0] = '\0';
 
     if (IsAbsoluteFileName(CommandArg0(pp->promiser)) || a.contain.shelltype == SHELL_TYPE_NONE)
     {
@@ -345,7 +348,7 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a, Promise *pp)
 
             if (a.module)
             {
-                ModuleProtocol(ctx, cmdline, line, !a.contain.nooutput, PromiseGetNamespace(pp));
+                ModuleProtocol(ctx, cmdline, line, !a.contain.nooutput, PromiseGetNamespace(pp), module_context);
             }
             else if ((!a.contain.nooutput) && (!EmptyString(line)))
             {

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -4825,7 +4825,10 @@ static int ExecModule(EvalContext *ctx, char *command, const char *ns)
 {
     FILE *pp;
     char *sp, line[CF_BUFSIZE];
+    char context[CF_BUFSIZE];
     int print = false;
+
+    context[0] = '\0';
 
     if ((pp = cf_popen(command, "rt", true)) == NULL)
     {
@@ -4866,7 +4869,7 @@ static int ExecModule(EvalContext *ctx, char *command, const char *ns)
             }
         }
 
-        ModuleProtocol(ctx, command, line, print, ns);
+        ModuleProtocol(ctx, command, line, print, ns, context);
     }
 
     cf_pclose(pp);
@@ -4877,28 +4880,42 @@ static int ExecModule(EvalContext *ctx, char *command, const char *ns)
 /* Level                                                             */
 /*********************************************************************/
 
-void ModuleProtocol(EvalContext *ctx, char *command, char *line, int print, const char *ns)
+void ModuleProtocol(EvalContext *ctx, char *command, char *line, int print, const char *ns, char* context)
 {
-    char name[CF_BUFSIZE], content[CF_BUFSIZE], context[CF_BUFSIZE];
+    char name[CF_BUFSIZE], content[CF_BUFSIZE];
     char arg0[CF_BUFSIZE];
     char *filename;
 
+    if (*context == '\0')
+    {
 /* Infer namespace from script name */
 
-    snprintf(arg0, CF_BUFSIZE, "%s", CommandArg0(command));
-    filename = basename(arg0);
+        snprintf(arg0, CF_BUFSIZE, "%s", CommandArg0(command));
+        filename = basename(arg0);
 
 /* Canonicalize filename into acceptable namespace name*/
 
-    CanonifyNameInPlace(filename);
-    strcpy(context, filename);
-    Log(LOG_LEVEL_VERBOSE, "Module context '%s'", context);
+        CanonifyNameInPlace(filename);
+        strcpy(context, filename);
+        Log(LOG_LEVEL_VERBOSE, "Module context '%s'", context);
+    }
 
     name[0] = '\0';
     content[0] = '\0';
 
     switch (*line)
     {
+    case '^':
+        content[0] = '\0';
+
+        // Allow modules to set their variable context (up to 50 characters)
+        if (1 == sscanf(line + 1, "context=%50[a-z]", content) && strlen(content) > 0)
+        {
+            Log(LOG_LEVEL_VERBOSE, "Module changed variable context from '%s' to '%s'", context, content);
+            strcpy(context, content);
+        }
+        break;
+
     case '+':
         Log(LOG_LEVEL_VERBOSE, "Activated classes '%s'", line + 1);
         if (CheckID(line + 1))

--- a/libpromises/evalfunction.h
+++ b/libpromises/evalfunction.h
@@ -33,7 +33,7 @@ FnCallResult FnCallHostInNetgroup(EvalContext *ctx, FnCall *fp, Rlist *finalargs
 FnCallResult CallFunction(EvalContext *ctx, const FnCallType *function, FnCall *fp, Rlist *finalargs);
 int FnNumArgs(const FnCallType *call_type);
 
-void ModuleProtocol(EvalContext *ctx, char *command, char *line, int print, const char *ns);
+void ModuleProtocol(EvalContext *ctx, char *command, char *line, int print, const char *ns, char* context);
 
 /* Implemented in Nova for Win32 */
 FnCallResult FnCallGroupExists(EvalContext *ctx, FnCall *fp, Rlist *finalargs);

--- a/tests/acceptance/08_commands/01_modules/set-context.cf
+++ b/tests/acceptance/08_commands/01_modules/set-context.cf
@@ -1,0 +1,77 @@
+#######################################################
+#
+# Test command modules
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "script_name" string => "$(this.promise_filename).script";
+
+}
+
+#######################################################
+
+bundle agent test
+{
+
+  classes:
+      "matched" expression => regextract(".+/([^/]+)$",
+					 "${init.script_name}",
+					 "script_basename");
+
+  commands:
+      "$(init.script_name)" module => "true";
+
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "list0" slist => {"abc", "def", "ghi"};
+      "list1" slist => {"{{abc}}", "  ' def}", "ghi'''"};
+      "list2" slist => {'{{a,bc}}', '  " de,f}', 'gh,,i"""'}; 
+      "list3" slist => {"{{a'bc',,}}", '  ",, d"ef}', "ghi,},'''"}; 
+
+      "actual0" string => join(":", "list0");
+      "actual1" string => join(":", "list1");
+      "actual2" string => join(":", "list2");
+      "actual3" string => join(":", "list3");
+
+      "canonical_script_basename" string => canonify("${test.script_basename[1]}");
+
+      "joined0" string => join(":", "xyz.mylist");
+      "joined1" string => join(":", "xyz.myalist");
+      "joined2" string => join(":", "xyz.myblist");
+      "joined3" string => join(":", "xyz.myclist");
+
+  classes:
+
+    any::
+      "var0ok" expression => strcmp("${this.joined0}" , "${this.actual0}");
+      "var1ok" expression => strcmp("${this.joined1}" , "${this.actual1}");
+      "var2ok" expression => strcmp("${this.joined2}" , "${this.actual2}");
+      "var3ok" expression => strcmp("${this.joined3}" , "${this.actual3}");
+      "var4ok" expression => strcmp("hello there" , "${xyz.myvar}");
+
+      "ok" and => { "myclass", "var0ok", "var1ok", "var2ok", "var3ok", "var4ok" };
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}
+

--- a/tests/acceptance/08_commands/01_modules/set-context.cf.script
+++ b/tests/acceptance/08_commands/01_modules/set-context.cf.script
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "^context=xyz" 
+echo "+myclass"
+echo "=myvar=hello there" 
+echo "@mylist={\"abc\", \"def\", \"ghi\"}" 
+echo "@myalist={\"{{abc}}\", \"  ' def}\", \"ghi'''\"}" 
+echo "@myblist={'{{a,bc}}', '  \" de,f}', 'gh,,i\"\"\"'}" 
+echo "@myclist={\"{{a'bc',,}}\", '  \",, d\"ef}', \"ghi,},'''\"}" 


### PR DESCRIPTION
Proposal to add `^context=xyz` to the module protocol to put all of a module's variables into bundle `xyz`.

Very useful for modules with names like `test.pl` or invoked multiple times or on Windows...

Also can be used for platform discovery modules to put variables in different bundles.

The code needs review, then I can write an acceptance test and documentation.
