### PR TITLE
use sys.workdir instead of hardcoded path. 

### DIFF
--- a/libpromises/bootstrap.c
+++ b/libpromises/bootstrap.c
@@ -387,7 +387,7 @@ bool WriteBuiltinFailsafePolicyToPath(const char *filename)
             "   \"Updated local policy from policy server\"\n"
             "      handle => \"cfe_internal_bootstrap_update_reports_got_policy\";\n"
             "  !got_policy.!have_promises_cf.have_ppkeys::\n"
-            "   \"Failed to copy policy from policy server at $(sys.policy_hub):/var/cfengine/masterfiles\n"
+            "   \"Failed to copy policy from policy server at $(sys.policy_hub):$(sys.workdir)/masterfiles\n"
             "       Please check\n"
             "       * cf-serverd is running on $(sys.policy_hub)\n"
             "       * network connectivity to $(sys.policy_hub) on port 5308\n"


### PR DESCRIPTION
Some distros use a different workdir.
