### PR TITLE
Fixes #2850: add hard classes pass_1 pass_2 pass_3 for each iteration over promises

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1201,6 +1201,18 @@ int ScheduleAgentOperations(EvalContext *ctx, Bundle *bp)
 
     for (int pass = 1; pass < CF_DONEPASSES; pass++)
     {
+
+        /* Define a hard class for the current pass number */
+        char pass_name_buf[CF_MAXVARSIZE];
+
+        /* First, remove old pass name (this will remove pass_0 the first time, but that's OK) */
+        sprintf(pass_name_buf, "pass_%d", pass-1);
+        EvalContextHeapRemoveHard(ctx, pass_name_buf);
+
+        /* Then add this pass name as a hard class */
+        sprintf(pass_name_buf, "pass_%d", pass);
+        EvalContextHeapAddHard(ctx, pass_name_buf);
+
         for (TypeSequence type = 0; AGENT_TYPESEQUENCE[type] != NULL; type++)
         {
             ClassBanner(ctx, type);


### PR DESCRIPTION
This Pull Request adds a Hard Class "pass_1", "pass_2" or "pass_3", depending on which iteration cf-agent is currently doing across a bundle.

This is in response to a [recent mailing list discussion](https://groups.google.com/forum/#!topic/help-cfengine/xhLRGvVq3eY) and [Redmine ticket #2850](https://cfengine.com/dev/issues/2850).

Thoughts?
