### PR TITLE
Acceptance tests to abuse Mustache

### DIFF
--- a/tests/acceptance/10_files/templating/mustache_abuse.cf
+++ b/tests/acceptance/10_files/templating/mustache_abuse.cf
@@ -1,0 +1,119 @@
+#######################################################
+#
+# Abusive Mustache relationship
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "tests" slist => { "0", "1", "2", "3", "4", "5", "6" };
+      "templates" container => parsejson('
+[
+ "{{x}}",
+ "{{x}} {{y}}",
+ "{{null}}",
+ "{{}}",
+ "{{#boolean}}IT IS TRUE{{/boolean}}",
+ "{{^boolean}}IT IS FALSE{{/boolean}}",
+ "{{#list}}{{k}}={{v}}, {{/list}}"
+]');
+
+  files:
+      "$(G.testfile).$(tests).tmpl"
+      create => "true",
+      edit_defaults => test_empty,
+      edit_line => init_insert_lines("$(templates[$(tests)])");
+}
+
+bundle edit_line init_insert_lines(lines)
+{
+  insert_lines:
+
+      "$(lines)"
+      comment => "Append lines if they don't exist";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "tdata" container => parsejson('
+[
+ "{ \\\"x\\\": 123 }",
+ "{ \\\"x\\\": 123, \\\"y\\\": 456 }",
+ "[ null ]",
+ "{ \\\"x\\\": 123, \\\"y\\\": 456 }",
+ "{\\\"boolean\\\": true}",
+ "{\\\"boolean\\\": false}",
+ "{ \\\"list\\\": [ { \\\"k\\\": 789, \\\"v\\\": 0 }, { \\\"k\\\": null, \\\"v\\\": true }, { \\\"k\\\": -1, \\\"v\\\": -2 } ] }",
+]');
+
+  files:
+      "$(G.testfile).$(init.tests)"
+      create => "true",
+      edit_defaults => test_empty,
+      edit_template => "$(G.testfile).$(init.tests).tmpl",
+      template_method => "mustache",
+      template_data => parsejson("$(tdata[$(init.tests)])");
+
+  reports:
+    DEBUG::
+      "Rendering template file $(G.testfile).$(init.tests).tmpl to $(G.testfile).$(init.tests)";
+}
+
+body edit_defaults test_empty
+{
+      empty_file_before_editing => "true";
+      edit_backup => "false";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "expected" container => parsejson('
+[
+ "123",
+ "123 456",
+ "",
+ "",
+ "IT IS TRUE"
+ "IT IS FALSE",
+ "789=0, =true, -1=-2, "
+]');
+
+      "actual_$(init.tests)" string => readfile("$(G.testfile).$(init.tests)", 10000);
+
+  classes:
+      "ok_$(init.tests)" expression => regcmp("$(expected[$(init.tests)])",
+                                              "$(actual_$(init.tests))");
+
+      "ok" and => { ok_0, ok_1, ok_2, ok_3, ok_4, ok_5 };
+
+  reports:
+    DEBUG::
+      "OK $(init.tests): Expected  '$(expected[$(init.tests)])' == '$(actual_$(init.tests))'"
+      ifvarclass => "ok_$(init.tests)";
+
+      "FAIL $(init.tests): Expected '$(expected[$(init.tests)])' <> '$(actual_$(init.tests))'"
+      ifvarclass => "!ok_$(init.tests)";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Subtest 5 (the last one) fails because `true` is serialized to an empty string and I think it should be serialized to `true`.  If I'm wrong, I'll rewrite.

Otherwise the test passes.
