### PR TITLE
Fix getaddrinfo() usage

### DIFF
--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -471,7 +471,7 @@ int OpenReceiverChannel(void)
 {
     struct addrinfo *response = NULL, *ap;
     struct addrinfo query = {
-        .ai_flags = AI_PASSIVE | AI_NUMERICHOST,
+        .ai_flags = AI_PASSIVE | AI_NUMERICSERV,
         .ai_family = AF_UNSPEC,
         .ai_socktype = SOCK_STREAM
     };


### PR DESCRIPTION
An easy one. While using an alternate server-client pair for tests, I must have stumbled on a bug (?) of getaddinfo() , which in turn had me revise these lines.

Please check that non-linux systems have the same (POSIX.1-2001) API.
