### PR TITLE
Redmine#3757: getindices() acceptance test for 2-level array

### DIFF
--- a/tests/acceptance/01_vars/02_functions/staging/getindices.cf
+++ b/tests/acceptance/01_vars/02_functions/staging/getindices.cf
@@ -1,0 +1,62 @@
+#######################################################
+#
+# Test that getindices on an array variable will resolve to 2 levels
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "user[name]"              string => "zamboni";
+      "user[fullname][first]"   string => "Diego";
+      "user[fullname][last]"    string => "Zamboni";
+      "user[dirs]"              slist => { "/home/zamboni",
+                                           "/tmp/zamboni",
+                                           "/export/home/zamboni" };
+
+      "fields"     slist => getindices("user");
+      "fields_sorted" slist => sort("fields", "lex");
+      "fields_str" string => join(",", "fields_sorted");
+
+      "userfields" slist => getindices("user[fullname]");
+      "userfields_sorted" slist => sort("userfields", "lex");
+      "userfields_str" string => join(",", "userfields_sorted");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "expected_fields" string => "dirs,fullname,name";
+      "expected_userfields" string => "first,last";
+
+  classes:
+      "ok_fields" expression => strcmp($(expected_fields), $(test.fields_str));
+      "ok_userfields" expression => strcmp($(expected_userfields), $(test.userfields_str));
+      "ok" and => { "ok_fields", "ok_userfields" };
+
+  reports:
+    DEBUG::
+      "fields = '$(test.fields_str)', expected = '$(expected_fields)'";
+      "userfields = '$(test.userfields_str)', expected = '$(expected_userfields)'";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
https://cfengine.com/dev/issues/3757

This acceptance test demonstrates that `getindices` fails to collect the indices correctly for a 2-level array.
