### PR TITLE
Redmine#3848: acceptance test to check that common bundles print their reports

### DIFF
--- a/tests/acceptance/14_reports/00_output/staging/report_in_common_bundle.cf
+++ b/tests/acceptance/14_reports/00_output/staging/report_in_common_bundle.cf
@@ -1,0 +1,38 @@
+# Check that reports are printed from common bundles (Redmine#3848 https://cfengine.com/dev/issues/3848)
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+
+}
+
+
+bundle agent test
+{
+  vars:
+      "subout" string => execresult("$(sys.cf_agent) -b runme -Kf $(this.promise_filename).sub", "noshell");
+}
+
+
+bundle agent check
+{
+  classes:
+      "ok" expression => regcmp(".*rhino_9d85a7796746fb3e2e2ac95f74e4b981564803de.*", "$(test.subout)");
+
+  reports:
+    DEBUG::
+      "$(test.subout)";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}
+### PROJECT_ID: core
+### CATEGORY_ID: 2

--- a/tests/acceptance/14_reports/00_output/staging/report_in_common_bundle.cf.sub
+++ b/tests/acceptance/14_reports/00_output/staging/report_in_common_bundle.cf.sub
@@ -1,0 +1,9 @@
+bundle agent runme
+{
+}
+
+bundle common report
+{
+  reports:
+      "$(this.bundle): rhino_9d85a7796746fb3e2e2ac95f74e4b981564803de";
+}


### PR DESCRIPTION
See https://cfengine.com/dev/issues/3848 for details

Acceptance test is in `staging` since it fails.
