### PR TITLE
Redmine#2778: acceptance test

### DIFF
--- a/tests/acceptance/10_files/09_insert_lines/selectlinematching.cf
+++ b/tests/acceptance/10_files/09_insert_lines/selectlinematching.cf
@@ -1,0 +1,96 @@
+##############################################################################
+#
+# Redmine #2778
+#   3.5.x: incorrect output of: 
+#    "insert_lines promise uses the same select_line_matching anchor [...]"
+#
+# This test is loosely modelled on "execresult_multiples.cf" (post-3.5.x).
+#
+# The original Redmine 2778 report concerned editing a "sendmail.mc" file.
+# But in developing this acceptance test, I discovered that some existing
+# tests in this area also exhibit this behaviour, such as "009.cf".
+#
+# This test has two subtests:
+#   o  a copy of "009.cf";
+#   o  the "sendmail.mc" edit from the original report.
+#
+# The subtests functionally pass but exhibit the incorrect output.
+#
+# Our intention is to fail if any of:
+#   o  incorrect output is seen (our prime concern)
+#   o  subtest itself functionally fails (its problem, not ours)
+#
+# David Lee <david.lee@ecmwf.int>
+# December 2013
+#
+##############################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+    any::
+      # Run subtests.  Need to be in verbose mode to see the output.
+      # The full verbose output is too big for variable assignment here.
+      # So extract (grep) only potentially interesting lines.
+      "subout_1" string => execresult("$(sys.cf_agent) -Kv -f $(this.promise_filename).sub_1 2>&1 | $(G.grep) -Ei 'select_line_matching'", "useshell");
+      "subout_2" string => execresult("$(sys.cf_agent) -Kv -f $(this.promise_filename).sub_2 2>&1 | $(G.grep) -Ei 'select_line_matching'", "useshell");
+
+  reports:
+    DEBUG::
+      "bundle test: this.promise_filename: $(this.promise_filename)";
+      "bundle test: subtest_1: $(this.promise_filename).sub_1";
+      "bundle test: subout_1:  $(subout_1)";
+      "bundle test: subtest_2: $(this.promise_filename).sub_2";
+      "bundle test: subout_2:  $(subout_2)";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    any::
+      # These patterns spell trouble.
+      "pattern_fail" string => ".*select_line_matching anchor.*";
+
+  # Examine output from 'test' to decide whether good or bad.
+  classes:
+    any::
+      "ok_pattern_1" not => regcmp("$(pattern_fail)", "$(test.subout_1)");
+      "ok_pattern_2" not => regcmp("$(pattern_fail)", "$(test.subout_2)");
+
+  reports:
+    DEBUG::
+      "Attempted subtest '$(this.promise_filename).sub_1' in verbose mode.";
+      "Significant output of sub_1 was '$(test.subout_1)'.";
+      "Attempted subtest '$(this.promise_filename).sub_2' in verbose mode.";
+      "Significant output of sub_2 was '$(test.subout_2)'.";
+
+    DEBUG.!ok_pattern_1::
+      "failing: pattern '$(pattern_fail)' in subtest_1";
+
+    DEBUG.!ok_pattern_2::
+      "failing: pattern '$(pattern_fail)' in subtest_2";
+
+    ok_pattern_1.ok_pattern_2::
+      "$(this.promise_filename) Pass";
+    !(ok_pattern_1.ok_pattern_2)::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/09_insert_lines/selectlinematching.cf.sub_1
+++ b/tests/acceptance/10_files/09_insert_lines/selectlinematching.cf.sub_1
@@ -1,0 +1,103 @@
+#######################################################
+#
+# Redmine #2778
+# This subtest should be identical to "009.cf" with the exception of
+# these comment lines.
+#
+#######################################################
+#
+# Insert a number of lines after the last instance of a line
+#
+#######################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+vars:
+        "states" slist => { "actual", "expected" };
+
+        "actual" string =>
+"BEGIN
+    One potato
+    Two potato
+    Two potatos
+    Four
+END";
+
+        "expected" string =>
+"BEGIN
+    One potato
+    Two potato
+    Two potatos
+    Three potatoe
+    Four
+END";
+
+files:
+        "$(G.testfile).$(states)"
+            create => "true",
+            edit_line => init_insert("$(init.$(states))"),
+            edit_defaults => init_empty;
+}
+
+bundle edit_line init_insert(str)
+{
+insert_lines:
+        "$(str)";
+}
+
+body edit_defaults init_empty
+{
+        empty_file_before_editing => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+vars:
+      "tstr" string =>
+"    One potato
+    Two potato
+    Three potatoe
+    Four";
+
+files:
+        "$(G.testfile).actual"
+            create => "true",
+            edit_line => test_insert("$(test.tstr)");
+
+}
+
+bundle edit_line test_insert(str)
+{
+insert_lines:
+        "$(str)"
+            location => test_after_last(".*potato.*");
+}
+
+body location test_after_last(line)
+{
+before_after => "after";
+first_last => "last";
+select_line_matching => "$(line)";
+}
+
+#######################################################
+
+bundle agent check
+{
+methods:
+        "any" usebundle => default_check_diff("$(G.testfile).actual",
+                                              "$(G.testfile).expected",
+                                              "$(this.promise_filename)");
+}
+

--- a/tests/acceptance/10_files/09_insert_lines/selectlinematching.cf.sub_2
+++ b/tests/acceptance/10_files/09_insert_lines/selectlinematching.cf.sub_2
@@ -1,0 +1,91 @@
+#######################################################
+#
+# Redmine 2778:
+#
+# A reduced form of the generating case.
+#
+#######################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+vars:
+        "states" slist => { "actual", "expected" };
+
+        "actual" string =>
+"dnl #
+dnl define(`SMART_HOST', `smtp.your.provider')dnl
+dnl #";
+
+        "expected" string =>
+"dnl #
+dnl define(`SMART_HOST', `smtp.your.provider')dnl
+define(`SMART_HOST', `mail1.$m')dnl
+define(`MAIL_HUB', `mail1.$m')dnl
+dnl #";
+
+files:
+        "$(G.testfile).$(states)"
+            create => "true",
+            edit_line => init_insert("$(init.$(states))"),
+            edit_defaults => init_empty;
+}
+
+bundle edit_line init_insert(str)
+{
+insert_lines:
+        "$(str)";
+}
+
+body edit_defaults init_empty
+{
+        empty_file_before_editing => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+vars:
+      "hostname" string => "mail1.$m";
+
+files:
+        "$(G.testfile).actual"
+            create => "true",
+            edit_line => test_insert("$(hostname)");
+
+}
+
+bundle edit_line test_insert(h)
+{
+  insert_lines:
+# These sendmail "define" lines comprise a cfengine multi-line string.
+"define(`SMART_HOST', `$(h)')dnl
+define(`MAIL_HUB', `$(h)')dnl"
+      location => location_sendmail_mc;
+}
+
+body location location_sendmail_mc
+{
+  select_line_matching => "^dnl.*SMART_HOST.*";
+  before_after => "after";
+}
+
+#######################################################
+
+bundle agent check
+{
+methods:
+        "any" usebundle => default_check_diff("$(G.testfile).actual",
+                                              "$(G.testfile).expected",
+                                              "$(this.promise_filename)");
+}
+


### PR DESCRIPTION
see https://cfengine.com/dev/issues/2778

Redmine 2778 with 3.5.x: "insert_lines promise uses the same select_line_matching anchor ..."

Although the "insert_lines" seems functionally to work, nevertheless it produces some alarming, misleading and highly undesirable messages to the user.

Several of the existing acceptance tests (in "10_files/09_insert_lines") also exhibit this same undesirable behaviour.  (Such a test, e.g. "009.cf", functionally passes;  but run it manually and look at the messages.)

This test is designed to trap this behaviour and fail if the messages occur.  It seems to pass on branch "master" but fail on branch "3.5.x".

I request that this be added not only to "master" but additionally to "3.5.x".
