### PR TITLE
rewrite the host name if the results of uname happen to be shorter than ...

### DIFF
--- a/cf-agent/Makefile.am
+++ b/cf-agent/Makefile.am
@@ -1,6 +1,6 @@
 sbin_PROGRAMS = cf-agent
 
-AM_CPPFLAGS = @CPPFLAGS@ -I$(srcdir)/../libpromises -I$(srcdir)/../libutils \
+AM_CPPFLAGS = @CPPFLAGS@ -I$(srcdir)/../libpromises -I$(srcdir)/../libutils -I$(srcdir)/../libcompat \
 	-I$(srcdir)/../libcfnet \
 	$(NOVA_CPPFLAGS) \
 	$(LIBVIRT_CPPFLAGS) \
@@ -35,7 +35,8 @@ LDADD = ../libpromises/libpromises.la \
 	$(LIBVIRT_LIBS) \
 	$(POSTGRESQL_LIBS) \
 	$(MYSQL_LIBS) \
-	$(LIBXML2_LIBS)
+	$(LIBXML2_LIBS) \
+	../libcompat/libcompat.la
 if HAVE_NOVA
 LDADD += ../nova/libcfagent/libcfagent.la
 endif

--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -70,8 +70,9 @@
 #include "bootstrap.h"
 #include "misc_lib.h"
 #include "buffer.h"
-
+#include "cf3.extern.h"
 #include "mod_common.h"
+#include "../libcompat/rpl_utsname.h"
 
 typedef enum
 {
@@ -614,7 +615,7 @@ static void ThisAgentInit(void)
   status which we need for setting returns
 */
 
-    snprintf(filename, CF_BUFSIZE, "%s/cfagent.%s.log", CFWORKDIR, VSYSNAME.nodename);
+    snprintf(filename, CF_BUFSIZE, "%s/cfagent.%s.log", CFWORKDIR, get_utsname_nodename());
     MapName(filename);
 
     if ((fp = fopen(filename, "a")) != NULL)

--- a/libcompat/rpl_utsname.c
+++ b/libcompat/rpl_utsname.c
@@ -1,0 +1,72 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+# include "rpl_utsname.h"
+# include "cf3.extern.h"
+# include "platform.h"
+
+
+const char *get_utsname_nodename()
+{
+    static bool initialised = false;
+    static char vsysname_nodename[CF_BUFSIZE];
+  
+  
+    if (!initialised)
+    {
+        if (sizeof(VSYSNAME.nodename) == 9)
+        {
+            char dnsname[CF_BUFSIZE] = "";
+            char fqn[CF_BUFSIZE];
+            char nodename[CF_BUFSIZE];
+
+            if (gethostname(fqn, sizeof(fqn)) != -1)
+            {
+                struct hostent *hp;
+
+                if ((hp = gethostbyname(fqn)))
+                {
+                    strncpy(dnsname, hp->h_name, CF_MAXVARSIZE);
+  
+                    int hnlen = (int)((strchr(dnsname, '.')) - dnsname) + 1;
+    
+                    if (strlen(nodename) < hnlen && (strstr(dnsname, nodename)))
+                    {
+                        strlcpy(vsysname_nodename, dnsname, hnlen);
+                    }  
+                }
+            }
+        }
+        else
+        {
+            strlcpy(vsysname_nodename, VSYSNAME.nodename, sizeof(VSYSNAME.nodename));
+        }
+        initialised = true;
+    }
+  
+    return vsysname_nodename;
+}
+
+
+            

--- a/libcompat/rpl_utsname.h
+++ b/libcompat/rpl_utsname.h
@@ -1,0 +1,30 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+# ifndef CFENGINE_RPL_UTSNAME
+# define CFENGINE_RPL_UTSNAME
+
+
+extern const char * get_utsname_nodename();
+
+# endif // CFENGINE_RPL_UTSNAME

--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -54,6 +54,7 @@ extern time_t CFSTARTTIME;
 extern time_t CFINITSTARTTIME;
 
 extern struct utsname VSYSNAME;
+
 extern char VIPADDRESS[CF_MAX_IP_LEN];
 extern char VPREFIX[];
 

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -77,10 +77,11 @@
 #include <string.h>
 #include <ctype.h>
 #include <limits.h>
-#ifdef HAVE_UNAME
+#if defined (HAVE_UNAME) && ! defined (__hpux)
 # include <sys/utsname.h>
 #else
-# define _SYS_NMLN       257
+
+# define _LOC_NMLN       257
 
 struct utsname
 {


### PR DESCRIPTION
Some platforms (HP-UX) truncate the node name part when calling uname(). Use the hostname part of the fully qualified domain name from gethostname() to rewrite the node name.
