### PR TITLE
Adding Version structure

### DIFF
--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -32,7 +32,8 @@ libutils_la_SOURCES = \
 	file_lib.c file_lib.h \
 	man.c man.h \
 	rb-tree.c rb-tree.h \
-	mustache.c mustache.h
+	mustache.c mustache.h \
+	cfversion.c cfversion.h
 
 CLEANFILES = *.gcno *.gcda
 

--- a/libutils/cfversion.c
+++ b/libutils/cfversion.c
@@ -1,0 +1,347 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <stdint.h>
+#include <ctype.h>
+#include <alloc.h>
+#include <cfversion.h>
+
+struct Version {
+    uint8_t major;
+    uint8_t minor;
+    uint8_t patch;
+    uint8_t extra;
+    uint8_t build;
+};
+
+#define Char2Dec(o, c) \
+    (o * 10) + c - '0'
+
+Version *VersionNew()
+{
+    Version *version = NULL;
+    version = xmalloc(sizeof(Version));
+    version->major = 0;
+    version->minor = 0;
+    version->patch = 0;
+    version->extra = 0;
+    version->build = 0;
+    return version;
+}
+
+Version *VersionNewFromCharP(const char *version, unsigned int size)
+{
+    if (!version)
+    {
+        return NULL;
+    }
+    /*
+     * Parse the version string
+     *
+     *                          +-> Done
+     *   '.'      '.'     '-'   |
+     * 0 ---- > 1 ----> 2 ----> 3 <-+
+     *                  | '.'       |
+     *                  +-----> 4 --+
+     */
+    uint16_t major = 0;
+    uint16_t minor = 0;
+    uint16_t patch = 0;
+    uint16_t extra = 0;
+    uint16_t build = 0;
+    uint16_t value = 0;
+    unsigned int i = 0;
+    int state = 0;
+    int error_condition = 0;
+
+    for (i = 0; i < size; ++i)
+    {
+        int is_period = 0;
+        int is_number = 0;
+        int is_dash = 0;
+        char current = 0;
+
+        current = version[i];
+        is_period = (current == '.') ? 1 : 0;
+        is_number = isdigit(current);
+        is_dash = (current == '-') ? 1 : 0;
+
+        if (value > 255)
+        {
+            error_condition = 1;
+            break;
+        }
+        switch (state)
+        {
+        case 0:
+            if (is_period)
+            {
+                state = 1;
+                major = (uint8_t)value;
+                value = 0;
+                break;
+            }
+            if (is_number)
+            {
+                value = Char2Dec(value, current);
+            }
+            else
+            {
+                error_condition = 1;
+                i = size + 1;
+                break;
+            }
+            break;
+        case 1:
+            if (is_period)
+            {
+                state = 2;
+                minor = (uint8_t)value;
+                value = 0;
+                break;
+            }
+            if (is_number)
+            {
+                value = Char2Dec(value, current);
+            }
+            else
+            {
+                error_condition = 1;
+                i = size + 1;
+                break;
+            }
+            break;
+        case 2:
+            if (is_period)
+            {
+                state = 4;
+                patch = (uint8_t)value;
+                value = 0;
+                break;
+            }
+            if (is_dash)
+            {
+                state = 3;
+                patch = value;
+                value = 0;
+                break;
+            }
+            if (is_number)
+            {
+                value = Char2Dec(value, current);
+            }
+            else
+            {
+                error_condition = 1;
+                i = size + 1;
+                break;
+            }
+            break;
+        case 3:
+            if (is_number)
+            {
+                value = Char2Dec(value, current);
+            }
+            else
+            {
+                error_condition = 1;
+                i = size + 1;
+                break;
+            }
+            break;
+        case 4:
+            if (is_dash)
+            {
+                state = 3;
+                extra = (uint8_t)value;
+                value = 0;
+                break;
+            }
+            if (is_number)
+            {
+                value = Char2Dec(value, current);
+            }
+            else
+            {
+                error_condition = 1;
+                i = size + 1;
+                break;
+            }
+            break;
+        default:
+            error_condition = 1;
+            break;
+        }
+    }
+    if (error_condition)
+    {
+        return NULL;
+    }
+    /* There are two valid exit states: 2 & 3, all other states indicate error */
+    if ((state == 2) || (state == 3))
+    {
+        if (state == 2)
+        {
+            if (value > 255)
+            {
+                return NULL;
+            }
+            patch = (uint8_t)value;
+        }
+        else
+        {
+            if (value > 255)
+            {
+                return NULL;
+            }
+            build = (uint8_t)value;
+        }
+    }
+    else
+    {
+        return NULL;
+    }
+    Version *v = VersionNew();
+    v->major = major;
+    v->minor = minor;
+    v->patch = patch;
+    v->extra = extra;
+    v->build = build;
+    return v;
+}
+
+Version *VersionNewFrom(Buffer *buffer)
+{
+    if (!buffer)
+    {
+        return NULL;
+    }
+    return VersionNewFromCharP(BufferData(buffer), BufferSize(buffer));
+}
+
+void VersionDestroy(Version **version)
+{
+    if (!version || !(*version))
+    {
+        return;
+    }
+    free (*version);
+    *version = NULL;
+}
+
+int VersionCompare(Version *a, Version *b)
+{
+    int comparison = 0;
+    if (a->major < b->major)
+    {
+        comparison = -10;
+    }
+    else if (a->major == b->major)
+    {
+        if (a->minor < b->minor)
+        {
+            comparison = -10;
+        }
+        else if (a->minor == b->minor)
+        {
+            if (a->patch < b->patch)
+            {
+                comparison = -10;
+            }
+            else if (a->patch == b->patch)
+            {
+                if (a->build < b->build)
+                {
+                    comparison = -10;
+                }
+                else if (a->build == b->build)
+                {
+                    comparison = 0;
+                }
+                else
+                {
+                    comparison = 10;
+                }
+            }
+            else
+            {
+                comparison = 10;
+            }
+        }
+        else
+        {
+            comparison = 10;
+        }
+    }
+    else
+    {
+        comparison = 10;
+    }
+    return comparison;
+}
+
+int VersionMajor(Version *version)
+{
+    if (!version)
+    {
+        return -1;
+    }
+    return (int)version->major;
+}
+
+int VersionMinor(Version *version)
+{
+    if (!version)
+    {
+        return -1;
+    }
+    return (int)version->minor;
+}
+
+int VersionPatch(Version *version)
+{
+    if (!version)
+    {
+        return -1;
+    }
+    return (int)version->patch;
+}
+
+int VersionExtra(Version *version)
+{
+    if (!version)
+    {
+        return -1;
+    }
+    return (int)version->extra;
+}
+
+int VersionBuild(Version *version)
+{
+    if (!version)
+    {
+        return -1;
+    }
+    return (int)version->build;
+}

--- a/libutils/cfversion.h
+++ b/libutils/cfversion.h
@@ -1,0 +1,94 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#ifndef CFVERSION_H
+#define CFVERSION_H
+
+#include <buffer.h>
+
+/**
+  @brief Version is a data structure to handle versions of software.
+
+  */
+
+typedef struct Version Version;
+
+/**
+  @brief Creates a new empty version. Use set version to initialize it.
+  @return An empty Version structure or NULL in case of error.
+  */
+Version *VersionNew();
+/**
+  @brief Creates a new version based on the given char pointer.
+  @param version Char pointer containing the version string.
+  @param size Length of the version string.
+  @return A fully initialized Version structure or NULL in case of error.
+  */
+Version *VersionNewFromCharP(const char *version, unsigned int size);
+/**
+  @brief Creates a new version based on the Buffer structure.
+  @param buffer Buffer containing the version string.
+  @return A fully initialized Version structure or NULL in case of error.
+  */
+Version *VersionNewFrom(Buffer *buffer);
+/**
+  @brief Destroys a Version structure.
+  @param version Version structure.
+  */
+void VersionDestroy(Version **version);
+/**
+  @brief Compares two versions.
+  @param a version a
+  @param b version b
+  @return <0 if a < b, 0 if a == b, >0 if a > b
+  @remarks The extra field is never included in the comparison.
+  */
+int VersionCompare(Version *a, Version *b);
+/**
+  @param version Version to operate on.
+  @return Returns the major version or -1 in case of error.
+  */
+int VersionMajor(Version *version);
+/**
+  @param version Version to operate on.
+  @return Returns the minor version or -1 in case of error.
+  */
+int VersionMinor(Version *version);
+/**
+  @param version Version to operate on.
+  @return Returns the patch version or -1 in case of error.
+  */
+int VersionPatch(Version *version);
+/**
+  @param version Version to operate on.
+  @return Returns the extra version or -1 in case of error.
+  */
+int VersionExtra(Version *version);
+/**
+  @param version Version to operate on.
+  @return Returns the build version or -1 in case of error.
+  */
+int VersionBuild(Version *version);
+
+#endif // CFVERSION_H

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -88,7 +88,8 @@ check_PROGRAMS = \
 	mon_processes_test \
 	mustache_test \
 	class_test \
-	tls_generic_test
+	tls_generic_test \
+	version_test
 
 if HAVE_AVAHI_CLIENT
 if HAVE_AVAHI_COMMON
@@ -266,4 +267,6 @@ mon_processes_test_SOURCES = mon_processes_test.c ../../cf-monitord/mon.h ../../
 mon_processes_test_LDADD = ../../libpromises/libpromises.la libtest.la
 tls_generic_test_SOURCES = tls_generic_test.c 
 tls_generic_test_LDADD = libtest.la ../../libutils/libutils.la ../../libpromises/libpromises.la ../../libcfnet/libcfnet.la
+
+version_test_SOURCES = version_test.c
 

--- a/tests/unit/version_test.c
+++ b/tests/unit/version_test.c
@@ -1,0 +1,161 @@
+#include <test.h>
+#include <string.h>
+#include <cfversion.h>
+#include <cfversion.c>
+#include <buffer.h>
+
+static void test_creation_destruction(void)
+{
+    char right_version[] = "1.2.3";
+    char wrong_version[] = "a.0.1";
+    char right_unix_version[] = "1.2.3-4";
+    char wrong_unix_version_0[] = "3-5.1-1";
+    char wrong_unix_version_1[] = "3.5-1-1";
+    char wrong_unix_version_2[] = "3.5.1.1";
+    char right_windows_version[] = "1.2.3.4-5";
+    char wrong_windows_version_0[] = "3-5.1.0-1";
+    char wrong_windows_version_1[] = "3.5-1.0-1";
+    char wrong_windows_version_2[] = "3.5.1-0-1";
+    char wrong_windows_version_3[] = "3.5.1.0.1";
+    char large_version_0[] = "256.1.2.3-4";
+    char large_version_1[] = "1.256.3-4";
+    char large_version_2[] = "1.2.256.3-4";
+    char large_version_3[] = "1.2.3.256-4";
+
+    Version *version = NULL;
+    version = VersionNew();
+    assert_true (version != NULL);
+    assert_int_equal(version->major, 0);
+    assert_int_equal(version->minor, 0);
+    assert_int_equal(version->patch, 0);
+    assert_int_equal(version->extra, 0);
+    assert_int_equal(version->build, 0);
+    VersionDestroy(&version);
+    assert_true (version == NULL);
+
+    version = VersionNewFromCharP(right_version, strlen(right_version));
+    assert_true(version != NULL);
+    assert_int_equal(version->major, 1);
+    assert_int_equal(version->minor, 2);
+    assert_int_equal(version->patch, 3);
+    assert_int_equal(version->extra, 0);
+    assert_int_equal(version->build, 0);
+    VersionDestroy(&version);
+    assert_true (version == NULL);
+
+    version = VersionNewFromCharP(right_unix_version, strlen(right_unix_version));
+    assert_true(version != NULL);
+    assert_int_equal(version->major, 1);
+    assert_int_equal(version->minor, 2);
+    assert_int_equal(version->patch, 3);
+    assert_int_equal(version->extra, 0);
+    assert_int_equal(version->build, 4);
+    VersionDestroy(&version);
+    assert_true (version == NULL);
+
+    version = VersionNewFromCharP(right_windows_version, strlen(right_windows_version));
+    assert_true(version != NULL);
+    assert_int_equal(version->major, 1);
+    assert_int_equal(version->minor, 2);
+    assert_int_equal(version->patch, 3);
+    assert_int_equal(version->extra, 4);
+    assert_int_equal(version->build, 5);
+    VersionDestroy(&version);
+    assert_true (version == NULL);
+
+    version = VersionNewFromCharP(wrong_version, strlen(wrong_version));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(wrong_unix_version_0, strlen(wrong_unix_version_0));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(wrong_unix_version_1, strlen(wrong_unix_version_1));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(wrong_unix_version_2, strlen(wrong_unix_version_2));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(wrong_windows_version_0, strlen(wrong_windows_version_0));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(wrong_windows_version_1, strlen(wrong_windows_version_1));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(wrong_windows_version_2, strlen(wrong_windows_version_2));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(wrong_windows_version_3, strlen(wrong_windows_version_3));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(large_version_0, strlen(large_version_0));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(large_version_1, strlen(large_version_1));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(large_version_2, strlen(large_version_2));
+    assert_true(version == NULL);
+    version = VersionNewFromCharP(large_version_3, strlen(large_version_3));
+    assert_true(version == NULL);
+
+    /* Creation from a buffer uses the same path as the creation from a char p, we just test the two main cases */
+    Buffer *buffer = NULL;
+    buffer = BufferNewFrom(right_version, strlen(right_version));
+    assert_true (buffer != NULL);
+    version = VersionNewFrom(buffer);
+    assert_true(version != NULL);
+    assert_int_equal(version->major, 1);
+    assert_int_equal(version->minor, 2);
+    assert_int_equal(version->patch, 3);
+    assert_int_equal(version->extra, 0);
+    assert_int_equal(version->build, 0);
+    VersionDestroy(&version);
+    assert_true (version == NULL);
+    BufferDestroy(&buffer);
+    assert_true(buffer == NULL);
+
+    buffer = BufferNewFrom(wrong_version, strlen(wrong_version));
+    assert_true (buffer != NULL);
+    version = VersionNewFrom(buffer);
+    assert_true(version == NULL);
+    BufferDestroy(&buffer);
+    assert_true(buffer == NULL);
+}
+
+static void test_comparison(void)
+{
+    char lowest_version[] = "0.0.0.0-0";
+    char normal_version[] = "1.2.3.0-4";
+    char normal_version_with_extra[] = "1.2.3.9-4";
+    char highest_version[] = "255.255.255.0-255";
+
+    Version *a = NULL;
+    Version *b = NULL;
+
+    a = VersionNewFromCharP(lowest_version, strlen(lowest_version));
+    assert_true(a != NULL);
+    b = VersionNewFromCharP(normal_version, strlen(normal_version));
+    assert_true(b != NULL);
+    assert_true(VersionCompare(a, b) < 0);
+    assert_true(VersionCompare(b, a) > 0);
+    assert_true(VersionCompare(a, b) != 0);
+
+    VersionDestroy(&a);
+    assert_true(a == NULL);
+    a = VersionNewFromCharP(normal_version_with_extra, strlen(normal_version_with_extra));
+    assert_true(a != NULL);
+    assert_int_equal(VersionCompare(a,b), 0);
+
+    VersionDestroy(&b);
+    assert_true(b == NULL);
+    b = VersionNewFromCharP(highest_version, strlen(highest_version));
+    assert_true(VersionCompare(a,b) < 0);
+
+    VersionDestroy(&a);
+    assert_true(a == NULL);
+    VersionDestroy(&b);
+    assert_true(b == NULL);
+}
+
+int main()
+{
+    PRINT_TEST_BANNER();
+    const UnitTest tests[] =
+    {
+        unit_test(test_creation_destruction)
+        , unit_test(test_comparison)
+    };
+
+    return run_tests(tests);
+}
+


### PR DESCRIPTION
This structure can be used to compare software versions. It is aimed
towards comparison of CFEngine versions.
It supports the following format:

major.minor.path.extra-build

The field 'extra' is never included in comparisons, it is only included for
compatibility with Windows systems.
