### PR TITLE
Use strlcpy() in preference to strncpy().

### DIFF
--- a/cf-serverd/server.c
+++ b/cf-serverd/server.c
@@ -1122,11 +1122,11 @@ static int VerifyConnection(ServerConnectionState *conn, char buf[CF_BUFSIZE])
         "Allowing %s to connect without (re)checking ID\n", ip_assert);
     Log(LOG_LEVEL_VERBOSE,
         "Non-verified Host ID is %s\n", dns_assert);
-    strncpy(conn->hostname, dns_assert, CF_MAXVARSIZE);
+    strlcpy(conn->hostname, dns_assert, CF_MAXVARSIZE);
     Log(LOG_LEVEL_VERBOSE,
         "Non-verified User ID seems to be %s\n",
         username);
-    strncpy(conn->username, username, CF_MAXVARSIZE);
+    strlcpy(conn->username, username, CF_MAXVARSIZE);
 
 #ifdef __MINGW32__            /* NT uses security identifier instead of uid */
 


### PR DESCRIPTION
Mikhail says the reverse change (git show -b af216a39) was a merge
conflict mistake, so let's put it back again !

I have built and tested this on x86_64 Debian jessie/sid.
