### PR TITLE
Redmine#3839: add sys.local_dirname

### DIFF
--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -25,6 +25,8 @@
 #ifndef CFENGINE_GENERIC_AGENT_H
 #define CFENGINE_GENERIC_AGENT_H
 
+#include <platform.h>
+
 #include <cf3.defs.h>
 
 #include <policy.h>


### PR DESCRIPTION
Attempt to resolve https://cfengine.com/dev/issues/3839

Uses `sys.local_dirname` as the variable name.

Possible issues:
- needs to be verified to ensure I'm passing the right parameters for `LoadPolicyInputFiles`
- relies on `realpath` which is not everywhere.  It may need a Windows or alternative implementation.
