### PR TITLE
Add cf-locate to contrib

### DIFF
--- a/contrib/cf-locate/README.md
+++ b/contrib/cf-locate/README.md
@@ -1,0 +1,33 @@
+# cf-locate
+
+This is a small perl script to help you locate and display bodies or bundles inside of your masterfiles.
+
+
+## Example
+
+    cf-locate sync_cp /var/cfengine/masterfiles
+    definition for sync_cp found in /var/cfengine/masterfiles/libraries/cfengine_stdlib.cf on line 1219
+
+    body copy_from sync_cp(from,server)
+    {
+    servers     => { "$(server)" };
+    source      => "$(from)";
+    purge       => "true";
+    preserve    => "true";
+    type_check  => "false";
+    }
+
+    cf-locate u_rcp /var/cfengine/masterfiles
+    definition for u_rcp found in /var/cfengine/masterfiles/update.cf on line 226
+
+    body copy_from u_rcp(from,server)
+    {
+     source      => "$(from)";
+     compare     => "digest";
+     trustkey    => "false";
+
+    !am_policy_hub::
+
+     servers => { "$(server)" };
+    }
+

--- a/contrib/cf-locate/cf-locate
+++ b/contrib/cf-locate/cf-locate
@@ -1,0 +1,27 @@
+#!/usr/bin/perl
+# Author: Nick Anderson <nick@cmdln.org>
+# This is a nasty hacked up thing to locate and show bundles or bodies
+
+use strict;
+use warnings;
+use Term::ANSIColor;
+
+my $body_or_bundle=$ARGV[0];
+my $search_path=$ARGV[1];
+
+my (@results) = `find $search_path -name "*.cf" | xargs egrep -n "(body|bundle)\\s.*\\s$body_or_bundle"`;
+
+foreach my $result (@results) {
+    my (@file) = split(':', $result);
+    print color("red")."definition for $body_or_bundle found in $file[0] on line $file[1]\n\n".color("reset");
+
+    undef $/;               # Enable 'slurp' mode
+    open (FILE, '<', "$file[0]") or die "Could not open $file[0]: $!";
+    
+    my $filea = <FILE>;      # Whole file here now...
+    
+    my ($stuff_that_interests_me) = ($filea =~ m/((body|bundle)\s+\w+\s+$body_or_bundle.*?}(?=[^}]+(?:body|bundle)\s+))/s);
+    
+    print color("green")."$stuff_that_interests_me".color("reset")."\n";
+    close (FILE) or die "Could not close $file[0]: $!";
+}


### PR DESCRIPTION
cf-locate is a perl script that helps locate and display bundles and
bodies across your policy.
