### PR TITLE
getfacl acceptance test should not fail on redhat

### DIFF
--- a/tests/acceptance/10_files/12_acl/acl.cf
+++ b/tests/acceptance/10_files/12_acl/acl.cf
@@ -42,7 +42,7 @@ bundle agent test
 {
   vars:
     linux::
-      "sanity_perms" string => execresult("$(init.cmd) $(G.testdir)$(G.DS)file", "noshell");
+      "sanity_perms" string => execresult("$(init.cmd) $(G.testdir)$(G.DS)file 2>&1 | $(G.grep) -v 'Removing leading'", "noshell");
   classes:
     linux::
       # Some filesystems don't have ACL capability, so we do this sanity check.


### PR DESCRIPTION
getfacl fails on RH because of an error message about removing leading '/' from absolute paths.
The option "--absolute-names" is meant to get rid of this message but it has no effect when supplied to the command.
This is why I am using grep to filter it and make the test succeed.

The test succeed however as a result of acl is not supported by the underlying system :(
