### PR TITLE
Get all process characteristics on FreeBSD: Redmine #1947

### DIFF
--- a/libpromises/classes.c
+++ b/libpromises/classes.c
@@ -77,11 +77,11 @@ const char *VPSOPTS[PLATFORM_CONTEXT_MAX] =
     "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* linux */
     "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,pri,rss,nlwp,stime,time,args",  /* solaris */
     "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,start,time,args",  /* freebsd */
-    "auxw",                     /* netbsd */
+    "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,start,time,args",  /* netbsd */
     "-elyf",                    /* cray */
     "-aW",                      /* NT */
     "-ef",                      /* Unixware */
-    "auxw",                     /* openbsd */
+    "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,start,time,args",       /* openbsd */
     "-ef",                      /* sco */
     "auxw",                     /* darwin */
     "-elyf",                    /* qnx */


### PR DESCRIPTION
Update ps options to get control over all process characteristics on FreeBSD systems.

Checked against the test case provided in https://cfengine.com/dev/issues/1947, and from my own tests. (FreeBSD 9.1, 8.2, 7.4)

I would like to wait for Igor feedback, in the meanwhile I will also update ps options for NetBSD and OpenBSD in the same PR, it wouldn't be too difficult
