### PR TITLE
Shorter command to get debian version.

### DIFF
--- a/tests/acceptance/00_basics/01_compiler/800.cf
+++ b/tests/acceptance/00_basics/01_compiler/800.cf
@@ -22,7 +22,7 @@ bundle agent test
 {
   vars:
     debian::
-      "myflavor" string => execresult("/bin/grep Debian.*GNU /etc/issue | /usr/bin/cut -d' ' -f3 | cut -d. -f1 | cut -d/ -f1", "useshell");
+      "myflavor" string => execresult("cat /etc/debian_version | /usr/bin/cut -d. -f1 | /usr/bin/cut -d/ -f1", "useshell");
 }
 
 #######################################################


### PR DESCRIPTION
Instead of parsing the relevant fragment out of /etc/issue, read
/etc/debian_version, which contains just that fragment, without any of
the other cruft in /etc/issue.  Still requires post-parsing of the
version, to stop at the first [./] in it, but at least it's terser.
