### PR TITLE
contain package methods with user and group: a first attempt at Feature#1899

### DIFF
--- a/cf-agent/vercmp.c
+++ b/cf-agent/vercmp.c
@@ -80,7 +80,7 @@ static VersionCmpResult RunCmpCommand(EvalContext *ctx, const char *command, con
         VarRefDestroy(ref_v2);
     }
 
-    FILE *pfp = a.packages.package_commands_useshell ? cf_popen_sh(expanded_command, "w") : cf_popen(expanded_command, "w", true);
+    FILE *pfp = a.packages.contain.shelltype ? cf_popen_sh(expanded_command, "w") : cf_popen(expanded_command, "w", true);
 
     if (pfp == NULL)
     {

--- a/cf-agent/vercmp.h
+++ b/cf-agent/vercmp.h
@@ -37,7 +37,7 @@ typedef enum
  *  a.packages.package_select
  *  a.packages.package_version_less_command
  *  a.packages.package_version_equal_command
- *  a.packages.package_commands_useshell
+ *  a.packages.contain.shelltype
  *  cfPS
  */
 VersionCmpResult CompareVersions(EvalContext *ctx, const char *v1, const char *v2, Attributes a, Promise *pp, PromiseResult *result);

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -64,6 +64,8 @@ static char *GetDefaultArch(const char *command);
 
 static int ExecPackageCommand(EvalContext *ctx, char *command, int verify, int setCmdClasses, Attributes a, Promise *pp, PromiseResult *result);
 
+static FILE *PopenPackageCommand(const Attributes* const a, const char* const cmd);
+
 static int PrependPatchItem(EvalContext *ctx, PackageItem ** list, char *item, PackageItem * chklist, const char *default_arch, Attributes a, Promise *pp);
 static int PrependMultiLinePackageItem(EvalContext *ctx, PackageItem ** list, char *item, int reset, const char *default_arch, Attributes a, Promise *pp);
 static int PrependListPackageItem(EvalContext *ctx, PackageItem ** list, char *item, const char *default_arch, Attributes a, Promise *pp);
@@ -187,7 +189,7 @@ static int PackageSanityCheck(EvalContext *ctx, Attributes a, Promise *pp)
         return false;
     }
 
-    if ((!a.packages.package_commands_useshell) && (a.packages.package_list_command) && (!IsExecutable(CommandArg0(a.packages.package_list_command))))
+    if ((a.packages.package_list_command) && (!IsExecutable(CommandArg0(a.packages.package_list_command))))
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a,
              "The proposed package list command '%s' was not executable",
@@ -398,22 +400,11 @@ static bool PackageListInstalledFromCommand(EvalContext *ctx, PackageItem **inst
 
     FILE *fin;
     
-    if (a.packages.package_commands_useshell)
+    if ((fin = PopenPackageCommand(&a, a.packages.package_list_command)) == NULL)
     {
-        if ((fin = cf_popen_sh(a.packages.package_list_command, "r")) == NULL)
-        {
-            Log(LOG_LEVEL_ERR, "Couldn't open the package list with command '%s'. (cf_popen_sh: %s)",
-                  a.packages.package_list_command, GetErrorStr());
-            return false;
-        }
-    }
-    else if ((fin = cf_popen(a.packages.package_list_command, "r", true)) == NULL)
-    {
-        Log(LOG_LEVEL_ERR, "Couldn't open the package list with command '%s'. (cf_popen: %s)",
-            a.packages.package_list_command, GetErrorStr());
         return false;
     }
-
+    
     const int reset = true, update = false;
     char buf[CF_BUFSIZE];
 
@@ -661,28 +652,17 @@ static int VerifyInstalledPackages(EvalContext *ctx, PackageManager **all_mgrs, 
             Log(LOG_LEVEL_VERBOSE, "Reading patches from '%s'", CommandArg0(a.packages.package_patch_list_command));
         }
 
-        if ((!a.packages.package_commands_useshell) && (!IsExecutable(CommandArg0(a.packages.package_patch_list_command))))
+        if (!IsExecutable(CommandArg0(a.packages.package_patch_list_command)))
         {
             Log(LOG_LEVEL_ERR, "The proposed patch list command '%s' was not executable",
                   a.packages.package_patch_list_command);
             return false;
         }
 
-        FILE *fin;
+        FILE *fin = NULL;
 
-        if (a.packages.package_commands_useshell)
+        if ((fin = PopenPackageCommand(&a, a.packages.package_patch_list_command)) == NULL)
         {
-            if ((fin = cf_popen_sh(a.packages.package_patch_list_command, "r")) == NULL)
-            {
-                Log(LOG_LEVEL_ERR, "Couldn't open the patch list with command '%s'. (cf_popen_sh: %s)",
-                      a.packages.package_patch_list_command, GetErrorStr());
-                return false;
-            }
-        }
-        else if ((fin = cf_popen(a.packages.package_patch_list_command, "r", true)) == NULL)
-        {
-            Log(LOG_LEVEL_ERR, "Couldn't open the patch list with command '%s'. (cf_popen: %s)",
-                  a.packages.package_patch_list_command, GetErrorStr());
             return false;
         }
 
@@ -2347,6 +2327,72 @@ char *PrefixLocalRepository(Rlist *repositories, char *package)
     return NULL;
 }
 
+static FILE *PopenPackageCommand(const Attributes* const a, const char* const cmd)
+{
+    FILE *fin = NULL;
+
+    Log(LOG_LEVEL_VERBOSE,
+        "Executing package command '%s' %s with shelltype: %d", 
+        cmd, a->packages.havepackagecontain ? "contained" : "", a->packages.contain.shelltype);
+
+    /* better uid|gid|chdir|chroot|bg logging? */
+
+    switch (a->packages.contain.shelltype)
+    {
+    case SHELL_TYPE_NONE: 
+        fin = (!a->packages.havepackagecontain)
+              ? cf_popen_sh(cmd, "r")
+              : cf_popensetuid(cmd, "r",
+                               a->packages.contain.owner,
+                               a->packages.contain.group,
+                               a->packages.contain.chdir,
+                               a->packages.contain.chroot,
+                               a->transaction.background);
+        break;
+
+    case SHELL_TYPE_USE: 
+        fin = (!a->packages.havepackagecontain)
+              ? cf_popen_sh(cmd, "r")
+              : cf_popen_shsetuid(cmd, "r",
+                                  a->packages.contain.owner,
+                                  a->packages.contain.group,
+                                  a->packages.contain.chdir,
+                                  a->packages.contain.chroot,
+                                  a->transaction.background);
+        break;
+
+#ifdef __MINGW32__
+    case SHELL_TYPE_POWERSHELL: 
+        fin = (!a->packages.havepackagecontain)
+              ? cf_popen_powershell(cmd, "r")
+              : cf_popen_powershell_setuid(cmd, "r",
+                                           a->packages.contain.owner,
+                                           a->packages.contain.group,
+                                           a->packages.contain.chdir,
+                                           a->packages.contain.chroot,
+                                           a->transaction.background);
+        break;
+#else
+    case SHELL_TYPE_POWERSHELL: 
+        Log(LOG_LEVEL_ERR, "Powershell is only supported on Windows");
+        return NULL;
+        break;
+#endif /* !__MINGW32__ */
+    }
+
+    if (fin == NULL)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Couldn't popen package command '%s'. (PopenPackageCommand: %s)",
+            cmd, GetErrorStr());
+        return NULL;
+    }
+    else
+    {
+        return fin;
+    }
+}
+
 int ExecPackageCommand(EvalContext *ctx, char *command, int verify, int setCmdClasses, Attributes a,
                        Promise *pp, PromiseResult *result)
 {
@@ -2355,7 +2401,7 @@ int ExecPackageCommand(EvalContext *ctx, char *command, int verify, int setCmdCl
     FILE *pfp;
     int packmanRetval = 0;
 
-    if ((!a.packages.package_commands_useshell) && (!IsExecutable(CommandArg0(command))))
+    if ((!a.packages.contain.shelltype) && (!IsExecutable(CommandArg0(command))))
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a, "The proposed package schedule command '%s' was not executable", command);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
@@ -2369,26 +2415,15 @@ int ExecPackageCommand(EvalContext *ctx, char *command, int verify, int setCmdCl
 
 /* Use this form to avoid limited, intermediate argument processing - long lines */
 
-    if (a.packages.package_commands_useshell)
+    pfp = PopenPackageCommand(&a, command);
+
+    if (pfp == NULL)
     {
-        Log(LOG_LEVEL_VERBOSE, "Running %s in shell", command);
-        if ((pfp = cf_popen_sh(command, "r")) == NULL)
-        {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a, "Couldn't start command '%20s'. (cf_popen_sh: %s)",
-                 command, GetErrorStr());
-            *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
-            return false;
-        }
-    }
-    else
-    {
-        if ((pfp = cf_popen(command, "r", true)) == NULL)
-        {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a, "Couldn't start command '%20s'. (cf_popen: %s)",
-                 command, GetErrorStr());
-            *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
-            return false;
-        }
+        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a, \
+            "Couldn't execute package command '%20s': %s)", \
+            command, GetErrorStr());
+        *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
+        return false;
     }
 
     Log(LOG_LEVEL_VERBOSE, "Executing %-.60s...", command);

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -166,9 +166,15 @@ Attributes GetPackageAttributes(const EvalContext *ctx, const Promise *pp)
 {
     Attributes attr = { {0} };
 
+    attr.havetrans = PromiseGetConstraintAsBoolean(ctx, CF_TRANSACTION, pp);
     attr.transaction = GetTransactionConstraints(ctx, pp);
+
+    attr.haveclasses = PromiseGetConstraintAsBoolean(ctx, CF_DEFINECLASSES, pp);
     attr.classes = GetClassDefinitionConstraints(ctx, pp);
+
+    attr.havepackages = PromiseGetConstraintAsBoolean(ctx, "packages", pp);
     attr.packages = GetPackageConstraints(ctx, pp);
+
     return attr;
 }
 
@@ -368,7 +374,7 @@ Environments GetEnvironmentsConstraints(const EvalContext *ctx, const Promise *p
 
 /*******************************************************************/
 
-ExecContain GetExecContainConstraints(const EvalContext *ctx, const Promise *pp)
+ExecContain GetPackageExecContainConstraints(const EvalContext *ctx, const Promise *pp)
 {
     ExecContain e;
 
@@ -376,11 +382,22 @@ ExecContain GetExecContainConstraints(const EvalContext *ctx, const Promise *pp)
     e.umask = PromiseGetConstraintAsOctal(ctx, "umask", pp);
     e.owner = PromiseGetConstraintAsUid(ctx, "exec_owner", pp);
     e.group = PromiseGetConstraintAsGid(ctx, "exec_group", pp);
-    e.preview = PromiseGetConstraintAsBoolean(ctx, "preview", pp);
-    e.nooutput = PromiseGetConstraintAsBoolean(ctx, "no_output", pp);
     e.timeout = PromiseGetConstraintAsInt(ctx, "exec_timeout", pp);
     e.chroot = ConstraintGetRvalValue(ctx, "chroot", pp, RVAL_TYPE_SCALAR);
     e.chdir = ConstraintGetRvalValue(ctx, "chdir", pp, RVAL_TYPE_SCALAR);
+
+    return e;
+}
+
+/*******************************************************************/
+
+ExecContain GetExecContainConstraints(const EvalContext *ctx, const Promise *pp)
+{
+    ExecContain e;
+
+    e = GetPackageExecContainConstraints(ctx, pp);
+    e.preview = PromiseGetConstraintAsBoolean(ctx, "preview", pp);
+    e.nooutput = PromiseGetConstraintAsBoolean(ctx, "no_output", pp);
 
     return e;
 }
@@ -1064,7 +1081,16 @@ Packages GetPackageConstraints(const EvalContext *ctx, const Promise *pp)
     Packages p;
     PackageAction action;
     PackageVersionComparator operator;
+    ExecContain contain;
     PackageActionPolicy change_policy;
+
+    memset(&contain, '\0', sizeof(contain));
+
+    p.havepackagecontain = PromiseGetConstraintAsBoolean(ctx, "contain", pp);
+    if (p.havepackagecontain)
+    {
+        p.contain = GetPackageExecContainConstraints(ctx, pp);
+    }
 
     p.have_package_methods = PromiseGetConstraintAsBoolean(ctx, "havepackage_method", pp);
     p.package_version = (char *) ConstraintGetRvalValue(ctx, "package_version", pp, RVAL_TYPE_SCALAR);
@@ -1081,6 +1107,7 @@ Packages GetPackageConstraints(const EvalContext *ctx, const Promise *pp)
     operator = PackageVersionComparatorFromString((char *) ConstraintGetRvalValue(ctx, "package_select", pp, RVAL_TYPE_SCALAR));
 
     p.package_select = operator;
+
     change_policy = PackageActionPolicyFromString((char *) ConstraintGetRvalValue(ctx, "package_changes", pp, RVAL_TYPE_SCALAR));
     p.package_changes = change_policy;
 
@@ -1114,15 +1141,6 @@ Packages GetPackageConstraints(const EvalContext *ctx, const Promise *pp)
     p.package_verify_command = (char *) ConstraintGetRvalValue(ctx, "package_verify_command", pp, RVAL_TYPE_SCALAR);
     p.package_noverify_regex = (char *) ConstraintGetRvalValue(ctx, "package_noverify_regex", pp, RVAL_TYPE_SCALAR);
     p.package_noverify_returncode = PromiseGetConstraintAsInt(ctx, "package_noverify_returncode", pp);
-
-    if (PromiseGetConstraint(ctx, pp, "package_commands_useshell") == NULL)
-    {
-        p.package_commands_useshell = true;
-    }
-    else
-    {
-        p.package_commands_useshell = PromiseGetConstraintAsBoolean(ctx, "package_commands_useshell", pp);
-    }
 
     p.package_name_convention = (char *) ConstraintGetRvalValue(ctx, "package_name_convention", pp, RVAL_TYPE_SCALAR);
     p.package_delete_convention = (char *) ConstraintGetRvalValue(ctx, "package_delete_convention", pp, RVAL_TYPE_SCALAR);

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1416,11 +1416,13 @@ typedef struct
 {
     PackageAction package_policy;
     int have_package_methods;
+    int havepackagecontain;
     char *package_version;
     Rlist *package_architectures;
     PackageVersionComparator package_select;
     PackageActionPolicy package_changes;
     Rlist *package_file_repositories;
+    ExecContain contain;
 
     char *package_default_arch_command;
 

--- a/libpromises/mod_packages.c
+++ b/libpromises/mod_packages.c
@@ -64,10 +64,25 @@ static const ConstraintSyntax package_method_constraints[] =
 
 static const BodySyntax package_method_body = BodySyntaxNew("package_method", package_method_constraints, NULL, SYNTAX_STATUS_NORMAL);
 
+static const ConstraintSyntax package_contain_constraints[] =
+{
+    ConstraintSyntaxNewOption("useshell", "useshell,noshell,powershell," CF_BOOL, "noshell/useshell/powershell embed the command in the given shell environment. Default value: useshell", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewString("exec_owner", "", "The user name or id under which to run the package manager process", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewString("exec_group", "", "The group name or id under which to run the package manager process", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewOption("umask", "0,77,22,27,72,077,002,022,027,072", "The umask value for the package manager process", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewInt("exec_timeout", "1,3600", "Timeout in seconds for package manager process completion", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewString("chdir", CF_ABSPATHRANGE, "Directory for setting current/base directory for the package manager process", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewString("chroot", CF_ABSPATHRANGE, "Directory of root sandbox for the package manager process", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewNull()
+};
+
+static const BodySyntax package_contain_body = BodySyntaxNew("contain", package_contain_constraints, NULL, SYNTAX_STATUS_NORMAL);
+
 static const ConstraintSyntax packages_constraints[] =
 {
     ConstraintSyntaxNewStringList("package_architectures", "", "Select the architecture for package selection", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBody("package_method", &package_method_body, "Criteria for installation and verification", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewBody("contain", &package_contain_body, "Criteria for \"package_method\" execution containment", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewOption("package_policy", "add,delete,reinstall,update,addupdate,patch,verify", "Criteria for package installation/upgrade on the current system. Default value: verify", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewOption("package_select", ">,<,==,!=,>=,<=", "A criterion for first acceptable match relative to \"package_version\"", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("package_version", "", "Version reference point for determining promised version", SYNTAX_STATUS_NORMAL),

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -292,6 +292,7 @@ FILE *cf_popensetuid(const char *command, const char *type, uid_t uid, gid_t gid
                 ArgFree(argv);
                 return NULL;
             }
+            Log(LOG_LEVEL_VERBOSE, "Directory changed to '%s'.", chdirv);
         }
 
         if (!CfSetuid(uid, gid))
@@ -479,6 +480,7 @@ FILE *cf_popen_shsetuid(const char *command, const char *type, uid_t uid, gid_t 
                 Log(LOG_LEVEL_ERR, "Couldn't chdir to '%s'. (chdir: %s)", chdirv, GetErrorStr());
                 return NULL;
             }
+            Log(LOG_LEVEL_VERBOSE, "Directory changed to '%s'.", chdirv);
         }
 
         if (!CfSetuid(uid, gid))
@@ -622,7 +624,7 @@ static int CfSetuid(uid_t uid, gid_t gid)
 
     if (gid != (gid_t) - 1)
     {
-        Log(LOG_LEVEL_VERBOSE, "Changing gid to %ju", (uintmax_t)gid);
+        Log(LOG_LEVEL_VERBOSE, "Changing gid to '%ju'", (uintmax_t)gid);
 
         if (setgid(gid) == -1)
         {


### PR DESCRIPTION
WIP - [redmine#1899](https://cfengine.com/dev/issues/1899):  could use a second glance/opinion on what's in the patch so far.

Here's a couple runs using a slightly modified `package_method npm`; you can clearly see the `uid` and `gid` being changed before executing the package manager:
https://gist.github.com/cdituri/7077583

Oddly enough `npm` references a lock file in `/root/.npm/` even though the command drops priviledge... maybe a bug in `npm` or I need to look into the `setuid / seteuid / setreuid` family further (???). Not sure, still needs more testing... some different package manager runs.
