### PR TITLE
Redmine#3584: add relocation options and --printlog to testall script

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -108,29 +108,6 @@ unix_seconds() {
   rm $BASE_WORKDIR/x
 }
 
-# We assume we're running this script from $objdir or $objdir/tests/acceptance
-[ -x `pwd`/cf-agent/cf-agent ] && DEFAGENT=`pwd`/cf-agent/cf-agent
-[ -x `pwd`/../../cf-agent/cf-agent ] && DEFAGENT=`pwd`/../../cf-agent/cf-agent
-AGENT=${AGENT:-${DEFAGENT}}
-
-[ -x `pwd`/cf-promises/cf-promises ] && DEFCF_PROMISES=`pwd`/cf-promises/cf-promises
-[ -x `pwd`/../../cf-promises/cf-promises ] && DEFCF_PROMISES=`pwd`/../../cf-promises/cf-promises
-CF_PROMISES=${CF_PROMISES:-${DEFCF_PROMISES}}
-
-[ -x `pwd`/cf-serverd/cf-serverd ] && DEFCF_SERVERD=`pwd`/cf-serverd/cf-serverd
-[ -x `pwd`/../../cf-serverd/cf-serverd ] && DEFCF_SERVERD=`pwd`/../../cf-serverd/cf-serverd
-CF_SERVERD=${CF_SERVERD:-${DEFCF_SERVERD}}
-
-[ -x `pwd`/cf-key/cf-key ] && DEFCF_KEY=`pwd`/cf-key/cf-key
-[ -x `pwd`/../../cf-key/cf-key ] && DEFCF_KEY=`pwd`/../../cf-key/cf-key
-CF_KEY=${CF_KEY:-${DEFCF_KEY}}
-
-if [ ! -x $AGENT -o ! -x $CF_PROMISES -o ! -x $CF_SERVERD -o ! -x $CF_KEY ]
-then
-	echo "ERROR can't find cf-agent or other binary. Are you sure you're running this from OBJDIR or OBJDIR/tests/acceptance?"
-	exit 1
-fi
-
 # echo
 # echo === Test environment: ===
 # echo AGENT=$AGENT
@@ -141,7 +118,7 @@ fi
 # echo
 
 usage() {
-  echo "testall [-q] [--gainroot=<command>] [--agent=<agent>] [--no-nova] [--staging] [--unsafe] [--no-network] [<test> <test>...]"
+  echo "testall [-q] [--gainroot=<command>] [--agent=<agent>] [--cfpromises=<cf-promises>] [--cfserverd=<cf-serverd>] [--cfkey=<cf-key>] [--no-nova] [--staging] [--unsafe] [--no-network] [<test> <test>...]"
   echo
   echo "If no test is given, all standard tests are run:"
   echo "  Tests with names of form <file>.cf are expected to run succesfully"
@@ -157,6 +134,15 @@ usage() {
   echo " --agent   provides a way to specify non-default cf-agent location,"
   echo "           and defaults to $DEFAGENT."
   echo
+  echo " --cfpromises  provides a way to specify non-default cf-promises location,"
+  echo "               and defaults to $DEFCF_PROMISES."
+  echo
+  echo " --cfserverd  provides a way to specify non-default cf-serverd location,"
+  echo "               and defaults to $DEFCF_SERVERD."
+  echo
+  echo " --cfkey  provides a way to specify non-default cf-key location,"
+  echo "               and defaults to $DEFCF_KEY."
+  echo
   echo " --staging enable tests in staging directories. They are not expected to pass."
   echo
   echo " --unsafe  enable tests in unsafe directories. WARNING! These tests modify the"
@@ -166,6 +152,7 @@ usage() {
   echo "           otherwise you will get incorrect results."
   echo
   echo " --no-network disable tests in network directories."
+  echo " --printlog   print the full test.log output immediately."
 }
 
 runtest() {
@@ -337,6 +324,14 @@ while true; do
       NETWORK_TESTS=0;;
     --agent=*)
       AGENT=${1#--agent=};;
+    --cfpromises=*)
+      CF_PROMISES=${1#--cfpromises=};;
+    --cfserverd=*)
+      CF_SERVERD=${1#--cfserverd=};;
+    --cfkey=*)
+      CF_KEY=${1#--cfkey=};;
+    --printlog)
+      PRINTLOG=1;;
     -*)
       echo "Unknown option: $1"
       exit 1;;
@@ -345,6 +340,29 @@ while true; do
   esac
   shift
 done
+
+# We assume we're running this script from $objdir or $objdir/tests/acceptance
+[ -x `pwd`/cf-agent/cf-agent ] && DEFAGENT=`pwd`/cf-agent/cf-agent
+[ -x `pwd`/../../cf-agent/cf-agent ] && DEFAGENT=`pwd`/../../cf-agent/cf-agent
+AGENT=${AGENT:-${DEFAGENT}}
+
+[ -x `pwd`/cf-promises/cf-promises ] && DEFCF_PROMISES=`pwd`/cf-promises/cf-promises
+[ -x `pwd`/../../cf-promises/cf-promises ] && DEFCF_PROMISES=`pwd`/../../cf-promises/cf-promises
+CF_PROMISES=${CF_PROMISES:-${DEFCF_PROMISES}}
+
+[ -x `pwd`/cf-serverd/cf-serverd ] && DEFCF_SERVERD=`pwd`/cf-serverd/cf-serverd
+[ -x `pwd`/../../cf-serverd/cf-serverd ] && DEFCF_SERVERD=`pwd`/../../cf-serverd/cf-serverd
+CF_SERVERD=${CF_SERVERD:-${DEFCF_SERVERD}}
+
+[ -x `pwd`/cf-key/cf-key ] && DEFCF_KEY=`pwd`/cf-key/cf-key
+[ -x `pwd`/../../cf-key/cf-key ] && DEFCF_KEY=`pwd`/../../cf-key/cf-key
+CF_KEY=${CF_KEY:-${DEFCF_KEY}}
+
+if [ ! -x "$AGENT" -o ! -x "$CF_PROMISES" -o ! -x "$CF_SERVERD" -o ! -x "$CF_KEY" ]
+then
+	echo "ERROR can't find cf-agent or other binary. Are you sure you're running this from OBJDIR or OBJDIR/tests/acceptance?  Check '$AGENT', '$CF_PROMISES', '$CF_SERVERD', and '$CF_KEY'"
+	exit 1
+fi
 
 if [ $# -gt 0 ]; then
   # We need to run all specified tests, but not unsafe ones.
@@ -434,6 +452,10 @@ END_TIME=$(unix_seconds)
   cat $XMLTMP >> $XML
 
   echo \<\/testsuite\> >> $XML
+
+if [ -n "$PRINTLOG" ]; then
+  cat $LOG
+fi
 
 if [ "$FAILED_TESTS" -ne 0 ] || [ "$FAILED_TO_CRASH_TESTS" -ne 0 ]; then
   exit 1


### PR DESCRIPTION
See https://cfengine.com/dev/issues/3584 and https://github.com/cfengine/masterfiles/pull/32

This allows the `testall` script to take alternate locations of all the binaries and adds a convenience `--printlog` option.
