### PR TITLE
Added an option for configure '--with-piddir=>directory>'.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,7 @@ AS_IF([test x"$enable_fhs" = xyes], [
   projdocdir='${exec_prefix}/share/doc/cfengine'
   WORKDIR='${localstatedir}/lib/cfengine'
   LOGDIR='${localstatedir}/lib/cfengine'
+  PIDDIR=='${localstatedir}/lib/cfengine'
 ], [
   if test x"$prefix" = xNONE || test x"$prefix" = x/var/cfengine; then
     prefix=/var/cfengine
@@ -147,15 +148,18 @@ AS_IF([test x"$enable_fhs" = xyes], [
       mingw*)
         WORKDIR=$(cmd /c "echo %PROGRAMFILES%\\Cfengine" | sed 's/\\/\\\\/g')
         LOGDIR=$(cmd /c "echo %PROGRAMFILES%\\Cfengine" | sed 's/\\/\\\\/g')
+        PIDDIR=$(cmd /c "echo %PROGRAMFILES%\\Cfengine" | sed 's/\\/\\\\/g')
       ;;
       *)
         WORKDIR=/var/cfengine
         LOGDIR=/var/cfengine
+        PIDDIR=/var/cfengine
       ;;
     esac
   else
     WORKDIR="${localstatedir}/cfengine"
     LOGDIR="${localstatedir}/cfengine"
+    PIDDIR="${localstatedir}/cfengine"
   fi
 
   sbindir='${exec_prefix}/bin' # /var/cfengine/bin despite being sbin_?
@@ -953,6 +957,7 @@ AC_ARG_WITH(workdir,
         if test x$withval != x ; then
             WORKDIR=$withval
             LOGDIR=$withval
+            PIDDIR==$withval
         fi
     ],
 )
@@ -982,6 +987,21 @@ adl_RECURSIVE_EVAL("${LOGDIR}", LOGDIR)
 AC_DEFINE_UNQUOTED(LOGDIR, "${LOGDIR}", [Logdir location])
 AC_SUBST(logdir, "${LOGDIR}")
 
+AC_ARG_WITH(piddir,
+    [  --with-piddir=LOGDIR  default internal for pid directory ],
+    [
+        if test x$withval != x ; then
+            PIDDIR=$withval
+        fi
+    ],
+)
+
+dnl Expand ${prefix} and whatnot in PIDDIR
+
+adl_RECURSIVE_EVAL("${PIDDIR}", PIDDIR)
+
+AC_DEFINE_UNQUOTED(PIDDIR, "${PIDDIR}", [piddir location])
+AC_SUBST(piddir, "${PIDDIR}")
 
 AC_ARG_WITH(shell, [AS_HELP_STRING([--with-shell=PATH],
                    [Specify path to POSIX-compatible shell (if not /bin/sh)])],
@@ -1135,6 +1155,7 @@ m4_indir(incstart[]incend, [nova/config.m4])
 
 AC_MSG_RESULT([-> Workdir: $WORKDIR])
 AC_MSG_RESULT([-> Logdir: $LOGDIR])
+AC_MSG_RESULT([-> Piddir: $PIDDIR])
 
 AC_MSG_RESULT( )
 

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1292,7 +1292,7 @@ void WritePID(char *filename)
 
     pthread_once(&pid_cleanup_once, RegisterPidCleanup);
 
-    snprintf(PIDFILE, CF_BUFSIZE - 1, "%s%c%s", CFWORKDIR, FILE_SEPARATOR, filename);
+    snprintf(PIDFILE, CF_BUFSIZE - 1, "%s%c%s", GetPidDir(), FILE_SEPARATOR, filename);
 
     if ((fp = fopen(PIDFILE, "w")) == NULL)
     {

--- a/libpromises/sysinfo.h
+++ b/libpromises/sysinfo.h
@@ -37,6 +37,7 @@ bool IsInterfaceAddress(const char *adr);
 void DetectDomainName(EvalContext *ctx, const char *orig_nodename);
 const char *GetWorkDir(void);
 const char *GetLogDir(void);
+const char *GetPidDir(void);
 
 void CreateHardClassesFromCanonification(EvalContext *ctx, const char *canonified);
 


### PR DESCRIPTION
When not specified it is the same as 'WORKDIR'.

This came up when building the debian package. We need to change the location of the pid files.  For testing we can override it with an environment variable 'CFENGINE_TEST_OVERRIDE_PIDDIR' and also defined 'sys.piddir', eg:

body common control
{
bundlesequence => { test };
}

bundle agent test
{
reports:
        any::
            "$(sys.workdir)";
            "$(sys.piddir)";
}
