### PR TITLE
Simplify and fix IsRegex detection by looking for special chars used by regular expression syntax. Add unit test.

### DIFF
--- a/libpromises/matching.c
+++ b/libpromises/matching.c
@@ -225,99 +225,17 @@ int BlockTextMatch(EvalContext *ctx, const char *regexp, const char *teststring,
 
 int IsRegex(char *str)
 {
-    char *sp;
-    int ret = false;
-    enum
-    { r_norm, r_norepeat, r_literal } special = r_norepeat;
-    int bracket = 0;
-    int paren = 0;
-
-/* Try to see when something is intended as a regular expression */
-
-    for (sp = str; *sp != '\0'; sp++)
-    {
-        if (special == r_literal)
-        {
-            special = r_norm;
-            continue;
-        }
-        else if (*sp == '\\')
-        {
-            special = r_literal;
-            continue;
-        }
-        else if (bracket && (*sp != ']'))
-        {
-            if (*sp == '[')
-            {
-                return false;
-            }
-            continue;
-        }
-
-        switch (*sp)
-        {
-        case '^':
-            special = (sp == str) ? r_norepeat : r_norm;
-            break;
-        case '*':
-        case '+':
-            if (special == r_norepeat)
-            {
-                return false;
-            }
-            special = r_norepeat;
-            ret = true;
-            break;
-        case '[':
-            special = r_norm;
-            bracket++;
-            ret = true;
-            break;
-        case ']':
-            if (bracket == 0)
-            {
-                return false;
-            }
-            bracket = 0;
-            special = r_norm;
-            break;
-        case '(':
-            special = r_norepeat;
-            paren++;
-            break;
-
-        case ')':
-            special = r_norm;
-            paren--;
-            if (paren < 0)
-            {
-                return false;
-            }
-            break;
-
-        case '|':
-            special = r_norepeat;
-            if (paren > 0)
-            {
-                ret = true;
-            }
-            break;
-
-        default:
-            special = r_norm;
-        }
-
-    }
-
-    if ((bracket != 0) || (paren != 0) || (special == r_literal))
+    if (!str)
     {
         return false;
     }
-    else
+
+    if (strcspn(str, "\\^${}[]().*+?|<>-&") == SafeStringLength(str))
     {
-        return ret;
+        return false;
     }
+
+    return true;
 }
 
 int IsPathRegex(char *str)

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -95,7 +95,8 @@ check_PROGRAMS = \
 	key_test \
 	cf_upgrade_test \
 	queue_test \
-	ring_buffer_test
+	ring_buffer_test \
+	matching_test
 
 if HAVE_AVAHI_CLIENT
 if HAVE_AVAHI_COMMON

--- a/tests/unit/matching_test.c
+++ b/tests/unit/matching_test.c
@@ -1,0 +1,45 @@
+#include <test.h>
+#include <matching.h>
+
+void test_is_regex(void)
+{
+    assert_false(IsRegex("string"));
+    assert_false(IsRegex("ala ma kota a kot ma ale"));
+
+    // commented cases fail
+    assert_true(IsRegex("^string"));
+    assert_true(IsRegex("^(string)"));
+    assert_true(IsRegex("string$"));
+    assert_true(IsRegex("(string)$"));
+    assert_true(IsRegex("string.*"));
+    assert_true(IsRegex("string*"));
+    assert_true(IsRegex("string."));
+    assert_true(IsRegex("a?"));
+    assert_true(IsRegex("a*"));
+    assert_true(IsRegex("a+"));
+    assert_true(IsRegex("a{3}"));
+    assert_true(IsRegex("a{3,6}"));
+    assert_true(IsRegex("(a|b)"));
+    assert_true(IsRegex("a(bcd)*"));
+    assert_true(IsRegex("c.+t"));
+    assert_true(IsRegex("a(bcd)?e"));
+    assert_true(IsRegex("a(bcd){2,3}e"));
+    assert_true(IsRegex("(yes)|(no)"));
+    assert_true(IsRegex("pro(b|n|r|l)ate"));
+    assert_true(IsRegex("c[aeiou]t"));
+    assert_true(IsRegex("^[a-zA-Z0-9_]+$"));
+    assert_true(IsRegex("\\d{5}"));
+    assert_true(IsRegex("\\d"));
+}
+
+int main()
+{
+    PRINT_TEST_BANNER();
+    const UnitTest tests[] =
+    {
+        unit_test(test_is_regex)
+    };
+
+    return run_tests(tests);
+}
+


### PR DESCRIPTION
Implementation of IsRegex was buggy and did not pass most of test cases attached in unit test. 
It tried to analyze the string to check if it has valid regular expression syntax.

New implementation take the problem by simple approach: if string contain regex syntax chars it's potentially a regular expression.

For checking is regex syntax is valid there is a seperate function in API to do this task. 
