### PR TITLE
Redmine#3323: @include proposal

### DIFF
--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -64,9 +64,13 @@ P.offsets.current += yyleng;
 
 #define YY_USER_ACTION yyuseraction();
 
-// Do not use lex - flex only
+#define MAX_INCLUDE_DEPTH 1
+YY_BUFFER_STATE include_stack[MAX_INCLUDE_DEPTH];
+int include_stack_ptr = 0;
 
 %}
+
+%x incl_state
 
 space      [ \t]+
 
@@ -75,6 +79,8 @@ newline    ([\n]|[\xd][\xa])
 line       ^.*$
 
 comment    #[^\n]*
+
+include    ^@include
 
 promises   bundle
 
@@ -164,6 +170,106 @@ promise_type   [a-zA-Z_]+:
                           P.line_pos += yyleng;
                           ParserDebug("\tL:body %d\n", P.line_pos);
                           return BODY;
+                      }
+
+{include}             {
+                      ParserDebug("\tL:include %d\n", P.line_pos);
+                      if ( include_stack_ptr >= MAX_INCLUDE_DEPTH )
+                      {
+                          ParserDebug("\tI: Includes nested too deeply\n" );
+                          exit( 1 );
+                      }
+                      BEGIN(incl_state);
+                      }
+
+<incl_state>[ \t]*         
+<incl_state>{qstring}  {
+                          ParserDebug("\tL:include state:qstring:%s\n", yytext);
+                          include_stack[include_stack_ptr++] = YY_CURRENT_BUFFER;
+
+                          char *fname = NULL;
+                          fname = xstrdup(yytext+1); // skip up to the opening quote
+                          fname[strlen(fname)-1] = '\0'; // clear the ending quote
+
+                          // check for leading path components, attempting to catch Windows paths
+                          if (fname == strchr(fname, '/') || (strlen(fname) > 3 && fname[2] == ':'))
+                          {
+                               ParserDebug("\tL:include_state:%s (absolute path, included in %s)\n", fname, P.filename);
+                          }
+                          else
+                          {
+                               ParserDebug("\tL:include_state:%s (relative path, included in %s)\n", fname, P.filename);
+                               char current[CFE_PARSER_PATH_MAX];
+                               char dirname[CFE_PARSER_PATH_MAX];
+
+                               if (NULL == realpath(P.filename, dirname))
+                               {
+                                   char error_str[CF_MAXVARSIZE];
+
+                                   snprintf(error_str, CF_MAXVARSIZE, "\tI: Could not resolve realpath of file '%s': %s\n", P.filename, strerror(errno));
+                                   yyerror(error_str);
+                                   exit(1);
+                               }
+
+                               char *chop = strrchr(dirname, '/');
+
+                               if (NULL == chop)
+                               {
+                                    chop = strrchr(dirname, '\\');
+                               }
+
+                               if (NULL != chop)
+                               {
+                                    *chop = '\0';
+                               }
+
+                               // this should work on Windows too
+                               snprintf(current, CFE_PARSER_PATH_MAX-1, "%s/%s", dirname, fname);
+                               free(fname);
+                               fname = xstrdup(current);
+                          }
+
+                          yyin = fopen(fname, "r" );
+
+                          if ( ! yyin )
+                          {
+                              char error_str[CF_MAXVARSIZE];
+
+                              snprintf(error_str, CF_MAXVARSIZE, "\tI: Could not open file '%s' for reading: %s\n", fname, strerror(errno));
+                              yyerror(error_str);
+                              exit(1);
+                          }
+                          else
+                          {
+                              ParserDebug("\tI: @Including file '%s'\n", fname);
+                          }
+
+                          strncpy(P.include_filename, fname, CFE_PARSER_PATH_MAX);
+                          free(fname);
+
+                          yy_switch_to_buffer( yy_create_buffer( yyin, YY_BUF_SIZE ) );
+
+                          BEGIN(INITIAL);
+                      }
+
+<incl_state>.[^'"]*   {
+                          yyerror("Not a valid include statement");
+                          exit(1);
+                      }
+
+
+<<EOF>>               {
+                          P.include_filename[0] = '\0';
+
+                          if ( --include_stack_ptr < 0 || !YY_CURRENT_BUFFER)
+                          {
+                              yyterminate();
+                          }
+                          else
+                          {
+                              yy_delete_buffer( YY_CURRENT_BUFFER );
+                              yy_switch_to_buffer(include_stack[include_stack_ptr] );
+                          }
                       }
 
 {id}                  {

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -1141,7 +1141,15 @@ gaitem:                IDSYNTAX
 static void ParseErrorVColumnOffset(int column_offset, const char *s, va_list ap)
 {
     char *errmsg = StringVFormat(s, ap);
-    fprintf(stderr, "%s:%d:%d: error: %s\n", P.filename, P.line_no, P.line_pos + column_offset, errmsg);
+
+    if (strlen(P.include_filename) > 0)
+    {
+        fprintf(stderr, "%s:%d:%d: error: (included file %s) %s\n", P.filename, P.line_no, P.line_pos + column_offset, P.include_filename, errmsg);
+    }
+    else
+    {
+        fprintf(stderr, "%s:%d:%d: error: %s\n", P.filename, P.line_no, P.line_pos + column_offset, errmsg);
+    }
     free(errmsg);
 
     /* FIXME: why this might be NULL? */
@@ -1192,7 +1200,15 @@ static void ParseWarningV(unsigned int warning, const char *s, va_list ap)
     char *errmsg = StringVFormat(s, ap);
     const char *warning_str = ParserWarningToString(warning);
 
-    fprintf(stderr, "%s:%d:%d: warning: %s [-W%s]\n", P.filename, P.line_no, P.line_pos, errmsg, warning_str);
+    if (strlen(P.include_filename) > 0)
+    {
+        fprintf(stderr, "%s:%d:%d: warning: (included file %s) %s [-W%s]\n", P.filename, P.line_no, P.line_pos, P.include_filename, errmsg, warning_str);
+    }
+    else
+    {
+        fprintf(stderr, "%s:%d:%d: warning: %s [-W%s]\n", P.filename, P.line_no, P.line_pos, errmsg, warning_str);
+    }
+
     fprintf(stderr, "%s\n", P.current_line);
     fprintf(stderr, "%*s\n", P.line_pos, "^");
 
@@ -1234,7 +1250,15 @@ static void fatal_yyerror(const char *s)
         sp++;
     }
 
-    fprintf(stderr, "%s: %d,%d: Fatal error during parsing: %s, near token \'%.20s\'\n", P.filename, P.line_no, P.line_pos, s, sp ? sp : "NULL");
+    if (strlen(P.include_filename) > 0)
+    {
+        fprintf(stderr, "%s: %d,%d: Fatal error during parsing: (included file %s) %s, near token \'%.20s\'\n", P.filename, P.line_no, P.line_pos, P.include_filename, s, sp ? sp : "NULL");
+    }
+    else
+    {
+        fprintf(stderr, "%s: %d,%d: Fatal error during parsing: %s, near token \'%.20s\'\n", P.filename, P.line_no, P.line_pos, s, sp ? sp : "NULL");
+    }
+
     exit(1);
 }
 

--- a/libpromises/parser.c
+++ b/libpromises/parser.c
@@ -87,6 +87,8 @@ Policy *ParserParseFile(const char *path, unsigned int warnings, unsigned int wa
     P.warnings_error = warnings_error;
 
     strncpy(P.filename, path, CF_MAXVARSIZE);
+    // no include is active by default
+    P.include_filename[0] = '\0';
 
     yyin = fopen(path, "r");
     if (yyin == NULL)

--- a/libpromises/parser_state.h
+++ b/libpromises/parser_state.h
@@ -28,6 +28,7 @@
 #include <cf3.defs.h>
 #include <rlist.h>
 
+#define CFE_PARSER_PATH_MAX PATH_MAX
 
 typedef struct
 {
@@ -35,7 +36,8 @@ typedef struct
     char blocktype[CF_MAXVARSIZE];
     char blockid[CF_MAXVARSIZE];
 
-    char filename[CF_MAXVARSIZE];
+    char filename[CFE_PARSER_PATH_MAX];
+    char include_filename[CFE_PARSER_PATH_MAX];
     char *current_line;
     int line_pos;
     int line_no;

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -172,6 +172,10 @@ struct utsname
 # endif
 #endif
 
+#ifndef PATH_MAX
+# define PATH_MAX 4096
+#endif
+
 #include <signal.h>
 
 #ifdef __MINGW32__

--- a/tests/acceptance/00_basics/01_compiler/include.cf
+++ b/tests/acceptance/00_basics/01_compiler/include.cf
@@ -1,0 +1,44 @@
+######################################################
+#
+#  Test that @include works
+#
+#####################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "dummy" string => "dummy";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "subout" string => execresult("$(sys.cf_agent) -Kvf $(this.promise_filename).sub | grep seagull", "useshell");
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok" expression => regcmp(".*seagull.*", "$(test.subout)");
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+    DEBUG::
+      "$(test.subout)";
+}

--- a/tests/acceptance/00_basics/01_compiler/include.cf.sub
+++ b/tests/acceptance/00_basics/01_compiler/include.cf.sub
@@ -1,0 +1,7 @@
+body common control
+{
+      bundlesequence => { run };
+}
+
+@include "include.cf.sub.sub1"
+@include 'include.cf.sub.sub2'

--- a/tests/acceptance/00_basics/01_compiler/include.cf.sub.sub1
+++ b/tests/acceptance/00_basics/01_compiler/include.cf.sub.sub1
@@ -1,0 +1,3 @@
+bundle agent run
+{
+  reports:

--- a/tests/acceptance/00_basics/01_compiler/include.cf.sub.sub2
+++ b/tests/acceptance/00_basics/01_compiler/include.cf.sub.sub2
@@ -1,0 +1,2 @@
+      "$(this.bundle): ran like a seagull.";
+}


### PR DESCRIPTION
Proposal to implement https://cfengine.com/dev/issues/3323

Briefly, you say `@include "filename"` and it gets included verbatim at the lexing stage, before the parser ever sees it.  This is noted in the `-d` output through `ParserDebug` but not in regular CFEngine logging.  Parsing errors and warnings _do_ show the included filename.

Absolute and relative filenames work; acceptance test (uses relative filenames) segfaults, but it works in standalone testing (see sample policy in Redmine).  I can't find the problem in my testing, and believe it's not due to my code.
