### PR TITLE
Correct spelling in a few places

### DIFF
--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -620,7 +620,7 @@ static void KeepControlPromises(EvalContext *ctx, Policy *policy)
                 if (BACKGROUND || INTERACTIVE)
                 {
                     Log(LOG_LEVEL_WARNING,
-                          "'background_children' setting from 'body runagent control' is overriden by command-line option.");
+                          "'background_children' setting from 'body runagent control' is overridden by command-line option.");
                 }
                 else
                 {

--- a/libpromises/dbm_priv.h
+++ b/libpromises/dbm_priv.h
@@ -44,7 +44,7 @@ const char *DBPrivGetFileExtension(void);
  * - NULL in case of generic error
  * - DB_PRIV_DATABASE_BROKEN in case database file is broken, need to be moved
       away and attempt to open database again should be performed.
- * - valid pointer to DBPriv * in case database was opened succesfully.
+ * - valid pointer to DBPriv * in case database was opened successfully.
  */
 DBPriv *DBPrivOpenDB(const char *dbpath);
 void DBPrivCloseDB(DBPriv *hdbp);

--- a/libpromises/files_lib.h
+++ b/libpromises/files_lib.h
@@ -42,7 +42,7 @@ void CreateEmptyFile(char *name);
  * @brief Deletes directory path recursively. Symlinks are not followed.
  *        Note that this function only deletes the contents of the directory, not the directory itself.
  * @param path
- * @return true if directory was deleted succesfully, false if one or more files were not deleted.
+ * @return true if directory was deleted successfully, false if one or more files were not deleted.
  */
 bool DeleteDirectoryTree(const char *path);
 

--- a/libpromises/process_lib.h
+++ b/libpromises/process_lib.h
@@ -44,7 +44,7 @@ time_t GetProcessStartTime(pid_t pid);
  * #process_start_time may be PROCESS_START_TIME_UNKNOWN, which will disable
  * safety check for killing right process.
  *
- * @return true if process was killed succesfully, false otherwise.
+ * @return true if process was killed successfully, false otherwise.
  */
 int GracefulTerminate(pid_t pid, time_t process_start_time);
 


### PR DESCRIPTION
This was found while updating Debian's cfengine package to 3.5.2.
