### PR TITLE
Strip LF/LN from the end of the string in some special cases

### DIFF
--- a/libutils/csv_parser.c
+++ b/libutils/csv_parser.c
@@ -273,6 +273,14 @@ static csv_parser_error LaunchCsvAutomata(char *str, Seq **newlist)
             *sn = *s; sn++;
             *sn = '\0'; sn = NULL;
         }
+        if(current_state == CSV_ST_NO_QUOTE_MODE || current_state == CSV_ST_PRE_START_SPACE)
+        {
+            int len = strlen(snatched);
+            if (len > 1 && snatched[len - 2] == '\r' && snatched[len - 1] == '\n')
+            {
+                snatched[len - 2] = '\0';
+            }
+        }
         SeqAppend(*newlist, (void *)xstrdup(snatched));
         snatched[0] = '\0';
     }

--- a/tests/unit/csv_parser_test.c
+++ b/tests/unit/csv_parser_test.c
@@ -92,6 +92,45 @@ static void test_new_csv_reader_lfln_at_end()
     }
 }
 
+static void test_new_csv_reader_lfln_at_end2()
+{
+    Seq *list = NULL;
+    char line[]="  Type    ,\"walo1\",  \"walo2\"   ,  \"wal\r\n,o \"\" 3\",  \"  ab,cd  \", walo solo , ,walo\r\n";
+
+    list = SeqParseCsvString(line);
+
+    assert_int_equal(list->length, 8);
+    assert_string_equal(list->data[7], "walo");
+    if (list != NULL)
+    {
+        SeqDestroy(list);
+    }
+    else
+    {
+        assert_true(false);
+    }
+}
+
+static void test_new_csv_reader_lfln_at_end3()
+{
+    Seq *list = NULL;
+    char line[]="  Type    ,\"walo1\",  \"walo2\"   ,  \"wal\r\n,o \"\" 3\",  \"  ab,cd  \", walo solo , , \r\n";
+
+
+    list = SeqParseCsvString(line);
+
+    assert_int_equal(list->length, 8);
+    assert_string_equal(list->data[7], " ");
+    if (list != NULL)
+    {
+        SeqDestroy(list);
+    }
+    else
+    {
+        assert_true(false);
+    }
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -101,6 +140,8 @@ int main()
         unit_test(test_new_csv_reader),
         unit_test(test_new_csv_reader_lfln),
         unit_test(test_new_csv_reader_lfln_at_end),
+        unit_test(test_new_csv_reader_lfln_at_end2),
+        unit_test(test_new_csv_reader_lfln_at_end3),
     };
 
     return run_tests(tests);


### PR DESCRIPTION
This is done for more RFC 4180 compliance where every line should end with 0xd 0xa
