### PR TITLE
Fixes #3734: Rename SuSE to SUSE and keep SuSE* classes for backwards compatibility

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1618,7 +1618,9 @@ static int Linux_Suse_Version(EvalContext *ctx)
     Log(LOG_LEVEL_VERBOSE, "This appears to be a SUSE system.");
     EvalContextClassPutHard(ctx, "SUSE", "inventory,source=agent,group=OS,comment=SUSE");
 
-    /* Keep this for backwards compatibility ("SUSE" used to be "SuSE") - remove in CFEngine 3.7 */
+    /* The correct spelling for SUSE is "SUSE" but CFEngine used to use "SuSE".
+     * Keep this for backwards compatibility until CFEngine 3.7
+     */
     EvalContextClassPutHard(ctx, "SuSE", "inventory,source=agent,group=OS,comment=SUSE,deprecated");
 
 /* Grab the first line from the file and then close it. */
@@ -1765,7 +1767,9 @@ static int Linux_Suse_Version(EvalContext *ctx)
                 strcat(classbuf, strminor);
                 EvalContextClassPutHard(ctx, classbuf, "inventory,source=agent,group=OS,comment=SUSE");
 
-                /* Keep this for backwards compatibility ("SUSE" used to be "SuSE") - remove in CFEngine 3.7 */
+                /* The correct spelling for SUSE is "SUSE" but CFEngine used to use "SuSE".
+                 * Keep this for backwards compatibility until CFEngine 3.7
+                 */
                 strcpy(classbuf, "SuSE");
                 EvalContextClassPutHard(ctx, classbuf, "inventory,source=agent,group=OS,comment=SUSE,deprecated");
                 strcat(classbuf, "_");
@@ -1798,7 +1802,9 @@ static int Linux_Suse_Version(EvalContext *ctx)
                 snprintf(classbuf, CF_MAXVARSIZE, "SUSE_%d", major);
                 SetFlavour(ctx, classbuf);
 
-                /* Keep this for backwards compatibility ("SUSE" used to be "SuSE") - remove in CFEngine 3.7 */
+                /* The correct spelling for SUSE is "SUSE" but CFEngine used to use "SuSE".
+                 * Keep this for backwards compatibility until CFEngine 3.7
+                 */
                 snprintf(classbuf, CF_MAXVARSIZE, "SuSE_%d", major);
                 EvalContextClassPutHard(ctx, classbuf, "inventory,source=agent,group=OS,comment=SUSE,deprecated");
 


### PR DESCRIPTION
This is a fix for Redmine #3734 (https://cfengine.com/dev/issues/3734).

I came across this bug recently and jumped on it because I am always confused too about the capitalization of the SuSE\* classes, and usually get it wrong. Please consider this my contribution to making any SuSE-based CFEngine users happier.
