### PR TITLE
honor the --docdir configure option.  

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ DIST_COMMON = README.md Makefile.am Makefile.in configure AUTHORS aclocal.m4 \
 
 EXTRA_DIST = ChangeLog INSTALL README.md LICENSE
 
-docsdir = $(projdocdir)
+docsdir = $(docdir)
 docs_DATA = README.md ChangeLog
 
 #

--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,6 @@ AC_ARG_ENABLE([fhs],
 AS_IF([test x"$enable_fhs" = xyes], [
   projlibdir='${libdir}/cfengine'
   projdatadir='${exec_prefix}/share/cfengine'
-  projdocdir='${exec_prefix}/share/doc/cfengine'
   WORKDIR='${localstatedir}/lib/cfengine'
   LOGDIR='${localstatedir}/lib/cfengine'
   PIDDIR=='${localstatedir}/lib/cfengine'
@@ -165,13 +164,11 @@ AS_IF([test x"$enable_fhs" = xyes], [
   sbindir='${exec_prefix}/bin' # /var/cfengine/bin despite being sbin_?
   projlibdir='${exec_prefix}/lib'
   projdatadir='${exec_prefix}/share'
-  projdocdir='${exec_prefix}/share/doc'
   mandir='${exec_prefix}/share/man'
 ])
 
 AC_SUBST(projlibdir)
 AC_SUBST(projdatadir)
-AC_SUBST(projdocdir)
 
 dnl ######################################################################
 dnl Enable debugging

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,4 +1,4 @@
-examplesdir = $(projdocdir)/examples
+examplesdir = $(docdir)/examples
 dist_examples_DATA = $(srcdir)/*.cf
 
 MAINTAINERCLEANFILES = Makefile.in mdate-sh


### PR DESCRIPTION
The projdocdir variable is replaced by docdir variable. projdocdir had the same functionality as --docdirconfigure option.  The default docdir value is: $(prefix)/share/doc/$(PACKAGE) (is the same as --enable-fhs option)
