### PR TITLE
Openvz support

### DIFF
--- a/src/cf3.defs.h
+++ b/src/cf3.defs.h
@@ -323,6 +323,7 @@ enum statepolicy
 enum classes
 {
     hard_class_unknown,
+    virt_host_vz_vzps,
     hp,
     aix,
     linuxx,

--- a/src/classes.c
+++ b/src/classes.c
@@ -27,6 +27,7 @@
 const char *CLASSTEXT[HARD_CLASSES_MAX] =
 {
     "<unknown>",
+    "virt_host_vz_vzps",
     "hpux",
     "aix",
     "linux",
@@ -48,6 +49,7 @@ const char *CLASSTEXT[HARD_CLASSES_MAX] =
 const char *VPSCOMM[HARD_CLASSES_MAX] =
 {
     "",
+    "/bin/vzps -E 0",           /* vz with vzps */
     "/bin/ps",                  /* hpux */
     "/bin/ps",                  /* aix */
     "/bin/ps",                  /* linux */
@@ -72,6 +74,7 @@ const char *VPSCOMM[HARD_CLASSES_MAX] =
 const char *VPSOPTS[HARD_CLASSES_MAX] =
 {
     "",
+    "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,pri,rss,nlwp,stime,time,args", /* vz with vzps */
     "-ef",                      /* hpux */
     "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args",  /* aix */
     "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,pri,rss,nlwp,stime,time,args",        /* linux */
@@ -93,6 +96,7 @@ const char *VPSOPTS[HARD_CLASSES_MAX] =
 const char *VFSTAB[HARD_CLASSES_MAX] =
 {
     "-",
+    "/etc/fstab",               /* vz with vzps */
     "/etc/fstab",               /* hpux */
     "/etc/filesystems",         /* aix */
     "/etc/fstab",               /* linux */

--- a/src/mon_network.c
+++ b/src/mon_network.c
@@ -37,6 +37,7 @@ Item *MON_UDP4 = NULL, *MON_UDP6 = NULL, *MON_TCP4 = NULL, *MON_TCP6 = NULL;
 static const char *VNETSTAT[HARD_CLASSES_MAX] =
 {
     "-",
+    "/bin/netstat -rn",         /* virt_host_vz_vzps */
     "/usr/bin/netstat -rn",     /* hpux */
     "/usr/bin/netstat -rn",     /* aix */
     "/bin/netstat -rn",         /* linux */

--- a/src/nfs.c
+++ b/src/nfs.c
@@ -42,6 +42,7 @@ static void DeleteThisItem(Item **liststart, Item *entry);
 static const char *VMOUNTCOMM[HARD_CLASSES_MAX] =
 {
     "",
+    "/bin/mount -va",           /* virt_host_vz_vzps */
     "/sbin/mount -ea",          /* hpux */
     "/usr/sbin/mount -t nfs",   /* aix */
     "/bin/mount -va",           /* linux */
@@ -63,6 +64,7 @@ static const char *VMOUNTCOMM[HARD_CLASSES_MAX] =
 static const char *VUNMOUNTCOMM[HARD_CLASSES_MAX] =
 {
     "",
+    "/bin/umount",              /* virt_host_vz_vzps */
     "/sbin/umount",             /* hpux */
     "/usr/sbin/umount",         /* aix */
     "/bin/umount",              /* linux */
@@ -84,6 +86,7 @@ static const char *VUNMOUNTCOMM[HARD_CLASSES_MAX] =
 static const char *VMOUNTOPTS[HARD_CLASSES_MAX] =
 {
     "",
+    "defaults",                 /* virt_host_vz_vzps */
     "bg,hard,intr",             /* hpux */
     "bg,hard,intr",             /* aix */
     "defaults",                 /* linux */


### PR DESCRIPTION
Detect OpenVZ/Virtuozzo and Parallels Cloud Server, and define the following hard classes:
- virt_host_openvz: for the openVZ host
- virt_host_vz_vzps: for openVZ host, if the /bin/vzps tool is available
- virt_guest_openvz: for the openVZ guest

On the host:

```
# cf-promises/cf-promises -v | grep openvz
virt_host_openvz
```

Inside an OpenVZ container:

```
# cf-promises/cf-promises -v |  grep openvz
virt_guest_openvz
```

On the OpenVZ host, the ps command list the processes on both host and containers, making the _processes_ promise type unusable.
The tool /bin/vzps let you select the host or container you want to have the processes from; so this PR add detection for this tool on the host, and define the class _virt_host_vz_vzps_, and uses vzps instead of of ps

This is contains part of the code and naming discussion in https://github.com/cfengine/core/pull/582, and also part of the patch proposed by Liviu Damian http://pastebin.com/ipTeh1Mk / https://groups.google.com/forum/#!topic/help-cfengine/h098EgAusoA

This Pull request is targeted on 3.4 because it corresponds to my need, but I'd be happy to create a new pull request as well for Master
