### PR TITLE
Redmine#3429: improve copy+purge acceptance test, fix bug, and improve message

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -613,7 +613,7 @@ static PromiseResult PurgeLocalFiles(EvalContext *ctx, Item *filelist, const cha
                 {
                     if (!DeleteDirectoryTree(filename))
                     {
-                        cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_FAIL, pp, attr, "Unable to purge directory '%s'", filename);
+                        cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_FAIL, pp, attr, "Unable to purge directory tree '%s'", filename);
                         result = PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
                     }
                     else if (rmdir(filename) == -1)

--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -498,6 +498,11 @@ static bool DeleteDirectoryTreeInternal(const char *basepath, const char *path)
                 {
                     failed = true;
                 }
+
+                if (rmdir(subpath) == -1)
+                {
+                    failed = true;
+                }
             }
             else
             {

--- a/tests/acceptance/10_files/01_create/copy_and_purge.cf
+++ b/tests/acceptance/10_files/01_create/copy_and_purge.cf
@@ -37,7 +37,7 @@ bundle agent init2
       "$(G.testfile)/source/1/2/3/."
       create => "true";
 
-      "$(G.testfile)/dest/1/2/should-be-removed/."
+      "$(G.testfile)/dest/1/2/should-be-removed/3/."
       create => "true";
 }
 


### PR DESCRIPTION
See https://cfengine.com/dev/issues/3429

Improved acceptance test as suggested by @phnakarin

Bug fixed, message improved so you can tell which condition triggered the message (there is another identical message from a different condition next door).
