### PR TITLE
Acceptance test for passing a container to the template_data attribute

### DIFF
--- a/tests/acceptance/10_files/templating/mustache_container_passing.cf
+++ b/tests/acceptance/10_files/templating/mustache_container_passing.cf
@@ -1,0 +1,79 @@
+#######################################################
+#
+# Demo from mustache.github.io
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "origtestdir" string => concat("$(G.cwd)/",
+				     dirname("$(this.promise_filename)"));
+
+  files:
+      "$(G.testfile)"
+      delete => init_delete;
+}
+
+body delete init_delete
+{
+      dirlinks => "delete";
+      rmdirs   => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "template_file" string => "$(init.origtestdir)/demo.mustache";
+      "data" container => readjson("$(init.origtestdir)/demo.json", 10000);
+
+  files:
+      "$(G.testfile)"
+      create => "true",
+      edit_template => "$(template_file)",
+      template_method => "mustache",
+      template_data => data;
+
+  reports:
+    DEBUG::
+      "Rendering template file $(template_file) to $(G.testfile)";
+}
+
+body copy_from sync_cp(from)
+{
+      source => "$(from)";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "expect" string => readfile("$(init.origtestdir)/demo.expected", 10000);
+      "actual" string => readfile("$(G.testfile)", 10000);
+
+  classes:
+      "ok" expression => regcmp("$(expect)", "$(actual)");
+
+  reports:
+    DEBUG::
+      "expect: '$(expect)'";
+      "actual: '$(actual)'";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
@sigurdteigen the notation is `data` as discussed (also see https://cfengine.com/dev/issues/3334 for symbolic references in general).