### PR TITLE
Refs #3395: adding support for openvz

### DIFF
--- a/cf-agent/nfs.c
+++ b/cf-agent/nfs.c
@@ -51,6 +51,7 @@ static void DeleteThisItem(Item **liststart, Item *entry);
 static const char *VMOUNTCOMM[PLATFORM_CONTEXT_MAX] =
 {
     "",
+    "/bin/mount -va",           /* virt_host_vz_vzps */
     "/sbin/mount -ea",          /* hpux */
     "/usr/sbin/mount -t nfs",   /* aix */
     "/bin/mount -va",           /* linux */
@@ -72,6 +73,7 @@ static const char *VMOUNTCOMM[PLATFORM_CONTEXT_MAX] =
 static const char *VUNMOUNTCOMM[PLATFORM_CONTEXT_MAX] =
 {
     "",
+    "/bin/umount",              /* virt_host_vz_vzps */
     "/sbin/umount",             /* hpux */
     "/usr/sbin/umount",         /* aix */
     "/bin/umount",              /* linux */
@@ -93,6 +95,7 @@ static const char *VUNMOUNTCOMM[PLATFORM_CONTEXT_MAX] =
 static const char *VMOUNTOPTS[PLATFORM_CONTEXT_MAX] =
 {
     "",
+    "defaults",                 /* virt_host_vz_vzps */
     "bg,hard,intr",             /* hpux */
     "bg,hard,intr",             /* aix */
     "defaults",                 /* linux */

--- a/cf-monitord/mon_network.c
+++ b/cf-monitord/mon_network.c
@@ -75,6 +75,7 @@ static const Sock ECGSOCKS[ATTR] =     /* extended to map old to new using enum 
 static const char *VNETSTAT[PLATFORM_CONTEXT_MAX] =
 {
     "-",
+    "/bin/netstat -rn",         /* virt_host_vz_vzps */
     "/usr/bin/netstat -rn",     /* hpux */
     "/usr/bin/netstat -rn",     /* aix */
     "/bin/netstat -rn",         /* linux */

--- a/libpromises/classes.c
+++ b/libpromises/classes.c
@@ -27,6 +27,7 @@
 const char *CLASSTEXT[PLATFORM_CONTEXT_MAX] =
 {
     "<unknown>",
+    "virt_host_vz_vzps",
     "hpux",
     "aix",
     "linux",
@@ -48,6 +49,7 @@ const char *CLASSTEXT[PLATFORM_CONTEXT_MAX] =
 const char *VPSCOMM[PLATFORM_CONTEXT_MAX] =
 {
     "",
+    "/bin/vzps",                /* virt_host_vz_vzps */
     "/bin/ps",                  /* hpux */
     "/bin/ps",                  /* aix */
     "/bin/ps",                  /* linux */
@@ -72,6 +74,7 @@ const char *VPSCOMM[PLATFORM_CONTEXT_MAX] =
 const char *VPSOPTS[PLATFORM_CONTEXT_MAX] =
 {
     "",
+    "-E 0 -o user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* virt_host_vz_vzps (with vzps, the -E 0 replace the -e) */
     "-ef",                      /* hpux */
     "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args", /* aix */
     "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* linux */
@@ -93,6 +96,7 @@ const char *VPSOPTS[PLATFORM_CONTEXT_MAX] =
 const char *VFSTAB[PLATFORM_CONTEXT_MAX] =
 {
     "-",
+    "/etc/fstab",               /* virt_host_vz_vzps */
     "/etc/fstab",               /* hpux */
     "/etc/filesystems",         /* aix */
     "/etc/fstab",               /* linux */


### PR DESCRIPTION
Detect OpenVZ/Virtuozzo and Parallels Cloud Server, and define the following hard classes:
- virt_host_openvz: for the openVZ host
- virt_host_vz_vzps: for openVZ host, if the /bin/vzps tool is available
- virt_guest_openvz: for the openVZ guest

On the host:

```
# cf-promises/cf-promises -v | grep openvz
virt_host_openvz
```

Inside an OpenVZ container:

```
# cf-promises/cf-promises -v |  grep openvz
virt_guest_openvz
```

On the OpenVZ host, the ps command list the processes on both host and containers, making the _processes_ promise type unusable.
The tool /bin/vzps let you select the host or container you want to have the processes from; so this PR add detection for this tool on the host, and define the class _virt_host_vz_vzps_, and uses vzps instead of of ps

This is contains part of the code and naming discussion in https://github.com/cfengine/core/pull/582, and also part of the patch proposed by Liviu Damian http://pastebin.com/ipTeh1Mk / https://groups.google.com/forum/#!topic/help-cfengine/h098EgAusoA

This PR is similar to https://github.com/cfengine/core/pull/949, but for branch master

I realized, while further testing it, that given the implementation of `vzps` available (there are somehow several implementation hanging around) the code may not do as expected ... 
