### PR TITLE
Fix assert setting sys variables for interfaces when none are detected

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -543,10 +543,22 @@ void GetInterfacesInfo(EvalContext *ctx)
 
     close(fd);
 
-    EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "interfaces", interfaces, DATA_TYPE_STRING_LIST);
-    EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "hardware_addresses", hardware, DATA_TYPE_STRING_LIST);
-    EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "hardware_flags", flags, DATA_TYPE_STRING_LIST);
-    EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "ip_addresses", ips, DATA_TYPE_STRING_LIST);
+    if (interfaces)
+    {
+      EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "interfaces", interfaces, DATA_TYPE_STRING_LIST);
+    }
+    if (hardware)
+    {
+      EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "hardware_addresses", hardware, DATA_TYPE_STRING_LIST);
+    }
+    if (flags)
+    {
+      EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "hardware_flags", flags, DATA_TYPE_STRING_LIST);
+    }
+    if (ips)
+    {
+      EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "ip_addresses", ips, DATA_TYPE_STRING_LIST);
+    }
 
     RlistDestroy(interfaces);
     RlistDestroy(hardware);


### PR DESCRIPTION
I came across this bug when I added _all_ my interfaces (except lo) to /var/cfengine/inputs/ignore_interfaces.rx. What happened is simple, running the agent output this:

```
cf-agent: env_context.c:1425: EvalContextVariablePut: Assertion `value' failed.
```

A bit of digging showed that the functions to put variables `assert` that variable values are not empty, but the interface detection loop doesn't worry if it didn't find any interfaces to add. A few ifs fix that.

Please let me know if this is not a suitable approach (so many ifs look ugly to me, but hey...), and I can work on another way round.
