### PR TITLE
Fix cf-monitord HISTOGRAM array initialization + update Changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 3.5.3
        Bug fixes:
+       - fix cf-monitord crash due to incorrect array initialization (Redmine #3180)
        - fix cf-serverd stat()'ing the file tree every second (Redmine #3479)
        - improve package comparison logic (Redmine ##3314)
        - correctly populate sys.hardware_addresses variable (Redmine #2936)

--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -142,9 +142,9 @@ void MonitorInitialize(void)
         LOCALAV.Q[i] = QDefinite(0.0);
     }
 
-    for (i = 0; i < 7; i++)
+    for (i = 0; i < CF_OBSERVABLES; i++)
     {
-        for (j = 0; j < CF_OBSERVABLES; j++)
+        for (j = 0; j < 7; j++)
         {
             for (k = 0; k < CF_GRAINS; k++)
             {


### PR DESCRIPTION
Redmine #3180
(cherry picked from commit e7c381603c5446a13e865dad6c64e4f35900ca45)
