### PR TITLE
Enable IndexBracketsBalance(..) when compiled with NDEBUG

### DIFF
--- a/libpromises/var_expressions.c
+++ b/libpromises/var_expressions.c
@@ -154,8 +154,6 @@ VarRef *VarRefCopyIndexless(const VarRef *ref)
     return copy;
 }
 
-
-#ifndef NDEBUG
 static bool IndexBracketsBalance(const char *var_string)
 {
     int count = 0;
@@ -173,7 +171,6 @@ static bool IndexBracketsBalance(const char *var_string)
 
     return count == 0;
 }
-#endif
 
 static size_t IndexCount(const char *var_string)
 {


### PR DESCRIPTION
24059e5b13e1bf17f9583a00af6feb4b322ea31a disabled it earlier because it was only used in an assert( ) call
