### PR TITLE
Don't use cache in {Public,Private}KeyFile

### DIFF
--- a/cf-agent/agent-diagnostics.c
+++ b/cf-agent/agent-diagnostics.c
@@ -91,45 +91,52 @@ AgentDiagnosticsResult AgentDiagnosticsCheckAmPolicyServer(const char *workdir)
 
 AgentDiagnosticsResult AgentDiagnosticsCheckPrivateKey(const char *workdir)
 {
-    const char *path = PrivateKeyFile(workdir);
-    assert(path);
+    char *path = PrivateKeyFile(workdir);
     struct stat sb;
+    AgentDiagnosticsResult res;
 
     if (stat(path, &sb) != 0)
     {
-        return AgentDiagnosticsResultNew(false, StringFormat("No private key found at '%s'", path));
+        res = AgentDiagnosticsResultNew(false, StringFormat("No private key found at '%s'", path));
     }
-
-    if (sb.st_mode != (S_IFREG | S_IWUSR | S_IRUSR))
+    else if (sb.st_mode != (S_IFREG | S_IWUSR | S_IRUSR))
     {
-        return AgentDiagnosticsResultNew(false, StringFormat("Private key found at '%s', but had incorrect permissions '%o'", path, sb.st_mode));
+        res = AgentDiagnosticsResultNew(false, StringFormat("Private key found at '%s', but had incorrect permissions '%o'", path, sb.st_mode));
+    }
+    else
+    {
+        res = AgentDiagnosticsResultNew(true, StringFormat("OK at '%s'", path));
     }
 
-    return AgentDiagnosticsResultNew(true, StringFormat("OK at '%s'", path));
+    free(path);
+    return res;
 }
 
 AgentDiagnosticsResult AgentDiagnosticsCheckPublicKey(const char *workdir)
 {
-    const char *path = PublicKeyFile(workdir);
-    assert(path);
+    char *path = PublicKeyFile(workdir);
     struct stat sb;
+    AgentDiagnosticsResult res;
 
     if (stat(path, &sb) != 0)
     {
-        return AgentDiagnosticsResultNew(false, StringFormat("No public key found at '%s'", path));
+        res = AgentDiagnosticsResultNew(false, StringFormat("No public key found at '%s'", path));
     }
-
-    if (sb.st_mode != (S_IFREG | S_IWUSR | S_IRUSR))
+    else if (sb.st_mode != (S_IFREG | S_IWUSR | S_IRUSR))
     {
-        return AgentDiagnosticsResultNew(false, StringFormat("Public key found at '%s', but had incorrect permissions '%o'", path, sb.st_mode));
+        res = AgentDiagnosticsResultNew(false, StringFormat("Public key found at '%s', but had incorrect permissions '%o'", path, sb.st_mode));
     }
-
-    if (sb.st_size != 426)
+    else if (sb.st_size != 426)
     {
-        return AgentDiagnosticsResultNew(false, StringFormat("Public key at '%s' had size %zd bytes, expected 426 bytes", path, sb.st_size));
+        res = AgentDiagnosticsResultNew(false, StringFormat("Public key at '%s' had size %zd bytes, expected 426 bytes", path, sb.st_size));
+    }
+    else
+    {
+        res = AgentDiagnosticsResultNew(true, StringFormat("OK at '%s'", path));
     }
 
-    return AgentDiagnosticsResultNew(true, StringFormat("OK at '%s'", path));
+    free(path);
+    return res;
 }
 
 static AgentDiagnosticsResult AgentDiagnosticsCheckDB(const char *workdir, dbid id)

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -137,8 +137,8 @@ int main(int argc, char *argv[])
     }
     else
     {
-        public_key_file = xstrdup(PublicKeyFile(GetWorkDir()));
-        private_key_file = xstrdup(PrivateKeyFile(GetWorkDir()));
+        public_key_file = PublicKeyFile(GetWorkDir());
+        private_key_file = PrivateKeyFile(GetWorkDir());
     }
 
     KeepKeyPromises(public_key_file, private_key_file);

--- a/libcfnet/client_protocol.c
+++ b/libcfnet/client_protocol.c
@@ -210,7 +210,9 @@ int AuthenticateAgent(AgentConnection *conn, bool trust_key)
         LoadSecretKeys();
         if ((PUBKEY == NULL) || (PRIVKEY == NULL))
         {
-            Log(LOG_LEVEL_ERR, "No public/private key pair found at '%s'", PublicKeyFile(GetWorkDir()));
+            char *pubkeyfile = PublicKeyFile(GetWorkDir());
+            Log(LOG_LEVEL_ERR, "No public/private key pair found at '%s'", pubkeyfile);
+            free(pubkeyfile);
             return false;
         }
     }

--- a/libpromises/crypto.h
+++ b/libpromises/crypto.h
@@ -39,7 +39,7 @@ RSA *HavePublicKey(const char *username, const char *ipaddress, const char *dige
 RSA *HavePublicKeyByIP(const char *username, const char *ipaddress);
 void SavePublicKey(const char *username, const char *digest, const RSA *key);
 
-const char *PublicKeyFile(const char *workdir);
-const char *PrivateKeyFile(const char *workdir);
+char *PublicKeyFile(const char *workdir);
+char *PrivateKeyFile(const char *workdir);
 
 #endif


### PR DESCRIPTION
It's cheap to compute those strings again, and they are used
very infrequently (in one-time code and error messages).
