### PR TITLE
eval() gets SI units

### DIFF
--- a/examples/eval.cf
+++ b/examples/eval.cf
@@ -27,6 +27,8 @@ bundle agent run
       "values[25]" string => "-3.400000 == -3.400001";
       "values[26]" string => "e";
       "values[27]" string => "pi";
+      "values[28]" string => "100m"; # 100 million
+      "values[29]" string => "100k"; # 100 thousand
 
       "indices" slist => getindices("values");
 

--- a/libpromises/math.pc
+++ b/libpromises/math.pc
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define YYRULECOUNT 18
+#define YYRULECOUNT 19
 #ifndef YY_MALLOC
 #define YY_MALLOC(C, N)		malloc(N)
 #endif
@@ -272,11 +272,12 @@ YY_LOCAL(void) yySet(yycontext *yy, char *text, int count)   { yy->__val[count]=
 
 #define	YYACCEPT	yyAccept(yy, yythunkpos0)
 
-YY_RULE(int) yy_Fname(yycontext *yy); /* 18 */
-YY_RULE(int) yy_CLOSE(yycontext *yy); /* 17 */
-YY_RULE(int) yy_OPEN(yycontext *yy); /* 16 */
-YY_RULE(int) yy_Funcall(yycontext *yy); /* 15 */
-YY_RULE(int) yy_Constant(yycontext *yy); /* 14 */
+YY_RULE(int) yy_Fname(yycontext *yy); /* 19 */
+YY_RULE(int) yy_CLOSE(yycontext *yy); /* 18 */
+YY_RULE(int) yy_OPEN(yycontext *yy); /* 17 */
+YY_RULE(int) yy_Funcall(yycontext *yy); /* 16 */
+YY_RULE(int) yy_Constant(yycontext *yy); /* 15 */
+YY_RULE(int) yy_SI_Unit(yycontext *yy); /* 14 */
 YY_RULE(int) yy_F_NUMBER(yycontext *yy); /* 13 */
 YY_RULE(int) yy_MOD(yycontext *yy); /* 12 */
 YY_RULE(int) yy_DIVIDE(yycontext *yy); /* 11 */
@@ -291,6 +292,71 @@ YY_RULE(int) yy_Sum(yycontext *yy); /* 3 */
 YY_RULE(int) yy_SPACE(yycontext *yy); /* 2 */
 YY_RULE(int) yy_Expr(yycontext *yy); /* 1 */
 
+YY_ACTION(void) yy_5_SI_Unit(yycontext *yy, char *yytext, int yyleng)
+{
+#define __ yy->__
+#define yypos yy->__pos
+#define yythunkpos yy->__thunkpos
+  yyprintf((stderr, "do yy_5_SI_Unit\n"));
+  {
+   math_eval_push(1000000000000000, yy->stack, &(yy->stackp)); ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+}
+YY_ACTION(void) yy_4_SI_Unit(yycontext *yy, char *yytext, int yyleng)
+{
+#define __ yy->__
+#define yypos yy->__pos
+#define yythunkpos yy->__thunkpos
+  yyprintf((stderr, "do yy_4_SI_Unit\n"));
+  {
+   math_eval_push(1000000000000, yy->stack, &(yy->stackp)); ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+}
+YY_ACTION(void) yy_3_SI_Unit(yycontext *yy, char *yytext, int yyleng)
+{
+#define __ yy->__
+#define yypos yy->__pos
+#define yythunkpos yy->__thunkpos
+  yyprintf((stderr, "do yy_3_SI_Unit\n"));
+  {
+   math_eval_push(1000000000, yy->stack, &(yy->stackp)); ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+}
+YY_ACTION(void) yy_2_SI_Unit(yycontext *yy, char *yytext, int yyleng)
+{
+#define __ yy->__
+#define yypos yy->__pos
+#define yythunkpos yy->__thunkpos
+  yyprintf((stderr, "do yy_2_SI_Unit\n"));
+  {
+   math_eval_push(1000000, yy->stack, &(yy->stackp)); ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+}
+YY_ACTION(void) yy_1_SI_Unit(yycontext *yy, char *yytext, int yyleng)
+{
+#define __ yy->__
+#define yypos yy->__pos
+#define yythunkpos yy->__thunkpos
+  yyprintf((stderr, "do yy_1_SI_Unit\n"));
+  {
+   math_eval_push(1000, yy->stack, &(yy->stackp)); ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+}
 YY_ACTION(void) yy_13_Constant(yycontext *yy, char *yytext, int yyleng)
 {
 #define __ yy->__
@@ -486,6 +552,19 @@ YY_ACTION(void) yy_1_Funcall(yycontext *yy, char *yytext, int yyleng)
 #undef yypos
 #undef yy
 }
+YY_ACTION(void) yy_2_Value(yycontext *yy, char *yytext, int yyleng)
+{
+#define __ yy->__
+#define yypos yy->__pos
+#define yythunkpos yy->__thunkpos
+  yyprintf((stderr, "do yy_2_Value\n"));
+  {
+   double scanned = 0; sscanf(yytext, "%lf", &scanned); math_eval_push(scanned, yy->stack, &(yy->stackp)); /*Log(LOG_LEVEL_ERR, "YY: read FP %lf", scanned);*/ ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+}
 YY_ACTION(void) yy_1_Value(yycontext *yy, char *yytext, int yyleng)
 {
 #define __ yy->__
@@ -493,7 +572,7 @@ YY_ACTION(void) yy_1_Value(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_Value\n"));
   {
-   double scanned = 0; sscanf(yytext, "%lf", &scanned); math_eval_push(scanned, yy->stack, &(yy->stackp)); /*Log(LOG_LEVEL_ERR, "YY: read FP %lf", scanned);*/ ;
+   double scanned = 0; sscanf(yytext, "%lf", &scanned); math_eval_push(math_eval_pop(yy->stack, &(yy->stackp)) * scanned, yy->stack, &(yy->stackp)); Log(LOG_LEVEL_ERR, "YY: read FP %lf", scanned); ;
   }
 #undef yythunkpos
 #undef yypos
@@ -693,156 +772,173 @@ YY_RULE(int) yy_Constant(yycontext *yy)
   yyprintf((stderr, "  fail %s @ %s\n", "Constant", yy->__buf+yy->__pos));
   return 0;
 }
-YY_RULE(int) yy_F_NUMBER(yycontext *yy)
+YY_RULE(int) yy_SI_Unit(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "F_NUMBER"));  yyText(yy, yy->__begin, yy->__end);  if (!(YY_BEGIN)) goto l33;
-  {  int yypos34= yy->__pos, yythunkpos34= yy->__thunkpos;  if (!yymatchChar(yy, '-')) goto l34;  goto l35;
-  l34:;	  yy->__pos= yypos34; yy->__thunkpos= yythunkpos34;
+  yyprintf((stderr, "%s\n", "SI_Unit"));
+  {  int yypos34= yy->__pos, yythunkpos34= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\000\010\000\000\000\010\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l35;  if (!yy_SPACE(yy)) goto l35;  yyDo(yy, yy_1_SI_Unit, yy->__begin, yy->__end);  goto l34;
+  l35:;	  yy->__pos= yypos34; yy->__thunkpos= yythunkpos34;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\000\040\000\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l36;  if (!yy_SPACE(yy)) goto l36;  yyDo(yy, yy_2_SI_Unit, yy->__begin, yy->__end);  goto l34;
+  l36:;	  yy->__pos= yypos34; yy->__thunkpos= yythunkpos34;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\200\000\000\000\200\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l37;  if (!yy_SPACE(yy)) goto l37;  yyDo(yy, yy_3_SI_Unit, yy->__begin, yy->__end);  goto l34;
+  l37:;	  yy->__pos= yypos34; yy->__thunkpos= yythunkpos34;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\000\000\020\000\000\000\020\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l38;  if (!yy_SPACE(yy)) goto l38;  yyDo(yy, yy_4_SI_Unit, yy->__begin, yy->__end);  goto l34;
+  l38:;	  yy->__pos= yypos34; yy->__thunkpos= yythunkpos34;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\000\000\001\000\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l33;  if (!yy_SPACE(yy)) goto l33;  yyDo(yy, yy_5_SI_Unit, yy->__begin, yy->__end);
   }
-  l35:;	  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l33;
-  l36:;	
-  {  int yypos37= yy->__pos, yythunkpos37= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l37;  goto l36;
-  l37:;	  yy->__pos= yypos37; yy->__thunkpos= yythunkpos37;
-  }
-  {  int yypos38= yy->__pos, yythunkpos38= yy->__thunkpos;  if (!yymatchChar(yy, '.')) goto l38;  goto l39;
-  l38:;	  yy->__pos= yypos38; yy->__thunkpos= yythunkpos38;
-  }
-  l39:;	
-  l40:;	
-  {  int yypos41= yy->__pos, yythunkpos41= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l41;  goto l40;
-  l41:;	  yy->__pos= yypos41; yy->__thunkpos= yythunkpos41;
-  }  yyText(yy, yy->__begin, yy->__end);  if (!(YY_END)) goto l33;  if (!yy_SPACE(yy)) goto l33;
-  yyprintf((stderr, "  ok   %s @ %s\n", "F_NUMBER", yy->__buf+yy->__pos));
+  l34:;	
+  yyprintf((stderr, "  ok   %s @ %s\n", "SI_Unit", yy->__buf+yy->__pos));
   return 1;
   l33:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  yyprintf((stderr, "  fail %s @ %s\n", "SI_Unit", yy->__buf+yy->__pos));
+  return 0;
+}
+YY_RULE(int) yy_F_NUMBER(yycontext *yy)
+{  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
+  yyprintf((stderr, "%s\n", "F_NUMBER"));  yyText(yy, yy->__begin, yy->__end);  if (!(YY_BEGIN)) goto l39;
+  {  int yypos40= yy->__pos, yythunkpos40= yy->__thunkpos;  if (!yymatchChar(yy, '-')) goto l40;  goto l41;
+  l40:;	  yy->__pos= yypos40; yy->__thunkpos= yythunkpos40;
+  }
+  l41:;	  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l39;
+  l42:;	
+  {  int yypos43= yy->__pos, yythunkpos43= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l43;  goto l42;
+  l43:;	  yy->__pos= yypos43; yy->__thunkpos= yythunkpos43;
+  }
+  {  int yypos44= yy->__pos, yythunkpos44= yy->__thunkpos;  if (!yymatchChar(yy, '.')) goto l44;  goto l45;
+  l44:;	  yy->__pos= yypos44; yy->__thunkpos= yythunkpos44;
+  }
+  l45:;	
+  l46:;	
+  {  int yypos47= yy->__pos, yythunkpos47= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l47;  goto l46;
+  l47:;	  yy->__pos= yypos47; yy->__thunkpos= yythunkpos47;
+  }  yyText(yy, yy->__begin, yy->__end);  if (!(YY_END)) goto l39;  if (!yy_SPACE(yy)) goto l39;
+  yyprintf((stderr, "  ok   %s @ %s\n", "F_NUMBER", yy->__buf+yy->__pos));
+  return 1;
+  l39:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "F_NUMBER", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_MOD(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "MOD"));  if (!yymatchChar(yy, '%')) goto l42;  if (!yy_SPACE(yy)) goto l42;
+  yyprintf((stderr, "%s\n", "MOD"));  if (!yymatchChar(yy, '%')) goto l48;  if (!yy_SPACE(yy)) goto l48;
   yyprintf((stderr, "  ok   %s @ %s\n", "MOD", yy->__buf+yy->__pos));
   return 1;
-  l42:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l48:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "MOD", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_DIVIDE(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "DIVIDE"));  if (!yymatchChar(yy, '/')) goto l43;  if (!yy_SPACE(yy)) goto l43;
+  yyprintf((stderr, "%s\n", "DIVIDE"));  if (!yymatchChar(yy, '/')) goto l49;  if (!yy_SPACE(yy)) goto l49;
   yyprintf((stderr, "  ok   %s @ %s\n", "DIVIDE", yy->__buf+yy->__pos));
   return 1;
-  l43:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l49:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DIVIDE", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_TIMES(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "TIMES"));  if (!yymatchChar(yy, '*')) goto l44;  if (!yy_SPACE(yy)) goto l44;
+  yyprintf((stderr, "%s\n", "TIMES"));  if (!yymatchChar(yy, '*')) goto l50;  if (!yy_SPACE(yy)) goto l50;
   yyprintf((stderr, "  ok   %s @ %s\n", "TIMES", yy->__buf+yy->__pos));
   return 1;
-  l44:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l50:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "TIMES", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_POW(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
   yyprintf((stderr, "%s\n", "POW"));
-  {  int yypos46= yy->__pos, yythunkpos46= yy->__thunkpos;  if (!yymatchChar(yy, '^')) goto l47;  if (!yy_SPACE(yy)) goto l47;  goto l46;
-  l47:;	  yy->__pos= yypos46; yy->__thunkpos= yythunkpos46;  if (!yymatchString(yy, "**")) goto l45;  if (!yy_SPACE(yy)) goto l45;
+  {  int yypos52= yy->__pos, yythunkpos52= yy->__thunkpos;  if (!yymatchChar(yy, '^')) goto l53;  if (!yy_SPACE(yy)) goto l53;  goto l52;
+  l53:;	  yy->__pos= yypos52; yy->__thunkpos= yythunkpos52;  if (!yymatchString(yy, "**")) goto l51;  if (!yy_SPACE(yy)) goto l51;
   }
-  l46:;	
+  l52:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "POW", yy->__buf+yy->__pos));
   return 1;
-  l45:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l51:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "POW", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_Value(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
   yyprintf((stderr, "%s\n", "Value"));
-  {  int yypos49= yy->__pos, yythunkpos49= yy->__thunkpos;  if (!yy_F_NUMBER(yy)) goto l50;  yyDo(yy, yy_1_Value, yy->__begin, yy->__end);  goto l49;
-  l50:;	  yy->__pos= yypos49; yy->__thunkpos= yythunkpos49;  if (!yy_Constant(yy)) goto l51;  goto l49;
-  l51:;	  yy->__pos= yypos49; yy->__thunkpos= yythunkpos49;  if (!yy_Funcall(yy)) goto l52;  goto l49;
-  l52:;	  yy->__pos= yypos49; yy->__thunkpos= yythunkpos49;  if (!yy_OPEN(yy)) goto l48;  if (!yy_Sum(yy)) goto l48;  if (!yy_CLOSE(yy)) goto l48;
+  {  int yypos55= yy->__pos, yythunkpos55= yy->__thunkpos;  if (!yy_F_NUMBER(yy)) goto l56;  if (!yy_SI_Unit(yy)) goto l56;  yyDo(yy, yy_1_Value, yy->__begin, yy->__end);  goto l55;
+  l56:;	  yy->__pos= yypos55; yy->__thunkpos= yythunkpos55;  if (!yy_F_NUMBER(yy)) goto l57;  yyDo(yy, yy_2_Value, yy->__begin, yy->__end);  goto l55;
+  l57:;	  yy->__pos= yypos55; yy->__thunkpos= yythunkpos55;  if (!yy_Constant(yy)) goto l58;  goto l55;
+  l58:;	  yy->__pos= yypos55; yy->__thunkpos= yythunkpos55;  if (!yy_Funcall(yy)) goto l59;  goto l55;
+  l59:;	  yy->__pos= yypos55; yy->__thunkpos= yythunkpos55;  if (!yy_OPEN(yy)) goto l54;  if (!yy_Sum(yy)) goto l54;  if (!yy_CLOSE(yy)) goto l54;
   }
-  l49:;	
+  l55:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "Value", yy->__buf+yy->__pos));
   return 1;
-  l48:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l54:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Value", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_CLOSE_ENOUGH(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "CLOSE_ENOUGH"));  if (!yymatchString(yy, "==")) goto l53;  if (!yy_SPACE(yy)) goto l53;
+  yyprintf((stderr, "%s\n", "CLOSE_ENOUGH"));  if (!yymatchString(yy, "==")) goto l60;  if (!yy_SPACE(yy)) goto l60;
   yyprintf((stderr, "  ok   %s @ %s\n", "CLOSE_ENOUGH", yy->__buf+yy->__pos));
   return 1;
-  l53:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l60:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CLOSE_ENOUGH", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_MINUS(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "MINUS"));  if (!yymatchChar(yy, '-')) goto l54;  if (!yy_SPACE(yy)) goto l54;
+  yyprintf((stderr, "%s\n", "MINUS"));  if (!yymatchChar(yy, '-')) goto l61;  if (!yy_SPACE(yy)) goto l61;
   yyprintf((stderr, "  ok   %s @ %s\n", "MINUS", yy->__buf+yy->__pos));
   return 1;
-  l54:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l61:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "MINUS", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_PLUS(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "PLUS"));  if (!yymatchChar(yy, '+')) goto l55;  if (!yy_SPACE(yy)) goto l55;
+  yyprintf((stderr, "%s\n", "PLUS"));  if (!yymatchChar(yy, '+')) goto l62;  if (!yy_SPACE(yy)) goto l62;
   yyprintf((stderr, "  ok   %s @ %s\n", "PLUS", yy->__buf+yy->__pos));
   return 1;
-  l55:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l62:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "PLUS", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_Product(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "Product"));  if (!yy_Value(yy)) goto l56;
-  l57:;	
-  {  int yypos58= yy->__pos, yythunkpos58= yy->__thunkpos;
-  {  int yypos59= yy->__pos, yythunkpos59= yy->__thunkpos;  if (!yy_POW(yy)) goto l60;  if (!yy_Value(yy)) goto l60;  yyDo(yy, yy_1_Product, yy->__begin, yy->__end);  goto l59;
-  l60:;	  yy->__pos= yypos59; yy->__thunkpos= yythunkpos59;  if (!yy_TIMES(yy)) goto l61;  if (!yy_Value(yy)) goto l61;  yyDo(yy, yy_2_Product, yy->__begin, yy->__end);  goto l59;
-  l61:;	  yy->__pos= yypos59; yy->__thunkpos= yythunkpos59;  if (!yy_DIVIDE(yy)) goto l62;  if (!yy_Value(yy)) goto l62;  yyDo(yy, yy_3_Product, yy->__begin, yy->__end);  goto l59;
-  l62:;	  yy->__pos= yypos59; yy->__thunkpos= yythunkpos59;  if (!yy_MOD(yy)) goto l58;  if (!yy_Value(yy)) goto l58;  yyDo(yy, yy_4_Product, yy->__begin, yy->__end);
+  yyprintf((stderr, "%s\n", "Product"));  if (!yy_Value(yy)) goto l63;
+  l64:;	
+  {  int yypos65= yy->__pos, yythunkpos65= yy->__thunkpos;
+  {  int yypos66= yy->__pos, yythunkpos66= yy->__thunkpos;  if (!yy_POW(yy)) goto l67;  if (!yy_Value(yy)) goto l67;  yyDo(yy, yy_1_Product, yy->__begin, yy->__end);  goto l66;
+  l67:;	  yy->__pos= yypos66; yy->__thunkpos= yythunkpos66;  if (!yy_TIMES(yy)) goto l68;  if (!yy_Value(yy)) goto l68;  yyDo(yy, yy_2_Product, yy->__begin, yy->__end);  goto l66;
+  l68:;	  yy->__pos= yypos66; yy->__thunkpos= yythunkpos66;  if (!yy_DIVIDE(yy)) goto l69;  if (!yy_Value(yy)) goto l69;  yyDo(yy, yy_3_Product, yy->__begin, yy->__end);  goto l66;
+  l69:;	  yy->__pos= yypos66; yy->__thunkpos= yythunkpos66;  if (!yy_MOD(yy)) goto l65;  if (!yy_Value(yy)) goto l65;  yyDo(yy, yy_4_Product, yy->__begin, yy->__end);
   }
-  l59:;	  goto l57;
-  l58:;	  yy->__pos= yypos58; yy->__thunkpos= yythunkpos58;
+  l66:;	  goto l64;
+  l65:;	  yy->__pos= yypos65; yy->__thunkpos= yythunkpos65;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "Product", yy->__buf+yy->__pos));
   return 1;
-  l56:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l63:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Product", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_Sum(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "Sum"));  if (!yy_Product(yy)) goto l63;
-  l64:;	
-  {  int yypos65= yy->__pos, yythunkpos65= yy->__thunkpos;
-  {  int yypos66= yy->__pos, yythunkpos66= yy->__thunkpos;  if (!yy_PLUS(yy)) goto l67;  if (!yy_Product(yy)) goto l67;  yyDo(yy, yy_1_Sum, yy->__begin, yy->__end);  goto l66;
-  l67:;	  yy->__pos= yypos66; yy->__thunkpos= yythunkpos66;  if (!yy_MINUS(yy)) goto l68;  if (!yy_Product(yy)) goto l68;  yyDo(yy, yy_2_Sum, yy->__begin, yy->__end);  goto l66;
-  l68:;	  yy->__pos= yypos66; yy->__thunkpos= yythunkpos66;  if (!yy_CLOSE_ENOUGH(yy)) goto l65;  if (!yy_Product(yy)) goto l65;  yyDo(yy, yy_3_Sum, yy->__begin, yy->__end);
+  yyprintf((stderr, "%s\n", "Sum"));  if (!yy_Product(yy)) goto l70;
+  l71:;	
+  {  int yypos72= yy->__pos, yythunkpos72= yy->__thunkpos;
+  {  int yypos73= yy->__pos, yythunkpos73= yy->__thunkpos;  if (!yy_PLUS(yy)) goto l74;  if (!yy_Product(yy)) goto l74;  yyDo(yy, yy_1_Sum, yy->__begin, yy->__end);  goto l73;
+  l74:;	  yy->__pos= yypos73; yy->__thunkpos= yythunkpos73;  if (!yy_MINUS(yy)) goto l75;  if (!yy_Product(yy)) goto l75;  yyDo(yy, yy_2_Sum, yy->__begin, yy->__end);  goto l73;
+  l75:;	  yy->__pos= yypos73; yy->__thunkpos= yythunkpos73;  if (!yy_CLOSE_ENOUGH(yy)) goto l72;  if (!yy_Product(yy)) goto l72;  yyDo(yy, yy_3_Sum, yy->__begin, yy->__end);
   }
-  l66:;	  goto l64;
-  l65:;	  yy->__pos= yypos65; yy->__thunkpos= yythunkpos65;
+  l73:;	  goto l71;
+  l72:;	  yy->__pos= yypos72; yy->__thunkpos= yythunkpos72;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "Sum", yy->__buf+yy->__pos));
   return 1;
-  l63:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l70:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Sum", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_SPACE(yycontext *yy)
 {
   yyprintf((stderr, "%s\n", "SPACE"));
-  l70:;	
-  {  int yypos71= yy->__pos, yythunkpos71= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l71;  goto l70;
-  l71:;	  yy->__pos= yypos71; yy->__thunkpos= yythunkpos71;
+  l77:;	
+  {  int yypos78= yy->__pos, yythunkpos78= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l78;  goto l77;
+  l78:;	  yy->__pos= yypos78; yy->__thunkpos= yythunkpos78;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "SPACE", yy->__buf+yy->__pos));
   return 1;
@@ -850,13 +946,13 @@ YY_RULE(int) yy_SPACE(yycontext *yy)
 YY_RULE(int) yy_Expr(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
   yyprintf((stderr, "%s\n", "Expr"));
-  {  int yypos73= yy->__pos, yythunkpos73= yy->__thunkpos;  if (!yy_SPACE(yy)) goto l74;  if (!yy_Sum(yy)) goto l74;  yyDo(yy, yy_1_Expr, yy->__begin, yy->__end);  goto l73;
-  l74:;	  yy->__pos= yypos73; yy->__thunkpos= yythunkpos73;  if (!yymatchDot(yy)) goto l72;  yyDo(yy, yy_2_Expr, yy->__begin, yy->__end);
+  {  int yypos80= yy->__pos, yythunkpos80= yy->__thunkpos;  if (!yy_SPACE(yy)) goto l81;  if (!yy_Sum(yy)) goto l81;  yyDo(yy, yy_1_Expr, yy->__begin, yy->__end);  goto l80;
+  l81:;	  yy->__pos= yypos80; yy->__thunkpos= yythunkpos80;  if (!yymatchDot(yy)) goto l79;  yyDo(yy, yy_2_Expr, yy->__begin, yy->__end);
   }
-  l73:;	
+  l80:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "Expr", yy->__buf+yy->__pos));
   return 1;
-  l72:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l79:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Expr", yy->__buf+yy->__pos));
   return 0;
 }

--- a/libpromises/math.peg
+++ b/libpromises/math.peg
@@ -36,7 +36,8 @@ Product	<- Value ( POW  Value		{ double r= math_eval_pop(yy->stack, &(yy->stackp
                  / MOD Value		{ double r= math_eval_pop(yy->stack, &(yy->stackp)), l= math_eval_pop(yy->stack, &(yy->stackp));  math_eval_push((long)l % (long)r, yy->stack, &(yy->stackp)); }
 		 )*
 
-Value	<- F_NUMBER			{ double scanned = 0; sscanf(yytext, "%lf", &scanned); math_eval_push(scanned, yy->stack, &(yy->stackp)); /*Log(LOG_LEVEL_ERR, "YY: read FP %lf", scanned);*/ }
+Value	<- F_NUMBER SI_Unit		{ double scanned = 0; sscanf(yytext, "%lf", &scanned); math_eval_push(math_eval_pop(yy->stack, &(yy->stackp)) * scanned, yy->stack, &(yy->stackp)); /* Log(LOG_LEVEL_ERR, "YY: read FP %lf", scanned); */ }
+         / F_NUMBER			{ double scanned = 0; sscanf(yytext, "%lf", &scanned); math_eval_push(scanned, yy->stack, &(yy->stackp)); /*Log(LOG_LEVEL_ERR, "YY: read FP %lf", scanned);*/ }
          / Constant
          / Funcall
 	 / OPEN Sum CLOSE
@@ -59,10 +60,17 @@ Constant <- "e" { math_eval_push(2.7182818284590452354, yy->stack, &(yy->stackp)
          / "sqrt2" { math_eval_push(1.41421356237309504880, yy->stack, &(yy->stackp)); }
          / "sqrt1_2" { math_eval_push(0.70710678118654752440, yy->stack, &(yy->stackp)); }
 
+SI_Unit  <- [kK] SPACE { math_eval_push(1000, yy->stack, &(yy->stackp)); }
+         /  [mM] SPACE { math_eval_push(1000000, yy->stack, &(yy->stackp)); }
+         /  [gG] SPACE { math_eval_push(1000000000, yy->stack, &(yy->stackp)); }
+         /  [tT] SPACE { math_eval_push(1000000000000, yy->stack, &(yy->stackp)); }
+         /  [pP] SPACE { math_eval_push(1000000000000000, yy->stack, &(yy->stackp)); }
+
 # Lexemes
 
 F_NUMBER <- < '-'? [0-9]+ '.'? [0-9]* > SPACE
 CLOSE_ENOUGH	<- '==' SPACE
+
 PLUS	<- '+' SPACE
 MINUS	<- '-' SPACE
 TIMES	<- '*' SPACE

--- a/tests/acceptance/01_vars/02_functions/eval.cf
+++ b/tests/acceptance/01_vars/02_functions/eval.cf
@@ -49,6 +49,8 @@ bundle agent init
       "values[30]" string => "3**0";
       "values[31]" string => "step(10)";
       "values[32]" string => "step(-10)";
+      "values[33]" string => "100k";
+      "values[34]" string => "(200m - 100k) / (2t + 2t)";
 }
 
 
@@ -102,6 +104,8 @@ bundle agent check
       "verify[30]" string => '1.000000';
       "verify[31]" string => '1.000000';
       "verify[32]" string => '0.000000';
+      "verify[33]" string => '100000.000000';
+      "verify[34]" string => '0.000050';
 
       "indices" slist => getindices("verify");
 
@@ -112,7 +116,8 @@ bundle agent check
       "ok" and => { ok_0, ok_1, ok_3, ok_4, ok_5, ok_6, ok_7, ok_8,
                     ok_9, ok_10, ok_11, ok_13, ok_14, ok_15, ok_16,
                     ok_17, ok_18, ok_19, ok_20, ok_21, ok_23, ok_24,
-                    ok_25 };
+                    ok_25, ok_26, ok_27, ok_28, ok_29, ok_30, ok_31,
+                    ok_32, ok_33, ok_34 };
 
   reports:
     DEBUG::


### PR DESCRIPTION
Very simple change, with acceptance test and documentation, to add SI units (`k`, `m`, `g`, `t`, and `p`) to the math evaluator, to be consistent with the `real` and `int` parsers in CFEngine.
