### PR TITLE
.gitignore: ignore vim temporary files and .sw[op] dot-files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,11 @@ galaxy
 TAGS
 cscope.*
 
+# vim
+*~
+.*.swp
+.*.swo
+
 # emacs
 
 *~


### PR DESCRIPTION
Noticed a vim section was missing. Ignore the ordering of my sections' placement... what can I say, I'm biased :)
