### PR TITLE
Redmine #3280 - Permit CFEngine to compare the package installed and the package promised on Debian Wheezy

### DIFF
--- a/masterfiles/libraries/cfengine_stdlib.cf
+++ b/masterfiles/libraries/cfengine_stdlib.cf
@@ -1585,7 +1585,7 @@ body package_method apt
 {
 package_changes => "bulk";
 package_list_command => "/usr/bin/dpkg -l";
-package_list_name_regex    => ".i\s+([^\s]+).*";
+package_list_name_regex    => ".i\s+([^\s:]+).*";
 package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
 package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
 package_name_convention => "$(name)";
@@ -1632,7 +1632,7 @@ package_list_command => "/usr/bin/dpkg -l";
 package_list_update_command => "/usr/bin/apt-get update";
 package_list_update_ifelapsed => "240";
 
-package_list_name_regex    => ".i\s+([^\s]+).*";
+package_list_name_regex    => ".i\s+([^\s:]+).*";
 package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
 
 package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
@@ -2113,7 +2113,7 @@ redhat::
 debian::
  package_changes => "bulk";
  package_list_command => "/usr/bin/dpkg -l";
- package_list_name_regex    => ".i\s+([^\s]+).*";
+ package_list_name_regex    => ".i\s+([^\s:]+).*";
  package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
  package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
  package_name_convention => "$(name)";


### PR DESCRIPTION
This is a proposal related to https://cfengine.com/dev/issues/3280.

This Pull Request will permit to compare on Debian Wheezy the name of the package installed and the name of the package promised. Since Wheezy, Debian is multiarch and the actual comparison does not work since the name contains `:amd64`, `:i586`,etc...

To fix that issue we have to add into the regexp for the name of the package to not match what contains `:`.
