### PR TITLE
Mustache: acceptance test for default case and extra debugging

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -411,6 +411,7 @@ exit:
 static JsonElement *DefaultTemplateData(const EvalContext *ctx)
 {
     JsonElement *hash = JsonObjectCreate(10);
+    Writer *w;
 
     {
         ClassTableIterator *it = EvalContextClassTableIteratorNewGlobal(ctx, NULL, true, true);
@@ -457,6 +458,11 @@ static JsonElement *DefaultTemplateData(const EvalContext *ctx)
         }
         VariableTableIteratorDestroy(it);
     }
+
+    w = StringWriter();
+    JsonWrite(w, hash, 0);
+    Log(LOG_LEVEL_DEBUG, "Generated DefaultTemplateData '%s'", StringWriterData(w));
+    WriterClose(w);
 
     return hash;
 }

--- a/tests/acceptance/10_files/templating/demo.datastate.mustache
+++ b/tests/acceptance/10_files/templating/demo.datastate.mustache
@@ -1,0 +1,9 @@
+<h1>{{test.header}}</h1>
+
+{{#test.items}}
+ {{.}}
+{{/test.items}}
+
+{{#empty}}
+  <p>The list is empty.</p>
+{{/empty}}

--- a/tests/acceptance/10_files/templating/mustache_datastate_demo.cf
+++ b/tests/acceptance/10_files/templating/mustache_datastate_demo.cf
@@ -1,0 +1,92 @@
+#######################################################
+#
+# Demo of Mustache templates with no external JSON data
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "origtestdir" string => concat("$(G.cwd)/",
+				     dirname("$(this.promise_filename)"));
+
+  files:
+      "$(G.testfile)"
+      delete => init_delete;
+}
+
+body delete init_delete
+{
+      dirlinks => "delete";
+      rmdirs   => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+  classes:
+      "empty" expression => "any";
+
+  vars:
+      "template_file" string => "$(init.origtestdir)/demo.datastate.mustache";
+      "header" string => "Colors";
+      "items" slist => { "red", "green", "blue" };
+
+  files:
+      "$(G.testfile)"
+      create => "true",
+      edit_template => "$(template_file)",
+      template_method => "mustache";
+
+  reports:
+    DEBUG::
+      "Rendering template file $(template_file) to $(G.testfile)";
+}
+
+body copy_from sync_cp(from)
+{
+      source => "$(from)";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "expect" string => '<h1>Colors</h1>
+
+ red
+ green
+ blue
+
+  <p>The list is empty.</p>
+';
+
+      "actual" string => readfile("$(G.testfile)", 10000);
+
+  classes:
+      "ok" expression => strcmp($(expect), $(actual));
+
+  reports:
+    DEBUG::
+      "'$(expect)' != '$(actual)'" ifvarclass => "!ok";
+      "'$(expect)' == '$(actual)'" ifvarclass => "ok";
+      "expect: '$(expect)'";
+      "actual: '$(actual)'";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
See https://cfengine.com/dev/issues/3279 https://cfengine.com/dev/issues/1762 for some details.
Acceptance test shows use cases:
- list of items
- conditional block based on class
- scalar variable expansion
