### PR TITLE
Adding 32 bits path to avahi paths

### DIFF
--- a/cf-agent/load_avahi.c
+++ b/cf-agent/load_avahi.c
@@ -30,7 +30,9 @@
 static const char *paths[3] = {
     "/usr/lib/x86_64-linux-gnu/libavahi-client.so.3",
     "/usr/lib/libavahi-client.so.3",
-    "/usr/lib64/libavahi-client.so.3"
+    "/usr/lib64/libavahi-client.so.3",
+	/* 32 bits variants */
+	"/usr/lib/i386-linux-gnu/libavahi-client.so.3"
 };
 
 static const char *getavahipath();


### PR DESCRIPTION
Currently we were looking only into 64 bits path for finding the avahi library.
This fix adds at least the 32 bits path from ubuntu to the resolution.
