### PR TITLE
.gitignore: in addition to ignoring "TAGS" ignore "tags".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ galaxy
 # tags
 
 TAGS
+tags
 cscope.*
 
 # vim


### PR DESCRIPTION
minor nitpick: .gitignore ignores "TAGS" but not "tags".
