### PR TITLE
added redhat and debian support for acceptance tests

### DIFF
--- a/masterfiles/lib/3.5/packages.cf
+++ b/masterfiles/lib/3.5/packages.cf
@@ -160,7 +160,7 @@ body package_method apt_get
       # Target a specific release, such as backports
       package_add_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
       package_list_update_command => "$(debian_knowledge.call_apt_get) update";
-      package_delete_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes -q remove";
+      package_delete_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes -q purge";
       package_update_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
       package_patch_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
       package_verify_command => "$(debian_knowledge.call_dpkg) -s";
@@ -204,6 +204,39 @@ body package_method apt_get_release(release)
       # make correct version comparisons
       package_version_less_command => "$(debian_knowledge.dpkg_compare_less)";
       package_version_equal_command => "$(debian_knowledge.dpkg_compare_equal)";
+
+}
+
+##
+
+body package_method named_apt_get
+{
+    package_changes => "bulk";
+    package_list_command => "$(debian_knowledge.call_dpkg) -l";
+    package_list_name_regex    => ".i\s+([^\s]+).*";
+    package_list_version_regex => ".i\s+[^\s]+\s+([^\s]+).*";
+    package_installed_regex => ".i.*"; # packages that have been uninstalled may be listed
+    package_name_convention => "$(name)=$(version)";
+
+    # set it to "0" to avoid caching of list during upgrade
+    package_list_update_ifelapsed => "240";
+
+    # Target a specific release, such as backports
+    package_add_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+    package_list_update_command => "$(debian_knowledge.call_apt_get) update";
+    package_delete_command => "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes -q purge";
+    package_update_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+    package_patch_command =>  "$(debian_knowledge.call_apt_get) $(debian_knowledge.dpkg_options) --yes install";
+    package_verify_command => "$(debian_knowledge.call_dpkg) -s";
+    package_noverify_returncode => "1";
+
+    package_patch_list_command => "$(debian_knowledge.call_apt_get) --just-print dist-upgrade";
+    package_patch_name_regex => "^Inst\s+(\S+)\s+.*";
+    package_patch_version_regex => "^Inst\s+\S+\s+\[?\(?([^\],\s]+).*";
+
+    # make correct version comparisons
+    package_version_less_command => "$(debian_knowledge.dpkg_compare_less)";
+    package_version_equal_command => "$(debian_knowledge.dpkg_compare_equal)";
 
 }
 
@@ -279,6 +312,42 @@ body package_method rpm_version(repo)
       package_delete_command => "/bin/rpm -e --nodeps";
       package_verify_command => "/bin/rpm -V";
       package_noverify_regex => ".*[^\s].*";
+}
+
+##
+
+body package_method named_yum_delete
+{
+      package_changes => "bulk";
+      package_list_command => "/usr/bin/yum --quiet list installed";
+      package_patch_list_command => "/usr/bin/yum --quiet check-update";
+
+      # Remember to escape special characters like |
+
+      package_list_name_regex    => "([^.]+).*";
+      package_list_version_regex => "[^\s]\s+([^\s]+).*";
+      package_list_arch_regex    => "[^.]+\.([^\s]+).*";
+
+      package_installed_regex => ".*(installed|\s+@).*";
+      package_name_convention => "$(name)-$(version).$(arch)";
+
+      # just give the package name to rpm to delete, otherwise it gets "name.*" (from package_name_convention above)
+      package_delete_convention => "$(name)-$(version).$(arch)";
+
+      # set it to "0" to avoid caching of list during upgrade
+      package_list_update_command => "/usr/bin/yum --quiet check-update";
+      package_list_update_ifelapsed => "240";
+
+      package_patch_installed_regex => "^\s.*";
+      package_patch_name_regex    => "([^.]+).*";
+      package_patch_version_regex => "[^\s]\s+([^\s]+).*";
+      package_patch_arch_regex    => "[^.]+\.([^\s]+).*";
+
+      package_add_command => "/usr/bin/yum -y install";
+      package_update_command => "/usr/bin/yum -y update";
+      package_patch_command => "/usr/bin/yum -y update";
+      package_delete_command => "/bin/rpm -e --nodeps";
+      package_verify_command => "/bin/rpm -V";
 }
 
 ##

--- a/tests/acceptance/17_packages/001.cf
+++ b/tests/acceptance/17_packages/001.cf
@@ -1,0 +1,87 @@
+#######################################################
+#
+# Test add named package
+# 
+#######################################################
+
+body common control
+{
+      inputs => { 
+                 "../default.cf.sub",                  
+                };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+
+
+#######################################################
+
+bundle agent init
+{
+  
+}
+
+#######################################################
+
+bundle agent test
+{
+    vars:
+        "name" string => "zip";
+ 
+    packages:
+        
+      
+        debian::
+        
+	    "$(name)"
+            package_policy => "add",
+            package_method => apt_get,
+            classes => test_set_class("pass","fail");
+            
+        redhat::
+        
+            "$(name)"
+            package_policy => "add",
+            package_method => yum_rpm,
+            classes => test_set_class("pass","fail");
+}
+
+
+
+body classes test_set_class(ok_class,notok_class)
+{
+    promise_kept => { "$(ok_class)" };
+    promise_repaired => { "$(ok_class)" };
+    repair_failed => { "$(notok_class)" };
+}
+
+#######################################################
+
+bundle agent check
+{
+
+    classes:
+  
+        redhat::
+            "has_pkg" expression => returnszero("/bin/rpm -qa | grep -qw $(test.name)", "useshell");
+            
+        debian::
+            "has_pkg" not => returnszero("/usr/bin/apt-cache policy $(test.name) | /bin/grep -q none", "useshell");
+      
+        any::
+            "ok" expression => "pass.!fail.has_pkg";
+  
+    reports:
+        ok::
+            "$(this.promise_filename) $(test.name) Pass";
+        !ok::
+            "$(this.promise_filename) $(test.name) FAIL";
+}
+
+body classes succesfully_executed(class)
+{
+    kept_returncodes => { "0" };
+    promise_kept => { "$(class)" };
+}
+

--- a/tests/acceptance/17_packages/002.cf
+++ b/tests/acceptance/17_packages/002.cf
@@ -1,0 +1,82 @@
+#######################################################
+#
+# Test remove named package
+#
+#######################################################
+
+body common control
+{
+    inputs => { 
+               "../default.cf.sub", 
+              };
+    bundlesequence  => { default("$(this.promise_filename)") };
+    version => "1.0";
+}
+
+
+
+#######################################################
+
+bundle agent init
+{
+  
+}
+
+#######################################################
+
+bundle agent test
+{
+    vars:
+        "name" slist => { "zip" };
+      
+    packages:
+  
+        debian::
+            "$(name)"
+            package_policy => "delete",
+            package_method => apt_get,
+            classes => test_set_class("pass","fail");
+      
+    redhat::
+        "$(name)"
+        package_policy => "delete",
+        package_method => yum_rpm,
+        classes => test_set_class("pass","fail");
+}
+
+
+
+body classes test_set_class(ok_class,notok_class)
+{
+    promise_kept => { "$(ok_class)" };
+    promise_repaired => { "$(ok_class)" };
+    repair_failed => { "$(notok_class)" };
+}
+
+#######################################################
+
+bundle agent check
+{
+
+    classes:
+        debian::
+            "has_pkg" expression => returnszero("/usr/bin/apt-cache policy $(test.name) | /bin/grep -q none", "useshell");
+        redhat::
+            "has_pkg" not => returnszero("/bin/rpm -qa | grep -qw $(test.name)", "useshell");
+
+        any::
+            "ok" expression => "pass.!fail.has_pkg";
+
+    reports:
+        ok::
+            "$(this.promise_filename) $(test.name)  Pass";
+        !ok::
+            "$(this.promise_filename) $(test.name) FAIL";
+}
+
+body classes succesfully_executed(class)
+{
+    kept_returncodes => { "0" };
+    promise_kept => { "$(class)" };
+}
+

--- a/tests/acceptance/17_packages/003.cf
+++ b/tests/acceptance/17_packages/003.cf
@@ -1,0 +1,95 @@
+#######################################################
+#
+# Test add multiple packages
+#
+#######################################################
+
+body common control
+{
+    inputs => { 
+               "../default.cf.sub", 
+              };
+    bundlesequence  => { default("$(this.promise_filename)") };
+    version => "1.0";
+}
+
+
+
+#######################################################
+
+bundle agent init
+{
+  
+}
+
+#######################################################
+
+bundle agent test
+{
+    vars:
+    
+        "name" slist => { "zip","unzip","vim"};
+      
+
+    packages:
+    
+        debian::
+        
+            "$(name)"
+            package_policy => "add",
+            package_method => apt_get,
+            classes => test_set_class("pass","fail");
+            
+        redhat::
+        
+            "$(name)"
+            package_policy => "add",
+            package_method => yum_rpm,
+            classes => test_set_class("pass","fail");
+}
+
+
+
+body classes test_set_class(ok_class,notok_class)
+{
+        promise_kept => { "$(ok_class)" };
+        promise_repaired => { "$(ok_class)" };
+        repair_failed => { "$(notok_class)" };
+}
+
+#######################################################
+
+bundle agent check
+{
+
+    classes:
+    
+        debian::
+        
+            "has_pkg" not => returnszero("/usr/bin/apt-cache policy $(test.name) | /bin/grep -q none", "useshell");
+            
+        redhat::
+        
+            "has_pkg" expression => returnszero("/bin/rpm -qa | grep -qw $(test.name)", "useshell");
+      
+        any::
+   
+            "ok" expression => "pass.!fail.has_pkg";
+
+    reports:
+  
+        ok::
+    
+            "$(this.promise_filename) $(test.name) Pass";
+      
+       !ok::
+    
+            "$(this.promise_filename) FAIL";
+}
+
+body classes succesfully_executed(class)
+{
+        kept_returncodes => { "0" };
+        promise_kept => { "$(class)" };
+}
+

--- a/tests/acceptance/17_packages/004.cf
+++ b/tests/acceptance/17_packages/004.cf
@@ -1,0 +1,96 @@
+#######################################################
+#
+# Test remove multiple packages
+#
+#######################################################
+
+body common control
+{
+    inputs => { 
+               "../default.cf.sub", 
+              };
+    bundlesequence  => { default("$(this.promise_filename)") };
+    version => "1.0";
+}
+
+
+
+#######################################################
+
+bundle agent init
+{
+  
+}
+
+#######################################################
+
+bundle agent test
+{
+    vars:
+    
+        "name" slist => { "zip","unzip","vim"};
+      
+
+    packages:
+    
+        debian::
+        
+            "$(name)"
+            package_policy => "delete",
+            package_method => apt_get,
+            classes => test_set_class("pass","fail");
+          
+        redhat::
+        
+            "$(name)"
+            package_policy => "delete",
+            package_method => yum_rpm,
+            classes => test_set_class("pass","fail");
+      
+}
+
+
+
+body classes test_set_class(ok_class,notok_class)
+{
+        promise_kept => { "$(ok_class)" };
+        promise_repaired => { "$(ok_class)" };
+        repair_failed => { "$(notok_class)" };
+}
+
+#######################################################
+
+bundle agent check
+{
+
+    classes:
+    
+        debian::
+        
+            "has_pkg" expression => returnszero("/usr/bin/apt-cache policy $(test.name) | /bin/grep -q none", "useshell");
+            
+        redhat::
+        
+            "has_pkg" not => returnszero("/bin/rpm -qa | grep -qw $(test.name)", "useshell");
+        
+        any::
+        
+            "ok" expression => "pass.!fail.has_pkg";
+
+    reports:
+    
+        ok::
+        
+            "$(this.promise_filename) $(test.name) Pass";
+            
+        !ok::
+        
+            "$(this.promise_filename) FAIL";
+}
+
+body classes succesfully_executed(class)
+{
+    kept_returncodes => { "0" };
+    promise_kept => { "$(class)" };
+}
+

--- a/tests/acceptance/17_packages/005.cf
+++ b/tests/acceptance/17_packages/005.cf
@@ -1,0 +1,95 @@
+#######################################################
+#
+# Test add a named versioned package
+#
+#######################################################
+
+body common control
+{
+    inputs => { 
+               "../default.cf.sub", 
+              };
+    bundlesequence  => { default("$(this.promise_filename)") };
+    version => "1.0";
+}
+
+
+
+
+#######################################################
+
+bundle agent init
+{
+  
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+
+      debian::
+          "name" string => "zip";
+          "arch" string => "amd64";
+          "version" string => "3.0-7";
+      redhat::
+          "name" string => "zip";
+          "arch" string => "x86_64";
+          "version" string => "3.0-1.el6";
+          
+  
+    packages:
+  
+        debian::
+          "$(name)"
+          package_policy => "add",
+          package_method => named_apt_get,
+          classes => test_set_class("pass","fail");
+     
+        redhat::
+            "$(name)-$(version).$(arch)"
+            package_policy => "add",
+            package_method => yum_rpm,
+            classes => test_set_class("pass","fail");
+}
+
+
+
+body classes test_set_class(ok_class,notok_class)
+{
+    promise_kept => { "$(ok_class)" };
+    promise_repaired => { "$(ok_class)" };
+    repair_failed => { "$(notok_class)" };
+}
+
+#######################################################
+
+bundle agent check
+{
+
+    classes:
+    
+        debian::
+            "has_pkg" not => returnszero("/usr/bin/apt-cache policy $(test.name) | /bin/grep -q none", "useshell");
+
+        redhat::
+            "has_pkg" expression => returnszero("/bin/rpm -qa | grep -qw $(test.name)", "useshell");
+            
+        any::
+            "ok" expression => "pass.!fail.has_pkg";
+  
+    reports:
+      ok::
+        "$(this.promise_filename) $(test.name)=$(test.version) installed Pass";
+      !ok::
+        "$(this.promise_filename) FAIL";
+}
+
+body classes succesfully_executed(class)
+{
+    kept_returncodes => { "0" };
+    promise_kept => { "$(class)" };
+}
+
+

--- a/tests/acceptance/17_packages/006.cf
+++ b/tests/acceptance/17_packages/006.cf
@@ -1,0 +1,98 @@
+#######################################################
+#
+# Test deletion a named versioned package
+#
+#######################################################
+
+body common control
+{
+    inputs => { 
+               "../default.cf.sub", 
+              };
+    bundlesequence  => { default("$(this.promise_filename)") };
+    version => "1.0";
+}
+
+
+
+#######################################################
+
+bundle agent init
+{
+  
+}
+
+#######################################################
+
+bundle agent test
+{
+    vars:
+
+        debian::
+            "name" string => "zip";
+            "arch" string => "amd64";
+            "version" string => "3.0-7";
+            
+        redhat::
+            "name" string => "zip";
+            "arch" string => "x86_64";
+            "version" string => "3.0-1.el6";
+          
+  
+    packages:
+  
+        debian::
+            "$(name)"
+            package_policy => "delete",
+            package_method => named_apt_get,
+            classes => test_set_class("pass","fail");
+     
+        redhat::
+            "$(name)"
+            package_version => "$(version)",
+            package_architectures => { "x86_64" },      
+            package_policy => "delete",
+            package_method => named_yum_delete,
+            classes => test_set_class("pass","fail");
+}
+
+
+
+body classes test_set_class(ok_class,notok_class)
+{
+    promise_kept => { "$(ok_class)" };
+    promise_repaired => { "$(ok_class)" };
+    repair_failed => { "$(notok_class)" };
+}
+
+#######################################################
+
+bundle agent check
+{
+
+    classes:
+    
+        debian::
+            "has_pkg" expression => returnszero("/usr/bin/apt-cache policy $(test.name) | /bin/grep -q none", "useshell");
+
+        redhat::
+            "has_pkg" not => returnszero("/bin/rpm -qa | grep -qw $(test.name)", "useshell");
+            
+        any::
+            "ok" expression => "pass.!fail.has_pkg";
+  
+    reports:
+      ok::
+        "$(this.promise_filename) $(test.name)=$(test.version)  Pass";
+      !ok::
+        "$(this.promise_filename) FAIL";
+}
+
+body classes succesfully_executed(class)
+{
+    kept_returncodes => { "0" };
+    promise_kept => { "$(class)" };
+}
+
+
+


### PR DESCRIPTION
These acceptance tests are testing basic package promises. There are six test policies. 

1..2 - add a named package/remove a named package
3..4 - add multiple named packages/remove multiple named packages
5..6 - add specific version/arch of a named package/remove specific version/arch of a named package

Proposed additions to masterfiles/packages that encompass more specific use cases for named packages in apt-get and yum/rpm
