### PR TITLE
Redmine#3697: copy_from remote_variable_prefix

### DIFF
--- a/cf-serverd/tls_server.c
+++ b/cf-serverd/tls_server.c
@@ -582,6 +582,7 @@ typedef enum
     PROTOCOL_COMMAND_CONTEXT,
     PROTOCOL_COMMAND_QUERY,
     PROTOCOL_COMMAND_CALL_ME_BACK,
+    PROTOCOL_COMMAND_SETVARPREFIX,
     PROTOCOL_COMMAND_BAD
 } ProtocolCommandNew;
 
@@ -597,6 +598,7 @@ static const char *PROTOCOL_NEW[PROTOCOL_COMMAND_BAD + 1] =
     "CONTEXT",
     "QUERY",
     "SCALLBACK",
+    "SETVARPREFIX",
     NULL
 };
 
@@ -622,11 +624,12 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
 {
     time_t tloc, trem = 0;
     char recvbuffer[CF_BUFSIZE + CF_BUFEXT], sendbuffer[CF_BUFSIZE];
-    char filename[CF_BUFSIZE], args[CF_BUFSIZE];
+    char filename[CF_BUFSIZE], temp_filename[CF_BUFSIZE], args[CF_BUFSIZE];
     long time_no_see = 0;
-    int drift, received;
+    int drift, received, scanned;
     ServerFileGetState get_args;
     Item *classes;
+    char remote_variable_prefix[CF_BUFSIZE] = "";
 
     /* We never double encrypt within the TLS layer */
     const int encrypted = 0;
@@ -713,7 +716,8 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
     case PROTOCOL_COMMAND_GET:
 
         memset(filename, 0, CF_BUFSIZE);
-        sscanf(recvbuffer, "GET %d %[^\n]", &(get_args.buf_size), filename);
+        memset(temp_filename, 0, CF_BUFSIZE);
+        sscanf(recvbuffer, "GET %d %[^\n]", &(get_args.buf_size), temp_filename);
 
         if ((get_args.buf_size < 0) || (get_args.buf_size > CF_BUFSIZE))
         {
@@ -728,6 +732,8 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
             RefuseAccess(conn, 0, recvbuffer);
             return false;
         }
+
+        snprintf(filename, CF_BUFSIZE-1, "%s%s", remote_variable_prefix, temp_filename);
 
         if (!AccessControl(ctx, filename, conn, false))
         {
@@ -755,7 +761,8 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
     case PROTOCOL_COMMAND_OPENDIR:
 
         memset(filename, 0, CF_BUFSIZE);
-        sscanf(recvbuffer, "OPENDIR %[^\n]", filename);
+        memset(temp_filename, 0, CF_BUFSIZE);
+        sscanf(recvbuffer, "OPENDIR %[^\n]", temp_filename);
 
         if (!conn->id_verified)
         {
@@ -763,6 +770,8 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
             RefuseAccess(conn, 0, recvbuffer);
             return false;
         }
+
+        snprintf(filename, CF_BUFSIZE-1, "%s%s", remote_variable_prefix, temp_filename);
 
         if (!AccessControl(ctx, filename, conn, true))        /* opendir don't care about privacy */
         {
@@ -784,9 +793,12 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
         }
 
         memset(filename, 0, CF_BUFSIZE);
-        sscanf(recvbuffer, "SYNCH %ld STAT %[^\n]", &time_no_see, filename);
+        memset(temp_filename, 0, CF_BUFSIZE);
+        sscanf(recvbuffer, "SYNCH %ld STAT %[^\n]", &time_no_see, temp_filename);
 
         trem = (time_t) time_no_see;
+
+        snprintf(filename, CF_BUFSIZE-1, "%s%s", remote_variable_prefix, temp_filename);
 
         if ((time_no_see == 0) || (filename[0] == '\0'))
         {
@@ -905,6 +917,7 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
     case PROTOCOL_COMMAND_CALL_ME_BACK:
 
         memset(filename, 0, CF_BUFSIZE);
+        memset(temp_filename, 0, CF_BUFSIZE);
         if (strncmp(recvbuffer, "SCALLBACK CALL_ME_BACK collect_calls", strlen("SCALLBACK CALL_ME_BACK collect_calls")) != 0)
         {
             Log(LOG_LEVEL_INFO, "CALL_ME_BACK protocol defect");
@@ -927,6 +940,28 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
             return false;
         }
         return ReceiveCollectCall(conn);
+
+    case PROTOCOL_COMMAND_SETVARPREFIX:
+
+        scanned = sscanf(recvbuffer, "SETVARPREFIX %[^\n]", remote_variable_prefix);
+
+        if (!conn->id_verified)
+        {
+            Log(LOG_LEVEL_INFO, "ID not verified");
+            RefuseAccess(conn, 0, recvbuffer);
+            return false;
+        }
+
+        if (scanned != 1)
+        {
+            Log(LOG_LEVEL_INFO, "Remote variable prefix setting was not parseable");
+            RefuseAccess(conn, 0, recvbuffer);
+            return false;
+        }
+
+        // TODO: evaluate remote_variable_prefix in the cf-serverd EvalContext
+        Log(LOG_LEVEL_INFO, "Remote variable prefix was set to '%s'", remote_variable_prefix);
+        return true;
 
     case PROTOCOL_COMMAND_BAD:
         Log(LOG_LEVEL_WARNING, "Unexpected protocol command: %s", recvbuffer);

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -419,6 +419,15 @@ static AgentConnection *ServerConnection(const char *server, FileCopy fc, int *e
                 *err = -2; // auth err
                 return NULL;
             }
+
+            if (fc.remote_variable_prefix && !SetVariablePrefix(conn, fc.remote_variable_prefix))
+            {
+                Log(LOG_LEVEL_ERR, "Requested setting of the variable prefix to '%s' with '%s' failed", fc.remote_variable_prefix, server);
+                errno = EPERM; // TODO: new error code?
+                DisconnectServer(conn, false);
+                *err = -2; // auth err // TODO: new error code?
+                return NULL;
+            }
             ConnectionInfoSetConnectionStatus(conn->conn_info, CF_CONNECTION_ESTABLISHED);
             break;
 

--- a/libcfnet/client_protocol.c
+++ b/libcfnet/client_protocol.c
@@ -168,6 +168,26 @@ int IdentifyAgent(ConnectionInfo *conn_info)
 
 /*********************************************************************/
 
+int SetVariablePrefix(AgentConnection *conn, char *remote_variable_prefix)
+{
+    char sendbuff[CF_BUFSIZE];
+
+    assert(NULL != remote_variable_prefix);
+    snprintf(sendbuff, sizeof(sendbuff), "SETVARPREFIX %s",
+             remote_variable_prefix);
+
+    if (SendTransaction(conn->conn_info, sendbuff, 0, CF_DONE) == -1)
+    {
+        Log(LOG_LEVEL_ERR,
+              "During initial agent connection, could not set remote_variable_prefix. (SendTransaction: %s)", GetErrorStr());
+        return false;
+    }
+
+    return true;
+}
+
+/*********************************************************************/
+
 static bool SetSessionKey(AgentConnection *conn)
 {
     BIGNUM *bp;

--- a/libcfnet/client_protocol.h
+++ b/libcfnet/client_protocol.h
@@ -30,6 +30,7 @@
 
 int IdentifyAgent(ConnectionInfo *connection);
 int AuthenticateAgent(AgentConnection *conn, bool trust_key);
+int SetVariablePrefix(AgentConnection *conn, char *remote_variable_prefix);
 int BadProtoReply(char *buf);
 int OKProtoReply(char *buf);
 int FailedProtoReply(char *buf);

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -916,6 +916,7 @@ FileCopy GetCopyConstraints(const EvalContext *ctx, const Promise *pp)
     f.encrypt = PromiseGetConstraintAsBoolean(ctx, "encrypt", pp);
     f.verify = PromiseGetConstraintAsBoolean(ctx, "verify", pp);
     f.purge = PromiseGetConstraintAsBoolean(ctx, "purge", pp);
+    f.remote_variable_prefix = PromiseGetConstraintAsRval(pp, "remote_variable_prefix", RVAL_TYPE_SCALAR);
     f.destination = NULL;
 
     return f;

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1128,6 +1128,7 @@ typedef struct
     int encrypt;
     int verify;
     int purge;
+    char *remote_variable_prefix;
     unsigned short portnumber;
     short timeout;
 } FileCopy;

--- a/libpromises/mod_files.c
+++ b/libpromises/mod_files.c
@@ -303,6 +303,7 @@ static const ConstraintSyntax copy_from_constraints[] =
     ConstraintSyntaxNewInt("portnumber", "1024,99999", "Port number to connect to on server host", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBool("preserve", "true/false whether to preserve file permissions on copied file. Default value: false", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBool("purge", "true/false purge files on client that do not match files on server when a depth_search is used. Default value: false", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewString("remote_variable_prefix", CF_IDRANGE, "Request that the remote tree root be at this location", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBool("stealth", "true/false whether to preserve time stamps on copied file. Default value: false", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewInt("timeout", "1,3600", "Connection timeout, seconds", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBool("trustkey", "true/false trust public keys from remote server if previously unknown. Default value: false", SYNTAX_STATUS_NORMAL),


### PR DESCRIPTION
See https://cfengine.com/dev/issues/3697

My first attempt to implement the `remote_variable_prefix` body parameter for `copy_from`.  It is not tested or fully implemented yet.  Unit or acceptance tests are not done.  But it's got a good heart and comes from humble roots, etc etc

It operates by having the client always set the prefix right after authenticating, if it's given.  The server then prepends that prefix to every filename requested in the connection.  That's it; there is nothing magic.

The **TODO** items/questions:
- on the server side, the `remote_variable_prefix` should be looked up as a variable name and if there's no such variable, the connection should be aborted
- on the client side, failing to set the prefix generates a `-2` error which is some kind of auth error.  I don't know what magic constant is right there.
