### PR TITLE
stdlib: add apt_get_del package_method

### DIFF
--- a/masterfiles/lib/3.5/packages.cf
+++ b/masterfiles/lib/3.5/packages.cf
@@ -176,6 +176,39 @@ body package_method apt_get
 
 }
 
+body package_method apt_get_del(delete_method)
+ # You need to pass 'remove' or 'purge' to this method, depending on
+ # which you want to use to remove the package. If this method is used 
+ # to do other operations, ie 'add', then you don't have to pass anything.
+{
+      package_changes => "bulk";
+      package_list_command => "$(debian_knowledge.call_dpkg) -l";
+      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
+      package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
+      package_name_convention => "$(name)";
+
+      # set it to "0" to avoid caching of list during upgrade
+      package_list_update_ifelapsed => "240";
+
+      package_add_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+      package_list_update_command => "$(debian_knowledge.call_apt_get) update";
+      package_delete_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes -q $(delete_method)";
+      package_update_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+      package_patch_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+      package_verify_command => "$(debian_knowledge.call_dpkg) -s";
+      package_noverify_returncode => "1";
+
+      package_patch_list_command => "$(debian_knowledge.call_apt_get) --just-print dist-upgrade";
+      package_patch_name_regex => "^Inst\s+(\S+)\s+.*";
+      package_patch_version_regex => "^Inst\s+\S+\s+\[?\(?([^\],\s]+).*";
+
+      # make correct version comparisons
+      package_version_less_command => "$(debian_knowledge.dpkg_compare_less)";
+      package_version_equal_command => "$(debian_knowledge.dpkg_compare_equal)";
+
+}
+
 body package_method apt_get_release(release)
 {
       package_changes => "bulk";

--- a/masterfiles/lib/3.6/packages.cf
+++ b/masterfiles/lib/3.6/packages.cf
@@ -176,6 +176,39 @@ body package_method apt_get
 
 }
 
+body package_method apt_get_del(delete_method)
+ # You need to pass 'remove' or 'purge' to this method, depending on
+ # which you want to use to remove the package. If this method is used 
+ # to do other operations, ie 'add', then you don't have to pass anything.
+{
+      package_changes => "bulk";
+      package_list_command => "$(debian_knowledge.call_dpkg) -l";
+      package_list_name_regex    => ".i\s+([^\s]+).*";
+      package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
+      package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
+      package_name_convention => "$(name)";
+
+      # set it to "0" to avoid caching of list during upgrade
+      package_list_update_ifelapsed => "240";
+
+      package_add_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+      package_list_update_command => "$(debian_knowledge.call_apt_get) update";
+      package_delete_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes -q $(delete_method)";
+      package_update_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+      package_patch_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+      package_verify_command => "$(debian_knowledge.call_dpkg) -s";
+      package_noverify_returncode => "1";
+
+      package_patch_list_command => "$(debian_knowledge.call_apt_get) --just-print dist-upgrade";
+      package_patch_name_regex => "^Inst\s+(\S+)\s+.*";
+      package_patch_version_regex => "^Inst\s+\S+\s+\[?\(?([^\],\s]+).*";
+
+      # make correct version comparisons
+      package_version_less_command => "$(debian_knowledge.dpkg_compare_less)";
+      package_version_equal_command => "$(debian_knowledge.dpkg_compare_equal)";
+
+}
+
 body package_method apt_get_release(release)
 {
       package_changes => "bulk";


### PR DESCRIPTION
This method allows you to pass either `purge` or `remove`, depending on which you want.

```
"unwanted-package"
 package_policy => "delete",
 package_method => apt_get_del("purge");
```

I would've liked to add this to the `apt_get` method, but couldn't figure out how to set the default as `remove`, if nothing is passed. Any hints? :)
