### PR TITLE
COPBL: Add file_select bigger_than(size) body

### DIFF
--- a/masterfiles/lib/3.5/files.cf
+++ b/masterfiles/lib/3.5/files.cf
@@ -1186,6 +1186,14 @@ body file_select size_range(from,to)
 
 ##
 
+body file_select bigger_than(size)
+{
+      search_size => irange("0","$(size)");
+      file_result => "!size";
+}
+
+##
+
 body file_select exclude(name)
 {
       leaf_name  => { "$(name)"};

--- a/masterfiles/lib/3.6/files.cf
+++ b/masterfiles/lib/3.6/files.cf
@@ -1186,6 +1186,14 @@ body file_select size_range(from,to)
 
 ##
 
+body file_select bigger_than(size)
+{
+      search_size => irange("0","$(size)");
+      file_result => "!size";
+}
+
+##
+
 body file_select exclude(name)
 {
       leaf_name  => { "$(name)"};


### PR DESCRIPTION
Hello,

It should be self-explanatory: may be used to select files to be rotated for example ;)
