### PR TITLE
cf-agent --bootstrap fails on Debian systems.

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -692,31 +692,51 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, char *from, char *to,
             char backup[CF_BUFSIZE];
             mode_t mask;
 
-            if (!attr.move_obstructions)
+            if (attr.copy.type_check)
             {
-                Log(LOG_LEVEL_INFO, "Path '%s' is a symlink. Unable to move it aside without move_obstructions is set",
-                      to);
-                return PROMISE_RESULT_NOOP;
-            }
+                if (!attr.move_obstructions)
+                {
+                    Log(LOG_LEVEL_INFO, "Path '%s' is a symlink. Unable to move it aside without move_obstructions is set",
+                          to);
+                    return PROMISE_RESULT_NOOP;
+                }
 
-            strcpy(backup, to);
-            DeleteSlash(to);
-            strcat(backup, ".cf-moved");
+                strcpy(backup, to);
+                DeleteSlash(to);
+                strcat(backup, ".cf-moved");
 
-            if (rename(to, backup) == -1)
-            {
-                Log(LOG_LEVEL_INFO, "Unable to backup old '%s'", to);
-                unlink(to);
-            }
+                if (rename(to, backup) == -1)
+                {
+                    Log(LOG_LEVEL_INFO, "Unable to backup old '%s'", to);
+                    unlink(to);
+                }
 
-            mask = umask(0);
-            if (mkdir(to, DEFAULTMODE) == -1)
-            {
-                Log(LOG_LEVEL_ERR, "Unable to make directory '%s'. (mkdir: %s)", to, GetErrorStr());
+                mask = umask(0);
+                if (mkdir(to, DEFAULTMODE) == -1)
+                {
+                    Log(LOG_LEVEL_ERR, "Unable to make directory '%s'. (mkdir: %s)", to, GetErrorStr());
+                    umask(mask);
+                    return PROMISE_RESULT_NOOP;
+                }
                 umask(mask);
-                return PROMISE_RESULT_NOOP;
             }
-            umask(mask);
+            else
+            {
+                struct stat tmpstat;
+
+                if (stat(to, &tmpstat) != 0)
+                {
+                    cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "Unable to stat newly created directory '%s'. (stat: %s)",
+                         to, GetErrorStr());
+                    return PROMISE_RESULT_WARN;
+                }
+
+                if (!S_ISDIR(tmpstat.st_mode))
+                {
+                    cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "Symlink does not point to a directory: '%s'", to);
+                    return PROMISE_RESULT_WARN;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Because sys.workdir/inputs is a symlink to /etc/cfengine3. The bootstrap process creates `failsafe.cf` in /etc/cfengine3, but cf-agent complains that this sys.workdir/inputs is a symlink and aborts the bootstrap process. Both must fail/complain or both must accept the symbolic link to the directory as destination.

This patch enable the last option. It will determine if the destination is a symlink to a directory and `copy_from` attribute `type_check : false` is set.  If both options are true the copy will be honored.
