### PR TITLE
Fixes for building on hpux

### DIFF
--- a/tests/unit/db_test.c
+++ b/tests/unit/db_test.c
@@ -84,7 +84,7 @@ void test_iter_delete_entry(void)
 static void CreateGarbage(const char *filename)
 {
     FILE *fh = fopen(filename, "w");
-    for(int i = 0; i < 1000; ++i)
+    for(int i = 0; i < 2; ++i)
     {
         fwrite("some garbage!", 14, 1, fh);
     }


### PR DESCRIPTION
Creating 1000 entries is too much on that small hard drive, therefore
reducing it to 2. After all, even one entry will do the trick of
corrupting the file.
(cherry picked from commit 2d8f47a18f09f85cb70eeb405f409756b2771b35)
