### PR TITLE
Yacc/AIX segfaults if yylen is used instead of strlen(yytext)

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -872,7 +872,8 @@ class:                 CLASS
                            ParserDebug("\tP:%s:%s:%s:%s class = %s\n", P.block, P.blocktype, P.blockid, P.currenttype, yytext);
 
                            /* class literal includes terminating :: */
-                           char *literal = xstrndup(yytext, yylen - 2);
+                           /* Warning : AIX does not like yylen     */
+                           char *literal = xstrndup(yytext, strlen(yytext) - 2);
 
                            ValidateClassLiteral(literal);
 


### PR DESCRIPTION
Fixes redmine core https://cfengine.com/dev/issues/3304
