### PR TITLE
Transitioning to a new Call Collect mode.

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -2443,7 +2443,7 @@ PromiseResult ScheduleCopyOperation(EvalContext *ctx, char *destination, Attribu
     else
     {
         int err = 0;
-        conn = NewServerConnection(attr.copy, attr.transaction.background, &err);
+        conn = NewServerConnection(attr.copy, attr.transaction.background, &err, -1);
 
         if (conn == NULL)
         {
@@ -2462,7 +2462,7 @@ PromiseResult ScheduleCopyOperation(EvalContext *ctx, char *destination, Attribu
          * client_code.c:SERVERLIST, so just close it right after transaction. */
         if (attr.transaction.background)
         {
-            DisconnectServer(conn);
+            DisconnectServer(conn, false);
         }
         else
         {

--- a/cf-serverd/cf-serverd-enterprise-stubs.h
+++ b/cf-serverd/cf-serverd-enterprise-stubs.h
@@ -36,7 +36,7 @@ ENTERPRISE_FUNC_3ARG_DECLARE(int, ReturnLiteralData, EvalContext *, ctx, char *,
 ENTERPRISE_FUNC_4ARG_DECLARE(int, SetServerListenState, EvalContext *, ctx, size_t, queue_size, bool, server_listen,
                              InitServerFunction, InitServerPtr);
 
-typedef void (*ServerEntryPointFunction)(EvalContext *ctx, int sd_reply, char *ipaddr);
+typedef void (*ServerEntryPointFunction)(EvalContext *ctx, char *ipaddr, ConnectionInfo *info);
 ENTERPRISE_VOID_FUNC_2ARG_DECLARE(void, TryCollectCall, int, collect_window, ServerEntryPointFunction, server_entry_point);
 ENTERPRISE_FUNC_1ARG_DECLARE(int, ReceiveCollectCall, ServerConnectionState *, conn);
 

--- a/cf-serverd/server.h
+++ b/cf-serverd/server.h
@@ -89,7 +89,7 @@ typedef struct
 struct ServerConnectionState_
 {
     EvalContext *ctx;
-    ConnectionInfo conn_info;
+    ConnectionInfo *conn_info;
     int synchronized;
     int trust;
     char hostname[CF_MAXVARSIZE];
@@ -120,7 +120,7 @@ typedef struct
 
 
 void KeepPromises(EvalContext *ctx, Policy *policy, GenericAgentConfig *config);
-void ServerEntryPoint(EvalContext *ctx, int sd_reply, char *ipaddr);
+void ServerEntryPoint(EvalContext *ctx, char *ipaddr, ConnectionInfo *info);
 void DeleteAuthList(Auth *ap);
 void PurgeOldConnections(Item **list, time_t now);
 

--- a/cf-serverd/tls_server.h
+++ b/cf-serverd/tls_server.h
@@ -45,6 +45,7 @@ int ServerIdentifyClient(const ConnectionInfo *conn_info,
                          char *username, size_t username_size);
 int ServerSendWelcome(const ServerConnectionState *conn);
 int ServerTLSSessionEstablish(ServerConnectionState *conn);
+int ServerTLSSessionEstablishCallCollectMode(ServerConnectionState *conn);
 bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn);
 
 

--- a/libcfnet/Makefile.am
+++ b/libcfnet/Makefile.am
@@ -11,4 +11,6 @@ libcfnet_la_SOURCES = \
 	client_code.c client_code.h \
 	classic.c classic.h \
 	tls_client.c tls_client.h \
-	tls_generic.c tls_generic.h
+	tls_generic.c tls_generic.h \
+	connection_info.c connection_info.h \
+	key.c key.h

--- a/libcfnet/cfnet.h
+++ b/libcfnet/cfnet.h
@@ -28,8 +28,7 @@
 
 
 #include <platform.h>
-#include <openssl/ssl.h>
-
+#include <connection_info.h>
 
 /* ************************************************ */
 /* The following were copied from cf3.defs.h and still exist there, TODO */
@@ -101,29 +100,10 @@ struct Stat_
     x.tv_usec = DEFAULT_TLS_TIMEOUT_USECONDS
 #define DEFAULT_TLS_TRIES 5
 
-
-typedef enum
-{
-    /* When connection is initialised ProtocolVersion is 0, i.e. undefined. */
-    CF_PROTOCOL_UNDEFINED = 0,
-    CF_PROTOCOL_CLASSIC,
-    CF_PROTOCOL_TLS
-} ProtocolVersion;
-
-typedef struct
-{
-    ProtocolVersion type;
-    int sd;                           /* Socket descriptor */
-    SSL *ssl;                         /* OpenSSL struct for TLS connections */
-    RSA *remote_key;
-    char remote_keyhash[EVP_MAX_MD_SIZE];       /* key hash */
-    char remote_keyhash_str[EVP_MAX_MD_SIZE*4]; /* key hash as a SHA=... string */
-} ConnectionInfo;
-
 typedef struct
 {
     int family;                 /* AF_INET or AF_INET6 */
-    ConnectionInfo conn_info;
+    ConnectionInfo *conn_info;
     int trust;                  /* true if key being accepted on trust */
     int authenticated;
     char username[CF_SMALLBUF];

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -25,6 +25,7 @@
 #include <cfnet.h>                                 /* struct ConnectionInfo */
 #include <client_code.h>
 #include <communication.h>
+#include <connection_info.h>
 #include <classic.h>                  /* RecvSocketStream */
 #include <net.h>                      /* SendTransaction,ReceiveTransaction */
 #include <tls_client.h>               /* TLSTry */
@@ -76,7 +77,7 @@ static int CacheStat(const char *file, struct stat *statbuf, const char *stattyp
 /**
   @param err Set to 0 on success, -1 no server responce, -2 authentication failure.
   */
-static AgentConnection *ServerConnection(const char *server, FileCopy fc, int *err);
+static AgentConnection *ServerConnection(const char *server, FileCopy fc, int *err, int s);
 
 int TryConnect(AgentConnection *conn, struct timeval *tvp, struct sockaddr *cinp, int cinpSz);
 
@@ -173,10 +174,10 @@ void DetermineCfenginePort()
 
 /*********************************************************************/
 
-AgentConnection *NewServerConnection(FileCopy fc, bool background, int *err)
+AgentConnection *NewServerConnection(FileCopy fc, bool background, int *err, int s)
 {
-    AgentConnection *conn;
-    Rlist *rp;
+    AgentConnection *conn = NULL;
+    Rlist *rp = NULL;
 
     for (rp = fc.servers; rp != NULL; rp = rp->next)
     {
@@ -199,7 +200,7 @@ AgentConnection *NewServerConnection(FileCopy fc, bool background, int *err)
             {
                 /* If background connection was requested, then don't cache it
                  * in SERVERLIST since it will be closed right afterwards. */
-                conn = ServerConnection(servername, fc, err);
+                conn = ServerConnection(servername, fc, err, s);
                 return conn;
             }
         }
@@ -213,7 +214,7 @@ AgentConnection *NewServerConnection(FileCopy fc, bool background, int *err)
             }
 
             /* This is first usage, need to open */
-            conn = ServerConnection(servername, fc, err);
+            conn = ServerConnection(servername, fc, err, s);
             if (conn != NULL)
             {
                 CacheServerConnection(conn, servername);
@@ -259,21 +260,20 @@ int TLSConnect(ConnectionInfo *conn_info, bool trust_server,
     {
         Log(LOG_LEVEL_INFO,
             "Server is TRUSTED, received key %s MATCHES stored one.",
-            conn_info->remote_keyhash_str);
+            ConnectionInfoPrintableKeyHash(conn_info));
     }
-    else                                                /* ret == 0 */
+    else   /* ret == 0 */
     {
         Log(LOG_LEVEL_WARNING, "%s: Server's public key is UNKNOWN!",
-            conn_info->remote_keyhash_str);
+            ConnectionInfoPrintableKeyHash(conn_info));
 
         if (trust_server)             /* We're most probably bootstrapping. */
         {
             Log(LOG_LEVEL_WARNING,
                 "%s: Explicitly trusting this key from now on.",
-                conn_info->remote_keyhash_str);
-
-            SavePublicKey(username, conn_info->remote_keyhash_str,
-                          conn_info->remote_key);
+                ConnectionInfoPrintableKeyHash(conn_info));
+            SavePublicKey(username, ConnectionInfoPrintableKeyHash(conn_info),
+                          KeyRSA(ConnectionInfoKey(conn_info)));
         }
         else
         {
@@ -300,7 +300,7 @@ int TLSConnect(ConnectionInfo *conn_info, bool trust_server,
     /* Server might hang up here, after we sent identification! We
      * must get the "OK WELCOME" message for everything to be OK. */
     char line[1024] = "";
-    ret = TLSRecvLine(conn_info->ssl, line, sizeof(line));
+    ret = TLSRecvLine(ConnectionInfoSSL(conn_info), line, sizeof(line));
     if (ret <= 0 ||
         (strncmp(line, "OK WELCOME", strlen("OK WELCOME")) != 0))
     {
@@ -312,9 +312,9 @@ int TLSConnect(ConnectionInfo *conn_info, bool trust_server,
 
 /*****************************************************************************/
 
-static AgentConnection *ServerConnection(const char *server, FileCopy fc, int *err)
+static AgentConnection *ServerConnection(const char *server, FileCopy fc, int *err, int s)
 {
-    AgentConnection *conn;
+    AgentConnection *conn = NULL;
     int ret;
     *err = 0;
 
@@ -329,7 +329,7 @@ static AgentConnection *ServerConnection(const char *server, FileCopy fc, int *e
     pthread_sigmask(SIG_BLOCK, &signal_mask, NULL);
 #endif
 
-    conn = NewAgentConn(server);
+    conn = NewAgentConn(server, false);
 
 /* username of the client - say root from Windows */
 
@@ -342,60 +342,73 @@ static AgentConnection *ServerConnection(const char *server, FileCopy fc, int *e
 
     /* TODO fix, this was supposed to check if the connection is cached (open
      * or unreachable). However conn was just alloc'd so it's always INVALID */
-    if (conn->conn_info.sd == SOCKET_INVALID)
+    if (ConnectionInfoSocket(conn->conn_info) == SOCKET_INVALID)
     {
-        if (!ServerConnect(conn, server, fc))
+        if (-1 == s)
         {
-            Log(LOG_LEVEL_INFO, "No server is responding on this port");
-            DisconnectServer(conn);
-            *err = -1;
-            return NULL;
-        }
+            if (!ServerConnect(conn, server, fc))
+            {
+                Log(LOG_LEVEL_INFO, "No server is responding on this port");
+                DisconnectServer(conn, false);
+                *err = -1;
+                return NULL;
+            }
 
-        if (conn->conn_info.sd < 0)                      /* INVALID or OFFLINE socket */
+            if (ConnectionInfoSocket(conn->conn_info) < 0)                      /* INVALID or OFFLINE socket */
+            {
+                UnexpectedError("ServerConnect() succeeded but socket descriptor is %d!",
+                                ConnectionInfoSocket(conn->conn_info));
+                *err = -1;
+                return NULL;
+            }
+        }
+        else
         {
-            UnexpectedError("ServerConnect() succeeded but socket descriptor is %d!",
-                            conn->conn_info.sd);
-            *err = -1;
-            return NULL;
+            /*
+             * In this mode the connection is already opened, most likely
+             * because of Call Collect.
+             * We don't need to connect to the server, we just need to populate
+             * the required structures.
+             */
         }
 
         switch (SELECTED_PROTOCOL)
         {
         case CF_PROTOCOL_TLS:
 
-            ret = TLSConnect(&conn->conn_info, fc.trustkey,
+            ret = TLSConnect(conn->conn_info, fc.trustkey,
                              conn->remoteip, conn->username);
 
             if (ret == -1)                                      /* Error */
             {
-                DisconnectServer(conn);
+                DisconnectServer(conn, false);
                 *err = -1;
                 return NULL;
             }
             else if (ret == 0)                             /* Auth/ID error */
             {
-                    DisconnectServer(conn);
+                    DisconnectServer(conn, false);
                     errno = EPERM;
                     *err = -2;
                     return NULL;
             }
-
             assert(ret == 1);
-            LastSaw1(conn->remoteip, conn->conn_info.remote_keyhash_str,
+            ConnectionInfoSetProtocolVersion(conn->conn_info, CF_PROTOCOL_TLS);
+            ConnectionInfoSetConnectionStatus(conn->conn_info, CF_CONNECTION_ESTABLISHED);
+            LastSaw1(conn->remoteip, ConnectionInfoPrintableKeyHash(conn->conn_info),
                      LAST_SEEN_ROLE_CONNECT);
             break;
 
         case CF_PROTOCOL_CLASSIC:
 
-            conn->conn_info.type = CF_PROTOCOL_CLASSIC;
+            ConnectionInfoSetProtocolVersion(conn->conn_info, CF_PROTOCOL_CLASSIC);
             conn->encryption_type = CfEnterpriseOptions();
 
-            if (!IdentifyAgent(&conn->conn_info))
+            if (!IdentifyAgent(conn->conn_info))
             {
                 Log(LOG_LEVEL_ERR, "Id-authentication for '%s' failed", VFQNAME);
                 errno = EPERM;
-                DisconnectServer(conn);
+                DisconnectServer(conn, false);
                 *err = -2; // auth err
                 return NULL;
             }
@@ -404,10 +417,11 @@ static AgentConnection *ServerConnection(const char *server, FileCopy fc, int *e
             {
                 Log(LOG_LEVEL_ERR, "Authentication dialogue with '%s' failed", server);
                 errno = EPERM;
-                DisconnectServer(conn);
+                DisconnectServer(conn, false);
                 *err = -2; // auth err
                 return NULL;
             }
+            ConnectionInfoSetConnectionStatus(conn->conn_info, CF_CONNECTION_ESTABLISHED);
             break;
 
         default:
@@ -422,25 +436,24 @@ static AgentConnection *ServerConnection(const char *server, FileCopy fc, int *e
 
 /*********************************************************************/
 
-void DisconnectServer(AgentConnection *conn)
+void DisconnectServer(AgentConnection *conn, int partial)
 {
-    /* Socket needs to be closed even after SSL_shutdown. */
-    if (conn->conn_info.sd >= 0)                  /* Not INVALID or OFFLINE */
+    if (!partial)
     {
-        if (conn->conn_info.type == CF_PROTOCOL_TLS &&
-            conn->conn_info.ssl != NULL)
+        /* Socket needs to be closed even after SSL_shutdown. */
+        if (ConnectionInfoSocket(conn->conn_info) >= 0)                  /* Not INVALID or OFFLINE */
         {
-            SSL_shutdown(conn->conn_info.ssl);
+            if (ConnectionInfoProtocolVersion(conn->conn_info) == CF_PROTOCOL_TLS &&
+                ConnectionInfoSSL(conn->conn_info) != NULL)
+            {
+                SSL_shutdown(ConnectionInfoSSL(conn->conn_info));
+            }
+
+            cf_closesocket(ConnectionInfoSocket(conn->conn_info));
+            Log(LOG_LEVEL_INFO, "Connection to %s is closed", conn->remoteip);
         }
-
-        cf_closesocket(conn->conn_info.sd);
-        conn->conn_info.sd = SOCKET_INVALID;
-
-        Log(LOG_LEVEL_INFO, "Connection to %s is closed",
-            conn->remoteip);
     }
-
-    DeleteAgentConn(conn);
+    DeleteAgentConn(conn, partial);
 }
 
 /*********************************************************************/
@@ -479,7 +492,7 @@ int cf_remote_stat(char *file, struct stat *buf, char *stattype, bool encrypt, A
 
     /* We encrypt only for CLASSIC protocol. The TLS protocol is always over
      * encrypted layer, so it does not support encrypted (S*) commands. */
-    encrypt = encrypt && (conn->conn_info.type == CF_PROTOCOL_CLASSIC);
+    encrypt = encrypt && (ConnectionInfoProtocolVersion(conn->conn_info) == CF_PROTOCOL_CLASSIC);
 
     if (encrypt)
     {
@@ -501,14 +514,14 @@ int cf_remote_stat(char *file, struct stat *buf, char *stattype, bool encrypt, A
         tosend = strlen(sendbuffer);
     }
 
-    if (SendTransaction(&conn->conn_info, sendbuffer, tosend, CF_DONE) == -1)
+    if (SendTransaction(conn->conn_info, sendbuffer, tosend, CF_DONE) == -1)
     {
         Log(LOG_LEVEL_INFO, "Transmission failed/refused talking to %.255s:%.255s. (stat: %s)",
             conn->this_server, file, GetErrorStr());
         return -1;
     }
 
-    if (ReceiveTransaction(&conn->conn_info, recvbuffer, NULL) == -1)
+    if (ReceiveTransaction(conn->conn_info, recvbuffer, NULL) == -1)
     {
         return -1;
     }
@@ -572,7 +585,7 @@ int cf_remote_stat(char *file, struct stat *buf, char *stattype, bool encrypt, A
 
         memset(recvbuffer, 0, CF_BUFSIZE);
 
-        if (ReceiveTransaction(&conn->conn_info, recvbuffer, NULL) == -1)
+        if (ReceiveTransaction(conn->conn_info, recvbuffer, NULL) == -1)
         {
             return -1;
         }
@@ -670,7 +683,7 @@ Item *RemoteDirList(const char *dirname, bool encrypt, AgentConnection *conn)
 
     /* We encrypt only for CLASSIC protocol. The TLS protocol is always over
      * encrypted layer, so it does not support encrypted (S*) commands. */
-    encrypt = encrypt && (conn->conn_info.type == CF_PROTOCOL_CLASSIC);
+    encrypt = encrypt && (ConnectionInfoProtocolVersion(conn->conn_info) == CF_PROTOCOL_CLASSIC);
 
     if (encrypt)
     {
@@ -692,14 +705,14 @@ Item *RemoteDirList(const char *dirname, bool encrypt, AgentConnection *conn)
         tosend = strlen(sendbuffer);
     }
 
-    if (SendTransaction(&conn->conn_info, sendbuffer, tosend, CF_DONE) == -1)
+    if (SendTransaction(conn->conn_info, sendbuffer, tosend, CF_DONE) == -1)
     {
         return NULL;
     }
 
     while (true)
     {
-        if ((n = ReceiveTransaction(&conn->conn_info, recvbuffer, NULL)) == -1)
+        if ((n = ReceiveTransaction(conn->conn_info, recvbuffer, NULL)) == -1)
         {
             return NULL;
         }
@@ -794,7 +807,7 @@ int CompareHashNet(const char *file1, const char *file2, bool encrypt, AgentConn
 
     /* We encrypt only for CLASSIC protocol. The TLS protocol is always over
      * encrypted layer, so it does not support encrypted (S*) commands. */
-    encrypt = encrypt && (conn->conn_info.type == CF_PROTOCOL_CLASSIC);
+    encrypt = encrypt && (ConnectionInfoProtocolVersion(conn->conn_info) == CF_PROTOCOL_CLASSIC);
 
     if (encrypt)
     {
@@ -827,13 +840,13 @@ int CompareHashNet(const char *file1, const char *file2, bool encrypt, AgentConn
         tosend = strlen(sendbuffer) + CF_SMALL_OFFSET + CF_DEFAULT_DIGEST_LEN;
     }
 
-    if (SendTransaction(&conn->conn_info, sendbuffer, tosend, CF_DONE) == -1)
+    if (SendTransaction(conn->conn_info, sendbuffer, tosend, CF_DONE) == -1)
     {
         Log(LOG_LEVEL_ERR, "Failed send. (SendTransaction: %s)", GetErrorStr());
         return false;
     }
 
-    if (ReceiveTransaction(&conn->conn_info, recvbuffer, NULL) == -1)
+    if (ReceiveTransaction(conn->conn_info, recvbuffer, NULL) == -1)
     {
         Log(LOG_LEVEL_ERR, "Failed receive. (ReceiveTransaction: %s)", GetErrorStr());
         Log(LOG_LEVEL_VERBOSE,  "No answer from host, assuming checksum ok to avoid remote copy for now...");
@@ -901,7 +914,7 @@ int EncryptCopyRegularFileNet(const char *source, const char *dest, off_t size, 
 
 /* Send proposition C0 - query */
 
-    if (SendTransaction(&conn->conn_info, workbuf, tosend, CF_DONE) == -1)
+    if (SendTransaction(conn->conn_info, workbuf, tosend, CF_DONE) == -1)
     {
         Log(LOG_LEVEL_ERR, "Couldn't send data. (SendTransaction: %s)", GetErrorStr());
         close(dd);
@@ -914,7 +927,7 @@ int EncryptCopyRegularFileNet(const char *source, const char *dest, off_t size, 
 
     while (more)
     {
-        if ((cipherlen = ReceiveTransaction(&conn->conn_info, buf, &more)) == -1)
+        if ((cipherlen = ReceiveTransaction(conn->conn_info, buf, &more)) == -1)
         {
             free(buf);
             return false;
@@ -1009,7 +1022,7 @@ int CopyRegularFileNet(const char *source, const char *dest, off_t size, bool en
 
     /* We encrypt only for CLASSIC protocol. The TLS protocol is always over
      * encrypted layer, so it does not support encrypted (S*) commands. */
-    encrypt = encrypt && (conn->conn_info.type == CF_PROTOCOL_CLASSIC);
+    encrypt = encrypt && (ConnectionInfoProtocolVersion(conn->conn_info) == CF_PROTOCOL_CLASSIC);
 
     if (encrypt)
     {
@@ -1044,7 +1057,7 @@ int CopyRegularFileNet(const char *source, const char *dest, off_t size, bool en
     snprintf(workbuf, CF_BUFSIZE, "GET %d %s", buf_size, source);
     tosend = strlen(workbuf);
 
-    if (SendTransaction(&conn->conn_info, workbuf, tosend, CF_DONE) == -1)
+    if (SendTransaction(conn->conn_info, workbuf, tosend, CF_DONE) == -1)
     {
         Log(LOG_LEVEL_ERR, "Couldn't send data");
         close(dd);
@@ -1074,17 +1087,17 @@ int CopyRegularFileNet(const char *source, const char *dest, off_t size, bool en
         }
 
         /* Stage C1 - receive */
-        switch(conn->conn_info.type)
+        switch(ConnectionInfoProtocolVersion(conn->conn_info))
         {
         case CF_PROTOCOL_CLASSIC:
-            n_read = RecvSocketStream(conn->conn_info.sd, buf, toget);
+            n_read = RecvSocketStream(ConnectionInfoSocket(conn->conn_info), buf, toget);
             break;
         case CF_PROTOCOL_TLS:
-            n_read = TLSRecv(conn->conn_info.ssl, buf, toget);
+            n_read = TLSRecv(ConnectionInfoSSL(conn->conn_info), buf, toget);
             break;
         default:
             UnexpectedError("CopyRegularFileNet: ProtocolVersion %d!",
-                            conn->conn_info.type);
+                            ConnectionInfoProtocolVersion(conn->conn_info));
             n_read = -1;
         }
 
@@ -1143,7 +1156,7 @@ int CopyRegularFileNet(const char *source, const char *dest, off_t size, bool en
             free(buf);
             unlink(dest);
             close(dd);
-            FlushFileStream(conn->conn_info.sd, size - n_read_total);
+            FlushFileStream(ConnectionInfoSocket(conn->conn_info), size - n_read_total);
             EVP_CIPHER_CTX_cleanup(&crypto_ctx);
             return false;
         }
@@ -1168,7 +1181,7 @@ int CopyRegularFileNet(const char *source, const char *dest, off_t size, bool en
         free(buf);
         unlink(dest);
         close(dd);
-        FlushFileStream(conn->conn_info.sd, size - n_read_total);
+        FlushFileStream(ConnectionInfoSocket(conn->conn_info), size - n_read_total);
         return false;
     }
 
@@ -1242,8 +1255,8 @@ int ServerConnect(AgentConnection *conn, const char *host, FileCopy fc)
         Log(LOG_LEVEL_VERBOSE, "Connecting to host %s (address %s) on port %s",
               host, txtaddr, strport);
 
-        conn->conn_info.sd = socket(ap->ai_family, ap->ai_socktype, ap->ai_protocol);
-        if (conn->conn_info.sd == -1)
+        ConnectionInfoSetSocket(conn->conn_info, socket(ap->ai_family, ap->ai_socktype, ap->ai_protocol));
+        if (ConnectionInfoSocket(conn->conn_info) == -1)
         {
             Log(LOG_LEVEL_ERR, "Couldn't open a socket. (socket: %s)", GetErrorStr());
             continue;
@@ -1264,8 +1277,8 @@ int ServerConnect(AgentConnection *conn, const char *host, FileCopy fc)
                 Log(LOG_LEVEL_ERR,
                     "Unable to lookup interface '%s' to bind. (getaddrinfo: %s)",
                       BINDINTERFACE, gai_strerror(err));
-                cf_closesocket(conn->conn_info.sd);
-                conn->conn_info.sd = SOCKET_INVALID;
+                cf_closesocket(ConnectionInfoSocket(conn->conn_info));
+                ConnectionInfoSetSocket(conn->conn_info, SOCKET_INVALID);
                 freeaddrinfo(response2);
                 freeaddrinfo(response);
                 return false;
@@ -1273,7 +1286,7 @@ int ServerConnect(AgentConnection *conn, const char *host, FileCopy fc)
 
             for (ap2 = response2; ap2 != NULL; ap2 = ap2->ai_next)
             {
-                if (bind(conn->conn_info.sd, ap2->ai_addr, ap2->ai_addrlen) == 0)
+                if (bind(ConnectionInfoSocket(conn->conn_info), ap2->ai_addr, ap2->ai_addrlen) == 0)
                 {
                     break;
                 }
@@ -1296,10 +1309,10 @@ int ServerConnect(AgentConnection *conn, const char *host, FileCopy fc)
 
     if (!connected)
     {
-        if (conn->conn_info.sd >= 0)                 /* not INVALID or OFFLINE socket */
+        if (ConnectionInfoSocket(conn->conn_info) >= 0)                 /* not INVALID or OFFLINE socket */
         {
-            cf_closesocket(conn->conn_info.sd);
-            conn->conn_info.sd = SOCKET_INVALID;
+            cf_closesocket(ConnectionInfoSocket(conn->conn_info));
+            ConnectionInfoSetSocket(conn->conn_info, SOCKET_INVALID);
         }
     }
 
@@ -1350,7 +1363,7 @@ static bool ServerOffline(const char *server)
                                  ipaddr);
             }
 
-            if (svp->conn->conn_info.sd == CF_COULD_NOT_CONNECT)
+            if (ConnectionInfoSocket(svp->conn->conn_info) == CF_COULD_NOT_CONNECT)
                 return true;
             else
                 return false;
@@ -1399,13 +1412,13 @@ static AgentConnection *GetIdleConnectionToServer(const char *server)
                     " connection to '%s' seems to be active...",
                     ipaddr);
             }
-            else if (svp->conn->conn_info.sd == CF_COULD_NOT_CONNECT)
+            else if (ConnectionInfoSocket(svp->conn->conn_info) == CF_COULD_NOT_CONNECT)
             {
                 Log(LOG_LEVEL_VERBOSE, "GetIdleConnectionToServer:"
                     " connection to '%s' is marked as offline...",
                     ipaddr);
             }
-            else if (svp->conn->conn_info.sd > 0)
+            else if (ConnectionInfoSocket(svp->conn->conn_info) > 0)
             {
                 Log(LOG_LEVEL_VERBOSE, "GetIdleConnectionToServer:"
                     " found connection to %s already open and ready.",
@@ -1417,7 +1430,7 @@ static AgentConnection *GetIdleConnectionToServer(const char *server)
             {
                 Log(LOG_LEVEL_VERBOSE,
                     " connection to '%s' is in unknown state %d...",
-                    ipaddr, svp->conn->conn_info.sd);
+                    ipaddr, ConnectionInfoSocket(svp->conn->conn_info));
             }
         }
     }
@@ -1480,7 +1493,7 @@ static void MarkServerOffline(const char *server)
         /* TODO assert conn->remoteip == svp->server? Why do we need both? */
         {
             /* Found it, mark offline */
-            conn->conn_info.sd = CF_COULD_NOT_CONNECT;
+            ConnectionInfoSetSocket(conn->conn_info, CF_COULD_NOT_CONNECT);
             return;
         }
     }
@@ -1489,9 +1502,10 @@ static void MarkServerOffline(const char *server)
     ServerItem *svp = xmalloc(sizeof(*svp));
     svp->server = xstrdup(ipaddr);
     svp->busy = false;
-    svp->conn = NewAgentConn(ipaddr);
-    svp->conn->conn_info.type = CF_PROTOCOL_CLASSIC;
-    svp->conn->conn_info.sd = CF_COULD_NOT_CONNECT;
+    svp->conn = NewAgentConn(ipaddr, false);
+    ConnectionInfoSetProtocolVersion(svp->conn->conn_info, CF_PROTOCOL_CLASSIC);
+    ConnectionInfoSetConnectionStatus(svp->conn->conn_info, CF_CONNECTION_NOT_ESTABLISHED);
+    ConnectionInfoSetSocket(svp->conn->conn_info, CF_COULD_NOT_CONNECT);
 
     ThreadLock(&cft_serverlist);
     SeqAppend(srvlist_tmp, svp);
@@ -1607,7 +1621,7 @@ void ConnectionsCleanup(void)
                              "NULL connection in SERVERLIST!");
         }
 
-        DisconnectServer(svp->conn);
+        DisconnectServer(svp->conn, false);
     }
 
     SeqClear(srvlist_tmp);
@@ -1653,14 +1667,14 @@ int TryConnect(AgentConnection *conn, struct timeval *tvp, struct sockaddr *cinp
     }
 
     /* set non-blocking socket */
-    arg = fcntl(conn->conn_info.sd, F_GETFL, NULL);
+    arg = fcntl(ConnectionInfoSocket(conn->conn_info), F_GETFL, NULL);
 
-    if (fcntl(conn->conn_info.sd, F_SETFL, arg | O_NONBLOCK) == -1)
+    if (fcntl(ConnectionInfoSocket(conn->conn_info), F_SETFL, arg | O_NONBLOCK) == -1)
     {
         Log(LOG_LEVEL_ERR, "Could not set socket to non-blocking mode. (fcntl: %s)", GetErrorStr());
     }
 
-    res = connect(conn->conn_info.sd, cinp, (socklen_t) cinpSz);
+    res = connect(ConnectionInfoSocket(conn->conn_info), cinp, (socklen_t) cinpSz);
 
     if (res < 0)
     {
@@ -1672,11 +1686,11 @@ int TryConnect(AgentConnection *conn, struct timeval *tvp, struct sockaddr *cinp
 
             FD_ZERO(&myset);
 
-            FD_SET(conn->conn_info.sd, &myset);
+            FD_SET(ConnectionInfoSocket(conn->conn_info), &myset);
 
             /* now wait for connect, but no more than tvp.sec */
-            res = select(conn->conn_info.sd + 1, NULL, &myset, NULL, tvp);
-            if (getsockopt(conn->conn_info.sd, SOL_SOCKET, SO_ERROR, (void *) (&valopt), &lon) != 0)
+            res = select(ConnectionInfoSocket(conn->conn_info) + 1, NULL, &myset, NULL, tvp);
+            if (getsockopt(ConnectionInfoSocket(conn->conn_info), SOL_SOCKET, SO_ERROR, (void *) (&valopt), &lon) != 0)
             {
                 Log(LOG_LEVEL_ERR, "Could not check connection status. (getsockopt: %s)", GetErrorStr());
                 return false;
@@ -1697,12 +1711,12 @@ int TryConnect(AgentConnection *conn, struct timeval *tvp, struct sockaddr *cinp
 
     /* connection suceeded; return to blocking mode */
 
-    if (fcntl(conn->conn_info.sd, F_SETFL, arg) == -1)
+    if (fcntl(ConnectionInfoSocket(conn->conn_info), F_SETFL, arg) == -1)
     {
         Log(LOG_LEVEL_ERR, "Could not set socket to blocking mode. (fcntl: %s)", GetErrorStr());
     }
 
-    if (SetReceiveTimeout(conn->conn_info.sd, tvp) == -1)
+    if (SetReceiveTimeout(ConnectionInfoSocket(conn->conn_info), tvp) == -1)
     {
         Log(LOG_LEVEL_ERR, "Could not set socket timeout. (SetReceiveTimeout: %s)", GetErrorStr());
     }

--- a/libcfnet/client_code.h
+++ b/libcfnet/client_code.h
@@ -35,10 +35,13 @@
 bool cfnet_init(void);
 void DetermineCfenginePort(void);
 /**
-  @param err Set to 0 on success, -1 no server responce, -2 authentication failure.
+  @param fc No idea
+  @param background Whether to cache the connection or not. Set to false to cache it.
+  @param err Set to 0 on success, -1 no server response, -2 authentication failure.
+  @param s Socket to use for the connection, only useful for call collect mode.
   */
-AgentConnection *NewServerConnection(FileCopy fc, bool background, int *err);
-void DisconnectServer(AgentConnection *conn);
+AgentConnection *NewServerConnection(FileCopy fc, bool background, int *err, int s);
+void DisconnectServer(AgentConnection *conn, int partial);
 int cf_remote_stat(char *file, struct stat *buf, char *stattype, bool encrypt, AgentConnection *conn);
 int CompareHashNet(const char *file1, const char *file2, bool encrypt, AgentConnection *conn);
 int CopyRegularFileNet(const char *source, const char *dest, off_t size, bool encrypt, AgentConnection *conn);
@@ -51,5 +54,5 @@ const Stat *ClientCacheLookup(AgentConnection *conn, const char *server_name, co
 /* Mark connection as free */
 void ServerNotBusy(AgentConnection *conn);
 
-
+int TLSConnectCallCollect(ConnectionInfo *conn_info, const char *username);
 #endif

--- a/libcfnet/communication.h
+++ b/libcfnet/communication.h
@@ -27,9 +27,22 @@
 
 #include <cfnet.h>
 
+/**
+  @brief Creates a new connection from Agent to Server.
 
-AgentConnection *NewAgentConn(const char *server_name);
-void DeleteAgentConn(AgentConnection *ap);
+  If partial is set to false then a normal initialization happens, setting partial to true makes this a partial structure (without ConnectionInfo).
+  This is used in Call Collect mode.
+  @param server_name Server to connect to.
+  @param partial Whether to initialize the internal ConnectionInfo or not.
+  @return A fully initialized AgentConnection or NULL in case of error.
+  */
+AgentConnection *NewAgentConn(const char *server_name, int partial);
+/**
+  @brief Destroys an AgentConnection.
+  @param ap AgentConnection structure.
+  @param partial If true then only a partial destruction is performed, i.e. the ConnectionInfo structure is not destructed.
+  */
+void DeleteAgentConn(AgentConnection *ap, int partial);
 int IsIPV6Address(char *name);
 int IsIPV4Address(char *name);
 int Hostname2IPString(char *dst, const char *hostname, size_t dst_size);

--- a/libcfnet/connection_info.c
+++ b/libcfnet/connection_info.c
@@ -1,0 +1,275 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <alloc.h>
+#include <cfnet.h>
+#include <refcount.h>
+#include <connection_info.h>
+
+/*
+ * We define the structure on the C file to force people to use the API.
+ * Do not move this declaration to the header file, otherwise this structure
+ * will become modifiable without accessing the API.
+ */
+struct ConnectionInfoData {
+    ProtocolVersion type;
+    ConnectionStatus status;
+    int sd;                           /* Socket descriptor */
+    SSL *ssl;                         /* OpenSSL struct for TLS connections */
+    Key *remote_key;
+};
+
+struct ConnectionInfo {
+    struct ConnectionInfoData *data;
+};
+
+ConnectionInfo *ConnectionInfoNew(void)
+{
+    struct ConnectionInfoData *data = NULL;
+    data = xmalloc(sizeof(struct ConnectionInfoData));
+    data->remote_key = NULL;
+    data->ssl = NULL;
+    data->sd = SOCKET_INVALID;
+    data->type = CF_PROTOCOL_UNDEFINED;
+    data->status = CF_CONNECTION_NOT_ESTABLISHED;
+
+    ConnectionInfo *info = NULL;
+    info = xmalloc(sizeof(ConnectionInfo));
+    info->data = data;
+
+    return info;
+}
+
+void ConnectionInfoDestroy(ConnectionInfo **info)
+{
+    if (!info || !*info)
+    {
+        return;
+    }
+    /* Destroy everything */
+    if ((*info)->data)
+    {
+        if ((*info)->data->ssl)
+        {
+            SSL_free((*info)->data->ssl);
+        }
+        if ((*info)->data->remote_key)
+        {
+            KeyDestroy(&(*info)->data->remote_key);
+        }
+    }
+    free ((*info)->data);
+    free (*info);
+    *info = NULL;
+}
+
+ProtocolVersion ConnectionInfoProtocolVersion(const ConnectionInfo *info)
+{
+    if (!info)
+    {
+        return CF_PROTOCOL_UNDEFINED;
+    }
+    if (!info->data)
+    {
+        return CF_PROTOCOL_UNDEFINED;
+    }
+    return info->data->type;
+}
+
+void ConnectionInfoSetProtocolVersion(ConnectionInfo *info, ProtocolVersion version)
+{
+    if (!info)
+    {
+        return;
+    }
+    if (!info->data)
+    {
+        return;
+    }
+    switch (version)
+    {
+    case CF_PROTOCOL_UNDEFINED:
+    case CF_PROTOCOL_CLASSIC:
+    case CF_PROTOCOL_TLS:
+        info->data->type = version;
+        break;
+    default:
+        break;
+    }
+}
+
+ConnectionStatus ConnectionInfoConnectionStatus(const ConnectionInfo *info)
+{
+    if (!info)
+    {
+        return CF_CONNECTION_NOT_ESTABLISHED;
+    }
+    if (!info->data)
+    {
+        return CF_CONNECTION_NOT_ESTABLISHED;
+    }
+    return info->data->status;
+}
+
+void ConnectionInfoSetConnectionStatus(ConnectionInfo *info, ConnectionStatus status)
+{
+    if (!info)
+    {
+        return;
+    }
+    if (!info->data)
+    {
+        return;
+    }
+    switch (status)
+    {
+    case CF_CONNECTION_NOT_ESTABLISHED:
+    case CF_CONNECTION_ESTABLISHED:
+        info->data->status = status;
+    default:
+        break;
+    }
+}
+
+int ConnectionInfoSocket(const ConnectionInfo *info)
+{
+    if (!info)
+    {
+        return -1;
+    }
+    if (!info->data)
+    {
+        return -1;
+    }
+    return info->data->sd;
+}
+
+void ConnectionInfoSetSocket(ConnectionInfo *info, int s)
+{
+    if (!info)
+    {
+        return;
+    }
+    if (!info->data)
+    {
+        return;
+    }
+    info->data->sd = s;
+}
+
+SSL *ConnectionInfoSSL(const ConnectionInfo *info)
+{
+    if (!info)
+    {
+        return NULL;
+    }
+    if (!info->data)
+    {
+        return NULL;
+    }
+    return info->data->ssl;
+}
+
+void ConnectionInfoSetSSL(ConnectionInfo *info, SSL *ssl)
+{
+    if (!info)
+    {
+        return;
+    }
+    if (!info->data)
+    {
+        return;
+    }
+    info->data->ssl = ssl;
+}
+
+const Key *ConnectionInfoKey(const ConnectionInfo *info)
+{
+    if (!info)
+    {
+        return NULL;
+    }
+    if (!info->data)
+    {
+        return NULL;
+    }
+    const Key *key = info->data->remote_key;
+    return key;
+}
+
+void ConnectionInfoSetKey(ConnectionInfo *info, Key *key)
+{
+    if (!info)
+    {
+        return;
+    }
+    if (!info->data)
+    {
+        return;
+    }
+    /* The key can be assigned only once on a session */
+    if (info->data->remote_key)
+    {
+        return;
+    }
+    if (!key)
+    {
+        return;
+    }
+    info->data->remote_key = key;
+}
+
+const unsigned char *ConnectionInfoBinaryKeyHash(ConnectionInfo *info, unsigned int *length)
+{
+    if (!info)
+    {
+        return NULL;
+    }
+    if (!info->data)
+    {
+        return NULL;
+    }
+    Key *connection_key = info->data->remote_key;
+    unsigned int real_length = 0;
+    const char *binary = KeyBinaryHash(connection_key, &real_length);
+    if (length)
+    {
+        *length = real_length;
+    }
+    return binary;
+}
+
+const unsigned char *ConnectionInfoPrintableKeyHash(ConnectionInfo *info)
+{
+    if (!info)
+    {
+        return NULL;
+    }
+    if (!info->data)
+    {
+        return NULL;
+    }
+    Key *connection_key = info->data->remote_key;
+    return KeyPrintableHash(connection_key);
+}

--- a/libcfnet/connection_info.h
+++ b/libcfnet/connection_info.h
@@ -1,0 +1,158 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#ifndef CONNECTION_INFO_H
+#define CONNECTION_INFO_H
+
+#include <platform.h>
+#include <openssl/ssl.h>
+#include <key.h>
+
+/**
+  @brief ConnectionInfo Structure and support routines
+
+  ConnectionInfo is used to abstract the underlying type of connection from our protocol implementation.
+  It can hold both a normal socket connection and a TLS stream.
+
+  Notice that despite being reference counted, we will not detach this structure once shared in order to
+  modify it. This arises from the fact that we handle a couple of structures that are opaque to us, such
+  as RSA and SSL. We cannot copy those structures since they are completely opaque, therefore we cannot
+  modify this structure once it has been shared. As a safety measure, the copy will fail if the structure
+  is not ready.
+  */
+
+/**
+  @brief Available protocol versions
+  */
+typedef enum
+{
+    /* When connection is initialised ProtocolVersion is 0, i.e. undefined. */
+    CF_PROTOCOL_UNDEFINED = 0, /*!< Protocol not defined yet */
+    CF_PROTOCOL_CLASSIC, /*!< Normal CFEngine protocol */
+    CF_PROTOCOL_TLS /*!< TLS protocol */
+} ProtocolVersion;
+
+/**
+  @brief States of the connection.
+  */
+typedef enum
+{
+    /* Status of the connection so we can detect if we need to negotiate a new connection or not */
+    CF_CONNECTION_NOT_ESTABLISHED, /*!< Connection not established yet */
+    CF_CONNECTION_ESTABLISHED /*!< Connection established */
+} ConnectionStatus;
+
+typedef struct ConnectionInfo ConnectionInfo;
+
+/**
+  @brief Creates a new ConnectionInfo structure.
+  @return A initialized ConnectionInfo structure, needs to be populated.
+  */
+ConnectionInfo *ConnectionInfoNew(void);
+/**
+  @brief Destroys a ConnectionInfo structure.
+  @param info Pointer to the ConectionInfo structure to be destroyed.
+  */
+void ConnectionInfoDestroy(ConnectionInfo **info);
+/**
+  @brief Protocol Version
+  @param info ConnectionInfo structure
+  @return Returns the protocol version or CF_PROTOCOL_UNDEFINED in case of error.
+  */
+ProtocolVersion ConnectionInfoProtocolVersion(const ConnectionInfo *info);
+/**
+  @brief Sets the protocol version
+
+  Notice that if an invalid protocol version is passed, the value will not be changed.
+  @param info ConnectionInfo structure.
+  @param version New protocol version
+  */
+void ConnectionInfoSetProtocolVersion(ConnectionInfo *info, ProtocolVersion version);
+/**
+  @brief Connection status
+  @param info ConnectionInfo structure
+  @return Returns the status of the connection or CF_CONNECTION_NOT_ESTABLISHED in case of error.
+*/
+ConnectionStatus ConnectionInfoConnectionStatus(const ConnectionInfo *info);
+/**
+  @brief Sets the connection status.
+  @param info ConnectionInfo structure.
+  @param status New status
+  */
+void ConnectionInfoSetConnectionStatus(ConnectionInfo *info, ConnectionStatus status);
+/**
+  @brief Connection socket
+
+  For practical reasons there is no difference between an invalid socket and an error on this routine.
+  @param info ConnectionInfo structure.
+  @return Returns the connection socket or -1 in case of error.
+  */
+int ConnectionInfoSocket(const ConnectionInfo *info);
+/**
+  @brief Sets the connection socket.
+  @param info ConnectionInfo structure.
+  @param s New connection socket.
+  */
+void ConnectionInfoSetSocket(ConnectionInfo *info, int s);
+/**
+  @brief SSL structure.
+  @param info ConnectionInfo structure.
+  @return The SSL structure attached to this connection or NULL in case of error.
+  */
+SSL *ConnectionInfoSSL(const ConnectionInfo *info);
+/**
+  @brief Sets the SSL structure.
+  @param info ConnectionInfo structure.
+  @param ssl SSL structure to attached to this connection.
+  */
+void ConnectionInfoSetSSL(ConnectionInfo *info, SSL *ssl);
+/**
+  @brief RSA key
+  @param info ConnectionInfo structure.
+  @return Returns the RSA key or NULL in case of error.
+  */
+const Key *ConnectionInfoKey(const ConnectionInfo *info);
+/**
+  @brief Sets the key for the connection structure.
+
+  This triggers a calculation of two other fields.
+  @param info ConnectionInfo structure.
+  @param key RSA key.
+  */
+void ConnectionInfoSetKey(ConnectionInfo *info, Key *key);
+/**
+  @brief A constant pointer to the binary hash of the key
+  @param info ConnectionInfo structure
+  @param length Length of the hash
+  @return Returns a constant pointer to the binary hash and if length is not NULL the size is stored there.
+  */
+const unsigned char *ConnectionInfoBinaryKeyHash(ConnectionInfo *info, unsigned int *length);
+/**
+  @brief A constant pointer to the binary hash of the key
+  @param info ConnectionInfo structure
+  @return Returns a printable representation of the hash. The string is '\0' terminated or NULL in case of failure.
+  */
+const unsigned char *ConnectionInfoPrintableKeyHash(ConnectionInfo *info);
+
+#endif // CONNECTION_INFO_H

--- a/libcfnet/key.c
+++ b/libcfnet/key.c
@@ -1,0 +1,135 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <alloc.h>
+#include <key.h>
+
+struct Key {
+    RSA *key;
+    Hash *hash;
+};
+
+Key *KeyNew(RSA *rsa, HashMethod method)
+{
+    if (!rsa)
+    {
+        return NULL;
+    }
+    Key *key = xmalloc (sizeof(Key));
+    key->key = rsa;
+    /* Hash the key */
+    key->hash = HashNewFromKey(rsa, method);
+    if (key->hash == NULL)
+    {
+        free (key);
+        return NULL;
+    }
+    return key;
+}
+
+void KeyDestroy(Key **key)
+{
+    if (!key || !*key)
+    {
+        return;
+    }
+    if ((*key)->key)
+    {
+        RSA_free((*key)->key);
+    }
+    if ((*key)->hash)
+    {
+        HashDestroy(&(*key)->hash);
+    }
+    free (*key);
+    *key = NULL;
+}
+
+const RSA *KeyRSA(const Key *key)
+{
+    if (!key)
+    {
+        return NULL;
+    }
+    const RSA *p = key->key;
+    return p;
+}
+
+const unsigned char *KeyBinaryHash(const Key *key, unsigned int *length)
+{
+    if (!key || !length)
+    {
+        return NULL;
+    }
+    return HashData(key->hash, length);
+}
+
+const unsigned char *KeyPrintableHash(const Key *key)
+{
+    if (!key)
+    {
+        return NULL;
+    }
+    return HashPrintable(key->hash);
+}
+
+HashMethod KeyHashMethod(const Key *key)
+{
+    if (!key)
+    {
+        return HASH_METHOD_NONE;
+    }
+    return HashType(key->hash);
+}
+
+int KeySetHashMethod(Key *key, HashMethod method)
+{
+    if (!key)
+    {
+        return -1;
+    }
+    /* We calculate the new hash before changing the value, in case there is an error. */
+    Hash *hash = NULL;
+    hash = HashNewFromKey(key->key, method);
+    if (hash == NULL)
+    {
+        return -1;
+    }
+    if (key->hash)
+    {
+        HashDestroy(&key->hash);
+    }
+    key->hash = hash;
+    return 0;
+}
+
+const Hash *KeyData(Key *key)
+{
+    if (!key)
+    {
+        return NULL;
+    }
+    const Hash *hash = key->hash;
+    return hash;
+}

--- a/libcfnet/key.h
+++ b/libcfnet/key.h
@@ -1,0 +1,90 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#ifndef KEY_H
+#define KEY_H
+
+#include <hash.h>
+#include <openssl/rsa.h>
+
+/**
+  @brief Structure to simplify the key management.
+
+  */
+typedef struct Key Key;
+
+/**
+  @brief Creates a new Key structure.
+  @param key RSA structure
+  @param hash Hash method to use when hashing the key.
+  @return A fully initialized Key structure or NULL in case of error.
+  */
+Key *KeyNew(RSA *rsa, HashMethod method);
+/**
+  @brief Destroys a structure of type Key.
+  @param key Structure to be destroyed.
+  */
+void KeyDestroy(Key **key);
+/**
+  @brief Constant pointer to the key data.
+  @param key Key
+  @return A constant pointer to the RSA structure.
+  */
+const RSA *KeyRSA(const Key *key);
+/**
+  @brief Binary hash of the key
+  @param key Key structure
+  @param length Length of the binary hash
+  @return A constant pointer to the binary hash or NULL in case of error.
+  */
+const unsigned char *KeyBinaryHash(const Key *key, unsigned int *length);
+/**
+  @brief Printable hash of the key.
+  @param key
+  @return A constant pointer to the printable hash of the key.
+  */
+const unsigned char *KeyPrintableHash(const Key *key);
+/**
+  @brief Method use to hash the key.
+  @param key Structure
+  @return Method used to hash the key.
+  */
+HashMethod KeyHashMethod(const Key *key);
+/**
+  @brief Changes the method used to hash the key.
+
+  This method triggers a rehashing of the key. This can be an expensive operation.
+  @param key Structure
+  @param hash New hashing mechanism.
+  @return 0 if successful, -1 in case of error.
+  */
+int KeySetHashMethod(Key *key, HashMethod method);
+/**
+  @brief Internal Hash data
+  @param key Structure
+  @return A constant pointer to the Hash structure or NULL in case of error.
+  */
+const Hash *KeyData(Key *key);
+
+#endif // KEY_H

--- a/libcfnet/net.c
+++ b/libcfnet/net.c
@@ -25,7 +25,7 @@
 #include <net.h>
 #include <classic.h>
 #include <tls_generic.h>
-
+#include <connection_info.h>
 #include <logging.h>
 #include <misc_lib.h>
 
@@ -60,18 +60,18 @@ int SendTransaction(const ConnectionInfo *conn_info, const char *buffer, int len
     LogRaw(LOG_LEVEL_DEBUG, "SendTransaction data: ",
            work + CF_INBAND_OFFSET, len);
 
-    switch(conn_info->type)
+    switch(ConnectionInfoProtocolVersion(conn_info))
     {
     case CF_PROTOCOL_CLASSIC:
-        ret = SendSocketStream(conn_info->sd, work,
+        ret = SendSocketStream(ConnectionInfoSocket(conn_info), work,
                                len + CF_INBAND_OFFSET);
         break;
     case CF_PROTOCOL_TLS:
-        ret = TLSSend(conn_info->ssl, work, len + CF_INBAND_OFFSET);
+        ret = TLSSend(ConnectionInfoSSL(conn_info), work, len + CF_INBAND_OFFSET);
         break;
     default:
         UnexpectedError("SendTransaction: ProtocolVersion %d!",
-                        conn_info->type);
+                        ConnectionInfoProtocolVersion(conn_info));
         ret = -1;
     }
 
@@ -91,17 +91,17 @@ int ReceiveTransaction(const ConnectionInfo *conn_info, char *buffer, int *more)
     int ret;
 
     /* Get control channel. */
-    switch(conn_info->type)
+    switch(ConnectionInfoProtocolVersion(conn_info))
     {
     case CF_PROTOCOL_CLASSIC:
-        ret = RecvSocketStream(conn_info->sd, proto, CF_INBAND_OFFSET);
+        ret = RecvSocketStream(ConnectionInfoSocket(conn_info), proto, CF_INBAND_OFFSET);
         break;
     case CF_PROTOCOL_TLS:
-        ret = TLSRecv(conn_info->ssl, proto, CF_INBAND_OFFSET);
+        ret = TLSRecv(ConnectionInfoSSL(conn_info), proto, CF_INBAND_OFFSET);
         break;
     default:
         UnexpectedError("ReceiveTransaction: ProtocolVersion %d!",
-                        conn_info->type);
+                        ConnectionInfoProtocolVersion(conn_info));
         ret = -1;
     }
     if (ret == -1 || ret == 0)
@@ -134,17 +134,17 @@ int ReceiveTransaction(const ConnectionInfo *conn_info, char *buffer, int *more)
     }
 
     /* Get data. */
-    switch(conn_info->type)
+    switch(ConnectionInfoProtocolVersion(conn_info))
     {
     case CF_PROTOCOL_CLASSIC:
-        ret = RecvSocketStream(conn_info->sd, buffer, len);
+        ret = RecvSocketStream(ConnectionInfoSocket(conn_info), buffer, len);
         break;
     case CF_PROTOCOL_TLS:
-        ret = TLSRecv(conn_info->ssl, buffer, len);
+        ret = TLSRecv(ConnectionInfoSSL(conn_info), buffer, len);
         break;
     default:
         UnexpectedError("ReceiveTransaction: ProtocolVersion %d!",
-                        conn_info->type);
+                        ConnectionInfoProtocolVersion(conn_info));
         ret = -1;
     }
 

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -33,6 +33,7 @@
 #include <libxml/xpathInternals.h>
 #endif
 
+#include <hash.h> /* Required for HashMethod */
 #include <sequence.h>
 #include <logging.h>
 
@@ -119,17 +120,6 @@
 #define CFD_FALSE "CFD_FALSE"
 #define CF_ANYCLASS "any"
 #define CF_SMALL_OFFSET 2
-
-/* digest sizes */
-#define CF_MD5_LEN 16
-#define CF_SHA_LEN 20
-#define CF_SHA1_LEN 20
-#define CF_BEST_LEN 0
-#define CF_CRYPT_LEN 64
-#define CF_SHA224_LEN 28
-#define CF_SHA256_LEN 32
-#define CF_SHA384_LEN 48
-#define CF_SHA512_LEN 64
 
 #define CF_DONE 't'
 #define CF_MORE 'm'
@@ -802,20 +792,6 @@ enum cftidylinks
     cfa_linkdelete,
     cfa_linkkeep
 };
-
-typedef enum
-{
-    HASH_METHOD_MD5,
-    HASH_METHOD_SHA224,
-    HASH_METHOD_SHA256,
-    HASH_METHOD_SHA384,
-    HASH_METHOD_SHA512,
-    HASH_METHOD_SHA1,
-    HASH_METHOD_SHA,
-    HASH_METHOD_BEST,
-    HASH_METHOD_CRYPT,
-    HASH_METHOD_NONE
-} HashMethod;
 
 enum cfnofile
 {

--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -34,7 +34,8 @@ libutils_la_SOURCES = \
 	rb-tree.c rb-tree.h \
 	mustache.c mustache.h \
 	cfversion.c cfversion.h \
-	unicode.c unicode.h
+	unicode.c unicode.h \
+    hash.c hash.h
 
 CLEANFILES = *.gcno *.gcda
 

--- a/libutils/hash.c
+++ b/libutils/hash.c
@@ -1,0 +1,363 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <alloc.h>
+#include <logging.h>
+#include <hash.h>
+
+static const char *CF_DIGEST_TYPES[10] =
+{
+    "md5",
+    "sha224",
+    "sha256",
+    "sha384",
+    "sha512",
+    "sha1",
+    "sha",
+    "best",
+    "crypt",
+    NULL
+};
+
+static const int CF_DIGEST_SIZES[10] =
+{
+    CF_MD5_LEN,
+    CF_SHA224_LEN,
+    CF_SHA256_LEN,
+    CF_SHA384_LEN,
+    CF_SHA512_LEN,
+    CF_SHA1_LEN,
+    CF_SHA_LEN,
+    CF_BEST_LEN,
+    CF_CRYPT_LEN,
+    CF_NO_HASH
+};
+
+struct Hash {
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned char printable[EVP_MAX_MD_SIZE * 4];
+    HashMethod method;
+    HashSize size;
+};
+
+/*
+ * These methods are not exported through the public API.
+ * These are internal methods used by the constructors of a
+ * Hash object. Do not export them since they have very little
+ * meaning outside of the constructors.
+ */
+Hash *HashBasicInit(HashMethod method)
+{
+    Hash *hash = xmalloc (sizeof(Hash));
+    hash->size = CF_DIGEST_SIZES[method];
+    hash->method = method;
+    memset(hash->digest, 0, EVP_MAX_MD_SIZE);
+    memset(hash->printable, 0, EVP_MAX_MD_SIZE * 4);
+    return hash;
+}
+
+void HashCalculatePrintableRepresentation(Hash *hash)
+{
+    switch (hash->method)
+    {
+        case HASH_METHOD_MD5:
+            strcpy(hash->printable, "MD5=");
+            break;
+        case HASH_METHOD_SHA224:
+        case HASH_METHOD_SHA256:
+        case HASH_METHOD_SHA384:
+        case HASH_METHOD_SHA512:
+        case HASH_METHOD_SHA:
+        case HASH_METHOD_SHA1:
+            strcpy(hash->printable, "SHA=");
+            break;
+        default:
+            strcpy(hash->printable, "UNK=");
+            break;
+    }
+
+    unsigned int i;
+    for (i = 0; i < hash->size; i++)
+    {
+        sprintf((char *) (hash->printable + 4 + 2 * i), "%02x", hash->digest[i]);
+    }
+    hash->printable[4 + 2 * hash->size] = '\0';
+}
+
+/*
+ * Constructors
+ * All constructors call two common methods: HashBasicInit(...) and HashCalculatePrintableRepresentation(...).
+ * Each constructor reads the data to create the Hash from different sources so after the basic
+ * initialization and up to the point where the hash is computed, each follows its own path.
+ */
+Hash *HashNew(const char *data, const unsigned int length, HashMethod method)
+{
+    if (!data || (length == 0))
+    {
+        return NULL;
+    }
+    if (method >= HASH_METHOD_NONE)
+    {
+        return NULL;
+    }
+    /*
+     * OpenSSL documentation marked EVP_DigestInit and EVP_DigestFinal functions as deprecated and
+     * recommends moving to EVP_DigestInit_ex and EVP_DigestFinal_ex.
+     */
+    EVP_MD_CTX *context = NULL;
+    const EVP_MD *md = NULL;
+    int md_len = 0;
+    md = EVP_get_digestbyname(CF_DIGEST_TYPES[method]);
+    if (md == NULL)
+    {
+        Log(LOG_LEVEL_INFO, "Digest type %s not supported by OpenSSL library", CF_DIGEST_TYPES[method]);
+        return NULL;
+    }
+    Hash *hash = HashBasicInit(method);
+    context = EVP_MD_CTX_create();
+    EVP_DigestInit_ex(context, md, NULL);
+    EVP_DigestUpdate(context, (unsigned char *) data, (size_t) length);
+    EVP_DigestFinal_ex(context, hash->digest, &md_len);
+    EVP_MD_CTX_destroy(context);
+    /* Update the printable representation */
+    HashCalculatePrintableRepresentation(hash);
+    /* Return the hash */
+    return hash;
+}
+
+Hash *HashNewFromDescriptor(const int descriptor, HashMethod method)
+{
+    if (descriptor < 0)
+    {
+        return NULL;
+    }
+    if (method >= HASH_METHOD_NONE)
+    {
+        return NULL;
+    }
+    char buffer[1024];
+    int read_count = 0;
+    EVP_MD_CTX *context = NULL;
+    const EVP_MD *md = NULL;
+    int md_len = 0;
+    md = EVP_get_digestbyname(CF_DIGEST_TYPES[method]);
+    if (md == NULL)
+    {
+        Log(LOG_LEVEL_INFO, "Digest type %s not supported by OpenSSL library", CF_DIGEST_TYPES[method]);
+        return NULL;
+    }
+    Hash *hash = HashBasicInit(method);
+    context = EVP_MD_CTX_create();
+    EVP_DigestInit_ex(context, md, NULL);
+    do {
+        read_count = read(descriptor, buffer, 1024);
+        EVP_DigestUpdate(context, (unsigned char *) buffer, (size_t) read_count);
+    } while (read_count > 0);
+    EVP_DigestFinal_ex(context, hash->digest, &md_len);
+    EVP_MD_CTX_destroy(context);
+    /* Update the printable representation */
+    HashCalculatePrintableRepresentation(hash);
+    /* Return the hash */
+    return hash;
+}
+
+Hash *HashNewFromKey(const RSA *rsa, HashMethod method)
+{
+    if (!rsa)
+    {
+        return NULL;
+    }
+    if (method >= HASH_METHOD_NONE)
+    {
+        return NULL;
+    }
+    EVP_MD_CTX *context = NULL;
+    const EVP_MD *md = NULL;
+    int md_len = 0;
+    unsigned char *buffer = NULL;
+    int buffer_length = 0;
+    int actual_length = 0;
+
+    if (rsa->n)
+    {
+        buffer_length = (size_t) BN_num_bytes(rsa->n);
+    }
+    else
+    {
+        buffer_length = 0;
+    }
+
+    if (rsa->e)
+    {
+        if (buffer_length < (size_t) BN_num_bytes(rsa->e))
+        {
+            buffer_length = (size_t) BN_num_bytes(rsa->e);
+        }
+    }
+    md = EVP_get_digestbyname(CF_DIGEST_TYPES[method]);
+    if (md == NULL)
+    {
+        Log(LOG_LEVEL_INFO, "Digest type %s not supported by OpenSSL library", CF_DIGEST_TYPES[method]);
+        return NULL;
+    }
+    Hash *hash = HashBasicInit(method);
+    context = EVP_MD_CTX_create();
+    EVP_DigestInit_ex(context, md, NULL);
+    buffer = xmalloc(buffer_length);
+    actual_length = BN_bn2bin(rsa->n, buffer);
+    EVP_DigestUpdate(context, buffer, actual_length);
+    actual_length = BN_bn2bin(rsa->e, buffer);
+    EVP_DigestUpdate(context, buffer, actual_length);
+    EVP_DigestFinal_ex(context, hash->digest, &md_len);
+    EVP_MD_CTX_destroy(context);
+    free (buffer);
+    /* Update the printable representation */
+    HashCalculatePrintableRepresentation(hash);
+    /* Return the hash */
+    return hash;
+}
+
+void HashDestroy(Hash **hash)
+{
+    if (!hash || !*hash)
+    {
+        return;
+    }
+    free (*hash);
+    *hash = NULL;
+}
+
+int HashCopy(Hash *origin, Hash **destination)
+{
+    if (!origin || !destination)
+    {
+        return -1;
+    }
+    *destination = xmalloc(sizeof(Hash));
+    memcpy((*destination)->digest, origin->digest, origin->size);
+    strncpy((*destination)->printable, origin->printable, (EVP_MAX_MD_SIZE * 4) - 1);
+    (*destination)->method = origin->method;
+    (*destination)->size = origin->size;
+    return 0;
+}
+
+int HashEqual(const Hash *a, const Hash *b)
+{
+    if (!a && !b)
+    {
+        return true;
+    }
+    if (!a && b)
+    {
+        return false;
+    }
+    if (a && !b)
+    {
+        return false;
+    }
+    if (a->method != b->method)
+    {
+        return false;
+    }
+    int i = 0;
+    for (i = 0; i < a->size; ++i)
+    {
+        if (a->digest[i] != b->digest[i])
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+const unsigned char *HashData(const Hash *hash, unsigned int *length)
+{
+    if (!hash || !length)
+    {
+        return NULL;
+    }
+    *length = hash->size;
+    return (const char *)hash->digest;
+}
+
+const unsigned char *HashPrintable(const Hash *hash)
+{
+    if (!hash)
+    {
+        return NULL;
+    }
+    return (const char *)hash->printable;
+}
+
+HashMethod HashType(const Hash *hash)
+{
+    if (!hash)
+    {
+        return HASH_METHOD_NONE;
+    }
+    return hash->method;
+}
+
+HashSize HashLength(const Hash *hash)
+{
+    if (!hash)
+    {
+        return CF_NO_HASH;
+    }
+    return hash->size;
+}
+
+/* Class methods */
+HashMethod HashIdFromName(const char *hash_name)
+{
+    int i;
+
+    for (i = 0; CF_DIGEST_TYPES[i] != NULL; i++)
+    {
+        if (hash_name && (strcmp(hash_name, CF_DIGEST_TYPES[i]) == 0))
+        {
+            return (HashMethod) i;
+        }
+    }
+
+    return HASH_METHOD_NONE;
+}
+
+const char *HashNameFromId(HashMethod hash_id)
+{
+    if (hash_id >= HASH_METHOD_NONE)
+    {
+        return NULL;
+    }
+    return CF_DIGEST_TYPES[hash_id];
+}
+
+HashSize HashSizeFromId(HashMethod hash_id)
+{
+    if (hash_id >= HASH_METHOD_NONE)
+    {
+        return CF_NO_HASH;
+    }
+    return CF_DIGEST_SIZES[hash_id];
+}

--- a/libutils/hash.h
+++ b/libutils/hash.h
@@ -1,0 +1,147 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#ifndef HASH_H
+#define HASH_H
+
+/**
+  @brief Hash implementations
+  */
+
+#include <openssl/rsa.h>
+typedef enum
+{
+    HASH_METHOD_MD5,
+    HASH_METHOD_SHA224,
+    HASH_METHOD_SHA256,
+    HASH_METHOD_SHA384,
+    HASH_METHOD_SHA512,
+    HASH_METHOD_SHA1,
+    HASH_METHOD_SHA,
+    HASH_METHOD_BEST,
+    HASH_METHOD_CRYPT,
+    HASH_METHOD_NONE
+} HashMethod;
+
+typedef enum {
+    CF_MD5_LEN = 16,
+    CF_SHA224_LEN = 28,
+    CF_SHA256_LEN = 32,
+    CF_SHA384_LEN = 48,
+    CF_SHA512_LEN = 64,
+    CF_SHA1_LEN = 20,
+    CF_SHA_LEN = 20,
+    CF_BEST_LEN = 0,
+    CF_CRYPT_LEN = 64,
+    CF_NO_HASH = 0
+} HashSize;
+
+typedef struct Hash Hash;
+
+/**
+  @brief Creates a new structure of type Hash.
+  @param data String to hash.
+  @param length Length of the string to hash.
+  @param method Hash method.
+  @return A structure of type Hash or NULL in case of error.
+  */
+Hash *HashNew(const char *data, const unsigned int length, HashMethod method);
+/**
+  @brief Creates a new structure of type Hash.
+  @param descriptor Either file descriptor or socket descriptor.
+  @param method Hash method.
+  @return A structure of type Hash or NULL in case of error.
+  */
+Hash *HashNewFromDescriptor(const int descriptor, HashMethod method);
+/**
+  @brief Creates a new structure of type Hash.
+  @param rsa RSA key to be hashed.
+  @param method Hash method.
+  @return A structure of type Hash or NULL in case of error.
+  */
+Hash *HashNewFromKey(const RSA *rsa, HashMethod method);
+/**
+  @brief Destroys a structure of type Hash.
+  @param hash The structure.
+  */
+void HashDestroy(Hash **hash);
+/**
+  @brief Copy a hash
+  @param origin Hash to be copied.
+  @param destination Hash to be copied to.
+  @return 0 if successful, -1 in any other case.
+  */
+int HashCopy(Hash *origin, Hash **destination);
+/**
+  @brief Checks if two hashes are equal.
+  @param a 1st hash to be compared.
+  @param b 2nd hash to be compared.
+  @return True if both hashes are equal and false in any other case.
+  */
+int HashEqual(const Hash *a, const Hash *b);
+/**
+  @brief Const pointer to the raw digest data, notice that this is a binary representation and not '\0' terminated.
+  @param hash Hash structure.
+  @param length Pointer to an unsigned int to hold the length of the data.
+  @return A const pointer to the raw digest data.
+  */
+const unsigned  char *HashData(const Hash *hash, unsigned int *length);
+/**
+  @brief Printable hash representation.
+  @param hash Hash structure.
+  @return A const pointer to the printable digest representation.
+  */
+const unsigned char *HashPrintable(const Hash *hash);
+/**
+  @brief Hash type.
+  @param hash Hash structure
+  @return The hash method used by this hash structure.
+  */
+HashMethod HashType(const Hash *hash);
+/**
+  @brief Hash length in bytes.
+  @param hash Hash structure
+  @return The hash length in bytes.
+  */
+HashSize HashLength(const Hash *hash);
+/**
+  @brief Returns the ID of the hash based on the name
+  @param hash_name Name of the hash.
+  @return Returns the ID of the hash from the name.
+  */
+HashMethod HashIdFromName(const char *hash_name);
+/**
+  @brief Returns the name of the hash based on the ID.
+  @param hash_id Id of the hash.
+  @return Returns the name of the hash.
+  */
+const char *HashNameFromId(HashMethod hash_id);
+/**
+  @brief Size of the hash
+  @param method Hash method
+  @return Returns the size of the hash or 0 in case of error.
+  */
+HashSize HashSizeFromId(HashMethod hash_id);
+
+#endif // HASH_H

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -88,7 +88,10 @@ check_PROGRAMS = \
 	mon_processes_test \
 	mustache_test \
 	class_test \
-	version_test
+	tls_generic_test \
+	version_test \
+	hash_test \
+	key_test
 
 if HAVE_AVAHI_CLIENT
 if HAVE_AVAHI_COMMON
@@ -275,3 +278,6 @@ endif
 
 version_test_SOURCES = version_test.c
 
+hash_test_SOURCES = hash_test.c ../../libutils/libutils.la
+
+key_test_SOURCES = key_test.c ../../libutils/libutils.la

--- a/tests/unit/hash_test.c
+++ b/tests/unit/hash_test.c
@@ -1,0 +1,230 @@
+#include <test.h>
+#include <unistd.h>
+#include <string.h>
+#include <hash.h>
+#include <openssl/rsa.h>
+ #include <openssl/evp.h>
+
+/*
+ * To test the hash implementation we need three things:
+ * - A string
+ * - A file
+ * - A RSA key
+ * We run one test for each, using two algorithms, MD5 and SHA256.
+ */
+static int initialized = 0;
+static char message[] = "This is a message";
+static int message_length = 0;
+static char file[] = "/tmp/hashXXXXXX";
+static int fd = -1;
+static RSA *rsa = NULL;
+void tests_setup()
+{
+    int result = 0;
+    fd = mkstemp(file);
+    if (fd < 0)
+    {
+        initialized = 0;
+        return;
+    }
+    message_length = strlen(message);
+    result = write(fd, message, message_length);
+    if (result < 0)
+    {
+        close (fd);
+        unlink (file);
+        initialized = 0;
+        return;
+    }
+    rsa = RSA_new();
+    if (rsa)
+    {
+        BIGNUM *bn = NULL;
+        bn = BN_new();
+        if (!bn)
+        {
+            close (fd);
+            unlink (file);
+            RSA_free(rsa);
+            initialized = 0;
+            return;
+        }
+        BN_set_word(bn, 3);
+        RSA_generate_key_ex(rsa, 1024, bn, NULL);
+        BN_free(bn);
+    }
+    OpenSSL_add_all_digests();
+    initialized = 1;
+}
+
+void tests_teardown()
+{
+    if (fd >= 0)
+    {
+        close (fd);
+        unlink (file);
+    }
+    if (rsa)
+    {
+        RSA_free(rsa);
+    }
+    initialized = 0;
+}
+#define ASSERT_IF_NOT_INITIALIZED \
+    assert_int_equal(1, initialized)
+/*
+ * Tests
+ * Each test does the same but from different sources, this is:
+ * 1. Create a new hash structure using MD5
+ * 2. Check the length of the generated hash.
+ * 3. Check the printable version (check that is not NULL).
+ * 4. Destroy the hash structure.
+ * 5. Create a new hash structure using SHA256.
+ * 6. Check the length of the generated hash.
+ * 7. Check the printable version (check that is not NULL).
+ * 8. Destroy the hash structure.
+ */
+static void test_HashString(void)
+{
+    ASSERT_IF_NOT_INITIALIZED;
+    Hash *hash = NULL;
+    unsigned int length = 0;
+    assert_true(hash == NULL);
+    hash = HashNew(message, message_length, HASH_METHOD_MD5);
+    assert_true(hash != NULL);
+    assert_int_equal(HASH_METHOD_MD5, HashType(hash));
+    assert_int_equal(CF_MD5_LEN, HashLength(hash));
+    assert_true(HashData(hash, &length) != NULL);
+    assert_int_equal(length, CF_MD5_LEN);
+    assert_true(HashPrintable(hash) != NULL);
+    const char *md5_hash = HashPrintable(hash);
+    assert_true((md5_hash[0] == 'M') && (md5_hash[1] == 'D') && (md5_hash[2] == '5') && (md5_hash[3] == '='));
+    HashDestroy(&hash);
+    assert_true(hash == NULL);
+    hash = HashNew(message, message_length, HASH_METHOD_SHA256);
+    assert_true(hash != NULL);
+    assert_int_equal(HASH_METHOD_SHA256, HashType(hash));
+    assert_int_equal(CF_SHA256_LEN, HashLength(hash));
+    assert_true(HashData(hash, &length) != NULL);
+    assert_int_equal(length, CF_SHA256_LEN);
+    assert_true(HashPrintable(hash) != NULL);
+    const char *sha256_hash = HashPrintable(hash);
+    assert_true((sha256_hash[0] == 'S') && (sha256_hash[1] == 'H') && (sha256_hash[2] == 'A') && (sha256_hash[3] == '='));
+    HashDestroy(&hash);
+    /* Negative cases */
+    assert_true(HashNew(NULL, message_length, HASH_METHOD_MD5) == NULL);
+    assert_true(HashNew(message, 0, HASH_METHOD_MD5) == NULL);
+    assert_true(HashNew(message, message_length, HASH_METHOD_NONE) == NULL);
+    assert_true(HashNew(message, 0, HASH_METHOD_NONE) == NULL);
+    assert_true(HashNew(NULL, message_length, HASH_METHOD_NONE) == NULL);
+}
+
+static void test_HashDescriptor(void)
+{
+    ASSERT_IF_NOT_INITIALIZED;
+    Hash *hash = NULL;
+    unsigned int length = 0;
+    assert_true(hash == NULL);
+    hash = HashNewFromDescriptor(fd, HASH_METHOD_MD5);
+    assert_true(hash != NULL);
+    assert_int_equal(HASH_METHOD_MD5, HashType(hash));
+    assert_int_equal(CF_MD5_LEN, HashLength(hash));
+    assert_true(HashData(hash, &length) != NULL);
+    assert_int_equal(length, CF_MD5_LEN);
+    assert_true(HashPrintable(hash) != NULL);
+    HashDestroy(&hash);
+    assert_true(hash == NULL);
+    hash = HashNewFromDescriptor(fd, HASH_METHOD_SHA256);
+    assert_true(hash != NULL);
+    assert_int_equal(HASH_METHOD_SHA256, HashType(hash));
+    assert_int_equal(CF_SHA256_LEN, HashLength(hash));
+    assert_true(HashData(hash, &length) != NULL);
+    assert_int_equal(length, CF_SHA256_LEN);
+    assert_true(HashPrintable(hash) != NULL);
+    HashDestroy(&hash);
+    /* Negative cases */
+    assert_true(HashNewFromDescriptor(-1, HASH_METHOD_MD5) == NULL);
+    assert_true(HashNewFromDescriptor(fd, HASH_METHOD_NONE) == NULL);
+    assert_true(HashNewFromDescriptor(-1, HASH_METHOD_NONE) == NULL);
+}
+
+static void test_HashKey(void)
+{
+    ASSERT_IF_NOT_INITIALIZED;
+    Hash *hash = NULL;
+    unsigned int length = 0;
+    assert_true(hash == NULL);
+    hash = HashNewFromKey(rsa, HASH_METHOD_MD5);
+    assert_true(hash != NULL);
+    assert_int_equal(HASH_METHOD_MD5, HashType(hash));
+    assert_int_equal(CF_MD5_LEN, HashLength(hash));
+    assert_true(HashData(hash, &length) != NULL);
+    assert_int_equal(length, CF_MD5_LEN);
+    assert_true(HashPrintable(hash) != NULL);
+    HashDestroy(&hash);
+    assert_true(hash == NULL);
+    hash = HashNewFromKey(rsa, HASH_METHOD_SHA256);
+    assert_true(hash != NULL);
+    assert_int_equal(HASH_METHOD_SHA256, HashType(hash));
+    assert_int_equal(CF_SHA256_LEN, HashLength(hash));
+    assert_true(HashData(hash, &length) != NULL);
+    assert_int_equal(length, CF_SHA256_LEN);
+    assert_true(HashPrintable(hash) != NULL);
+    HashDestroy(&hash);
+    /* Negative cases */
+    assert_true(HashNewFromKey(NULL, HASH_METHOD_MD5) == NULL);
+    assert_true(HashNewFromKey(rsa, HASH_METHOD_NONE) == NULL);
+    assert_true(HashNewFromKey(NULL, HASH_METHOD_NONE) == NULL);
+}
+
+static void test_HashCopy(void)
+{
+    ASSERT_IF_NOT_INITIALIZED;
+    Hash *hash = NULL;
+    Hash *copy = NULL;
+    unsigned int length = 0;
+    assert_true(hash == NULL);
+    hash = HashNew(message, message_length, HASH_METHOD_MD5);
+    assert_true(hash != NULL);
+    assert_int_equal(HASH_METHOD_MD5, HashType(hash));
+    assert_int_equal(CF_MD5_LEN, HashLength(hash));
+    assert_true(HashData(hash, &length) != NULL);
+    assert_int_equal(length, CF_MD5_LEN);
+    assert_true(HashPrintable(hash) != NULL);
+    assert_int_equal(0, HashCopy(hash, &copy));
+    assert_int_equal(HASH_METHOD_MD5, HashType(copy));
+    assert_int_equal(CF_MD5_LEN, HashLength(copy));
+    assert_true(HashData(copy, &length) != NULL);
+    assert_int_equal(length, CF_MD5_LEN);
+    assert_true(HashPrintable(copy) != NULL);
+    assert_string_equal(HashPrintable(hash), HashPrintable(copy));
+    HashDestroy(&copy);
+    assert_true(copy == NULL);
+    /* Negative cases */
+    assert_int_equal(-1, HashCopy(NULL, &copy));
+    assert_int_equal(-1, HashCopy(hash, NULL));
+    assert_int_equal(-1, HashCopy(NULL, NULL));
+    /* Finish */
+    HashDestroy(&hash);
+    assert_true(hash == NULL);
+}
+
+/*
+ * Main routine
+ * Notice the calls to both setup and teardown.
+ */
+int main()
+{
+    PRINT_TEST_BANNER();
+    tests_setup();
+    const UnitTest tests[] =
+    {
+        unit_test(test_HashString),
+        unit_test(test_HashDescriptor),
+        unit_test(test_HashKey)
+    };
+    int result = run_tests(tests);
+    tests_teardown();
+    return result;
+}
+

--- a/tests/unit/key_test.c
+++ b/tests/unit/key_test.c
@@ -1,0 +1,102 @@
+#include <test.h>
+#include <unistd.h>
+#include <string.h>
+#include <key.h>
+#include <openssl/rsa.h>
+#include <openssl/evp.h>
+
+/*
+ * Initialization
+ */
+static int initialized = 0;
+static RSA *rsa = NULL;
+void test_setup()
+{
+    rsa = RSA_new();
+    if (rsa)
+    {
+        BIGNUM *bn = NULL;
+        bn = BN_new();
+        if (!bn)
+        {
+            RSA_free(rsa);
+            initialized = 0;
+            return;
+        }
+        BN_set_word(bn, 3);
+        RSA_generate_key_ex(rsa, 1024, bn, NULL);
+        BN_free(bn);
+    }
+    initialized = 1;
+}
+
+void test_teardown()
+{
+    rsa = NULL;
+    initialized = 0;
+}
+#define ASSERT_IF_NOT_INITIALIZED \
+    assert_int_equal(1, initialized)
+/*
+ * Tests
+ */
+static void test_key_basic(void)
+{
+    test_setup();
+    ASSERT_IF_NOT_INITIALIZED;
+    Key *key = NULL;
+    assert_true(key == NULL);
+    key = KeyNew(rsa, HASH_METHOD_MD5);
+    assert_true(key != NULL);
+    assert_int_equal(HASH_METHOD_MD5, KeyHashMethod(key));
+    assert_true(rsa == KeyRSA(key));
+    unsigned int length = 0;
+    assert_true(KeyBinaryHash(key, &length) != NULL);
+    assert_int_equal(CF_MD5_LEN, length);
+    assert_true(KeyPrintableHash(key) != NULL);
+    /* Negative cases */
+    assert_true(NULL == KeyNew(NULL, HASH_METHOD_MD5));
+    assert_true(NULL == KeyNew(rsa, HASH_METHOD_NONE));
+    assert_true(NULL == KeyNew(NULL, HASH_METHOD_NONE));
+    /* Finish */
+    KeyDestroy(&key);
+    assert_true(key == NULL);
+    test_teardown();
+}
+
+static void test_key_hash(void)
+{
+    test_setup();
+    ASSERT_IF_NOT_INITIALIZED;
+    Key *key = NULL;
+    assert_true(key == NULL);
+    key = KeyNew(rsa, HASH_METHOD_MD5);
+    assert_true(key != NULL);
+    assert_int_equal(HASH_METHOD_MD5, KeyHashMethod(key));
+    /* We now examine the first four bytes of the hash, to check the printable bit */
+    const char *md5_hash = KeyPrintableHash(key);
+    assert_true((md5_hash[0] == 'M') && (md5_hash[1] == 'D') && (md5_hash[2] == '5') && (md5_hash[3] == '='));
+    /* When we change the hashing algorithm, a new hash is automatically generated. */
+    assert_int_equal(0, KeySetHashMethod(key, HASH_METHOD_SHA256));
+    const char *sha256_hash = KeyPrintableHash(key);
+    assert_true((sha256_hash[0] == 'S') && (sha256_hash[1] == 'H') && (sha256_hash[2] == 'A') && (sha256_hash[3] == '='));
+    KeyDestroy(&key);
+    test_teardown();
+}
+
+/*
+ * Main routine
+ * Notice the calls to both setup and teardown.
+ */
+int main()
+{
+    PRINT_TEST_BANNER();
+    const UnitTest tests[] =
+    {
+        unit_test(test_key_basic),
+        unit_test(test_key_hash)
+    };
+    OpenSSL_add_all_digests();
+    int result = run_tests(tests);
+    return result;
+}

--- a/tests/unit/redirection_test.c
+++ b/tests/unit/redirection_test.c
@@ -1,0 +1,83 @@
+#include <test.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <wait.h>
+
+/*
+ * This test checks for different types of IPC to check that redirection of
+ * STDIN will work.
+ * This test is only significant in Linux, because this is only used by the
+ * hub process that only runs on Linux.
+ */
+static char redirection[] = "/tmp/redirectionXXXXXX";
+static char *path = NULL;
+static char *message = "This is the message to be written by our helper";
+static char message_back[128];
+static void test_fd_redirection(void)
+{
+    assert_true(path != NULL);
+    /*
+     * Create a file for writing, then start a new process and wait for it
+     * to write to the file.
+     * Check the contents of the file.
+     */
+    int fd = -1;
+    fd = mkstemp(redirection);
+    assert_int_not_equal(-1, fd);
+    /* Start the new process */
+    int pid = 0;
+    pid = fork();
+    assert_int_not_equal(-1, pid);
+    if (pid == 0)
+    {
+        /* Child */
+        dup2(fd, STDIN_FILENO);
+        char *argv[] = { path, message, NULL };
+        char *envp[] = { NULL };
+        execve(path, argv, envp);
+        exit(-1);
+    }
+    else
+    {
+        /* Parent */
+        int status = 0;
+        int options = 0;
+        /* Wait for the child to be done */
+        assert_int_equal(waitpid(pid, &status, options), pid);
+        /* Did it exit correctly? */
+        assert_true(WIFEXITED(status));
+        assert_int_equal(WEXITSTATUS(status), 0);
+        /* Rewind the file so we can check the message */
+        lseek(fd, 0, SEEK_SET);
+        /* Read back the message */
+        assert_int_equal(strlen(message), read(fd, message_back, strlen(message)));
+        /* Compare it */
+        assert_string_equal(message, message_back);
+    }
+    close (fd);
+}
+
+void tests_teardown()
+{
+    unlink (redirection);
+}
+
+int main(int argc, char **argv)
+{
+    PRINT_TEST_BANNER();
+    /* Find the proper path for our helper */
+    char *base = dirname(argv[0]);
+    char helper = "/redirection_test_stub";
+    sprintf(path, "%s%s", base, helper);
+    const UnitTest tests[] =
+    {
+        unit_test(test_fd_redirection)
+    };
+    tests_teardown();
+    return run_tests(tests);
+}
+

--- a/tests/unit/redirection_test_stub.c
+++ b/tests/unit/redirection_test_stub.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+
+int main(int argc, char **argv)
+{
+    if (argc < 2)
+        return -1;
+    char *text = argv[1];
+    int output = STDIN_FILENO;
+    int result = 0;
+    result = write(output, text, strlen(text));
+    if (result < 0)
+        return -1;
+    fsync(output);
+    return 0;
+}


### PR DESCRIPTION
Currently we were copying code from cf-hub into cf-serverd to do the
query. This led to some problems regarding both synchronization and
code understandability.
The new approach is to share the connection received by cf-serverd with
cf-hub and let cf-hub add the connection to its internal queue. That way
cf-hub will take ownership of the connection and query the agent at its own
convenience.
