### PR TITLE
tag VerifyServices() as static to match prototype

### DIFF
--- a/cf-agent/verify_services.c
+++ b/cf-agent/verify_services.c
@@ -159,7 +159,7 @@ static void SetServiceDefaults(Attributes *a)
 /* Level                                                                     */
 /*****************************************************************************/
 
-PromiseResult VerifyServices(EvalContext *ctx, Attributes a, Promise *pp)
+static PromiseResult VerifyServices(EvalContext *ctx, Attributes a, Promise *pp)
 {
     CfLock thislock;
 


### PR DESCRIPTION
Something I noticed while perusing the code last night; VerifyServices() is declared as static but not defined as such.
