### PR TITLE
Avoid appending empty include dir to CPPFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -202,7 +202,10 @@ if test "x$with_postgresql" != "xno"; then
    # pg_config is only for native builds
    if test "x$cross_compiling" = "xno"; then
       if test x`which $PG_CONFIG` != x ; then
-         CPPFLAGS="$CPPFLAGS -I`$PG_CONFIG --includedir`"
+         pg_include_dir=`$PG_CONFIG --includedir`
+         if test -n "$pg_include_dir"; then
+            CPPFLAGS="$CPPFLAGS -I$pg_include_dir"
+         fi
       fi
    fi
 
@@ -229,7 +232,10 @@ if test "x$with_mysql" != "xno"; then
    # mysql_config is only for native builds
    if test "x$cross_compiling" = "xno"; then
       if test x`which $MYSQL_CONFIG` != x ; then
-         CPPFLAGS="$CPPFLAGS `$MYSQL_CONFIG --include`"
+         mysql_include_dir=`$MYSQL_CONFIG --include`
+         if test -n "$mysql_include_dir"; then
+            CPPFLAGS="$CPPFLAGS $mysql_include_dir"
+         fi
       fi
    fi
 
@@ -375,7 +381,10 @@ if test "x$with_libxml2" != xno; then
    # xml2-config is only for native builds
    if test "x$cross_compiling" = "xno"; then
       if test x`which $XML2_CONFIG` != x ; then
-         CPPFLAGS="$CPPFLAGS `$XML2_CONFIG --cflags`"
+         xml2_include_dir=`$XML2_CONFIG --cflags`
+         if test -n "$xml2_include_dir"; then
+            CPPFLAGS="$CPPFLAGS $xml2_include_dir"
+         fi
       fi
    fi
 


### PR DESCRIPTION
Previously, this resulted in invalid compile options such as the following tokyocabinet test:
gcc -o conftest -pthread -g -O2 -O2 -DNDEBUG   -I/usr/local/include -I    conftest.c -ltokyocabinet

Resulting in the following output:
...
/usr/bin/ld: /usr/lib/debug/usr/lib/x86_64-linux-gnu/crt1.o(.debug_info): relocation 20 has invalid symbol index 19
/usr/lib/gcc/x86_64-linux-gnu/4.6/../../../x86_64-linux-gnu/crt1.o: In function _start':
(.text+0x20): undefined reference to 'main'
...

Due to : `-I    conftest.c` in the end
