### PR TITLE
Harmonize uses of exit()

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -419,7 +419,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteVersion(w);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'h':
             {
@@ -427,7 +427,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-agent", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'M':
             {
@@ -454,7 +454,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 AgentDiagnosticsRunAllChecksNova(workdir, out, &AgentDiagnosticsRun, &AgentDiagnosticsResultNew);
                 FileWriterDetach(out);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
@@ -473,7 +473,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-agent", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(1);
+            exit(EXIT_FAILURE);
         }
     }
 
@@ -1049,7 +1049,7 @@ static void KeepPromiseBundles(EvalContext *ctx, const Policy *policy, GenericAg
     else if (!EvalContextVariableControlCommonGet(ctx, COMMON_CONTROL_BUNDLESEQUENCE, &retval))
     {
         Log(LOG_LEVEL_ERR, "No bundlesequence in the common control body");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     for (rp = (Rlist *) retval.item; rp != NULL; rp = rp->next)
@@ -1273,7 +1273,7 @@ static void CheckAgentAccess(Rlist *list, const Policy *policy)
                 if (!access)
                 {
                     Log(LOG_LEVEL_ERR, "File '%s' is not owned by an authorized user (security exception)", input_file);
-                    exit(1);
+                    exit(EXIT_FAILURE);
                 }
             }
             else if (CFPARANOID && IsPrivileged())
@@ -1282,7 +1282,7 @@ static void CheckAgentAccess(Rlist *list, const Policy *policy)
                 {
                     Log(LOG_LEVEL_ERR, "File '%s' is not owned by uid %ju (security exception)", input_file,
                           (uintmax_t)getuid());
-                    exit(1);
+                    exit(EXIT_FAILURE);
                 }
             }
         }
@@ -1291,7 +1291,7 @@ static void CheckAgentAccess(Rlist *list, const Policy *policy)
     }
 
     Log(LOG_LEVEL_ERR, "You are denied access to run this policy");
-    exit(1);
+    exit(EXIT_FAILURE);
 }
 #endif /* !__MINGW32__ */
 
@@ -1668,7 +1668,7 @@ static PromiseResult ParallelFindAndVerifyFilesPromises(EvalContext *ctx, const 
 
                 Log(LOG_LEVEL_VERBOSE, "Exiting backgrounded promise");
                 PromiseRef(LOG_LEVEL_VERBOSE, pp);
-                _exit(0);
+                _exit(EXIT_SUCCESS);
                 // TODO: need to solve this
             }
         }

--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -421,7 +421,7 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a,
     if ((a.transaction.background) && outsourced)
     {
         Log(LOG_LEVEL_VERBOSE, "Backgrounded command '%s' is done - exiting", cmdline);
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 #endif /* !__MINGW32__ */
 

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -269,7 +269,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteVersion(w);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'h':
             {
@@ -277,7 +277,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-execd", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'M':
             {
@@ -293,7 +293,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
 
         case 'x':
             Log(LOG_LEVEL_ERR, "Self-diagnostic functionality is retired.");
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
@@ -308,7 +308,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-execd", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(1);
+            exit(EXIT_FAILURE);
 
         }
     }
@@ -366,7 +366,7 @@ void StartServer(EvalContext *ctx, Policy *policy, GenericAgentConfig *config, E
     if ((!NO_FORK) && (fork() != 0))
     {
         Log(LOG_LEVEL_INFO, "cf-execd starting %.24s", ctime(&now));
-        _exit(0);
+        _exit(EXIT_SUCCESS);
     }
 
     if (!NO_FORK)

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -180,7 +180,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteVersion(w);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'v':
             LogSetGlobalLevel(LOG_LEVEL_VERBOSE);
@@ -214,7 +214,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-key", OPTIONS, HINTS, false);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'M':
             {
@@ -241,7 +241,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-key", OPTIONS, HINTS, false);
                 FileWriterDetach(w);
             }
-            exit(1);
+            exit(EXIT_FAILURE);
 
         }
     }

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -186,7 +186,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteVersion(w);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'h':
             {
@@ -194,7 +194,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-monitord", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'M':
             {
@@ -210,7 +210,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
 
         case 'x':
             Log(LOG_LEVEL_ERR, "Self-diagnostic functionality is retired.");
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
@@ -225,7 +225,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-monitord", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(1);
+            exit(EXIT_FAILURE);
         }
     }
 

--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -284,7 +284,7 @@ void MonitorStartServer(EvalContext *ctx, const Policy *policy)
     if ((!NO_FORK) && (fork() != 0))
     {
         Log(LOG_LEVEL_INFO, "cf-monitord: starting");
-        _exit(0);
+        _exit(EXIT_SUCCESS);
     }
 
     if (!NO_FORK)
@@ -369,7 +369,7 @@ static Averages EvalAvQ(EvalContext *ctx, char *t)
     if ((lastweek_vals = GetCurrentAverages(t)) == NULL)
     {
         Log(LOG_LEVEL_ERR, "Error reading average database");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
 /* Discard any apparently anomalous behaviour before renormalizing database */

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -296,7 +296,7 @@ GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteVersion(w);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'h':
             {
@@ -304,7 +304,7 @@ GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-promises", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'M':
             {
@@ -332,7 +332,7 @@ GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
 
         case 'x':
             Log(LOG_LEVEL_ERR, "Self-diagnostic functionality is retired.");
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
@@ -347,7 +347,7 @@ GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-promises", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(1);
+            exit(EXIT_FAILURE);
 
         }
     }

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
     if (BACKGROUND && INTERACTIVE)
     {
         Log(LOG_LEVEL_ERR, "You cannot specify background mode and interactive mode together");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
 /* HvB */
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
                     if (fork() == 0)    /* child process */
                     {
                         HailServer(ctx, RlistScalarValue(rp));
-                        exit(0);
+                        exit(EXIT_SUCCESS);
                     }
                     else        /* parent process */
                     {
@@ -332,7 +332,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteVersion(w);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'h':
             {
@@ -340,7 +340,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-runagent", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'M':
             {
@@ -356,7 +356,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
 
         case 'x':
             Log(LOG_LEVEL_ERR, "Self-diagnostic functionality is retired.");
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
@@ -371,7 +371,7 @@ static GenericAgentConfig *CheckOpts(EvalContext *ctx, int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-runagent", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(1);
+            exit(EXIT_FAILURE);
 
         }
     }
@@ -395,7 +395,7 @@ static void ThisAgentInit(void)
     {
         Log(LOG_LEVEL_ERR,
               "The specified remote options include a useless --file option. The remote server has promised to ignore this, thus it is disallowed.");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 }
 

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -196,7 +196,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteVersion(w);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'h':
             {
@@ -204,7 +204,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-serverd", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'M':
             {
@@ -220,22 +220,22 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
 
         case 'x':
             Log(LOG_LEVEL_ERR, "Self-diagnostic functionality is retired.");
-            exit(0);
+            exit(EXIT_SUCCESS);
         case 'A':
 #ifdef HAVE_AVAHI_CLIENT_CLIENT_H
 #ifdef HAVE_AVAHI_COMMON_ADDRESS_H
             Log(LOG_LEVEL_NOTICE, "Generating Avahi configuration file.");
             if (GenerateAvahiConfig("/etc/avahi/services/cfengine-hub.service") != 0)
             {
-                exit(1);
+                exit(EXIT_FAILURE);
             }
             cf_popen("/etc/init.d/avahi-daemon restart", "r", true);
             Log(LOG_LEVEL_NOTICE, "Avahi configuration file generated successfuly.");
-            exit(0);
+            exit(EXIT_SUCCESS);
 #endif
 #endif
             Log(LOG_LEVEL_ERR, "Generating avahi configuration can only be done when avahi-daemon and libavahi are installed on the machine.");
-            exit(0);
+            exit(EXIT_SUCCESS);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
@@ -250,7 +250,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteHelp(w, "cf-serverd", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
-            exit(1);
+            exit(EXIT_FAILURE);
 
         }
     }
@@ -338,7 +338,7 @@ void StartServer(EvalContext *ctx, Policy **policy, GenericAgentConfig *config)
 
     if ((!NO_FORK) && (fork() != 0))
     {
-        _exit(0);
+        _exit(EXIT_SUCCESS);
     }
 
     if (!NO_FORK)
@@ -411,7 +411,7 @@ void StartServer(EvalContext *ctx, Policy **policy, GenericAgentConfig *config)
                 else
                 {
                     Log(LOG_LEVEL_ERR, "select failed. (select: %s)", GetErrorStr());
-                    exit(1);
+                    exit(EXIT_FAILURE);
                 }
             }
             else if (!ret_val) /* No data waiting, we must have timed out! */
@@ -455,13 +455,13 @@ int InitServer(size_t queue_size)
     if ((sd = OpenReceiverChannel()) == -1)
     {
         Log(LOG_LEVEL_ERR, "Unable to start server");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     if (listen(sd, queue_size) == -1)
     {
         Log(LOG_LEVEL_ERR, "listen failed. (listen: %s)", GetErrorStr());
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     return sd;
@@ -506,7 +506,7 @@ int OpenReceiverChannel(void)
                        &yes, sizeof(yes)) == -1)
         {
             Log(LOG_LEVEL_ERR, "Socket option SO_REUSEADDR was not accepted. (setsockopt: %s)", GetErrorStr());
-            exit(1);
+            exit(EXIT_FAILURE);
         }
 
         struct linger cflinger = {
@@ -517,7 +517,7 @@ int OpenReceiverChannel(void)
                        &cflinger, sizeof(cflinger)) == -1)
         {
             Log(LOG_LEVEL_ERR, "Socket option SO_LINGER was not accepted. (setsockopt: %s)", GetErrorStr());
-            exit(1);
+            exit(EXIT_FAILURE);
         }
 
         if (bind(sd, ap->ai_addr, ap->ai_addrlen) != -1)
@@ -544,7 +544,7 @@ int OpenReceiverChannel(void)
     if (sd < 0)
     {
         Log(LOG_LEVEL_ERR, "Couldn't open/bind a socket");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     freeaddrinfo(response);

--- a/cf-upgrade/configuration.c
+++ b/cf-upgrade/configuration.c
@@ -175,7 +175,7 @@ void ConfigurationAddArgument(Configuration *configuration, char *argument)
     {
         log_entry(LogCritical, "A maximum of %d arguments can be specified, aborting",
                   CF_UPGRADE_MAX_ARGUMENTS);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 }
 

--- a/cf-upgrade/process.c
+++ b/cf-upgrade/process.c
@@ -196,7 +196,7 @@ int private_run_process_finish(const char *command, char **args, char **envp)
      * and hope for the best. Notice that if the process failed to start we
      * would have caught it in the if loop above.
      */
-    exit(0);
+    exit(EXIT_SUCCESS);
 }
 /*
  * There is an interesting difference in the Windows way of doing things versus

--- a/ext/rpmvercmp.c
+++ b/ext/rpmvercmp.c
@@ -242,11 +242,11 @@ int main(int argc, char **argv)
 
     if (rstreq(argv[2], "lt"))
     {
-        exit(rc == -1 ? 0 : 1);
+        exit(rc == -1 ? EXIT_SUCCESS : EXIT_FAILURE);
     }
     else
     {
-        exit(rc == 0 ? 0 : 1);
+        exit(rc == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
     }
 }
 

--- a/libcompat/getopt.c
+++ b/libcompat/getopt.c
@@ -706,7 +706,7 @@ main (argc, argv)
       printf ("\n");
     }
 
-  exit (0);
+  exit(EXIT_SUCCESS);
 }
 
 #endif /* TEST */

--- a/libcompat/getopt1.c
+++ b/libcompat/getopt1.c
@@ -175,7 +175,7 @@ main (argc, argv)
       printf ("\n");
     }
 
-  exit (0);
+  exit(EXIT_SUCCESS);
 }
 
 #endif /* TEST */

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -327,7 +327,7 @@ void GetInterfacesInfo(EvalContext *ctx)
     if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) == -1)
     {
         Log(LOG_LEVEL_ERR, "Couldn't open socket. (socket: %s)", GetErrorStr());
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     list.ifc_len = sizeof(ifbuf);
@@ -340,7 +340,7 @@ void GetInterfacesInfo(EvalContext *ctx)
 # endif
     {
         Log(LOG_LEVEL_ERR, "Couldn't get interfaces - old kernel? Try setting CF_IFREQ to 1024. (ioctl: %s)", GetErrorStr());
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     char last_name[sizeof(ifp->ifr_name)] = "";

--- a/libpromises/audit.c
+++ b/libpromises/audit.c
@@ -160,7 +160,7 @@ void FatalError(const EvalContext *ctx, char *s, ...)
 
     EndAudit(ctx, 0);
 #ifdef NDEBUG
-    exit(1);
+    exit(EXIT_FAILURE);
 #else
     abort();
 #endif

--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -178,7 +178,7 @@ promise_type   [a-zA-Z_]+:
                       if ( include_stack_ptr >= MAX_INCLUDE_DEPTH )
                       {
                           ParserDebug("\tI: Includes nested too deeply\n" );
-                          exit( 1 );
+                          exit(EXIT_FAILURE);
                       }
                       BEGIN(incl_state);
                       }
@@ -209,7 +209,7 @@ promise_type   [a-zA-Z_]+:
 
                                    snprintf(error_str, CF_MAXVARSIZE, "\tI: Could not resolve realpath of file '%s': %s\n", P.filename, strerror(errno));
                                    yyerror(error_str);
-                                   exit(1);
+                                   exit(EXIT_FAILURE);
                                }
 
                                char *chop = strrchr(dirname, '/');
@@ -238,7 +238,7 @@ promise_type   [a-zA-Z_]+:
 
                               snprintf(error_str, CF_MAXVARSIZE, "\tI: Could not open file '%s' for reading: %s\n", fname, strerror(errno));
                               yyerror(error_str);
-                              exit(1);
+                              exit(EXIT_FAILURE);
                           }
                           else
                           {
@@ -255,7 +255,7 @@ promise_type   [a-zA-Z_]+:
 
 <incl_state>.[^'"]*   {
                           yyerror("Not a valid include statement");
-                          exit(1);
+                          exit(EXIT_FAILURE);
                       }
 
 

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -1167,7 +1167,7 @@ static void ParseErrorVColumnOffset(int column_offset, const char *s, va_list ap
         if (P.error_count > 12)
         {
             fprintf(stderr, "Too many errors");
-            exit(1);
+            exit(EXIT_FAILURE);
         }
     }
 
@@ -1228,7 +1228,7 @@ static void ParseWarningV(unsigned int warning, const char *s, va_list ap)
     if (P.error_count > 12)
     {
         fprintf(stderr, "Too many errors");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -1263,7 +1263,7 @@ static void fatal_yyerror(const char *s)
         fprintf(stderr, "%s: %d,%d: Fatal error during parsing: %s, near token \'%.20s\'\n", P.filename, P.line_no, P.line_pos, s, sp ? sp : "NULL");
     }
 
-    exit(1);
+    exit(EXIT_FAILURE);
 }
 
 static int RelevantBundle(const char *agent, const char *blocktype)

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -74,7 +74,7 @@ static Rlist *NewExpArgs(EvalContext *ctx, const FnCall *fp)
             Log(LOG_LEVEL_ERR, "Arguments to function '%s' do not tally. Expected %d not %d",
                   fp->name, FnNumArgs(fn), len);
             PromiseRef(LOG_LEVEL_ERR, fp->caller);
-            exit(1);
+            exit(EXIT_FAILURE);
         }
     }
 

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1111,14 +1111,14 @@ static Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_
         }
 
         Log(LOG_LEVEL_ERR, "Can't stat file '%s' for parsing. (stat: %s)", input_path, GetErrorStr());
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
 #ifndef _WIN32
     if (config->check_not_writable_by_others && (statbuf.st_mode & (S_IWGRP | S_IWOTH)))
     {
         Log(LOG_LEVEL_ERR, "File %s (owner %ju) is writable by others (security exception)", input_path, (uintmax_t)statbuf.st_uid);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 #endif
 
@@ -1127,7 +1127,7 @@ static Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_
     if (!FileCanOpen(input_path, "r"))
     {
         Log(LOG_LEVEL_ERR, "Can't open file '%s' for parsing", input_path);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     Policy *policy = NULL;

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -401,7 +401,7 @@ static void LogLockCompletion(char *cflog, int pid, char *str, char *op, char *o
     if ((fp = fopen(cflog, "a")) == NULL)
     {
         Log(LOG_LEVEL_ERR, "Can't open lock-log file '%s'. (fopen: %s)", cflog, GetErrorStr());
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     if ((tim = time((time_t *) NULL)) == -1)

--- a/libpromises/parser.c
+++ b/libpromises/parser.c
@@ -99,7 +99,7 @@ Policy *ParserParseFile(AgentType agent_type, const char *path, unsigned int war
     if (yyin == NULL)
     {
         Log(LOG_LEVEL_ERR, "While opening file '%s' for parsing. (fopen: %s)", path, GetErrorStr());
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     while (!feof(yyin))
@@ -109,7 +109,7 @@ Policy *ParserParseFile(AgentType agent_type, const char *path, unsigned int war
         if (ferror(yyin))
         {
             perror("cfengine");
-            exit(1);
+            exit(EXIT_FAILURE);
         }
     }
 

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -194,7 +194,7 @@ FILE *cf_popen(const char *command, const char *type, bool capture_stderr)
             Log(LOG_LEVEL_ERR, "Couldn't run '%s'. (execv: %s)", argv[0], GetErrorStr());
         }
 
-        _exit(1);
+        _exit(EXIT_FAILURE);
     }
     else
     {
@@ -297,7 +297,7 @@ FILE *cf_popensetuid(const char *command, const char *type, uid_t uid, gid_t gid
 
         if (!CfSetuid(uid, gid))
         {
-            _exit(1);
+            _exit(EXIT_FAILURE);
         }
 
         if (execv(argv[0], argv) == -1)
@@ -305,7 +305,7 @@ FILE *cf_popensetuid(const char *command, const char *type, uid_t uid, gid_t gid
             Log(LOG_LEVEL_ERR, "Couldn't run '%s'. (execv: %s)", argv[0], GetErrorStr());
         }
 
-        _exit(1);
+        _exit(EXIT_FAILURE);
     }
     else
     {
@@ -386,7 +386,7 @@ FILE *cf_popen_sh(const char *command, const char *type)
         CloseChildrenFD();
 
         execl(SHELL_PATH, "sh", "-c", command, NULL);
-        _exit(1);
+        _exit(EXIT_FAILURE);
     }
     else
     {
@@ -484,11 +484,11 @@ FILE *cf_popen_shsetuid(const char *command, const char *type, uid_t uid, gid_t 
 
         if (!CfSetuid(uid, gid))
         {
-            _exit(1);
+            _exit(EXIT_FAILURE);
         }
 
         execl(SHELL_PATH, "sh", "-c", command, NULL);
-        _exit(1);
+        _exit(EXIT_FAILURE);
     }
     else
     {

--- a/libpromises/signals.c
+++ b/libpromises/signals.c
@@ -51,7 +51,7 @@ void MakeSignalPipe()
     {
         Log(LOG_LEVEL_CRIT, "Could not create internal communication pipe. Cannot continue. (socketpair: '%s')",
             GetErrorStr());
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     for (int c = 0; c < 2; c++)
@@ -61,7 +61,7 @@ void MakeSignalPipe()
         {
             Log(LOG_LEVEL_CRIT, "Could not create internal communication pipe. Cannot continue. (fcntl: '%s')",
                 GetErrorStr());
-            exit(1);
+            exit(EXIT_FAILURE);
         }
 #else // __MINGW32__
         u_long enable = 1;
@@ -69,7 +69,7 @@ void MakeSignalPipe()
         {
             Log(LOG_LEVEL_CRIT, "Could not create internal communication pipe. Cannot continue. (ioctlsocket: '%s')",
                 GetErrorStr());
-            exit(1);
+            exit(EXIT_FAILURE);
         }
 #endif // __MINGW32__
     }
@@ -91,7 +91,7 @@ void HandleSignalsForAgent(int signum)
     {
         /* TODO don't exit from the signal handler, just set a flag. Reason is
          * that all the atexit() hooks we register are not reentrant. */
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
     else if (signum == SIGUSR1)
     {
@@ -119,7 +119,7 @@ void HandleSignalsForAgent(int signum)
                 // going on.
                 Log(LOG_LEVEL_CRIT, "Could not write to signal pipe. Unsafe to continue. (write: '%s')",
                     GetErrorStr());
-                _exit(1);
+                _exit(EXIT_FAILURE);
             }
         }
     }
@@ -163,7 +163,7 @@ void HandleSignalsForDaemon(int signum)
                 // going on.
                 Log(LOG_LEVEL_CRIT, "Could not write to signal pipe. Unsafe to continue. (write: '%s')",
                     GetErrorStr());
-                _exit(1);
+                _exit(EXIT_FAILURE);
             }
         }
     }

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -196,7 +196,7 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
             if (execl(SHELL_PATH, "sh", "-c", command, NULL) == -1)
             {
                 Log(LOG_LEVEL_ERR, "Command '%s' failed. (execl: %s)", command, GetErrorStr());
-                exit(1);
+                exit(EXIT_FAILURE);
             }
         }
         else
@@ -206,7 +206,7 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
             if (execv(argv[0], argv) == -1)
             {
                 Log(LOG_LEVEL_ERR, "Command '%s' failed. (execv: %s)", argv[0], GetErrorStr());
-                exit(1);
+                exit(EXIT_FAILURE);
             }
         }
     }

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -177,7 +177,7 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp, bool allow_d
         if (Epimenides(ctx, PromiseGetBundle(pp)->ns, PromiseGetBundle(pp)->name, pp->promiser, rval, 0))
         {
             Log(LOG_LEVEL_ERR, "Variable '%s' contains itself indirectly - an unkeepable promise", pp->promiser);
-            exit(1);
+            exit(EXIT_FAILURE);
         }
         else
         {

--- a/tests/acceptance/mock-package-manager.c
+++ b/tests/acceptance/mock-package-manager.c
@@ -307,7 +307,7 @@ static void AddPackage(PackagePattern *pattern)
     if (SeqLength(matching_available) == 0)
     {
         fprintf(stderr, "Unable to find any package matching %s\n", SerializePackagePattern(pattern));
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < SeqLength(matching_available); i++)
@@ -319,7 +319,7 @@ static void AddPackage(PackagePattern *pattern)
         if (SeqLength(FindPackages(INSTALLED_PACKAGES_FILE_NAME, pat)) > 0)
         {
             fprintf(stderr, "Package %s is already installed.\n", SerializePackage(p));
-            exit(1);
+            exit(EXIT_FAILURE);
         }
     }
 
@@ -334,7 +334,7 @@ static void AddPackage(PackagePattern *pattern)
     }
 
     SavePackages(INSTALLED_PACKAGES_FILE_NAME, installed_packages);
-    exit(0);
+    exit(EXIT_SUCCESS);
 }
 
 /******************************************************************************/
@@ -434,7 +434,7 @@ int main(int argc, char *argv[])
                 GenericAgentWriteHelp(w, "mock-package-manager - pretend that you are managing packages!", OPTIONS, HINTS, false);
                 FileWriterDetach(w);
             }
-            exit(1);
+            exit(EXIT_FAILURE);
         }
 
     }

--- a/tests/load/db_load.c
+++ b/tests/load/db_load.c
@@ -130,7 +130,7 @@ static void TestCursorIteration(CF_DB *db)
     {
         fprintf(stderr, "Test: could not create cursor");
         pthread_exit((void*)STATUS_ERROR);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     char *key;
@@ -176,7 +176,7 @@ static void TestCursorIteration(CF_DB *db)
     if(!DeleteDBCursor(dbc))
     {
         fprintf(stderr, "Test: could not delete cursor");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
 }
@@ -213,7 +213,7 @@ int main(int argc, char **argv)
     if (argc != 2)
     {
         fprintf(stderr, "Usage: db_load <num_threads>\n");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     /* To clean up after databases are closed */
@@ -327,7 +327,7 @@ void FatalError(const EvalContext *ctx, char *fmt, ...)
         Log(LOG_LEVEL_ERR, "Fatal CFEngine error (no description)");
     }
 
-    exit(1);
+    exit(EXIT_FAILURE);
 }
 
 

--- a/tests/unit/file_lib_test.c
+++ b/tests/unit/file_lib_test.c
@@ -75,7 +75,7 @@ static void chdir_or_exit(const char *path)
     if (chdir(path) < 0)
     {
         // Don't risk writing into folders we shouldn't. Just bail.
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -137,7 +137,7 @@ static void return_to_test_dir(void)
     if (fchdir(ORIG_DIR) < 0)
     {
         // Don't risk writing into folders we shouldn't. Just bail.
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 }
 

--- a/tests/unit/tls_generic_test.c
+++ b/tests/unit/tls_generic_test.c
@@ -58,7 +58,7 @@ void child_cycle(int channel)
     {
         message = -1;
         result = write(channel, &message, sizeof(int));
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
     /*
      * Create a unix socket
@@ -79,7 +79,7 @@ void child_cycle(int channel)
     {
         message = -1;
         result = write(channel, &message, sizeof(int));
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
     /*
      * Start listening for connections
@@ -89,7 +89,7 @@ void child_cycle(int channel)
     {
         message = -1;
         result = write(channel, &message, sizeof(int));
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
     /*
      * Signal the parent that we are ok.
@@ -100,7 +100,7 @@ void child_cycle(int channel)
      */
     if (result < 0)
     {
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
     /*
      * Send the name of the public key file.
@@ -108,7 +108,7 @@ void child_cycle(int channel)
     result = write(channel, server_name_template_public, strlen(server_name_template_public));
     if (result < 0)
     {
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
     /*
      * Send the name of the certificate file.
@@ -116,7 +116,7 @@ void child_cycle(int channel)
     result = write(channel, server_certificate_template_public, strlen(server_certificate_template_public));
     if (result < 0)
     {
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
     /*
      * Now wait until somebody calls.
@@ -180,7 +180,7 @@ void child_cycle(int channel)
         SSL_free(ssl);
         remote_socket = -1;
     }
-    exit(0);
+    exit(EXIT_SUCCESS);
 }
 
 int start_child_process()


### PR DESCRIPTION
Using standard constants instead of 1 or 0 to improve readability, and maybe some portability gains:

exit(3):

```
The  use  of EXIT_SUCCESS and EXIT_FAILURE is slightly more portable (to non-UNIX environments)
than  the use of 0 and some nonzero value like 1 or -1.  In particular, VMS uses a different convention.
```

Notes:
- I've not modified the exit() calls when the returned value is different from 1 or 0 (don't break something people/tools have maybe started relying on)
- I've not modified 3rdparty/ directory, because I'm not aware of your policy about changes to 3rd party stuff.
