### PR TITLE
3.5.x (RM #3472): Fix compilation on Solaris 11.

### DIFF
--- a/libpromises/Makefile.am
+++ b/libpromises/Makefile.am
@@ -101,7 +101,8 @@ libpromises_la_SOURCES = \
         verify_classes.c verify_classes.h \
         verify_reports.c \
         verify_vars.c verify_vars.h \
-        rpl_utsname.c rpl_utsname.h
+        rpl_utsname.c rpl_utsname.h \
+        zones.c zones.h
 
 if !HAVE_NOVA
 libpromises_la_SOURCES += \

--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -35,9 +35,7 @@
 #include "rlist.h"
 #include "policy.h"
 
-#ifdef HAVE_ZONE_H
-# include <zone.h>
-#endif
+#include "zones.h"
 
 static int SelectProcRangeMatch(char *name1, char *name2, int min, int max, char **names, char **line);
 static int SelectProcRegexMatch(char *name1, char *name2, char *regex, char **colNames, char **line);
@@ -645,20 +643,13 @@ static void GetProcessColumnNames(char *proc, char **names, int *start, int *end
 #ifndef __MINGW32__
 static const char *GetProcessOptions(void)
 {
-# ifdef HAVE_GETZONEID
-    zoneid_t zid;
-    char zone[ZONENAME_MAX];
     static char psopts[CF_BUFSIZE];
 
-    zid = getzoneid();
-    getzonenamebyid(zid, zone, ZONENAME_MAX);
-
-    if (strcmp(zone, "global") == 0)
+    if (IsGlobalZone())
     {
         snprintf(psopts, CF_BUFSIZE, "%s,zone", VPSOPTS[VSYSTEMHARDCLASS]);
         return psopts;
     }
-# endif
 
 # ifdef __linux__
     if (strncmp(VSYSNAME.release, "2.4", 3) == 0)
@@ -717,46 +708,6 @@ static int ExtractPid(char *psentry, char **names, int *end)
 
     return pid;
 }
-
-#ifndef __MINGW32__
-static int ForeignZone(char *s)
-{
-// We want to keep the banner
-
-    if (strstr(s, "%CPU"))
-    {
-        return false;
-    }
-
-# ifdef HAVE_GETZONEID
-    zoneid_t zid;
-    char *sp, zone[ZONENAME_MAX];
-
-    zid = getzoneid();
-    getzonenamebyid(zid, zone, ZONENAME_MAX);
-
-    if (strcmp(zone, "global") == 0)
-    {
-        if (strcmp(s + strlen(s) - 6, "global") == 0)
-        {
-            *(s + strlen(s) - 6) = '\0';
-
-            for (sp = s + strlen(s) - 1; isspace(*sp); sp--)
-            {
-                *sp = '\0';
-            }
-
-            return false;
-        }
-        else
-        {
-            return true;
-        }
-    }
-# endif
-    return false;
-}
-#endif
 
 #ifndef __MINGW32__
 int LoadProcessTable(Item **procdata)

--- a/libpromises/zones.c
+++ b/libpromises/zones.c
@@ -1,0 +1,89 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <zones.h>
+
+#ifdef HAVE_ZONE_H
+# include <zone.h>
+#endif
+
+#ifndef __MINGW32__
+
+bool IsGlobalZone()
+{
+#ifdef HAVE_GETZONEID
+    zoneid_t zid;
+    char zone[ZONENAME_MAX];
+
+    zid = getzoneid();
+    getzonenamebyid(zid, zone, ZONENAME_MAX);
+
+    if (strcmp(zone, "global") == 0)
+    {
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+bool ForeignZone(char *s)
+{
+// We want to keep the banner
+
+    if (strstr(s, "%CPU"))
+    {
+        return false;
+    }
+
+# ifdef HAVE_GETZONEID
+    zoneid_t zid;
+    char *sp, zone[ZONENAME_MAX];
+
+    zid = getzoneid();
+    getzonenamebyid(zid, zone, ZONENAME_MAX);
+
+    if (strcmp(zone, "global") == 0)
+    {
+        if (strcmp(s + strlen(s) - 6, "global") == 0)
+        {
+            *(s + strlen(s) - 6) = '\0';
+
+            for (sp = s + strlen(s) - 1; isspace(*sp); sp--)
+            {
+                *sp = '\0';
+            }
+
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+# endif
+    return false;
+}
+
+#endif // !__MINGW32__

--- a/libpromises/zones.h
+++ b/libpromises/zones.h
@@ -1,0 +1,35 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commerical Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#ifndef ZONES_H
+#define ZONES_H
+
+#include <bool.h>
+
+#ifndef __MINGW32__
+bool IsGlobalZone();
+bool ForeignZone(char *s);
+#endif
+
+#endif // ZONES_H


### PR DESCRIPTION
The DATA_TYPE_STRING enum value is defined in their zone.h file, but
we also use it in evaluation code, so compile these functions in a
separate file that doesn't include cf3.defs.h.

Fixes issue #3472.

Back-port of 5e24267e7d045ab7cf70b17dd3f927667d90476c for 3.5.3.
Conflicts resolved in:
    libpromises/Makefile.am
    libpromises/processes_select.c
