### PR TITLE
Unmerge FACILITY for syslog client and Windows Error Log.

### DIFF
--- a/libpromises/syslog_client.c
+++ b/libpromises/syslog_client.c
@@ -26,13 +26,22 @@
 
 #include <cf3.defs.h>
 
+/*
+ * Set by cf-agent/cf-serverd from body agent/server control.
+ */
 static char SYSLOG_HOST[MAXHOSTNAMELEN] = "localhost";
+/*
+ * Set by cf-agent/cf-serverd from body agent/server control.
+ */
 static uint16_t SYSLOG_PORT = 514;
-int FACILITY;
+/*
+ * Set by cf-agent/cf-serverd/cf-execd from body agent/exec/server control.
+ */
+static int SYSLOG_FACILITY = LOG_USER;
 
 void SetSyslogFacility(int facility)
 {
-    FACILITY = facility;
+    SYSLOG_FACILITY = facility;
 }
 
 bool SetSyslogHost(const char *host)
@@ -56,7 +65,7 @@ void SetSyslogPort(uint16_t port)
 void RemoteSysLog(int log_priority, const char *log_string)
 {
     time_t now = time(NULL);
-    int sd, pri = log_priority | FACILITY;
+    int sd, pri = log_priority | SYSLOG_FACILITY;
 
     int err;
     struct addrinfo query, *response, *ap;


### PR DESCRIPTION
FACILITY variable was very awkward: while being internal to syslog client implementation, it was also
reused by Windows Error Log client in Enterprise.

Fortunately, both were set in sync, so we can just use two module-static variables instead of one shared.

While on this, add comments depicting lifetime of globals in syslog module.
