### PR TITLE
Queue implementation

### DIFF
--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -35,7 +35,8 @@ libutils_la_SOURCES = \
 	mustache.c mustache.h \
 	cfversion.c cfversion.h \
 	unicode.c unicode.h \
-    hash.c hash.h
+    hash.c hash.h \
+    queue.c queue.h
 
 CLEANFILES = *.gcno *.gcda
 

--- a/libutils/queue.c
+++ b/libutils/queue.c
@@ -1,0 +1,284 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <alloc.h>
+#include <queue.h>
+#include <refcount.h>
+
+struct QueueNode {
+    void *data;                 /*!< Pointer to the stored element */
+    struct QueueNode *next;     /*!< Next element in the queue or NULL */
+    struct QueueNode *previous; /*!< Pointer to the previous element or NULL */
+};
+
+struct Queue {
+    int node_count;      /*!< Number of elements in the queue */
+    RefCount *ref_count; /*!< Refcount element to simplify copying */
+    void (*copy)(const void *source, void **destination); /*!< Copies one element */
+    void (*destroy)(void *element); /*!< Destroys an element */
+    struct QueueNode *queue; /*!< Queue of elements */
+    struct QueueNode *head; /*!< Pointer to the start of the queue */
+    struct QueueNode *tail; /*!< Pointer to the end of the queue */
+};
+
+/*
+ * Detaches a queue of its data. In order to do this, it first creates a copy
+ * of the data and then detaches from the reference count.
+ * After it creates a new reference count and attaches to it.
+ */
+static int QueueDetach(Queue *queue)
+{
+    /* We cannot detach without a copy function */
+    if (!queue || !queue->copy)
+    {
+        return -1;
+    }
+
+    struct QueueNode *copy_start = NULL;
+    struct QueueNode *copy_current = NULL;
+    struct QueueNode *next = queue->queue;
+    struct QueueNode *current = NULL;
+
+    do {
+        current = next;
+        next = current->next;
+
+        struct QueueNode *p = xcalloc(1, sizeof(struct QueueNode));
+        queue->copy(current->data, &p->data);
+
+        if (NULL == copy_start)
+        {
+            copy_start = p;
+            copy_current = copy_start;
+        }
+        else
+        {
+            copy_current->next = p;
+            p->previous = copy_current;
+            copy_current = p;
+        }
+    } while (next != NULL);
+    /* Now it is time to detach and use the new queue instead of the old one. */
+    RefCountDetach(queue->ref_count, queue);
+    RefCountNew(&queue->ref_count);
+    RefCountAttach(queue->ref_count, queue);
+    queue->queue = copy_start;
+    queue->head = copy_start;
+    queue->tail = copy_current;
+    return 0;
+}
+
+/*
+ * This method is only used when copying a structure, therefore we only need
+ * to check the original structure since the copy will be overwritten anyways.
+ * This method only makes sure that the copy is pointing to the original data
+ * and that it attaches to the right RefCount structure.
+ */
+static int QueueAttach(Queue *original, Queue *copy)
+{
+    /* We avoid attaching if no copy function is found, otherwise we will not be able to detach */
+    if (!original || !copy || !original->copy)
+    {
+        return -1;
+    }
+    copy->ref_count = original->ref_count;
+    copy->queue = original->queue;
+    copy->head = original->head;
+    copy->tail = original->tail;
+    copy->node_count = original->node_count;
+    RefCountAttach(original->ref_count, copy);
+    return 0;
+}
+
+Queue *QueueNew(void (*copy)(const void *source, void **destination), void (*destroy)(void *))
+{
+    if (!copy)
+    {
+        return NULL;
+    }
+    Queue *queue = xcalloc(1, sizeof(Queue));
+    queue->copy = copy;
+    queue->destroy = destroy;
+    RefCountNew(&queue->ref_count);
+    RefCountAttach(queue->ref_count, queue);
+    return queue;
+}
+
+void QueueDestroy(Queue **queue)
+{
+    if (!queue || !*queue)
+    {
+        return;
+    }
+    /* If queue is shared, the just detach */
+    if (RefCountIsShared((*queue)->ref_count))
+    {
+        /* Shared, we detach and move on */
+        RefCountDetach((*queue)->ref_count, (*queue));
+    }
+    else
+    {
+        /* We need to destroy the queue */
+        struct QueueNode *current = (*queue)->queue;
+        while (current)
+        {
+            struct QueueNode *next = current->next;
+            if ((*queue)->destroy)
+            {
+                (*queue)->destroy(current->data);
+            }
+            else
+            {
+                free(current->data);
+            }
+            free(current);
+            current = next;
+        }
+    }
+    /* Destroy the container */
+    free(*queue);
+    *queue = NULL;
+}
+
+int QueueCopy(Queue *origin, Queue **destination)
+{
+    if (!origin || !destination)
+    {
+        return -1;
+    }
+    *destination = xcalloc(1, sizeof(Queue));
+    (*destination)->copy = origin->copy;
+    (*destination)->destroy = origin->destroy;
+    if (origin->node_count > 0)
+    {
+        /* Attach it to our data */
+        if (QueueAttach(origin, *destination) < 0)
+        {
+            free(*destination);
+            *destination = NULL;
+            return -1;
+        }
+    }
+    else
+    {
+        /* This is equivalent to creating a new queue */
+        RefCountNew(&(*destination)->ref_count);
+        RefCountAttach((*destination)->ref_count, (*destination));
+    }
+    return 0;
+}
+
+int QueueEnqueue(Queue *queue, void *element)
+{
+    if (!queue || !element)
+    {
+        return -1;
+    }
+    struct QueueNode *node = xcalloc(1, sizeof(struct QueueNode));
+    node->data = element;
+    /* Check if shared, if so detach first */
+    if (RefCountIsShared(queue->ref_count))
+    {
+        if (QueueDetach(queue) < 0)
+        {
+            return -1;
+        }
+    }
+    /* Now adjust the queue */
+    if (queue->tail)
+    {
+        queue->tail->next = node;
+        node->previous = queue->tail;
+        queue->tail = node;
+    }
+    else
+    {
+        /* first element */
+        queue->queue = node;
+        queue->tail = node;
+        queue->head = node;
+    }
+    ++queue->node_count;
+    return 0;
+}
+
+void *QueueDequeue(Queue *queue)
+{
+    if (!queue || (queue->node_count < 1))
+    {
+        return NULL;
+    }
+    /* Check if shared, if so detach first */
+    if (RefCountIsShared(queue->ref_count))
+    {
+        if (QueueDetach(queue) < 0)
+        {
+            return NULL;
+        }
+    }
+    /* Fix the list pointers and counters */
+    struct QueueNode *node = queue->head;
+    void *data = node->data;
+    queue->queue = node->next;
+    queue->head = node->next;
+    if (queue->head)
+    {
+        queue->head->previous = NULL;
+    }
+    else
+    {
+        /* Empty queue */
+        queue->head = NULL;
+        queue->tail = NULL;
+        queue->queue = NULL;
+    }
+    --queue->node_count;
+    /* Free the node */
+    free(node);
+    /* Return the data */
+    return data;
+}
+
+void *QueueHead(Queue *queue)
+{
+    if (!queue || (queue->node_count < 1))
+    {
+        return NULL;
+    }
+    return queue->head->data;
+}
+
+int QueueCount(const Queue *queue)
+{
+    return queue ? queue->node_count : -1;
+}
+
+bool QueueIsEmpty(const Queue *queue)
+{
+    if (!queue)
+    {
+        return true;
+    }
+    return (queue->node_count == 0) ? true : false;
+}

--- a/libutils/queue.h
+++ b/libutils/queue.h
@@ -1,0 +1,99 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <platform.h>
+
+#ifndef CFENGINE_QUEUE_H
+#define CFENGINE_QUEUE_H
+
+/**
+  @brief Reference counted Queue implementation.
+
+  This queue implementation is reference counted in order to make it easier to
+  copy it. For the reference count implementation to work properly it is needed
+  to pass a copy function.
+  The elements are stored as pointers, therefore it is important not to free the
+  elements after adding them to the queue.
+  When the queue is destroyed, the destroy function will be called for each
+  element in order to free all the memory. If the queue is reference counted,
+  then no elements will be destroyed because the queue will simply detach.
+  Notice that if no destroy function is passed, then free() is called on each
+  pointer, therefore for simple types it is acceptable to set destroy to NULL
+  (as long as elements are allocated on the heap).
+  */
+
+typedef struct Queue Queue;
+
+/**
+  @brief Creates a new Queue.
+  @param copy Function to copy elements.
+  @param destroy Function to destroy elements.
+  @return A fully constructed Queue or NULL in case of problems.
+  */
+Queue *QueueNew(void (*copy)(const void *source, void **destination), void (*destroy)(void *));
+/**
+  @brief Destroys a Queue.
+  @param queue  Queue to be destroyed.
+  */
+void QueueDestroy(Queue **queue);
+/**
+  @brief Copies a queue to a new queue.
+  @param origin Original queue.
+  @param destination Destination queue.
+  @return 0 if successful, -1 in case of error.
+  */
+int QueueCopy(Queue *origin, Queue **destination);
+/**
+  @brief Enqueues an element.
+  @param queue Queue to operate.
+  @param element Element to enqueue.
+  @return 0 if enqueued, -1 in any other case.
+  */
+int QueueEnqueue(Queue *queue, void *element);
+/**
+  @brief Dequeues the first element and returns it.
+  @param queue Queue to operate.
+  @return The first element in the queue.
+  */
+void *QueueDequeue(Queue *queue);
+/**
+  @brief Returns a pointer to the first element in the queue without dequeueing it.
+  @param queue Queue to operate on.
+  @return A pointer to the first element in the queue or NULL in case of error.
+  */
+void *QueueHead(Queue *queue);
+/**
+  @brief Number of elements in the queue.
+  @param queue Queue to operate on.
+  @return The number of elements in the queue or -1 in case of error.
+  */
+int QueueCount(const Queue *queue);
+/**
+  @brief Whether the queue is empty or not.
+  @param queue Queue to operate on.
+  @return True if the queue is empty and false in any other case.
+  */
+bool QueueIsEmpty(const Queue *queue);
+
+#endif // CFENGINE_QUEUE_H

--- a/libutils/refcount.c
+++ b/libutils/refcount.c
@@ -83,14 +83,13 @@ int RefCountDetach(RefCount *ref, void *owner)
     {
         return -1;
     }
-    assert(ref->user_count > 1);
     if (ref->user_count <= 1)
     {
         /*
          * Semantics: If 1 that means that we are the only users, if 0 nobody is using it.
          * In either case we are safe to destroy the refcount.
          */
-        return -1;
+        return 0;
     }
     RefCountNode *p = NULL;
     int found = 0;

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -92,7 +92,8 @@ check_PROGRAMS = \
 	version_test \
 	hash_test \
 	key_test \
-	cf_upgrade_test
+	cf_upgrade_test \
+	queue_test
 
 if HAVE_AVAHI_CLIENT
 if HAVE_AVAHI_COMMON
@@ -298,3 +299,4 @@ $(CFUPGRADE)/command_line.h $(CFUPGRADE)/configuration.c $(CFUPGRADE)/configurat
 $(CFUPGRADE)/process.c $(CFUPGRADE)/process.h $(CFUPGRADE)/update.c $(CFUPGRADE)/update.h
 cf_upgrade_test_CFLAGS = -I$(CFUPGRADE)
 
+queue_test_SOURCES = queue_test.c

--- a/tests/unit/queue_test.c
+++ b/tests/unit/queue_test.c
@@ -1,0 +1,301 @@
+#include <test.h>
+#include <string.h>
+#include <queue.c>
+#include <queue.h>
+
+/*
+ * Helper functions:
+ * copy: Copies an element, in this case strings.
+ * destroy: frees the memory, in this case strings.
+ */
+static void copy(const void *source, void **destination)
+{
+    *destination = xstrdup(source);
+}
+
+static void destroy(void *element)
+{
+    free(element);
+}
+
+/*
+ * String to use on the tests, they need to be strdup'ed otherwise there will be
+ * a segfault caused by this data being on the stack.
+ */
+char first_string[] = "first string";
+char second_string[] = "second string";
+char third_string[] = "third string";
+
+/* Flag to make sure we only run other tests if the basic are in place */
+static bool basic_test_passed = false;
+
+/* This test just checks that the basics are in place, not the functionality */
+static void queue_basic_test(void)
+{
+    Queue *queue = NULL;
+
+    QueueDestroy(&queue);
+    assert_int_equal(-1, QueueCopy(queue, NULL));
+    assert_int_equal(-1, QueueEnqueue(queue, NULL));
+    assert_true(NULL == QueueDequeue(queue));
+    assert_true(NULL == QueueHead(queue));
+    assert_int_equal(-1, QueueCount(queue));
+
+    assert_true(NULL == QueueNew(NULL, NULL));
+    assert_true(NULL == QueueNew(NULL, destroy));
+
+    assert_true(queue == NULL);
+    queue = QueueNew(copy, NULL);
+    assert_true(queue != NULL);
+    assert_int_equal(0, queue->node_count);
+    assert_true(NULL == queue->head);
+    assert_true(NULL == queue->tail);
+    assert_true(NULL == queue->queue);
+    assert_true(NULL != queue->ref_count);
+    assert_true(NULL != queue->copy);
+    assert_true(NULL == queue->destroy);
+    QueueDestroy(&queue);
+    assert_true(queue == NULL);
+
+    queue = QueueNew(copy, destroy);
+    assert_true(queue != NULL);
+    assert_int_equal(0, queue->node_count);
+    assert_true(NULL == queue->head);
+    assert_true(NULL == queue->tail);
+    assert_true(NULL == queue->queue);
+    assert_true(NULL != queue->ref_count);
+    assert_true(NULL != queue->copy);
+    assert_true(NULL != queue->destroy);
+    QueueDestroy(&queue);
+    assert_true(queue == NULL);
+
+    /* Mark as passed so other tests can run */
+    basic_test_passed = true;
+}
+
+static void queue_enqueue_dequeue_test(void)
+{
+    /* If basic tests failed, there is no point in running this */
+    assert_true(basic_test_passed);
+
+    Queue *queue = NULL;
+    char *first = xstrdup(first_string);
+    char *second = xstrdup(second_string);
+    char *third = xstrdup(third_string);
+
+    queue = QueueNew(copy, destroy);
+    assert_true(queue != NULL);
+
+    /* Enqueue some elements */
+    char *head = NULL;
+    assert_int_equal(0, QueueEnqueue(queue, first));
+    assert_int_equal(1, queue->node_count);
+    assert_true(queue->head->data == first);
+    assert_true(queue->tail->data == first);
+    assert_true(queue->queue->data == first);
+    head = QueueHead(queue);
+    assert_true(NULL != head);
+    assert_string_equal(head, first);
+
+    assert_int_equal(0, QueueEnqueue(queue, second));
+    assert_int_equal(2, queue->node_count);
+    assert_true(queue->head->data == first);
+    assert_true(queue->tail->data == second);
+    assert_true(queue->queue->data == first);
+    head = QueueHead(queue);
+    assert_true(NULL != head);
+    assert_string_equal(head, first);
+
+    assert_int_equal(0, QueueEnqueue(queue, third));
+    assert_int_equal(3, queue->node_count);
+    assert_true(queue->head->data == first);
+    assert_true(queue->head->next->data == second);
+    assert_true(queue->tail->previous->data == second);
+    assert_true(queue->tail->data == third);
+    assert_true(queue->queue->data == first);
+    head = QueueHead(queue);
+    assert_true(NULL != head);
+    assert_string_equal(head, first);
+
+    /* Dequeue some elements */
+    char *data = QueueDequeue(queue);
+    assert_true(NULL != data);
+    assert_string_equal(data, first);
+    assert_int_equal(2, queue->node_count);
+    assert_true(queue->head->data == second);
+    assert_true(queue->tail->data == third);
+    assert_true(queue->queue->data == second);
+    head = QueueHead(queue);
+    assert_true(NULL != head);
+    assert_string_equal(head, second);
+
+    data = QueueDequeue(queue);
+    assert_true(NULL != data);
+    assert_string_equal(data, second);
+    assert_int_equal(1, queue->node_count);
+    assert_true(queue->head->data == third);
+    assert_true(queue->tail->data == third);
+    assert_true(queue->queue->data == third);
+    head = QueueHead(queue);
+    assert_true(NULL != head);
+    assert_string_equal(head, third);
+
+    data = QueueDequeue(queue);
+    assert_true(NULL != data);
+    assert_string_equal(data, third);
+    assert_int_equal(0, queue->node_count);
+    assert_true(queue->head == NULL);
+    assert_true(queue->tail == NULL);
+    assert_true(queue->queue == NULL);
+    head = QueueHead(queue);
+    assert_true(NULL == head);
+
+    /* Destroy the empty queue no data should be freed now */
+    QueueDestroy(&queue);
+    assert_true(NULL == queue);
+    assert_true(NULL != first);
+    assert_true(NULL != second);
+    assert_true(NULL != third);
+
+    /* Create a new queue and fill it */
+    queue = QueueNew(copy, destroy);
+    assert_true(queue != NULL);
+    assert_int_equal(0, QueueEnqueue(queue, first));
+    assert_int_equal(0, QueueEnqueue(queue, second));
+    assert_int_equal(0, QueueEnqueue(queue, third));
+    /* Destroy the queue, all data should be freed now */
+    QueueDestroy(&queue);
+    assert_true(NULL == queue);
+}
+
+static void queue_copy_test(void)
+{
+    /* If basic tests failed, there is no point in running this */
+    assert_true(basic_test_passed);
+
+    Queue *queue = NULL;
+    Queue *queue_copy = NULL;
+    char *first = xstrdup(first_string);
+    char *second = xstrdup(second_string);
+    char *third = xstrdup(third_string);
+
+    queue = QueueNew(copy, destroy);
+    assert_true(queue != NULL);
+
+    /* Enqueue one element */
+    assert_int_equal(0, QueueEnqueue(queue, first));
+    assert_int_equal(1, queue->node_count);
+    /* Copy the queue */
+    assert_int_equal(0, QueueCopy(queue, &queue_copy));
+    assert_int_equal(queue->node_count, queue_copy->node_count);
+    assert_int_equal(1, queue_copy->node_count);
+    assert_true(queue->ref_count == queue_copy->ref_count);
+    assert_true(queue->head == queue_copy->head);
+    /* Add one element to the copy, this will detach them */
+    assert_int_equal(0, QueueEnqueue(queue_copy, second));
+    assert_int_equal(1, queue->node_count);
+    assert_int_equal(2, queue_copy->node_count);
+    assert_true(queue->ref_count != queue_copy->ref_count);
+    assert_true(queue->head != queue_copy->head);
+    assert_string_equal(queue->head->data, queue_copy->head->data);
+    /* Add the same element to the original queue */
+    assert_int_equal(0, QueueEnqueue(queue, second));
+    assert_int_equal(2, queue->node_count);
+    assert_int_equal(2, queue_copy->node_count);
+    assert_true(queue->ref_count != queue_copy->ref_count);
+    assert_true(queue->head != queue_copy->head);
+    assert_string_equal(queue->head->data, queue_copy->head->data);
+    assert_string_equal(queue->tail->data, queue_copy->tail->data);
+    /* Destroy the original queue */
+    QueueDestroy(&queue);
+    assert_true(NULL == queue);
+    /* Make the original a copy of the copy */
+    assert_int_equal(0, QueueCopy(queue_copy, &queue));
+    assert_int_equal(queue->node_count, queue_copy->node_count);
+    assert_int_equal(2, queue_copy->node_count);
+    assert_true(queue->ref_count == queue_copy->ref_count);
+    assert_true(queue->head == queue_copy->head);
+    /* Destroy the copy, the copy of the copy shouldn't be affected */
+    QueueDestroy(&queue_copy);
+    assert_true(NULL == queue_copy);
+    assert_int_equal(2, queue->node_count);
+    /* Finally copy again and add one element to the original */
+    assert_int_equal(0, QueueCopy(queue, &queue_copy));
+    assert_int_equal(queue->node_count, queue_copy->node_count);
+    assert_int_equal(2, queue_copy->node_count);
+    assert_true(queue->ref_count == queue_copy->ref_count);
+    assert_true(queue->head == queue_copy->head);
+    /* Add the element */
+    assert_int_equal(0, QueueEnqueue(queue, third));
+    assert_int_equal(3, queue->node_count);
+    assert_int_equal(2, queue_copy->node_count);
+    assert_true(queue->ref_count != queue_copy->ref_count);
+    assert_true(queue->head != queue_copy->head);
+    assert_string_equal(queue->head->data, queue_copy->head->data);
+    /* Destroy both queues */
+    QueueDestroy(&queue);
+    assert_true(NULL == queue);
+    QueueDestroy(&queue_copy);
+    assert_true(NULL == queue_copy);
+    /* Final test, copy an empty queue */
+    queue = QueueNew(copy, destroy);
+    assert_true(queue != NULL);
+    assert_int_equal(0, QueueCopy(queue, &queue_copy));
+    assert_int_equal(0, queue->node_count);
+    assert_int_equal(queue->node_count, queue_copy->node_count);
+    assert_true(queue->ref_count != queue_copy->ref_count);
+    assert_true(NULL == queue->head);
+    assert_true(queue->head == queue_copy->head);
+    assert_true(queue->tail == queue_copy->tail);
+    assert_true(queue->queue == queue_copy->queue);
+    QueueDestroy(&queue);
+    assert_true(NULL == queue);
+    QueueDestroy(&queue_copy);
+    assert_true(NULL == queue_copy);
+}
+
+static void queue_api_test(void)
+{
+    /* If basic tests failed, there is no point in running this */
+    assert_true(basic_test_passed);
+
+    Queue *queue = NULL;
+    char *first = xstrdup(first_string);
+
+    queue = QueueNew(copy, destroy);
+    assert_true(queue != NULL);
+    assert_true(QueueIsEmpty(queue));
+    /* Enqueue the element */
+    char *head = NULL;
+    char *data = NULL;
+    assert_int_equal(0, QueueEnqueue(queue, first));
+    assert_int_equal(1, QueueCount(queue));
+    assert_false(QueueIsEmpty(queue));
+    /* Ask for the first element without dequeuing it */
+    head = QueueHead(queue);
+    assert_int_equal(1, QueueCount(queue));
+    assert_string_equal(head, first);
+    assert_false(QueueIsEmpty(queue));
+    /* Dequeue the first element */
+    data = QueueDequeue(queue);
+    assert_int_equal(0, QueueCount(queue));
+    assert_string_equal(head, data);
+    assert_true(QueueIsEmpty(queue));
+    /* Destroy the queue */
+    QueueDestroy(&queue);
+    assert_true(NULL == queue);
+    assert_true(QueueIsEmpty(queue));
+}
+
+int main()
+{
+    PRINT_TEST_BANNER();
+    const UnitTest tests[] =
+    {
+        unit_test(queue_basic_test),
+        unit_test(queue_enqueue_dequeue_test),
+        unit_test(queue_copy_test),
+        unit_test(queue_api_test)
+    };
+    return run_tests(tests);
+}


### PR DESCRIPTION
This is a simple FIFO implementation using reference counting and
copy on write.

It implements the basic queue operations:
- Head: Return a pointer to the first element without dequeuing it.
- Enqueue: Adds one element to the end of the queue.
- Dequeue: Dequeues the first element of the queue and returns a
  pointer to it.

In addition, it implements the basic administrative functions:
- New
- Destroy
- Copy
