### PR TITLE
Noop files promises mean check existence

### DIFF
--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1625,6 +1625,12 @@ typedef struct
     StorageMount mount;
     StorageVolume volume;
 
+    /* TODO: All "action" flags need to go inside one big int, each action
+     * signified with a bitflag. E.g. for files promise type it could be
+     * FILES_ACTION_CREATE, FILES_ACTION_RENAME etc. That way it would be easy
+     * to test if any action is set, and it would be better defined what
+     * consists an "action". */
+
     int havedepthsearch;
     int haveselect;
     int haverename;

--- a/tests/acceptance/10_files/13_fileexists/001.cf
+++ b/tests/acceptance/10_files/13_fileexists/001.cf
@@ -1,0 +1,85 @@
+###########################################################################
+#
+# Test that an empty files promise,
+# verifies that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/empty_file"
+      classes => if_kept("found_means_kept");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+    found_means_kept::
+      "$(this.promise_filename) Pass";
+    !found_means_kept::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/002.cf
+++ b/tests/acceptance/10_files/13_fileexists/002.cf
@@ -1,0 +1,85 @@
+###########################################################################
+#
+# Test that an empty files promise,
+# verifies that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/empty_file"
+      classes => if_repaired("found_means_repaired");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+   !found_means_repaired::
+      "$(this.promise_filename) Pass";
+   found_means_repaired::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/003.cf
+++ b/tests/acceptance/10_files/13_fileexists/003.cf
@@ -1,0 +1,85 @@
+###########################################################################
+#
+# Test that an empty files promise,
+# verifies that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/empty_file"
+      classes => if_repair_failed("found_means_failed");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+   !found_means_failed::
+      "$(this.promise_filename) Pass";
+   found_means_failed::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/004.cf
+++ b/tests/acceptance/10_files/13_fileexists/004.cf
@@ -1,0 +1,85 @@
+###########################################################################
+#
+# Test that an empty files promise,
+# verifies that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/inexistent_file"
+      classes => if_kept("notfound_means_kept");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+    !notfound_means_kept::
+      "$(this.promise_filename) Pass";
+    notfound_means_kept::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/005.cf
+++ b/tests/acceptance/10_files/13_fileexists/005.cf
@@ -1,0 +1,85 @@
+###########################################################################
+#
+# Test that an empty files promise,
+# verifies that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/inexistent_file"
+      classes => if_repaired("notfound_means_repaired");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+    !notfound_means_repaired::
+      "$(this.promise_filename) Pass";
+    notfound_means_repaired::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/006.cf
+++ b/tests/acceptance/10_files/13_fileexists/006.cf
@@ -1,0 +1,85 @@
+###########################################################################
+#
+# Test that an empty files promise,
+# verifies that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/inexistent_file"
+      classes => if_repair_failed("notfound_means_failed");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+    notfound_means_failed::
+      "$(this.promise_filename) Pass";
+    !notfound_means_failed::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/007.cf
+++ b/tests/acceptance/10_files/13_fileexists/007.cf
@@ -1,0 +1,86 @@
+###########################################################################
+#
+# Test that a files promise consisting only of body_select, verifies
+# that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/empty_file"
+      file_select => only_empty,
+      classes => if_kept("found_means_kept");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+    found_means_kept::
+      "$(this.promise_filename) Pass";
+    !found_means_kept::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/008.cf
+++ b/tests/acceptance/10_files/13_fileexists/008.cf
@@ -1,0 +1,86 @@
+###########################################################################
+#
+# Test that a files promise consisting only of body_select, verifies
+# that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/empty_file"
+      file_select => only_empty,
+      classes => if_repaired("found_means_repaired");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+   !found_means_repaired::
+      "$(this.promise_filename) Pass";
+   found_means_repaired::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/009.cf
+++ b/tests/acceptance/10_files/13_fileexists/009.cf
@@ -1,0 +1,86 @@
+###########################################################################
+#
+# Test that a files promise consisting only of body_select, verifies
+# that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/empty_file"
+      file_select => only_empty,
+      classes => if_repair_failed("found_means_failed");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+   !found_means_failed::
+      "$(this.promise_filename) Pass";
+   found_means_failed::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/010.cf
+++ b/tests/acceptance/10_files/13_fileexists/010.cf
@@ -1,0 +1,86 @@
+###########################################################################
+#
+# Test that a files promise consisting only of body_select, verifies
+# that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/full_file"
+      file_select => only_empty,
+      classes => if_kept("notfound_means_kept");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+    !notfound_means_kept::
+      "$(this.promise_filename) Pass";
+    notfound_means_kept::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/011.cf
+++ b/tests/acceptance/10_files/13_fileexists/011.cf
@@ -1,0 +1,86 @@
+###########################################################################
+#
+# Test that a files promise consisting only of body_select, verifies
+# that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/full_file"
+      file_select => only_empty,
+      classes => if_repaired("notfound_means_repaired");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+    !notfound_means_repaired::
+      "$(this.promise_filename) Pass";
+    notfound_means_repaired::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/13_fileexists/012.cf
+++ b/tests/acceptance/10_files/13_fileexists/012.cf
@@ -1,0 +1,86 @@
+###########################################################################
+#
+# Test that a files promise consisting only of body_select, verifies
+# that a file exists, without changing anything if it does not.
+#
+# file exists => promise kept, not repaired, not failed
+#
+# file does not exist => promise failed, not kept, not repaired
+#
+###########################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+body edit_defaults empty
+{
+  empty_file_before_editing => "true";
+  edit_backup => "false";
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+bundle agent init
+{
+files:
+
+  "$(G.testdir)/empty_file"
+       create => "true";
+
+  "$(G.testdir)/full_file"
+       create => "true",
+edit_defaults => empty,
+    edit_line => init_insert("$(body)");
+}
+
+#######################################################
+
+body file_select only_empty
+{
+  search_size => irange("0", "0");
+  file_result => "size";
+}
+
+body classes if_kept(x)
+{
+  promise_kept => { "$(x)" };
+}
+
+body classes if_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+}
+
+body classes if_repair_failed(x)
+{
+  repair_failed => { "$(x)" };
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/full_file"
+      file_select => only_empty,
+      classes => if_repair_failed("notfound_means_failed");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+    notfound_means_failed::
+      "$(this.promise_filename) Pass";
+    !notfound_means_failed::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
This consists of only one commit (the last one, a357da8). It's supposed to be merged after pull #1145 so ignore the rest.

Had to implement this after ranting so much on the mailing list. Check the acceptance tests commited to see what I mean by "empty files promises".

It's an RFC so please flame as much as you like.
