### PR TITLE
bin and module folder access rule fix

### DIFF
--- a/masterfiles/controls/cf_serverd.cf
+++ b/masterfiles/controls/cf_serverd.cf
@@ -43,12 +43,12 @@ bundle server access_rules()
       "$(def.dir_bin)"
       handle => "server_access_grant_access_binary",
       comment => "Grant access to binary for cf-runagent",
-      admit   => { ".*$(def.domain)", @(def.acl) };
+      admit   => { ".*\.$(def.domain)", @(def.acl) };
 
       "$(def.dir_modules)"
       handle => "server_access_grant_access_modules",
       comment => "Grant access to modules directory",
-      admit   => { ".*$(def.domain)", @(def.acl) };
+      admit   => { ".*\.$(def.domain)", @(def.acl) };
 
       # Uncomment the promise below to allow cf-runagent to
       # access cf-agent on Windows machines


### PR DESCRIPTION
The bin and the module folder access rules should match `.*\.domain` and not only `\*domain`.
The dot is missing.
That's like this in any other access rule, so I think it was intended like this.
