### PR TITLE
Fix build error: Indentation typo in cf-agent/Makefile.am

### DIFF
--- a/cf-agent/Makefile.am
+++ b/cf-agent/Makefile.am
@@ -71,12 +71,12 @@ libcf_agent_la_SOURCES = \
 if !NT
 libcf_agent_la_SOURCES += nfs.c nfs.h
 
- if HAVE_USERPROGS
+if HAVE_USERPROGS
   libcf_agent_la_SOURCES += verify_users_unix.c
   libcf_agent_la_LIBADD += -lpam
- else
+else
   libcf_agent_la_SOURCES += verify_users_stub.c
- endif
+endif
 endif
 
 if HAVE_AVAHI_CLIENT


### PR DESCRIPTION
Since 4a6bd9384c7d563441e791759db11637b03ba948 I'm stuck on:

```
Making all in cf-agent
Makefile:884: *** missing separator.  Stop.
Makefile:578: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
Makefile:501: recipe for target 'all' failed
make: *** [all] Error 2
```
