### PR TITLE
Add convenience this.promise_dirname variable, with acceptance test.

### DIFF
--- a/libpromises/env_context.c
+++ b/libpromises/env_context.c
@@ -925,7 +925,16 @@ void EvalContextStackPushPromiseFrame(EvalContext *ctx, const Promise *owner, bo
 
     if (PromiseGetBundle(owner)->source_path)
     {
-        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promise_filename", PromiseGetBundle(owner)->source_path, DATA_TYPE_STRING);
+        char path[CF_BUFSIZE];
+        snprintf(path, CF_BUFSIZE, "%s", PromiseGetBundle(owner)->source_path);
+
+        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promise_filename", path, DATA_TYPE_STRING);
+
+        // We now make path just the directory name!
+        DeleteSlash(path);
+        ChopLastNode(path);
+
+        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promise_dirname", path, DATA_TYPE_STRING);
         char number[CF_SMALLBUF];
         snprintf(number, CF_SMALLBUF, "%zu", owner->offset.line);
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promise_linenumber", number, DATA_TYPE_STRING);

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -798,7 +798,7 @@ static SyntaxTypeMatch CheckParseOpts(const char *s, const char *range)
 
 int CheckParseVariableName(const char *name)
 {
-    const char *reserved[] = { "promiser", "handle", "promise_filename", "promise_linenumber", "this", NULL };
+    const char *reserved[] = { "promiser", "handle", "promise_filename", "promise_dirname", "promise_linenumber", "this", NULL };
     char scopeid[CF_MAXVARSIZE], vlval[CF_MAXVARSIZE];
     int count = 0, level = 0;
 

--- a/tests/acceptance/01_vars/01_basic/promise_dirname.cf
+++ b/tests/acceptance/01_vars/01_basic/promise_dirname.cf
@@ -1,0 +1,38 @@
+# Test $(this.promise_dirname)
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "expected" string => dirname($(this.promise_filename));
+}
+
+#######################################################
+
+bundle agent test
+{
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok" expression => strcmp($(init.expected), $(this.promise_dirname));
+
+  reports:
+    DEBUG::
+      "$(this.promise_filename) expected dirname $(init.expected), actual $(this.promise_dirname)";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Trivial but convenient feature.  Acceptance test doesn't test `this.promise_filename` since pretty much every other acceptance test does.

Documentation will be added upon merge.
