### PR TITLE
Redmine#3446: ignore source position when unique-hashing promises

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -569,27 +569,7 @@ static void PromiseRuntimeHash(const Promise *pp, const char *salt, unsigned cha
         }
     }
 
-    char *str = NULL;
-    if (pp->offset.start)
-    {
-        xasprintf(&str, "%u", (unsigned int)pp->offset.start);
-        EVP_DigestUpdate(&context, str, strlen(str));
-        free(str);
-    }
-
-    if (pp->offset.end)
-    {
-        xasprintf(&str, "%u", (unsigned int)pp->offset.end);
-        EVP_DigestUpdate(&context, str, strlen(str));
-        free(str);
-    }
-
-    if (pp->offset.line)
-    {
-        xasprintf(&str, "%u", (unsigned int)pp->offset.line);
-        EVP_DigestUpdate(&context, str, strlen(str));
-        free(str);
-    }
+    // Unused: pp start, end, and line attributes (describing source position).
 
     if (salt)
     {

--- a/libpromises/verify_reports.c
+++ b/libpromises/verify_reports.c
@@ -51,7 +51,8 @@ void VerifyReportPromise(EvalContext *ctx, Promise *pp)
 
     a = GetReportsAttributes(ctx, pp);
 
-    snprintf(unique_name, CF_EXPANDSIZE - 1, "%s_%zu", pp->promiser, pp->offset.line);
+    // We let AcquireLock worry about making a unique name
+    snprintf(unique_name, CF_EXPANDSIZE - 1, "%s", pp->promiser);
     thislock = AcquireLock(ctx, unique_name, VUQNAME, CFSTARTTIME, a.transaction, pp, false);
 
     // Handle return values before locks, as we always do this

--- a/tests/acceptance/14_reports/00_output/report_once.cf
+++ b/tests/acceptance/14_reports/00_output/report_once.cf
@@ -1,0 +1,37 @@
+# Check that reports are printed just once (Redmine#3446 https://cfengine.com/dev/issues/3446)
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+bundle agent init
+{
+
+}
+
+
+bundle agent test
+{
+vars:
+  "subout" string => execresult("$(sys.cf_agent) -Kf $(this.promise_filename).sub", "noshell");
+}
+
+
+bundle agent check
+{
+# If the output contains the string "ONCE" twice then we fail
+classes:
+  "ok" not => regcmp(".*ONCE.*ONCE.*", "$(test.subout)");
+
+reports:
+  DEBUG::
+    "$(test.subout)";
+
+  ok::
+    "$(this.promise_filename) Pass";
+  !ok::
+    "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/14_reports/00_output/report_once.cf.sub
+++ b/tests/acceptance/14_reports/00_output/report_once.cf.sub
@@ -1,0 +1,11 @@
+body common control
+{
+      bundlesequence => { run };
+}
+
+bundle agent run
+{
+  reports:
+      "should be printed just ONCE";
+      "should be printed just ONCE";
+}


### PR DESCRIPTION
As described in https://cfengine.com/dev/issues/3446 with an acceptance test AND source comments!

The source position should not matter for identical promises.  All the CFEngine acceptance tests pass after removing it.
