### PR TITLE
Fix a logical operator inversion : && instead of ||

### DIFF
--- a/cf-agent/verify_databases.c
+++ b/cf-agent/verify_databases.c
@@ -388,7 +388,7 @@ static int CheckDatabaseSanity(Attributes a, Promise *pp)
         {
             commas = CountChar(RlistScalarValue(rp), ',');
 
-            if ((commas > 2) && (commas < 1))
+            if ((commas > 2) || (commas < 1))
             {
                 Log(LOG_LEVEL_ERR, "SQL Column format should be NAME,TYPE[,SIZE]");
                 retval = false;


### PR DESCRIPTION
Found haphazardly while looking for something completely different.

```
if ((commas > 2) && (commas < 1))
```

Will be obviously always false, the Log() statement below helps to find the desired logic: "If less than 1 or more than 2 SQL columns"
