### PR TITLE
Regexp compilation errors: be more explicit about the failure

### DIFF
--- a/libpromises/matching.c
+++ b/libpromises/matching.c
@@ -45,8 +45,8 @@ static pcre *CompileRegExp(const char *regexp)
 
     if (rx == NULL)
     {
-        Log(LOG_LEVEL_ERR, "Regular expression error '%s' in expression '%s' at %d", errorstr, regexp,
-              erroffset);
+        Log(LOG_LEVEL_ERR, "Regular expression error: pcre_compile() '%s' in expression '%s' (offset: %d)", 
+              errorstr, regexp, erroffset);
     }
 
     return rx;


### PR DESCRIPTION
Hello,

I was facing the following error during a promises debug session (3.4.5), here is a self-contained example:

/tmp/foo

```
[[foo]
```

bundle.cf

```
body common control
{
    bundlesequence => {
            "regexp",
    };  
}

bundle agent regexp
{
  files:
    "/tmp/foo"
      create    =>  "true",
      edit_line =>  my_edit_line;
}

bundle edit_line my_edit_line {
  replace_patterns:
    "[[foo"
      replace_with => value("replacestring");
  }

body replace_with value(x)
{ 
  replace_value => "$(x)";
}        
```

Error message was:

```
Regular expression error "missing terminating ] for character class" in expression "[[foo" at 5
```

The debugging would have been faster if I had the following informations:
- **missing terminating ] for character class** is a message from libpcre, not CFEngine itself
- **at 5** is the offset inside the pattern causing the compilation error.

On the current master, the message is more verbose:

```
error: /default/regexp/files/'/tmp/foo'/default/my_edit_line: Regular expression error 'missing terminating ] for character class' in expression '[[foo' at 5
```

I suggest to clarify **at** with **(offset: xx)** and to give a clue about pcre. This way, the advanced user can quickly move to regexp modification (thanks to pcre documentation?), while regular user is not penalized:

```
error: /default/regexp/files/'/tmp/foo'/default/my_edit_line: Regular expression error: pcre_compile() 'missing terminating ] for character class' in expression '[[foo' (offset: 5)
```

But maybe was I too tired, and the error message clear as crystal?

Also, while I'm at it, is it worthwhile to document the flags used internally by **pcre_compile()** in  CompileRegExp() ? 
I mean PCRE_MULTILINE | PCRE_DOTALL, maybe this can be useful to regexp ninjas ? If so, I will issue another PR
