### PR TITLE
Redmine#3283: implement ^meta protocol extension and getvariablemetatags+getclassmetatags functions

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -194,6 +194,7 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a,
     char cmdOutBuf[CF_BUFSIZE];
     int cmdOutBufPos = 0;
     int lineOutLen;
+    StringSet *module_tags = NULL;
     char module_context[CF_BUFSIZE];
 
     module_context[0] = '\0';
@@ -353,7 +354,7 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a,
 
             if (a.module)
             {
-                ModuleProtocol(ctx, cmdline, line, !a.contain.nooutput, PromiseGetNamespace(pp), module_context);
+                ModuleProtocol(ctx, cmdline, line, !a.contain.nooutput, PromiseGetNamespace(pp), module_context, &module_tags);
             }
             else if ((!a.contain.nooutput) && (!EmptyString(line)))
             {

--- a/libpromises/evalfunction.h
+++ b/libpromises/evalfunction.h
@@ -27,12 +27,13 @@
 
 #include <cf3.defs.h>
 #include <rlist.h>
+#include <set.h>
 
 FnCallResult FnCallHostInNetgroup(EvalContext *ctx, FnCall *fp, Rlist *finalargs);
 
 int FnNumArgs(const FnCallType *call_type);
 
-void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print, const char *ns, char* context);
+void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print, const char *ns, char* context, StringSet **tags);
 
 /* Implemented in Nova for Win32 */
 FnCallResult FnCallGroupExists(EvalContext *ctx, FnCall *fp, Rlist *finalargs);

--- a/libpromises/var_expressions.c
+++ b/libpromises/var_expressions.c
@@ -243,7 +243,7 @@ VarRef *VarRefParseFromNamespaceAndScope(const char *qualified_name, const char 
 
         if (!IndexBracketsBalance(indices_start - 1))
         {
-            Log(LOG_LEVEL_ERR, "Broken variable expressoin, index brackets do not balance, in '%s'", qualified_name);
+            Log(LOG_LEVEL_ERR, "Broken variable expression, index brackets do not balance, in '%s'", qualified_name);
         }
         else
         {

--- a/tests/acceptance/01_vars/02_functions/gettags.cf
+++ b/tests/acceptance/01_vars/02_functions/gettags.cf
@@ -1,0 +1,56 @@
+# Test that getvariabletags and getclasstags work correctly
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+}
+
+bundle common init
+{
+  classes:
+      "myclass" expression => "any", meta => { "mytag1" };
+      "myotherclass" expression => "any", meta => { "mytag5", "mytag51" };
+      "myplainclass" expression => "any";
+
+  vars:
+      "tests" slist => { "1", "2", "3", "4", "5" };
+      "myvar" string => "123", meta => { "mytag3" };
+      "myothervar" string => "123";
+}
+
+bundle agent test
+{
+  vars:
+      "tags1" slist => getclassmetatags("myclass");
+      "tags2" slist => getclassmetatags("myplainclass");
+      "tags3" slist => getvariablemetatags("init.myvar");
+      "tags4" slist => getvariablemetatags("init.myothervar");
+      "tags5" slist => getclassmetatags("myotherclass");
+
+      "actual[$(init.tests)]" string => format('%S', "tags$(init.tests)");
+}
+
+bundle agent check
+{
+  vars:
+      "expected[1]" string => '{ "source=promise", "mytag1" }';
+      "expected[2]" string => '{ "source=promise" }';
+      "expected[3]" string => '{ "source=promise", "mytag3" }';
+      "expected[4]" string => '{ "source=promise" }';
+      "expected[5]" string => '{ "source=promise", "mytag5", "mytag51" }';
+
+  classes:
+      "ok_$(init.tests)" expression => strcmp("$(test.actual[$(init.tests)])", "$(expected[$(init.tests)])");
+
+      "ok" and => { ok_1, ok_2, ok_3, ok_4, ok_5,  };
+
+  reports:
+    DEBUG::
+      "Pass case $(init.tests)" ifvarclass => "ok_$(init.tests)";
+      "FAIL case $(init.tests): actual '$(test.actual[$(init.tests)])', expected '$(expected[$(init.tests)])'" ifvarclass => "!ok_$(init.tests)";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/08_commands/01_modules/set-context.cf
+++ b/tests/acceptance/08_commands/01_modules/set-context.cf
@@ -42,8 +42,8 @@ bundle agent check
   vars:
       "list0" slist => {"abc", "def", "ghi"};
       "list1" slist => {"{{abc}}", "  ' def}", "ghi'''"};
-      "list2" slist => {'{{a,bc}}', '  " de,f}', 'gh,,i"""'}; 
-      "list3" slist => {"{{a'bc',,}}", '  ",, d"ef}', "ghi,},'''"}; 
+      "list2" slist => {'{{a,bc}}', '  " de,f}', 'gh,,i"""'};
+      "list3" slist => {"{{a'bc',,}}", '  ",, d"ef}', "ghi,},'''"};
 
       "actual0" string => join(":", "list0");
       "actual1" string => join(":", "list1");

--- a/tests/acceptance/08_commands/01_modules/set-tags.cf
+++ b/tests/acceptance/08_commands/01_modules/set-tags.cf
@@ -1,0 +1,107 @@
+#######################################################
+#
+# Test the ^meta module protocol extension
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle common init
+{
+  vars:
+      "script_name" string => "$(this.promise_filename).script";
+
+}
+
+#######################################################
+
+bundle agent test
+{
+  commands:
+      "$(init.script_name)" module => "true";
+
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "xyzvars" slist => variablesmatching("default:xyz.*");
+
+      "list0" slist => {"abc", "def", "ghi"};
+      "list1" slist => {"{{abc}}", "  ' def}", "ghi'''"};
+      "list2" slist => {'{{a,bc}}', '  " de,f}', 'gh,,i"""'};
+      "list3" slist => {"{{a'bc',,}}", '  ",, d"ef}', "ghi,},'''"};
+
+      "actual0" string => join(":", "list0");
+      "actual1" string => join(":", "list1");
+      "actual2" string => join(":", "list2");
+      "actual3" string => join(":", "list3");
+
+      "joined0" string => join(":", "xyz.mylist");
+      "joined1" string => join(":", "xyz.myalist");
+      "joined2" string => join(":", "xyz.myblist");
+      "joined3" string => join(":", "xyz.myclist");
+
+      "tags0" slist => getvariablemetatags("xyz.mylist");
+      "tags1" slist => getvariablemetatags("xyz.myalist");
+      "tags2" slist => getvariablemetatags("xyz.myblist");
+      "tags3" slist => getclassmetatags("mycclass");
+
+      "jtags0" string => join(",", "tags0");
+      "jtags1" string => join(",", "tags1");
+      "jtags2" string => join(",", "tags2");
+      "jtags3" string => join(",", "tags3");
+
+      "etags0" string => "xyz,abc=def,,??what is this??,source=module";
+      "etags1" string => "xyz,abc=def,,??what is this??,source=module";
+      "etags2" string => "1,2,3,source=module";
+      "etags3" string => "a,b,c,source=module";
+
+  classes:
+
+    any::
+      "var0ok" expression => strcmp("${this.joined0}" , "${this.actual0}");
+      "var1ok" expression => strcmp("${this.joined1}" , "${this.actual1}");
+      "var2ok" expression => strcmp("${this.joined2}" , "${this.actual2}");
+      "var3ok" expression => strcmp("${this.joined3}" , "${this.actual3}");
+      "var4ok" expression => strcmp("hello there" , "${xyz.myvar}");
+
+      "tags0ok" expression => strcmp($(jtags0), $(etags0));
+      "tags1ok" expression => strcmp($(jtags1), $(etags1));
+      "tags2ok" expression => strcmp($(jtags2), $(etags2));
+      "tags3ok" expression => strcmp($(jtags3), $(etags3));
+
+      "ok" and => { "myclass", "var0ok", "var1ok", "var2ok", "var3ok", "var4ok",
+                    "tags0ok", "tags1ok", "tags2ok", "tags3ok", };
+
+  reports:
+    DEBUG::
+      "xyzvars = $(xyzvars)";
+
+      "tags0ok => strcmp('$(jtags0)', '$(etags0)')" ifvarclass => "tags0ok";
+      "tags1ok => strcmp('$(jtags1)', '$(etags1)')" ifvarclass => "tags1ok";
+      "tags2ok => strcmp('$(jtags2)', '$(etags2)')" ifvarclass => "tags2ok";
+      "tags3ok => strcmp('$(jtags3)', '$(etags3)')" ifvarclass => "tags3ok";
+
+      "tags0 NOT ok => strcmp('$(jtags0)', '$(etags0)')" ifvarclass => "!tags0ok";
+      "tags1 NOT ok => strcmp('$(jtags1)', '$(etags1)')" ifvarclass => "!tags1ok";
+      "tags2 NOT ok => strcmp('$(jtags2)', '$(etags2)')" ifvarclass => "!tags2ok";
+      "tags3 NOT ok => strcmp('$(jtags3)', '$(etags3)')" ifvarclass => "!tags3ok";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/01_modules/set-tags.cf.script
+++ b/tests/acceptance/08_commands/01_modules/set-tags.cf.script
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+echo "^context=xyz"
+echo "^meta=xyz,abc=def,,??what is this??"
+echo "+myclass"
+echo "=myvar=hello there"
+echo "@mylist={\"abc\", \"def\", \"ghi\"}"
+echo "@myalist={\"{{abc}}\", \"  ' def}\", \"ghi'''\"}"
+echo "^meta=1,2,3"
+echo "@myblist={'{{a,bc}}', '  \" de,f}', 'gh,,i\"\"\"'}"
+echo "+mybclass"
+echo "^meta=a,b,c"
+echo "@myclist={\"{{a'bc',,}}\", '  \",, d\"ef}', \"ghi,},'''\"}"
+echo "+mycclass"


### PR DESCRIPTION
This is finishing up the work defined in https://cfengine.com/dev/issues/3283
- implement `getvariablemetatags(varname)` function to get the `meta` tags of a variable (with acceptance test)
- implement `getclassmetatags(varname)` function to get the `meta` tags of a class (with acceptance test)
- implement `^meta=a,b,c` extension to module protocol (acceptance test `tests/acceptance/08_commands/01_modules/set-tags.cf` is **not** working yet, review welcome)
