### PR TITLE
Redmine#1032: fix 1-byte read issue

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -5248,7 +5248,7 @@ static void *CfReadFile(char *filename, int maxsize)
 
     size = buflen;
 
-    if ( buflen > 1)
+    if ( size > 0)
     {
       for (i = 0; i < size - 1 && result[i] != '\0' ; i++)
       {


### PR DESCRIPTION
- with 1-byte strings, we still need to ensure the last newline is stripped
- use `size`, not `buflen` for clarity
