### PR TITLE
Reformulating code to avoid nasty surprises

### DIFF
--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -286,7 +286,7 @@ static bool find_newline(char *buffer, size_t *length)
 int TLSRecvLine(SSL *ssl, char *buf, size_t buf_size)
 {
     int ret;
-    int got = 0;
+    size_t got = 0;
     buf_size -= 1;               /* Reserve one space for terminating '\0' */
     bool found = false;
 
@@ -313,5 +313,5 @@ int TLSRecvLine(SSL *ssl, char *buf, size_t buf_size)
         Log(LOG_LEVEL_ERR, "No new line found and the buffer is already full");
         return -1;
     }
-    return got;
+    return (int)got;
 }


### PR DESCRIPTION
GCC emits a warning when a pointer of a certain type is reinterpreted
as something else and assigned. The potential issue is that GCC might
reorder the way the pointer is read/written because it might assume the
wrong type, therefore it is better to avoid such things.
