### PR TITLE
Fix strftime unit test.

### DIFF
--- a/tests/acceptance/01_vars/02_functions/strftime.cf
+++ b/tests/acceptance/01_vars/02_functions/strftime.cf
@@ -35,7 +35,7 @@ bundle agent init
     Saturday::
       "dow" string => "6";
     Sunday::
-      "dow" string => "7";
+      "dow" string => "0";
 
   files:
       "$(G.testfile).expected"


### PR DESCRIPTION
The test tests/acceptance/01_vars/02_functions/strftime.cf would fail
builds on Sundays. The policy specified Sunday as 7 but strftime specifies
Sunday as 0.

From `strftime(3)`:

```
 %w    is replaced by the weekday (Sunday as the first day of the week)
       as a decimal number (0-6).
```
