### PR TITLE
cf3parse.y: make comma-after-promiser message more helpful

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -396,9 +396,13 @@ promise_decl:          promise_line ';'
                            {
                               ParseError("Expected '->', got '%s'", yytext);
                            }
-                           else if (yychar == IDSYNTAX || yychar == ',')
+                           else if (yychar == IDSYNTAX)
                            {
                               ParseError("Expected attribute, got '%s'", yytext);
+                           }
+                           else if (yychar == ',')
+                           {
+                              ParseError("Expected attribute, got '%s' (comma after promiser is not allowed since 3.5.0)", yytext);
                            }
                            else
                            {


### PR DESCRIPTION
Please consider this patch.  It makes a common error in policy clearer by saying what it is and in what version it became an error.
