### PR TITLE
NULL terminate the buffer received from TLSRecv(..)

### DIFF
--- a/tests/unit/tls_generic_test.c
+++ b/tests/unit/tls_generic_test.c
@@ -1325,6 +1325,8 @@ static void test_TLSBasicIO(void)
      */
     result = TLSRecv(ssl, input_buffer, output_buffer_length);
     assert_int_equal(output_buffer_length, result);
+
+    input_buffer[output_buffer_length] = '\0';
     assert_string_equal(output_buffer, input_buffer);
     /*
      * Brilliant! We transmitted and received data using simple communication.


### PR DESCRIPTION
assert_string_equal(..) fails because the received string is not null terminated

![tls_test_failure](https://f.cloud.github.com/assets/1265825/1482181/74e9ee9e-46d9-11e3-863c-87bd808f0bca.png)
