### PR TITLE
fix for bug #3517 HPUX hosts truncate the hostname to eight characters

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -70,7 +70,7 @@
 #include "bootstrap.h"
 #include "misc_lib.h"
 #include "buffer.h"
-
+#include "rpl_utsname.h"
 #include "mod_common.h"
 
 typedef enum
@@ -614,7 +614,7 @@ static void ThisAgentInit(void)
   status which we need for setting returns
 */
 
-    snprintf(filename, CF_BUFSIZE, "%s/cfagent.%s.log", CFWORKDIR, VSYSNAME.nodename);
+    snprintf(filename, CF_BUFSIZE, "%s/cfagent.%s.log", CFWORKDIR, get_utsname_nodename());
     MapName(filename);
 
     if ((fp = fopen(filename, "a")) != NULL)

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -51,6 +51,7 @@
 #include "promiser_regex_resolver.h"
 #include "ornaments.h"
 #include "audit.h"
+#include "rpl_utsname.h"
 
 static void LoadSetuid(Attributes a);
 static void SaveSetuid(EvalContext *ctx, Attributes a, Promise *pp);
@@ -605,7 +606,7 @@ static void LoadSetuid(Attributes a)
     edits.backup = BACKUP_OPTION_NO_BACKUP;
     edits.maxfilesize = 1000000;
 
-    snprintf(filename, CF_BUFSIZE, "%s/cfagent.%s.log", CFWORKDIR, VSYSNAME.nodename);
+    snprintf(filename, CF_BUFSIZE, "%s/cfagent.%s.log", CFWORKDIR, get_utsname_nodename());
     MapName(filename);
 
     if (!LoadFileAsItemList(&VSETUIDLIST, filename, edits))
@@ -624,7 +625,7 @@ static void SaveSetuid(EvalContext *ctx, Attributes a, Promise *pp)
     b.edits.maxfilesize = 1000000;
 
     char filename[CF_BUFSIZE];
-    snprintf(filename, CF_BUFSIZE, "%s/cfagent.%s.log", CFWORKDIR, VSYSNAME.nodename);
+    snprintf(filename, CF_BUFSIZE, "%s/cfagent.%s.log", CFWORKDIR, get_utsname_nodename());
     MapName(filename);
 
     PurgeItemList(&VSETUIDLIST, "SETUID/SETGID");

--- a/libpromises/Makefile.am
+++ b/libpromises/Makefile.am
@@ -100,7 +100,8 @@ libpromises_la_SOURCES = \
         vars.c vars.h \
         verify_classes.c verify_classes.h \
         verify_reports.c \
-        verify_vars.c verify_vars.h
+        verify_vars.c verify_vars.h \
+        rpl_utsname.c rpl_utsname.h
 
 if !HAVE_NOVA
 libpromises_la_SOURCES += \

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -55,7 +55,7 @@
 #include "audit.h"
 #include "verify_classes.h"
 #include "verify_vars.h"
-
+#include "rpl_utsname.h"
 #ifdef HAVE_NOVA
 # include "cf.nova.h"
 #endif
@@ -1152,7 +1152,10 @@ static void CheckWorkingDirectories(EvalContext *ctx)
         Log(LOG_LEVEL_ERR, "Couldn't get kernel name info. (uname: %s)", GetErrorStr());
         memset(&VSYSNAME, 0, sizeof(VSYSNAME));
     }
-
+    if (init_utsname_nodename() == -1)
+    {
+      Log(LOG_LEVEL_ERR, "Unable to initialize vsysname_nodename.nodename in rpl_utsname.c");
+    }
     snprintf(vbuff, CF_BUFSIZE, "%s%c.", CFWORKDIR, FILE_SEPARATOR);
     MakeParentDirectory(vbuff, false);
 

--- a/libpromises/rpl_utsname.c
+++ b/libpromises/rpl_utsname.c
@@ -1,0 +1,80 @@
+/*
+Copyright (C) CFEngine AS
+
+This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+To the extent this program is licensed as part of the Enterprise
+versions of CFEngine, the applicable Commerical Open Source License
+(COSL) may apply to this file if you as a licensee so wish it. See
+included file COSL.txt.
+*/
+
+# include "rpl_utsname.h"
+# include "cf3.defs.h"
+# include "cf3.extern.h"
+# include "platform.h"
+
+
+uts_nodename_t vsysname_nodename = { .initialised = 0, .nodename = {0} };
+
+const char *get_utsname_nodename()
+{
+    if (vsysname_nodename.initialised == 0)
+    {
+        return "";
+    }
+    else
+    {
+        return vsysname_nodename.nodename;
+    }
+}
+
+int init_utsname_nodename()
+{
+    if (vsysname_nodename.initialised == 0)
+    {  
+        char dnsname[RPL_UTSNAME_BUFSIZE] = "";
+        char fqn[RPL_UTSNAME_BUFSIZE];
+            
+# if defined (__hpux)
+        if (gethostname(fqn, sizeof(fqn)) != -1)
+        {
+            struct hostent *hp;
+
+            if ((hp = gethostbyname(fqn)))
+            {
+                strncpy(dnsname, hp->h_name, RPL_UTSNAME_BUFSIZE);
+
+                int hnlen = (int)((strchr(dnsname, '.')) - dnsname) + 1;
+    
+                strlcpy(vsysname_nodename.nodename, dnsname, hnlen);    
+            }
+            else
+            {
+                return -1;
+            }
+        }
+        else
+        {
+            return -1;
+        }
+# else     
+        strlcpy(vsysname_nodename.nodename, VSYSNAME.nodename, sizeof(VSYSNAME.nodename));
+# endif  
+        vsysname_nodename.initialised = 1;
+    }
+    return 0;
+}

--- a/libpromises/rpl_utsname.h
+++ b/libpromises/rpl_utsname.h
@@ -1,0 +1,39 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+# ifndef CFENGINE_RPL_UTSNAME
+# define CFENGINE_RPL_UTSNAME
+
+# define RPL_UTSNAME_BUFSIZE 257
+
+typedef struct uts_nodename
+{
+  int initialised;
+  char nodename[RPL_UTSNAME_BUFSIZE];
+} uts_nodename_t;
+
+extern uts_nodename_t vsysname_nodename;
+
+extern const char * get_utsname_nodename();
+extern int init_utsname_nodename();
+# endif // CFENGINE_RPL_UTSNAME

--- a/libpromises/sysinfo.c
+++ b/libpromises/sysinfo.c
@@ -38,6 +38,7 @@
 #include "misc_lib.h"
 #include "rlist.h"
 #include "audit.h"
+#include "rpl_utsname.h"
 
 #ifdef HAVE_ZONE_H
 # include <zone.h>
@@ -318,7 +319,10 @@ void GetNameInfo3(EvalContext *ctx, AgentType agent_type)
         Log(LOG_LEVEL_ERR, "Couldn't get kernel name info!. (uname: %s)", GetErrorStr());
         memset(&VSYSNAME, 0, sizeof(VSYSNAME));
     }
-
+    if (init_utsname_nodename() == -1)
+    {
+      Log(LOG_LEVEL_ERR, "Unable to initialize vsysname_nodename.nodename in rpl_utsname.c");
+    }
 #ifdef _AIX
     snprintf(real_version, _SYS_NMLN, "%.80s.%.80s", VSYSNAME.version, VSYSNAME.release);
     strncpy(VSYSNAME.release, real_version, _SYS_NMLN);
@@ -387,7 +391,7 @@ void GetNameInfo3(EvalContext *ctx, AgentType agent_type)
     }
 #endif
 
-    DetectDomainName(ctx, VSYSNAME.nodename);
+    DetectDomainName(ctx, get_utsname_nodename());
 
     if ((tloc = time((time_t *) NULL)) == -1)
     {
@@ -402,11 +406,11 @@ void GetNameInfo3(EvalContext *ctx, AgentType agent_type)
     {
         Log(LOG_LEVEL_VERBOSE, "------------------------------------------------------------------------");
     }
-    Log(LOG_LEVEL_VERBOSE, "Host name is: %s", VSYSNAME.nodename);
+    Log(LOG_LEVEL_VERBOSE, "Host name is: %s", get_utsname_nodename());
     Log(LOG_LEVEL_VERBOSE, "Operating System Type is %s", VSYSNAME.sysname);
     Log(LOG_LEVEL_VERBOSE, "Operating System Release is %s", VSYSNAME.release);
     Log(LOG_LEVEL_VERBOSE, "Architecture = %s", VSYSNAME.machine);
-    Log(LOG_LEVEL_VERBOSE, "Using internal soft-class %s for host %s", workbuf, VSYSNAME.nodename);
+    Log(LOG_LEVEL_VERBOSE, "Using internal soft-class %s for host %s", workbuf, get_utsname_nodename());
     Log(LOG_LEVEL_VERBOSE, "The time is now %s", ctime(&tloc));
     if (LEGACY_OUTPUT)
     {
@@ -636,7 +640,7 @@ void GetNameInfo3(EvalContext *ctx, AgentType agent_type)
 
     if ((hp = gethostbyname(VFQNAME)) == NULL)
     {
-        Log(LOG_LEVEL_VERBOSE, "Hostname lookup failed on node name '%s'", VSYSNAME.nodename);
+        Log(LOG_LEVEL_VERBOSE, "Hostname lookup failed on node name '%s'", get_utsname_nodename());
         return;
     }
     else

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -77,18 +77,18 @@
 #include <string.h>
 #include <ctype.h>
 #include <limits.h>
-#ifdef HAVE_UNAME
+#if defined (HAVE_UNAME) && !defined (__hpux)
 # include <sys/utsname.h>
 #else
-# define _SYS_NMLN       257
+# define _LOC_NMLN       257
 
 struct utsname
 {
-    char sysname[_SYS_NMLN];
-    char nodename[_SYS_NMLN];
-    char release[_SYS_NMLN];
-    char version[_SYS_NMLN];
-    char machine[_SYS_NMLN];
+    char sysname[_LOC_NMLN];
+    char nodename[_LOC_NMLN];
+    char release[_LOC_NMLN];
+    char version[_LOC_NMLN];
+    char machine[_LOC_NMLN];
 };
 
 #endif


### PR DESCRIPTION
Fixes bug #3517 where HPUX hostname is truncated to 8 characters

Added a global struct with initialised variable plus an initialise function that is called from generic_agent.c
