### PR TITLE
libutils/safe_open: fix case that a dir ends in slash/

### DIFF
--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -232,9 +232,12 @@ int safe_open(const char *pathname, int flags, ...)
         next_component = strchr(component + 1, '/');
         if (next_component)
         {
-            *next_component = '\0';
-            // Eliminate double slashes.
-            while (*(++next_component) == '/') { /*noop*/ }
+            *(next_component++) = '\0';
+        }
+        if (! *component)
+        {
+            // empty part between 2 slashes or slash at end of string
+            continue;
         }
 
         struct stat stat_before, stat_after;


### PR DESCRIPTION
The loop that splits a path into "component" dirs would try to process
the empty string after a final slash like in "some/dir/" .
You see, the (now removed) inner while-loop would skip successive
slashes, but only in the middle of the path string.
Now, empty components are skipped, which uses the outer loop to find
next component after an empty (double-slash) directory.
