### PR TITLE
contrib/cfengine-code-style.el: Fix file header and footer lines for ELPA compatibility

### DIFF
--- a/contrib/cfengine-code-style.el
+++ b/contrib/cfengine-code-style.el
@@ -1,25 +1,28 @@
-;;;
-;;; C code style for CFEngine project.
-;;;
-;;; Author: Mikhail Gusarov <mikhail.gusarov@cfengine.com>
-;;;
-;;;
-;;; Usage:
-;;;
-;;; To enable coding style for the current buffer:
-;;;
-;;;     M-x c-set-style cfengine
-;;;
-;;; To enable coding style permanently, create file .dir-locals.el with the
-;;; following contents in the directory with the source code:
-;;;
-;;;     ((c-mode . ((c-file-style . "cfengine"))))
-;;;
+;;; cfengine-code-style.el --- C code style for CFEngine project.
+
+;; Author: Mikhail Gusarov <mikhail.gusarov@cfengine.com>
+;; URL: https://github.com/cfengine/core
+
+;;; Commentary:
+
+;; Usage:
+;;
+;; To enable coding style for the current buffer:
+;;
+;;     M-x c-set-style cfengine
+;;
+;; To enable coding style permanently, create file .dir-locals.el with the
+;; following contents in the directory with the source code:
+;;
+;;     ((c-mode . ((c-file-style . "cfengine"))))
+;;
 
 ;;
 ;; TODO: special rule for C99 (Foo) { 1, 2, 3 } initializers.
 ;; TODO: special rule for whitespace between if/while/for and paren.
 ;;
+
+;;; Code:
 
 (defconst cfengine-c-style
   '(;; 4 spaces
@@ -59,3 +62,5 @@
 (add-hook 'c-mode-hook 'cfengine-c-mode-hook)
 
 (provide 'cfengine-code-style)
+
+;;; cfengine-code-style.el ends here


### PR DESCRIPTION
This commit makes `cfengine-code-style.el` installable with `package.el`. 
- Fix header line
- Add footer line
- Add Commentary section
- Add Code section
- Change semicolons of header comment lines from three to two

For information about this fix, See following GNU Emacs Manual:
- [Simple-Packages](http://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html)
- [Library-Headers](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html)

Re: milkypostman/melpa/pull/1226

/cc @tzz
