### PR TITLE
Fixing a problem with dlclose and avahi

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1881,7 +1881,13 @@ static int AutomaticBootstrap(GenericAgentConfig *config)
         ret = -1;
     };
 
-    dlclose(avahi_handle);
+	if (avahi_handle)
+	{
+		/*
+		 * This case happens when dlopen does not manage to open the library.
+		 */
+    	dlclose(avahi_handle);
+	}
     ListDestroy(&foundhubs);
 
     return ret;


### PR DESCRIPTION
In situations where dlopen does not fail but does not load the library,
the handle will be NULL (see issue 3337 in Redmine).

This fix checks if avahi_handle is not NULL before calling dlclose in order
to avoid the agent from crashing unnecessarily.

Once this is integrated into master this needs to be cherry-picked into 3.5.x.
