### PR TITLE
Fixing the real cause for the TLS test failure

### DIFF
--- a/tests/unit/tls_generic_test.c
+++ b/tests/unit/tls_generic_test.c
@@ -971,7 +971,7 @@ int SSL_write(SSL *ssl, const void *buf, int num)
 {
     if (USING(SSL_write))
         return original_SSL_write(ssl, buf, num);
-    return SSL_write_result;
+    return (SSL_write_result > num) ? num : SSL_write_result;
 }
 
 int SSL_read(SSL *ssl, void *buf, int num)
@@ -986,7 +986,7 @@ int SSL_read(SSL *ssl, void *buf, int num)
             temp[i] = SSL_read_buffer[i];
         return i;
     }
-    return SSL_read_result;
+    return (SSL_read_result > num) ? num : SSL_read_result;
 }
 int SSL_get_shutdown(const SSL *ssl)
 {


### PR DESCRIPTION
The mocking function for SSL_read was returning the value that I assigned,
regardless of the size of the buffer. This commit fixes that, if the buffer
is smaller than the value assigned, then the size of the buffer is returned
instead. Same fix was applied to the write function.
