### PR TITLE
Bring in optional libmatheval and support it in the eval() function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,6 +383,21 @@ fi
 
 AM_CONDITIONAL([HAVE_LIBXML2], [test "x$with_libxml2" != "xno" && test "x$ac_cv_lib_xml2_xmlFirstElementChild" = xyes])
 
+dnl matheval
+
+AC_ARG_WITH([matheval],
+    [AS_HELP_STRING([--with-matheval[[=PATH]]], [support math expression evaluation])],
+    [], [with_matheval=check])
+
+if test "x$with_matheval" != xno; then
+   CF3_WITH_LIBRARY(matheval, [
+      AC_CHECK_LIB(matheval, evaluator_create, [], [if test "x$with_matheval" != xcheck; then AC_MSG_ERROR(Cannot find matheval library); fi])
+      AC_CHECK_HEADERS(matheval.h, [], [if test "x$with_matheval" != xcheck; then AC_MSG_ERROR(Cannot find matheval library headers); fi])
+   ])
+fi
+
+AM_CONDITIONAL([HAVE_LIBMATHEVAL], [test "x$with_matheval" != "xno" && test "x$ac_cv_lib_matheval_evaluator_create" = xyes])
+
 dnl avahi
 
 AC_CHECK_HEADERS(avahi-client/client.h, AM_CONDITIONAL(HAVE_AVAHI_CLIENT, true), AM_CONDITIONAL(HAVE_AVAHI_CLIENT, false), [])
@@ -818,10 +833,10 @@ dnl ######################################################################
 dnl Collect all the options
 dnl ######################################################################
 
-CPPFLAGS="$CPPFLAGS $TOKYOCABINET_CPPFLAGS $QDBM_CPPFLAGS $PCRE_CPPFLAGS $OPENSSL_CPPFLAGS $MONGO_CPPFLAGS $SQLITE3_CPPFLAGS $LIBACL_CPPFLAGS"
-CFLAGS="$CFLAGS $TOKYOCABINET_CFLAGS $QDBM_CFLAGS $PCRE_CFLAGS $OPENSSL_CFLAGS $MONGO_CFLAGS $SQLITE3_CFLAGS $LIBACL_CFLAGS"
-LDFLAGS="$LDFLAGS $TOKYOCABINET_LDFLAGS $QDBM_LDFLAGS $PCRE_LDFLAGS $OPENSSL_LDFLAGS $MONGO_LDFLAGS $SQLITE3_LDFLAGS $LIBACL_LDFLAGS"
-LIBS="$LIBS $TOKYOCABINET_LIBS $QDBM_LIBS $PCRE_LIBS $OPENSSL_LIBS $MONGO_LIBS $SQLITE3_LIBS $LIBACL_LIBS"
+CPPFLAGS="$CPPFLAGS $TOKYOCABINET_CPPFLAGS $QDBM_CPPFLAGS $PCRE_CPPFLAGS $OPENSSL_CPPFLAGS $MONGO_CPPFLAGS $SQLITE3_CPPFLAGS $LIBACL_CPPFLAGS $MATHEVAL_CPPFLAGS"
+CFLAGS="$CFLAGS $TOKYOCABINET_CFLAGS $QDBM_CFLAGS $PCRE_CFLAGS $OPENSSL_CFLAGS $MONGO_CFLAGS $SQLITE3_CFLAGS $LIBACL_CFLAGS $MATHEVAL_CFLAGS"
+LDFLAGS="$LDFLAGS $TOKYOCABINET_LDFLAGS $QDBM_LDFLAGS $PCRE_LDFLAGS $OPENSSL_LDFLAGS $MONGO_LDFLAGS $SQLITE3_LDFLAGS $LIBACL_LDFLAGS $MATHEVAL_LDFLAGS"
+LIBS="$LIBS $TOKYOCABINET_LIBS $QDBM_LIBS $PCRE_LIBS $OPENSSL_LIBS $MONGO_LIBS $SQLITE3_LIBS $LIBACL_LIBS $MATHEVAL_LIBS"
 
 dnl ######################################################################
 dnl OS specific stuff
@@ -1091,6 +1106,12 @@ if test "x$ac_cv_lib_xml2_xmlFirstElementChild" = xyes; then
   AC_MSG_RESULT([-> libxml2: $LIBXML2_PATH])
 else
   AC_MSG_RESULT([-> libxml2: disabled])
+fi
+
+if test "x$ac_cv_lib_matheval_evaluator_create" = xyes; then
+  AC_MSG_RESULT([-> matheval: $MATHEVAL_PATH])
+else
+  AC_MSG_RESULT([-> matheval: disabled])
 fi
 
 m4_indir(incstart[]incend, [nova/config.m4])

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -61,6 +61,9 @@
 
 #include <libgen.h>
 
+#ifdef HAVE_LIBMATHEVAL
+#include <matheval.h>
+#endif
 
 /*
  * This module contains numeruous functions which don't use all their parameters
@@ -3879,6 +3882,54 @@ static FnCallResult FnCallStrftime(EvalContext *ctx, FnCall *fp, Rlist *finalarg
 }
 
 /*********************************************************************/
+
+static FnCallResult FnCallEval(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
+{
+    char *input = RlistScalarValue(finalargs);
+    char *type = RlistScalarValue(finalargs->next);
+    char *options = RlistScalarValue(finalargs->next->next);
+    if (0 != strcmp(type, "math") || 0 != strcmp(options, "novars"))
+    {
+        Log(LOG_LEVEL_ERR, "Unknown %s evaluation type %s or options %s", fp->name, type, options);
+        return (FnCallResult) { FNCALL_FAILURE };
+    }
+
+#ifndef HAVE_LIBMATHEVAL
+    Log(LOG_LEVEL_ERR, "%s error: CFEngine was not compiled with matheval support", fp->name);
+    input = NULL;
+    return (FnCallResult) { FNCALL_FAILURE };
+#else
+    void *f;                       // Function evaluator
+    char **names;                  // Variable names found in input
+    int count;                     // Count of variables found in input
+
+    /* Create evaluator for function.  */
+    f = evaluator_create (input);
+    if (NULL == f)
+    {
+        Log(LOG_LEVEL_INFO, "%s parsing error with expression '%s'", fp->name, input);
+        return (FnCallResult) { FNCALL_SUCCESS, { xstrdup(""), RVAL_TYPE_SCALAR } };
+    }
+
+    /* Print variable names appearing in function. */
+    evaluator_get_variables (f, &names, &count);
+
+    if (count > 0)
+    {
+        Log(LOG_LEVEL_INFO, "%s input error with expression '%s': symbolic variables not allowed (%d found)", fp->name, input, count);
+        evaluator_destroy (f);
+        return (FnCallResult) { FNCALL_FAILURE };
+    }
+
+    char out[CF_BUFSIZE];
+    sprintf(out, "%lf", evaluator_evaluate(f, 0, NULL, NULL));
+    evaluator_destroy (f);
+
+    return (FnCallResult) { FNCALL_SUCCESS, { xstrdup(out), RVAL_TYPE_SCALAR } };
+#endif
+}
+
+/*********************************************************************/
 /* Read functions                                                    */
 /*********************************************************************/
 
@@ -5654,6 +5705,14 @@ FnCallArg FORMAT_ARGS[] =
     {NULL, DATA_TYPE_NONE, NULL}
 };
 
+FnCallArg EVAL_ARGS[] =
+{
+    {CF_ANYSTRING, DATA_TYPE_STRING, "Input string"},
+    {"math", DATA_TYPE_OPTION, "Evaluation type"},
+    {"novars", DATA_TYPE_OPTION, "Evaluation options"},
+    {NULL, DATA_TYPE_NONE, NULL}
+};
+
 /*********************************************************/
 /* FnCalls are rvalues in certain promise constraints    */
 /*********************************************************/
@@ -5678,6 +5737,7 @@ const FnCallType CF_FNCALL_TYPES[] =
     FnCallTypeNew("dirname", DATA_TYPE_STRING, DIRNAME_ARGS, &FnCallDirname, "Return the parent directory name for given path", false, FNCALL_CATEGORY_FILES, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("diskfree", DATA_TYPE_INT, DISKFREE_ARGS, &FnCallDiskFree, "Return the free space (in KB) available on the directory's current partition (0 if not found)", false, FNCALL_CATEGORY_FILES, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("escape", DATA_TYPE_STRING, ESCAPE_ARGS, &FnCallEscape, "Escape regular expression characters in a string", false, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
+    FnCallTypeNew("eval", DATA_TYPE_STRING, EVAL_ARGS, &FnCallEval, "Evaluate a mathematical expression", false, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("every", DATA_TYPE_CONTEXT, EVERY_SOME_NONE_ARGS, &FnCallEverySomeNone, "True if every element in the named list matches the given regular expression", false, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("execresult", DATA_TYPE_STRING, EXECRESULT_ARGS, &FnCallExecResult, "Execute named command and assign output to variable", false, FNCALL_CATEGORY_UTILS, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("fileexists", DATA_TYPE_CONTEXT, FILESTAT_ARGS, &FnCallFileStat, "True if the named file can be accessed", false, FNCALL_CATEGORY_FILES, SYNTAX_STATUS_NORMAL),

--- a/tests/acceptance/01_vars/02_functions/eval.cf
+++ b/tests/acceptance/01_vars/02_functions/eval.cf
@@ -1,0 +1,118 @@
+#######################################################
+#
+# Test eval()
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "values[0]" string => "x";
+      "values[1]" string => "+ 200";
+      "values[2]" string => "200 + 100";
+      "values[3]" string => "200 - 100";
+      "values[4]" string => "- - -";
+      "values[5]" string => "2 - (3 - 1)";
+      "values[6]" string => "";
+      "values[7]" string => "3 / 0";
+      "values[8]" string => "3^3)";
+      "values[9]" string => "(-1)^2";
+      "values[10]" string => "sin(20)";
+      "values[11]" string => "cos(20)";
+      "values[12]" string => "asin(0.2)";
+      "values[13]" string => "acos(0.2)";
+      "values[14]" string => "tan(20)";
+      "values[15]" string => "atan(0.2)";
+      "values[16]" string => "log(0.2)";
+      "values[17]" string => "ln2";
+      "values[18]" string => "ln10";
+      "values[19]" string => "20 % 3";
+      "values[20]" string => "sqrt(0.2)";
+      "values[21]" string => "ceil(3.5)";
+      "values[22]" string => "floor(3.4)";
+      "values[23]" string => "abs(-3.4)";
+      "values[24]" string => "-3.4 -3.4";
+      "values[25]" string => "-3.400000 -3.400001";
+      "values[26]" string => "pi";
+      "values[27]" string => "e";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "indices" slist => getindices("init.values");
+
+      "eval[$(indices)]" string => eval("$(init.values[$(indices)])", "math", "novars");
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      # note this test will be MUCH more accurate when we have sprintf and rounding
+      "verify[0]" string => '';
+      "verify[1]" string => '';
+      "verify[2]" string => '300.000000';
+      "verify[3]" string => '100.000000';
+      "verify[4]" string => '';
+      "verify[5]" string => '0.000000';
+      "verify[6]" string => '';
+      "verify[7]" string => 'inf';
+      "verify[8]" string => '';
+      "verify[9]" string => '1.000000';
+      "verify[10]" string => '0.912945';
+      "verify[11]" string => '0.408082';
+      "verify[12]" string => '0.201358';
+      "verify[13]" string => '1.369438';
+      "verify[14]" string => '2.237161';
+      "verify[15]" string => '0.197396';
+      "verify[16]" string => '-1.609438';
+      "verify[17]" string => '0.693147';
+      "verify[18]" string => '2.302585';
+      "verify[19]" string => '';
+      "verify[20]" string => '0.447214';
+      "verify[21]" string => '';
+      "verify[22]" string => '';
+      "verify[23]" string => '3.400000';
+      "verify[24]" string => '-6.800000';
+      "verify[25]" string => '-6.800001';
+      "verify[26]" string => '3.141593';
+      "verify[27]" string => '2.718282';
+
+      "indices" slist => getindices("verify");
+
+  classes:
+      "ok_$(indices)" expression => strcmp("$(test.eval[$(indices)])", "$(verify[$(indices)])");
+      "not_ok_$(indices)" not => strcmp("$(test.eval[$(indices)])", "$(verify[$(indices)])");
+
+      "ok" and => { ok_0, ok_1, ok_3, ok_4, ok_5, ok_6, ok_7, ok_8,
+                    ok_9, ok_10, ok_11, ok_13, ok_14, ok_15, ok_16,
+                    ok_17, ok_18, ok_19, ok_20, ok_21, ok_23, ok_24,
+                    ok_25 };
+
+  reports:
+    DEBUG::
+      "OK math eval('$(init.values[$(indices)])') = '$(test.eval[$(indices)])'"
+      ifvarclass => "ok_$(indices)";
+
+      "FAIL math eval('$(init.values[$(indices)])') = '$(test.eval[$(indices)])' (expected '$(verify[$(indices)])')"
+      ifvarclass => "not_ok_$(indices)";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Using the optional GNU libmatheval, we get:
- symbolic evaluation (disabled for now)
- function differentiation (unused for now)
- parsing of infix expressions with parenthesis
- all the math goodness you expect, including standard constants and the hyperbolic inverse cosecant `acsch` (gesundheit)
- robust parser; acceptance test shows its usage
- no rounding (use `format` for that)
- fast evaluation

I left the function parameters as a type (currenly only `math`) and some options (currently only `novars`) to support future expansions; I feel strongly that leaving these parameters is very useful as our evaluation needs grow.  For instance we may need a logical evaluation mode that can parse Boolean logic.
