### PR TITLE
Suggestion for CFengine internal log files rotation

### DIFF
--- a/masterfiles/def.cf
+++ b/masterfiles/def.cf
@@ -51,4 +51,11 @@ bundle common def
       "cfe_log_dirs"     slist => {
                                     "$(sys.workdir)/outputs"
                                   };
+
+  classes:
+
+    ### Enable special features policies. Set to "any" to enable.
+
+    # Internal CFEngine log files rotation
+    "cfengine_internal_rotate_logs" expression  =>  "!any";
 }

--- a/masterfiles/promises.cf
+++ b/masterfiles/promises.cf
@@ -100,14 +100,14 @@ bundle agent main
       comment => "Just a pre-defined policy bundled with the package",
       handle => "main_methods_any_init_msg";
 
+    cfengine_internal_rotate_logs::
       # CFEngine generates internal log files that need to be rotated.
-      # Uncomment the following lines to get a sane default rotation of these files
-      #
-      # "rotate_promise_summary" usebundle => logrotate("@(def.cfe_log_files)", "1m", "10"),
-      #                          comment   => "Rotate log files once their size reach 1MB, keep 10 versions";
-      #
-      # "rotate_outputs"         usebundle => prunedir("@(def.cfe_log_dirs)", "30"),
-      #                          comment   => "Delete outputs/* files older than 30 days";
+      # Have a look at def.cf to enable rotation of these files
+      "rotate_promise_summary" usebundle => logrotate("@(def.cfe_log_files)", "1m", "10"),
+                               comment   => "Rotate log files once their size reach 1MB, keep 10 versions";
+
+      "rotate_outputs"         usebundle => prunedir("@(def.cfe_log_dirs)", "30"),
+                               comment   => "Delete outputs/* files older than 30 days";
 
 }
 


### PR DESCRIPTION
Hello,

Regarding bug report https://cfengine.com/dev/issues/3017, here is a try to add rotation for some CFEngine internals log files (promise_summary.log, cfengine/outputs/*), and to also handle rotation for cf3.hostname.runlog file (at the moment it is handled internally with Rotatefiles(), to be consistent.

Any feedback is welcome
