### PR TITLE
Fix for building on HPUX

### DIFF
--- a/tests/unit/db_test.c
+++ b/tests/unit/db_test.c
@@ -94,15 +94,16 @@ static void CreateGarbage(const char *filename)
 void test_recreate(void)
 {
     /* Test that recreating database works properly */
-
+#ifdef HAVE_LIBTOKYOCABINET
     char tcdb_db[CF_BUFSIZE];
     snprintf(tcdb_db, CF_BUFSIZE, "%s/cf_classes.tcdb", CFWORKDIR);
     CreateGarbage(tcdb_db);
-
+#endif
+#ifdef HAVE_LIBQDBM
     char qdbm_db[CF_BUFSIZE];
     snprintf(qdbm_db, CF_BUFSIZE, "%s/cf_classes.qdbm", CFWORKDIR);
     CreateGarbage(qdbm_db);
-
+#endif
     CF_DB *db;
     assert_int_equal(OpenDB(&db, dbid_classes), true);
     CloseDB(db);


### PR DESCRIPTION
The current HPUX machine has very little space, creating
both a tdb and a qdbm database for testing makes it run out
of space.
(cherry picked from commit 05a7e7c36b36801a5d16d64df96c8fc331efc4c4)
