### PR TITLE
Remove unreachable trust-checking code and associated machinery

### DIFF
--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -580,7 +580,6 @@ void CheckFileChanges(EvalContext *ctx, Policy **policy, GenericAgentConfig *con
             SV.allowciphers = NULL;
 
             DeleteItemList(SV.trustkeylist);
-            DeleteItemList(SV.skipverify);
             DeleteItemList(SV.attackerlist);
             DeleteItemList(SV.nonattackerlist);
             DeleteItemList(SV.multiconnlist);
@@ -612,7 +611,6 @@ void CheckFileChanges(EvalContext *ctx, Policy **policy, GenericAgentConfig *con
             SV.rolestop = NULL;
 
             SV.trustkeylist = NULL;
-            SV.skipverify = NULL;
             SV.attackerlist = NULL;
             SV.nonattackerlist = NULL;
             SV.multiconnlist = NULL;

--- a/cf-serverd/server.h
+++ b/cf-serverd/server.h
@@ -60,7 +60,6 @@ typedef struct
     Item *allowuserlist;                              /* "allowusers" */
     Item *multiconnlist;                              /* "allowallconnects" */
     Item *trustkeylist;                               /* "trustkeysfrom" */
-    Item *skipverify;
     char *allowciphers;
 
     Auth *admit;
@@ -91,7 +90,6 @@ struct ServerConnectionState_
     EvalContext *ctx;
     ConnectionInfo *conn_info;
     int synchronized;
-    int trust;
     char hostname[CF_MAXVARSIZE];
     char username[CF_MAXVARSIZE];
 #ifdef __MINGW32__

--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -232,14 +232,6 @@ void Summarize()
     {
         Log(LOG_LEVEL_VERBOSE, "USERS '%s'", ip->name);
     }
-
-    Log(LOG_LEVEL_VERBOSE, "Host IPs from NAT which we don't verify:");
-
-    for (ip = SV.skipverify; ip != NULL; ip = ip->next)
-    {
-        Log(LOG_LEVEL_VERBOSE, "IP '%s'", ip->name);
-    }
-
 }
 
 /*******************************************************************/
@@ -387,18 +379,6 @@ static void KeepControlPromises(EvalContext *ctx, Policy *policy, GenericAgentCo
 
             if (strcmp(cp->lval, CFS_CONTROLBODY[SERVER_CONTROL_SKIP_VERIFY].lval) == 0)
             {
-                Rlist *rp;
-
-                Log(LOG_LEVEL_VERBOSE, "Setting skip verify connections from ...");
-
-                for (rp = (Rlist *) retval.item; rp != NULL; rp = rp->next)
-                {
-                    if (!IsItemIn(SV.skipverify, RlistScalarValue(rp)))
-                    {
-                        AppendItem(&SV.skipverify, RlistScalarValue(rp), cp->classes);
-                    }
-                }
-
                 continue;
             }
 

--- a/cf-serverd/tls_server.c
+++ b/cf-serverd/tls_server.c
@@ -461,7 +461,6 @@ int ServerTLSSessionEstablish(ServerConnectionState *conn)
                     "%s: Explicitly trusting this key from now on.",
                     KeyPrintableHash(ConnectionInfoKey(conn->conn_info)));
 
-                conn->trust = true;
                 SavePublicKey("root", KeyPrintableHash(ConnectionInfoKey(conn->conn_info)),
                               KeyRSA(ConnectionInfoKey(conn->conn_info)));
             }
@@ -545,7 +544,6 @@ int ServerTLSSessionEstablishCallCollectMode(ServerConnectionState *conn)
                 "%s: Explicitly trusting this key from now on.",
                 KeyPrintableHash(ConnectionInfoKey(conn->conn_info)));
 
-            conn->trust = true;
             SavePublicKey("root", KeyPrintableHash(ConnectionInfoKey(conn->conn_info)),
                           KeyRSA(ConnectionInfoKey(conn->conn_info)));
         }

--- a/contrib/katepart-cfengine.highlight.xml
+++ b/contrib/katepart-cfengine.highlight.xml
@@ -133,7 +133,6 @@
       <item> trustkeysfrom</item>
       <item> allowusers </item>
       <item> dynamicaddresses </item>
-      <item> skipverify </item>
       <item> logallconnections </item>
       <item> logencryptedtransfers </item>
       <item> hostnamekeys </item>

--- a/contrib/textpad/cfengine.syn
+++ b/contrib/textpad/cfengine.syn
@@ -287,7 +287,6 @@ service_dependence_chain
 service_type
 signals
 skipidentify
-skipverify
 smtpserver
 source
 splaytime

--- a/libpromises/bootstrap.c
+++ b/libpromises/bootstrap.c
@@ -394,7 +394,7 @@ bool WriteBuiltinFailsafePolicyToPath(const char *filename)
             "       Please check\n"
             "       * cf-serverd is running on $(sys.policy_hub)\n"
             "       * network connectivity to $(sys.policy_hub) on port 5308\n"
-            "       * masterfiles 'body server control' - in particular allowconnects, trustkeysfrom and skipverify\n"
+            "       * masterfiles 'body server control' - in particular allowconnects, trustkeysfrom\n"
             "       * masterfiles 'bundle server' -> access: -> masterfiles -> admit/deny\n"
             "       It is often useful to restart cf-serverd in verbose mode (cf-serverd -v) on $(sys.policy_hub) to diagnose connection issues.\n"
             "       When updating masterfiles, wait (usually 5 minutes) for files to propagate to inputs on $(sys.policy_hub) before retrying.\"\n"

--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -320,7 +320,7 @@ const ConstraintSyntax CFS_CONTROLBODY[] =
     ConstraintSyntaxNewInt("maxconnections", CF_VALRANGE, "Maximum number of connections that will be accepted by cf-serverd. Default value: 30 remote queries", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewInt("port", "1024,99999", "Default port for cfengine server. Default value: 5308", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewOption("serverfacility", CF_FACILITY, "Menu option for syslog facility level. Default value: LOG_USER", SYNTAX_STATUS_NORMAL),
-    ConstraintSyntaxNewStringList("skipverify", "", "List of IPs or hostnames for which we expect no DNS binding and cannot verify", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewStringList("skipverify", "", "This option is deprecated, does nothing and is kept for backward compatibility.", SYNTAX_STATUS_DEPRECATED),
     ConstraintSyntaxNewStringList("trustkeysfrom", "", "List of IPs from whom we accept public keys on trust", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBool("listen", "true/false enable server daemon to listen on defined port. Default value: true", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("allowciphers", "", "List of ciphers the server accepts. For Syntax help see man page for \"openssl ciphers\". Default is \"AES256-GCM-SHA384:AES256-SHA\"", SYNTAX_STATUS_NORMAL),


### PR DESCRIPTION
There used to be a time when cf-serverd checked IP reported by the
client and did some trust calculations based on that (including
denying connections from NATed hosts, because NATed hosts didn't
know their IP address as it is seen from cf-serverd side).

In order to overcome NAT issue "skipverify" option has been introduced, to
exclude some IPs/networks from IP/DNS lookup checks.

In CFEngine 3.0 this code became unreachable and stayed like this until today,
and nobody noticed. Hence, it's safe to remove it and deprecate "skipverify"
option.

Note that github interface is not very good for reviewing diffs, so I suggest you to get this branch and do a
git diff --patience.
