### PR TITLE
Constify EvalContextVariableGet

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -65,11 +65,11 @@
 
 #define CF_RECURSION_LIMIT 100
 
-static Rlist *AUTO_DEFINE_LIST = NULL; /* GLOBAL_P */
+static const Rlist *AUTO_DEFINE_LIST = NULL; /* GLOBAL_P */
 
 Item *VSETUIDLIST = NULL; /* GLOBAL_X */
 
-Rlist *SINGLE_COPY_LIST = NULL; /* GLOBAL_P */
+const Rlist *SINGLE_COPY_LIST = NULL; /* GLOBAL_P */
 static Rlist *SINGLE_COPY_CACHE = NULL; /* GLOBAL_X */
 
 static bool TransformFile(EvalContext *ctx, char *file, Attributes attr, const Promise *pp, PromiseResult *result);
@@ -105,7 +105,7 @@ static int VerifyFinderType(EvalContext *ctx, const char *file, Attributes a, co
 static void VerifyFileChanges(const char *file, struct stat *sb, Attributes attr, const Promise *pp);
 static PromiseResult VerifyFileIntegrity(EvalContext *ctx, const char *file, Attributes attr, const Promise *pp);
 
-void SetFileAutoDefineList(Rlist *auto_define_list)
+void SetFileAutoDefineList(const Rlist *auto_define_list)
 {
     AUTO_DEFINE_LIST = auto_define_list;
 }
@@ -169,11 +169,9 @@ bool VerifyFileLeaf(EvalContext *ctx, char *path, struct stat *sb, Attributes at
 }
 
 /* Checks whether item matches a list of wildcards */
-static int MatchRlistItem(EvalContext *ctx, Rlist *listofregex, const char *teststring)
+static int MatchRlistItem(EvalContext *ctx, const Rlist *listofregex, const char *teststring)
 {
-    Rlist *rp;
-
-    for (rp = listofregex; rp != NULL; rp = rp->next)
+    for (const Rlist *rp = listofregex; rp != NULL; rp = rp->next)
     {
         /* Avoid using regex if possible, due to memory leak */
 

--- a/cf-agent/verify_files_utils.h
+++ b/cf-agent/verify_files_utils.h
@@ -29,9 +29,9 @@
 #include <cfnet.h>                                       /* AgentConnection */
 
 extern Item *VSETUIDLIST;
-extern Rlist *SINGLE_COPY_LIST;
+extern const Rlist *SINGLE_COPY_LIST;
 
-void SetFileAutoDefineList(Rlist *auto_define_list);
+void SetFileAutoDefineList(const Rlist *auto_define_list);
 
 bool VerifyFileLeaf(EvalContext *ctx, char *path, struct stat *sb, Attributes attr, const Promise *pp, PromiseResult *result);
 int DepthSearch(EvalContext *ctx, char *name, struct stat *sb, int rlevel, Attributes attr, const Promise *pp, dev_t rootdevice, PromiseResult *result);

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -99,9 +99,7 @@ PromiseResult VerifyPackagesPromise(EvalContext *ctx, const Promise *pp)
     {
         const char *reserved = reserved_vars[c];
         VarRef *var_ref = VarRefParseFromScope(reserved, "this");
-        Rval rval;
-        DataType dt;
-        if (EvalContextVariableGet(ctx, var_ref, &rval, &dt))
+        if (EvalContextVariableGet(ctx, var_ref, NULL))
         {
             Log(LOG_LEVEL_WARNING, "$(%s) variable has a special meaning in packages promises. "
                 "Things may not work as expected if it is already defined.", reserved);

--- a/cf-execd/exec-config.c
+++ b/cf-execd/exec-config.c
@@ -87,8 +87,8 @@ ExecConfig *ExecConfigNew(bool scheduled_run, const EvalContext *ctx, const Poli
 
             VarRef *ref = VarRefParseFromScope(cp->lval, "control_executor");
 
-            Rval retval;
-            if (!EvalContextVariableGet(ctx, ref, &retval, NULL))
+            const void *value = EvalContextVariableGet(ctx, ref, NULL);
+            if (!value)
             {
                 /* FIXME: figure out whether this is reachable */
                 // TODO: should've been checked before this point. change to programming error
@@ -102,41 +102,41 @@ ExecConfig *ExecConfigNew(bool scheduled_run, const EvalContext *ctx, const Poli
             if (strcmp(cp->lval, CFEX_CONTROLBODY[EXEC_CONTROL_MAILFROM].lval) == 0)
             {
                 free(exec_config->mail_from_address);
-                exec_config->mail_from_address = xstrdup(retval.item);
+                exec_config->mail_from_address = xstrdup(value);
                 Log(LOG_LEVEL_DEBUG, "mailfrom '%s'", exec_config->mail_from_address);
             }
             else if (strcmp(cp->lval, CFEX_CONTROLBODY[EXEC_CONTROL_MAILTO].lval) == 0)
             {
                 free(exec_config->mail_to_address);
-                exec_config->mail_to_address = xstrdup(retval.item);
+                exec_config->mail_to_address = xstrdup(value);
                 Log(LOG_LEVEL_DEBUG, "mailto '%s'", exec_config->mail_to_address);
             }
             else if (strcmp(cp->lval, CFEX_CONTROLBODY[EXEC_CONTROL_MAILSUBJECT].lval) == 0)
             {
                 free(exec_config->mail_subject);
-                exec_config->mail_subject = xstrdup(retval.item);
+                exec_config->mail_subject = xstrdup(value);
                 Log(LOG_LEVEL_DEBUG, "mailsubject '%s'", exec_config->mail_subject);
             }
             else if (strcmp(cp->lval, CFEX_CONTROLBODY[EXEC_CONTROL_SMTPSERVER].lval) == 0)
             {
                 free(exec_config->mail_server);
-                exec_config->mail_server = xstrdup(retval.item);
+                exec_config->mail_server = xstrdup(value);
                 Log(LOG_LEVEL_DEBUG, "smtpserver '%s'", exec_config->mail_server);
             }
             else if (strcmp(cp->lval, CFEX_CONTROLBODY[EXEC_CONTROL_EXECCOMMAND].lval) == 0)
             {
                 free(exec_config->exec_command);
-                exec_config->exec_command = xstrdup(retval.item);
+                exec_config->exec_command = xstrdup(value);
                 Log(LOG_LEVEL_DEBUG, "exec_command '%s'", exec_config->exec_command);
             }
             else if (strcmp(cp->lval, CFEX_CONTROLBODY[EXEC_CONTROL_AGENT_EXPIREAFTER].lval) == 0)
             {
-                exec_config->agent_expireafter = IntFromString(retval.item);
+                exec_config->agent_expireafter = IntFromString(value);
                 Log(LOG_LEVEL_DEBUG, "agent_expireafter %d", exec_config->agent_expireafter);
             }
             else if (strcmp(cp->lval, CFEX_CONTROLBODY[EXEC_CONTROL_MAILMAXLINES].lval) == 0)
             {
-                exec_config->mail_max_lines = IntFromString(retval.item);
+                exec_config->mail_max_lines = IntFromString(value);
                 Log(LOG_LEVEL_DEBUG, "maxlines %d", exec_config->mail_max_lines);
             }
         }

--- a/cf-execd/execd-config.c
+++ b/cf-execd/execd-config.c
@@ -70,8 +70,8 @@ ExecdConfig *ExecdConfigNew(const EvalContext *ctx, const Policy *policy)
 
             VarRef *ref = VarRefParseFromScope(cp->lval, "control_executor");
 
-            Rval retval;
-            if (!EvalContextVariableGet(ctx, ref, &retval, NULL))
+            const void *value = EvalContextVariableGet(ctx, ref, NULL);
+            if (!value)
             {
                 // TODO: should've been checked before this point. change to programming error
                 Log(LOG_LEVEL_ERR, "Unknown lval '%s' in exec control body", cp->lval);
@@ -84,12 +84,12 @@ ExecdConfig *ExecdConfigNew(const EvalContext *ctx, const Policy *policy)
             if (strcmp(cp->lval, CFEX_CONTROLBODY[EXEC_CONTROL_EXECUTORFACILITY].lval) == 0)
             {
                 free(execd_config->log_facility);
-                execd_config->log_facility = xstrdup(retval.item);
+                execd_config->log_facility = xstrdup(value);
                 Log(LOG_LEVEL_DEBUG, "executorfacility '%s'", execd_config->log_facility);
             }
             else if (strcmp(cp->lval, CFEX_CONTROLBODY[EXEC_CONTROL_SPLAYTIME].lval) == 0)
             {
-                int time = IntFromString(RvalScalarValue(retval));
+                int time = IntFromString(value);
                 execd_config->splay_time = (int) (time * SECONDS_PER_MINUTE * GetSplay());
             }
             else if (strcmp(cp->lval, CFEX_CONTROLBODY[EXEC_CONTROL_SCHEDULE].lval) == 0)
@@ -97,7 +97,7 @@ ExecdConfig *ExecdConfigNew(const EvalContext *ctx, const Policy *policy)
                 Log(LOG_LEVEL_DEBUG, "Loading user-defined schedule...");
                 StringSetClear(execd_config->schedule);
 
-                for (const Rlist *rp = retval.item; rp; rp = rp->next)
+                for (const Rlist *rp = value; rp; rp = rp->next)
                 {
                     StringSetAdd(execd_config->schedule, xstrdup(RlistScalarValue(rp)));
                     Log(LOG_LEVEL_DEBUG, "Adding '%s'", RlistScalarValue(rp));

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -243,8 +243,6 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
 
 static void KeepPromises(EvalContext *ctx, const Policy *policy)
 {
-    Rval retval;
-
     Seq *constraints = ControlBodyConstraints(policy, AGENT_TYPE_MONITOR);
     if (constraints)
     {
@@ -258,15 +256,13 @@ static void KeepPromises(EvalContext *ctx, const Policy *policy)
             }
 
             VarRef *ref = VarRefParseFromScope(cp->lval, "control_monitor");
-
-            if (!EvalContextVariableGet(ctx, ref, &retval, NULL))
+            const void *value = EvalContextVariableGet(ctx, ref, NULL);
+            VarRefDestroy(ref);
+            if (!value)
             {
                 Log(LOG_LEVEL_ERR, "Unknown lval '%s' in monitor control body", cp->lval);
-                VarRefDestroy(ref);
                 continue;
             }
-
-            VarRefDestroy(ref);
 
             if (strcmp(cp->lval, CFM_CONTROLBODY[MONITOR_CONTROL_HISTOGRAMS].lval) == 0)
             {
@@ -275,12 +271,12 @@ static void KeepPromises(EvalContext *ctx, const Policy *policy)
 
             if (strcmp(cp->lval, CFM_CONTROLBODY[MONITOR_CONTROL_TCP_DUMP].lval) == 0)
             {
-                MonNetworkSnifferEnable(BooleanFromString(retval.item));
+                MonNetworkSnifferEnable(BooleanFromString(value));
             }
 
             if (strcmp(cp->lval, CFM_CONTROLBODY[MONITOR_CONTROL_FORGET_RATE].lval) == 0)
             {
-                sscanf(retval.item, "%lf", &FORGETRATE);
+                sscanf(value, "%lf", &FORGETRATE);
                 Log(LOG_LEVEL_DEBUG, "forget rate %f", FORGETRATE);
             }
         }

--- a/cf-upgrade/update.c
+++ b/cf-upgrade/update.c
@@ -39,7 +39,6 @@
 int private_copy_to_temporary_location(const char *source, const char *destination)
 {
     struct stat source_stat;
-    int result = 0;
     int source_fd = -1;
     int destination_fd = -1;
 
@@ -48,7 +47,7 @@ int private_copy_to_temporary_location(const char *source, const char *destinati
     {
         goto bad_nofd;
     }
-    result = fstat(source_fd, &source_stat);
+    fstat(source_fd, &source_stat);
     unlink (destination);
     destination_fd = open(destination, O_WRONLY|O_CREAT|O_EXCL, S_IRWXU|S_IRGRP|S_IROTH);
     if (destination_fd < 0)

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -847,13 +847,12 @@ FileChange GetChangeMgtConstraints(const EvalContext *ctx, const Promise *pp)
 FileCopy GetCopyConstraints(const EvalContext *ctx, const Promise *pp)
 {
     FileCopy f;
-    char *value;
     long min, max;
     int pval;
 
     f.source = PromiseGetConstraintAsRval(pp, "source", RVAL_TYPE_SCALAR);
 
-    value = PromiseGetConstraintAsRval(pp, "compare", RVAL_TYPE_SCALAR);
+    const char *value = PromiseGetConstraintAsRval(pp, "compare", RVAL_TYPE_SCALAR);
 
     if (value == NULL)
     {

--- a/libpromises/audit.c
+++ b/libpromises/audit.c
@@ -78,29 +78,22 @@ void EndAudit(const EvalContext *ctx, int background_tasks)
         return;
     }
 
-    char *sp, string[CF_BUFSIZE];
-    Rval retval = { 0 };
-
     double total = (double) (PR_KEPT + PR_NOTKEPT + PR_REPAIRED) / 100.0;
 
-    if (EvalContextVariableControlCommonGet(ctx, COMMON_CONTROL_VERSION, &retval))
+    const char *version = EvalContextVariableControlCommonGet(ctx, COMMON_CONTROL_VERSION);
+    if (!version)
     {
-        sp = (char *) retval.item;
-    }
-    else
-    {
-        sp = "(not specified)";
+        version = "(not specified)";
     }
 
     if (total == 0)
     {
-        *string = '\0';
-        Log(LOG_LEVEL_VERBOSE, "Outcome of version '%s', no checks were scheduled", sp);
+        Log(LOG_LEVEL_VERBOSE, "Outcome of version '%s', no checks were scheduled", version);
         return;
     }
     else
     {
-        LogTotalCompliance(sp, background_tasks);
+        LogTotalCompliance(version, background_tasks);
     }
 }
 

--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -81,7 +81,7 @@ extern int CFA_MAXTHREADS;
 extern AgentType THIS_AGENT_TYPE;
 extern int SHOWREPORTS;
 extern int LASTSEENEXPIREAFTER;
-extern char *DEFAULT_COPYTYPE;
+extern const char *DEFAULT_COPYTYPE;
 extern Item *PROCESSTABLE;
 
 extern const char *const DAY_TEXT[];

--- a/libpromises/cf3globals.c
+++ b/libpromises/cf3globals.c
@@ -72,7 +72,7 @@ char CFWORKDIR[CF_BUFSIZE] = ""; /* GLOBAL_C */
 /*
   Default value for copytype attribute. Loaded by cf-agent from body control
 */
-char *DEFAULT_COPYTYPE = NULL; /* GLOBAL_P */
+const char *DEFAULT_COPYTYPE = NULL; /* GLOBAL_P */
 
 /*
   Keys for the agent. Loaded by GAInitialize (and hence every time policy is

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -135,7 +135,7 @@ const Bundle *EvalContextStackCurrentBundle(const EvalContext *ctx);
 
 bool EvalContextVariablePut(EvalContext *ctx, const VarRef *ref, const void *value, DataType type, const char *tags);
 bool EvalContextVariablePutSpecial(EvalContext *ctx, SpecialScope scope, const char *lval, const void *value, DataType type, const char *tags);
-bool EvalContextVariableGet(const EvalContext *ctx, const VarRef *ref, Rval *rval_out, DataType *type_out);
+const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *ref, DataType *type_out);
 bool EvalContextVariableRemoveSpecial(const EvalContext *ctx, SpecialScope scope, const char *lval);
 bool EvalContextVariableRemove(const EvalContext *ctx, const VarRef *ref);
 StringSet *EvalContextVariableTags(const EvalContext *ctx, const VarRef *ref);
@@ -145,7 +145,7 @@ VariableTableIterator *EvalContextVariableTableIteratorNew(const EvalContext *ct
 bool EvalContextFunctionCacheGet(const EvalContext *ctx, const FnCall *fp, const Rlist *args, Rval *rval_out);
 void EvalContextFunctionCachePut(EvalContext *ctx, const FnCall *fp, const Rlist *args, const Rval *rval);
 
-bool EvalContextVariableControlCommonGet(const EvalContext *ctx, CommonControl lval, Rval *rval_out);
+const void  *EvalContextVariableControlCommonGet(const EvalContext *ctx, CommonControl lval);
 
 
 /* - Parsing/evaluating expressions - */

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1530,24 +1530,24 @@ static FnCallResult FnCallRegList(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist
 
     VarRef *ref = VarRefParse(naked);
 
-    Rval retval;
-    if (!EvalContextVariableGet(ctx, ref, &retval, NULL))
+    DataType value_type = DATA_TYPE_NONE;
+    const Rlist *value = EvalContextVariableGet(ctx, ref, &value_type);
+    VarRefDestroy(ref);
+
+    if (!value)
     {
         Log(LOG_LEVEL_VERBOSE, "Function REGLIST was promised a list called '%s' but this was not found", listvar);
-        VarRefDestroy(ref);
         return FnFailure();
     }
 
-    if (retval.type != RVAL_TYPE_LIST)
+    if (DataTypeToRvalType(value_type) != RVAL_TYPE_LIST)
     {
         Log(LOG_LEVEL_VERBOSE, "Function reglist was promised a list called '%s' but this variable is not a list",
-              listvar);
+            listvar);
         return FnFailure();
     }
 
-    const Rlist *list = retval.item;
-
-    for (const Rlist *rp = list; rp != NULL; rp = rp->next)
+    for (const Rlist *rp = value; rp != NULL; rp = rp->next)
     {
         if (strcmp(RlistScalarValue(rp), CF_NULL_VALUE) == 0)
         {
@@ -1594,17 +1594,16 @@ static FnCallResult FnCallGetIndices(EvalContext *ctx, FnCall *fp, Rlist *finala
     VarRef *ref = VarRefParseFromBundle(RlistScalarValue(finalargs), PromiseGetBundle(fp->caller));
 
     DataType type = DATA_TYPE_NONE;
-    Rval rval;
-    EvalContextVariableGet(ctx, ref, &rval, &type);
+    const void *value = EvalContextVariableGet(ctx, ref, &type);
 
     Rlist *keys = NULL;
     if (type == DATA_TYPE_CONTAINER)
     {
-        if (JsonGetElementType(RvalContainerValue(rval)) == JSON_ELEMENT_TYPE_CONTAINER)
+        if (JsonGetElementType(value) == JSON_ELEMENT_TYPE_CONTAINER)
         {
-            if (JsonGetContrainerType(RvalContainerValue(rval)) == JSON_CONTAINER_TYPE_OBJECT)
+            if (JsonGetContrainerType(value) == JSON_CONTAINER_TYPE_OBJECT)
             {
-                JsonIterator iter = JsonIteratorInit(RvalContainerValue(rval));
+                JsonIterator iter = JsonIteratorInit(value);
                 const char *key = NULL;
                 while ((key = JsonIteratorNextKey(&iter)))
                 {
@@ -1613,7 +1612,7 @@ static FnCallResult FnCallGetIndices(EvalContext *ctx, FnCall *fp, Rlist *finala
             }
             else
             {
-                for (size_t i = 0; i < JsonLength(RvalContainerValue(rval)); i++)
+                for (size_t i = 0; i < JsonLength(value); i++)
                 {
                     Rval key = (Rval) { StringFromLong(i), RVAL_TYPE_SCALAR };
                     RlistAppendRval(&keys, key);
@@ -1652,15 +1651,14 @@ static FnCallResult FnCallGetValues(EvalContext *ctx, FnCall *fp, Rlist *finalar
     VarRef *ref = VarRefParseFromBundle(RlistScalarValue(finalargs), PromiseGetBundle(fp->caller));
 
     DataType type = DATA_TYPE_NONE;
-    Rval rval;
-    EvalContextVariableGet(ctx, ref, &rval, &type);
+    const void *value = EvalContextVariableGet(ctx, ref, &type);
 
     Rlist *values = NULL;
     if (type == DATA_TYPE_CONTAINER)
     {
-        if (JsonGetElementType(RvalContainerValue(rval)) == JSON_ELEMENT_TYPE_CONTAINER)
+        if (JsonGetElementType(value) == JSON_ELEMENT_TYPE_CONTAINER)
         {
-            JsonIterator iter = JsonIteratorInit(RvalContainerValue(rval));
+            JsonIterator iter = JsonIteratorInit(value);
             const JsonElement *el = NULL;
             while ((el = JsonIteratorNextValue(&iter)))
             {
@@ -1755,28 +1753,15 @@ static FnCallResult FnCallGrep(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
 
 static FnCallResult FnCallSum(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
 {
-    Rval rval2;
     double sum = 0;
 
-    VarRef *ref = VarRefParse(RlistScalarValue(finalargs));
-
-    if (!EvalContextVariableGet(ctx, ref, &rval2, NULL))
+    const Rlist *input_list = GetListReferenceArgument(ctx, fp, RlistScalarValue(finalargs), NULL);
+    if (!input_list)
     {
-        Log(LOG_LEVEL_VERBOSE, "Function sum was promised a list called '%s' but this was not found", ref->lval);
-        VarRefDestroy(ref);
         return FnFailure();
     }
 
-    if (rval2.type != RVAL_TYPE_LIST)
-    {
-        Log(LOG_LEVEL_VERBOSE, "Function sum was promised a list called '%s' but this was not found", ref->lval);
-        VarRefDestroy(ref);
-        return FnFailure();
-    }
-
-    VarRefDestroy(ref);
-
-    for (const Rlist *rp = (const Rlist *) rval2.item; rp != NULL; rp = rp->next)
+    for (const Rlist *rp = input_list; rp; rp = rp->next)
     {
         double x;
 
@@ -1797,28 +1782,15 @@ static FnCallResult FnCallSum(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *fi
 
 static FnCallResult FnCallProduct(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
 {
-    Rval rval2;
     double product = 1.0;
 
-    VarRef *ref = VarRefParse(RlistScalarValue(finalargs));
-
-    if (!EvalContextVariableGet(ctx, ref, &rval2, NULL))
+    const Rlist *input_list = GetListReferenceArgument(ctx, fp, RlistScalarValue(finalargs), NULL);
+    if (!input_list)
     {
-        Log(LOG_LEVEL_VERBOSE, "Function 'product' was promised a list called '%s' but this was not found", ref->lval);
-        VarRefDestroy(ref);
         return FnFailure();
     }
 
-    if (rval2.type != RVAL_TYPE_LIST)
-    {
-        Log(LOG_LEVEL_VERBOSE, "Function 'product' was promised a list called '%s' but this was not found", ref->lval);
-        VarRefDestroy(ref);
-        return FnFailure();
-    }
-
-    VarRefDestroy(ref);
-
-    for (const Rlist *rp = (const Rlist *) rval2.item; rp != NULL; rp = rp->next)
+    for (const Rlist *rp = input_list; rp; rp = rp->next)
     {
         double x;
         if (!DoubleFromString(RlistScalarValue(rp), &x))
@@ -1839,29 +1811,16 @@ static FnCallResult FnCallProduct(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist
 static FnCallResult FnCallJoin(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
 {
     char *joined = NULL;
-    Rval rval2;
     int size = 0;
 
     const char *join = RlistScalarValue(finalargs);
-    VarRef *ref = VarRefParse(RlistScalarValue(finalargs->next));
-
-    if (!EvalContextVariableGet(ctx, ref, &rval2, NULL))
+    const Rlist *input_list = GetListReferenceArgument(ctx, fp, RlistScalarValue(finalargs->next), NULL);
+    if (!input_list)
     {
-        Log(LOG_LEVEL_VERBOSE, "Function 'join' was promised a list called '%s.%s' but this was not (yet) found", ref->scope, ref->lval);
-        VarRefDestroy(ref);
         return FnFailure();
     }
 
-    if (rval2.type != RVAL_TYPE_LIST)
-    {
-        Log(LOG_LEVEL_VERBOSE, "Function 'join' was promised a list called '%s' but this was not (yet) found", ref->lval);
-        VarRefDestroy(ref);
-        return FnFailure();
-    }
-
-    VarRefDestroy(ref);
-
-    for (const Rlist *rp = RvalRlistValue(rval2); rp != NULL; rp = rp->next)
+    for (const Rlist *rp = input_list; rp != NULL; rp = rp->next)
     {
         if (strcmp(RlistScalarValue(rp), CF_NULL_VALUE) == 0)
         {
@@ -1874,7 +1833,7 @@ static FnCallResult FnCallJoin(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *f
     joined = xcalloc(1, size + 1);
     size = 0;
 
-    for (const Rlist *rp = (const Rlist *) rval2.item; rp != NULL; rp = rp->next)
+    for (const Rlist *rp = input_list; rp != NULL; rp = rp->next)
     {
         if (strcmp(RlistScalarValue(rp), CF_NULL_VALUE) == 0)
         {
@@ -1970,7 +1929,7 @@ static FnCallResult FnCallGetFields(EvalContext *ctx, FnCall *fp, Rlist *finalar
 
 /*********************************************************************/
 
-static FnCallResult FnCallCountLinesMatching(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
+static FnCallResult FnCallCountLinesMatching(ARG_UNUSED EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
 {
     int lcount = 0;
     FILE *fin;
@@ -2022,7 +1981,7 @@ static FnCallResult FnCallCountLinesMatching(EvalContext *ctx, ARG_UNUSED FnCall
 
 /*********************************************************************/
 
-static FnCallResult FnCallLsDir(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
+static FnCallResult FnCallLsDir(ARG_UNUSED EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
 {
     char line[CF_BUFSIZE];
     Dir *dirh = NULL;
@@ -2154,7 +2113,6 @@ static FnCallResult FnCallMapList(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist
 {
     char expbuf[CF_EXPANDSIZE];
     Rlist *newlist = NULL;
-    Rval rval;
     DataType retype;
 
     const char *map = RlistScalarValue(finalargs);
@@ -2173,7 +2131,8 @@ static FnCallResult FnCallMapList(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist
     VarRef *ref = VarRefParse(naked);
 
     retype = DATA_TYPE_NONE;
-    if (!EvalContextVariableGet(ctx, ref, &rval, &retype))
+    const Rlist *list = EvalContextVariableGet(ctx, ref, &retype);
+    if (!list)
     {
         VarRefDestroy(ref);
         return FnFailure();
@@ -2186,7 +2145,7 @@ static FnCallResult FnCallMapList(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist
         return FnFailure();
     }
 
-    for (const Rlist *rp = RvalRlistValue(rval); rp != NULL; rp = rp->next)
+    for (const Rlist *rp = list; rp != NULL; rp = rp->next)
     {
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "this", RlistScalarValue(rp), DATA_TYPE_STRING, "source=function,function=maplist");
 
@@ -2228,8 +2187,9 @@ static FnCallResult FnCallMergeData(EvalContext *ctx, FnCall *fp, Rlist *args)
     {
         VarRef *ref = VarRefParseFromBundle(RlistScalarValue(arg), PromiseGetBundle(fp->caller));
 
-        Rval rval;
-        if (!EvalContextVariableGet(ctx, ref, &rval, NULL))
+        DataType value_type = DATA_TYPE_NONE;
+        const JsonElement *value = EvalContextVariableGet(ctx, ref, &value_type);
+        if (value_type != DATA_TYPE_CONTAINER)
         {
             Log(LOG_LEVEL_ERR, "Function mergedata, argument '%s' does not resolve to a container", RlistScalarValue(arg));
             SeqDestroy(containers);
@@ -2237,7 +2197,7 @@ static FnCallResult FnCallMergeData(EvalContext *ctx, FnCall *fp, Rlist *args)
             return FnFailure();
         }
 
-        SeqAppend(containers, RvalContainerValue(rval));
+        SeqAppend(containers, (void *)value);
 
         VarRefDestroy(ref);
     }
@@ -2274,11 +2234,9 @@ static FnCallResult FnCallSelectServers(EvalContext *ctx, FnCall *fp, Rlist *fin
  /* ReadTCP(localhost,80,'GET index.html',1000) */
 {
     AgentConnection *conn = NULL;
-    Rlist *hostnameip;
     char buffer[CF_BUFSIZE], naked[CF_MAXVARSIZE];
     int val = 0, n_read = 0, count = 0;
     short portnum;
-    Rval retval;
     buffer[0] = '\0';
 
     char *listvar = RlistScalarValue(finalargs);
@@ -2299,8 +2257,9 @@ static FnCallResult FnCallSelectServers(EvalContext *ctx, FnCall *fp, Rlist *fin
     }
 
     VarRef *ref = VarRefParse(naked);
-
-    if (!EvalContextVariableGet(ctx, ref, &retval, NULL))
+    DataType value_type;
+    const Rlist *hostnameip = EvalContextVariableGet(ctx, ref, &value_type);
+    if (!hostnameip)
     {
         Log(LOG_LEVEL_VERBOSE,
             "Function selectservers was promised a list called '%s' but this was not found from context '%s.%s'",
@@ -2311,14 +2270,13 @@ static FnCallResult FnCallSelectServers(EvalContext *ctx, FnCall *fp, Rlist *fin
 
     VarRefDestroy(ref);
 
-    if (retval.type != RVAL_TYPE_LIST)
+    if (DataTypeToRvalType(value_type) != RVAL_TYPE_LIST)
     {
         Log(LOG_LEVEL_VERBOSE,
             "Function selectservers was promised a list called '%s' but this variable is not a list", listvar);
         return FnFailure();
     }
 
-    hostnameip = RvalRlistValue(retval);
     val = IntFromString(maxbytes);
     portnum = (short) IntFromString(port);
 
@@ -2346,7 +2304,7 @@ static FnCallResult FnCallSelectServers(EvalContext *ctx, FnCall *fp, Rlist *fin
         PromiseTypeAppendPromise(tp, "function", (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, NULL);
     }
 
-    for (Rlist *rp = hostnameip; rp != NULL; rp = rp->next)
+    for (const Rlist *rp = hostnameip; rp != NULL; rp = rp->next)
     {
         Log(LOG_LEVEL_DEBUG, "Want to read %d bytes from port %d at '%s'", val, portnum, RlistScalarValue(rp));
 
@@ -2849,39 +2807,49 @@ static FnCallResult FnCallFilter(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
 static const Rlist *GetListReferenceArgument(const EvalContext *ctx, const FnCall *fp, const char *lval_str, DataType *datatype_out)
 {
     VarRef *ref = VarRefParse(lval_str);
-    Rval rval_out;
 
-    if (!EvalContextVariableGet(ctx, ref, &rval_out, datatype_out))
+    DataType value_type = DATA_TYPE_NONE;
+    const Rlist *value = EvalContextVariableGet(ctx, ref, &value_type);
+    if (!value)
     {
         Log(LOG_LEVEL_INFO,
             "Could not resolve expected list variable '%s' in function '%s'",
             lval_str,
             fp->name);
         VarRefDestroy(ref);
+        if (datatype_out)
+        {
+            *datatype_out = DATA_TYPE_NONE;
+        }
         return NULL;
     }
 
     VarRefDestroy(ref);
 
-    if (rval_out.type != RVAL_TYPE_LIST)
+    if (DataTypeToRvalType(value_type) != RVAL_TYPE_LIST)
     {
-        if (datatype_out)
+        if (value_type)
         {
-            Log(LOG_LEVEL_VERBOSE,
-                "Function '%s' expected a list variable reference, got variable of type '%s'",
-                fp->name,
-                DataTypeToString(*datatype_out));
+            Log(LOG_LEVEL_VERBOSE, "Function '%s' expected a list variable reference, got variable of type '%s'",
+                fp->name, DataTypeToString(value_type));
         }
         else
         {
             Log(LOG_LEVEL_VERBOSE,
-                "Function '%s' expected a list variable reference, got variable of a different type",
-                fp->name);
+                "Function '%s' expected a list variable reference, got variable of a different type", fp->name);
+        }
+        if (datatype_out)
+        {
+            *datatype_out = DATA_TYPE_NONE;
         }
         return NULL;
     }
 
-    return rval_out.item;
+    if (datatype_out)
+    {
+        *datatype_out = value_type;
+    }
+    return value;
 }
 
 /*********************************************************************/
@@ -3200,15 +3168,27 @@ static FnCallResult FnCallNth(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
 
     VarRef *ref = VarRefParseFromBundle(varname, PromiseGetBundle(fp->caller));
     DataType type = DATA_TYPE_NONE;
-    Rval rval;
-    EvalContextVariableGet(ctx, ref, &rval, &type);
+    const void *value = EvalContextVariableGet(ctx, ref, &type);
     VarRefDestroy(ref);
 
     if (type == DATA_TYPE_CONTAINER)
     {
         Rlist *return_list = NULL;
 
-        const char* const jstring = RvalContainerPrimitiveAsString(rval, index);
+        const char *jstring = NULL;
+        if (JsonGetElementType(value) == JSON_ELEMENT_TYPE_CONTAINER)
+        {
+            if (index < JsonLength(value))
+            {
+
+                const JsonElement* const jelement = JsonAt(value, index);
+
+                if (JsonGetElementType(jelement) == JSON_ELEMENT_TYPE_PRIMITIVE)
+                {
+                    jstring = JsonPrimitiveGetAsString(jelement);
+                }
+            }
+        }
 
         if (jstring != NULL)
         {
@@ -3258,18 +3238,14 @@ static FnCallResult FnCallEverySomeNone(EvalContext *ctx, FnCall *fp, Rlist *fin
 
 static FnCallResult FnCallSort(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
 {
-    VarRef *ref = VarRefParse(RlistScalarValue(finalargs));
     const char *sort_type = RlistScalarValue(finalargs->next); // list identifier
-    Rval list_var_rval;
-    DataType list_var_dtype = DATA_TYPE_NONE;
 
-    if (!EvalContextVariableGet(ctx, ref, &list_var_rval, &list_var_dtype))
+    DataType list_var_dtype = DATA_TYPE_NONE;
+    const Rlist *input_list = GetListReferenceArgument(ctx, fp, RlistScalarValue(finalargs), &list_var_dtype);
+    if (!input_list)
     {
-        VarRefDestroy(ref);
         return FnFailure();
     }
-
-    VarRefDestroy(ref);
 
     if (list_var_dtype != DATA_TYPE_STRING_LIST)
     {
@@ -3280,23 +3256,23 @@ static FnCallResult FnCallSort(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *f
 
     if (strcmp(sort_type, "int") == 0)
     {
-        sorted = IntSortRListNames(RlistCopy(RvalRlistValue(list_var_rval)));
+        sorted = IntSortRListNames(RlistCopy(input_list));
     }
     else if (strcmp(sort_type, "real") == 0)
     {
-        sorted = RealSortRListNames(RlistCopy(RvalRlistValue(list_var_rval)));
+        sorted = RealSortRListNames(RlistCopy(input_list));
     }
     else if (strcmp(sort_type, "IP") == 0 || strcmp(sort_type, "ip") == 0)
     {
-        sorted = IPSortRListNames(RlistCopy(RvalRlistValue(list_var_rval)));
+        sorted = IPSortRListNames(RlistCopy(input_list));
     }
     else if (strcmp(sort_type, "MAC") == 0 || strcmp(sort_type, "mac") == 0)
     {
-        sorted = MACSortRListNames(RlistCopy(RvalRlistValue(list_var_rval)));
+        sorted = MACSortRListNames(RlistCopy(input_list));
     }
     else // "lex"
     {
-        sorted = AlphaSortRListNames(RlistCopy(RvalRlistValue(list_var_rval)));
+        sorted = AlphaSortRListNames(RlistCopy(input_list));
     }
 
     return (FnCallResult) { FNCALL_SUCCESS, (Rval) { sorted, RVAL_TYPE_LIST } };
@@ -3563,8 +3539,7 @@ static FnCallResult FnCallIsVariable(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rl
     else
     {
         VarRef *ref = VarRefParse(lval);
-        Rval rval = { 0 };
-        found = EvalContextVariableGet(ctx, ref, &rval, NULL);
+        found = EvalContextVariableGet(ctx, ref, NULL) != NULL;
         VarRefDestroy(ref);
     }
 
@@ -4001,7 +3976,7 @@ static FnCallResult FnCallPeerLeaders(ARG_UNUSED EvalContext *ctx, ARG_UNUSED Fn
 
 /*********************************************************************/
 
-static FnCallResult FnCallRegCmp(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
+static FnCallResult FnCallRegCmp(ARG_UNUSED EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
 {
     char buffer[CF_BUFSIZE];
 
@@ -4054,7 +4029,7 @@ static FnCallResult FnCallRegExtract(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rl
 
 /*********************************************************************/
 
-static FnCallResult FnCallRegLine(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
+static FnCallResult FnCallRegLine(ARG_UNUSED EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
 {
     FILE *fin;
 
@@ -4606,20 +4581,18 @@ static FnCallResult FnCallParseJson(ARG_UNUSED EvalContext *ctx, ARG_UNUSED FnCa
 
 static FnCallResult FnCallStoreJson(EvalContext *ctx, FnCall *fp, Rlist *finalargs)
 {
-    char buf[CF_BUFSIZE];
-    char *varname = RlistScalarValue(finalargs);
+    const char *varname = RlistScalarValue(finalargs);
     VarRef *ref = VarRefParseFromBundle(varname, PromiseGetBundle(fp->caller));
 
     DataType type = DATA_TYPE_NONE;
-    Rval rval;
-    EvalContextVariableGet(ctx, ref, &rval, &type);
+    const JsonElement *value = EvalContextVariableGet(ctx, ref, &type);
 
     if (type == DATA_TYPE_CONTAINER)
     {
         Writer *w = StringWriter();
         int length;
 
-        JsonWrite(w, RvalContainerValue(rval), 0);
+        JsonWrite(w, value, 0);
         Log(LOG_LEVEL_DEBUG, "%s: from data container %s, got JSON data '%s'", fp->name, varname, StringWriterData(w));
 
         length = strlen(StringWriterData(w));
@@ -4628,16 +4601,17 @@ static FnCallResult FnCallStoreJson(EvalContext *ctx, FnCall *fp, Rlist *finalar
             Log(LOG_LEVEL_INFO, "%s: truncating data container %s JSON data from %d bytes to %d", fp->name, varname, length, CF_BUFSIZE);
         }
 
+        char buf[CF_BUFSIZE];
         snprintf(buf, CF_BUFSIZE, "%s", StringWriterData(w));
         WriterClose(w);
+
+        return FnReturn(buf);
     }
     else
     {
         Log(LOG_LEVEL_VERBOSE, "%s: data container %s could not be found or has an invalid type", fp->name, varname);
         return FnFailure();
     }
-
-    return FnReturn(buf);
 }
 
 
@@ -4838,13 +4812,7 @@ static FnCallResult FnCallSplitString(ARG_UNUSED EvalContext *ctx, ARG_UNUSED Fn
 
 static FnCallResult FnCallFileSexist(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlist *finalargs)
 {
-    Rlist *rp, *files;
     char naked[CF_MAXVARSIZE];
-    Rval retval;
-    struct stat sb;
-
-/* begin fn specific content */
-
     char *listvar = RlistScalarValue(finalargs);
 
     if (IsVarList(listvar))
@@ -4858,8 +4826,9 @@ static FnCallResult FnCallFileSexist(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rl
     }
 
     VarRef *ref = VarRefParse(naked);
-
-    if (!EvalContextVariableGet(ctx, ref, &retval, NULL))
+    DataType input_list_type = DATA_TYPE_NONE;
+    const Rlist *input_list = EvalContextVariableGet(ctx, ref, &input_list_type);
+    if (!input_list)
     {
         Log(LOG_LEVEL_VERBOSE, "Function filesexist was promised a list called '%s' but this was not found", listvar);
         VarRefDestroy(ref);
@@ -4868,17 +4837,15 @@ static FnCallResult FnCallFileSexist(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rl
 
     VarRefDestroy(ref);
 
-    if (retval.type != RVAL_TYPE_LIST)
+    if (DataTypeToRvalType(input_list_type) != RVAL_TYPE_LIST)
     {
-        Log(LOG_LEVEL_VERBOSE, "Function filesexist was promised a list called '%s' but this variable is not a list",
-              listvar);
+        Log(LOG_LEVEL_VERBOSE, "Function filesexist was promised a list called '%s' but this variable is not a list", listvar);
         return FnFailure();
     }
 
-    files = (Rlist *) retval.item;
-
-    for (rp = files; rp != NULL; rp = rp->next)
+    for (const Rlist *rp = input_list; rp != NULL; rp = rp->next)
     {
+        struct stat sb;
         if (stat(RlistScalarValue(rp), &sb) == -1)
         {
             return FnReturnContext(false);
@@ -5048,21 +5015,22 @@ static FnCallResult FnCallMakerule(EvalContext *ctx, ARG_UNUSED FnCall *fp, Rlis
 
         VarRef *ref = VarRefParse(naked);
 
-        Rval retval;
-        if (!EvalContextVariableGet(ctx, ref, &retval, NULL))
+        DataType input_list_type = DATA_TYPE_NONE;
+        const Rlist *input_list = EvalContextVariableGet(ctx, ref, &input_list_type);
+        if (!input_list)
         {
             Log(LOG_LEVEL_VERBOSE, "Function 'makerule' was promised a list called '%s' but this was not found", listvar);
             VarRefDestroy(ref);
             return FnFailure();
         }
 
-       if (retval.type != RVAL_TYPE_LIST)
+       if (DataTypeToRvalType(input_list_type) != RVAL_TYPE_LIST)
        {
            Log(LOG_LEVEL_WARNING, "Function 'makerule' was promised a list called '%s' but this variable is not a list", listvar);
            return FnFailure();
        }
 
-       list = retval.item;
+       list = (Rlist *)input_list;
     }
 
     struct stat statbuf;

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -331,7 +331,6 @@ static void ExpandAndMapIteratorsFromScalar(EvalContext *ctx, const Bundle *bund
                                             Rlist **containers, Rlist **full_expansion)
 {
     char *sp;
-    Rval rval;
     Rlist *tmp_list = NULL;
     char v[CF_BUFSIZE], buffer[CF_BUFSIZE];
 
@@ -374,7 +373,7 @@ static void ExpandAndMapIteratorsFromScalar(EvalContext *ctx, const Bundle *bund
             if (ExtractInnerCf3VarString(sp, v))
             {
                 Rlist *inner_expansion = NULL;
-                Rlist *exp, *tmp;
+                Rlist *exp = NULL;
                 int success = 0;
                 int increment;
 
@@ -403,13 +402,15 @@ static void ExpandAndMapIteratorsFromScalar(EvalContext *ctx, const Bundle *bund
                     // var is the expanded name of the variable in its native context
                     // finalname will be the mapped name in the local context "this."
 
-                    if (EvalContextVariableGet(ctx, inner_ref, &rval, NULL))
+                    DataType value_type = DATA_TYPE_NONE;
+                    const void *value = EvalContextVariableGet(ctx, inner_ref, &value_type);
+                    if (value)
                     {
                         char *mangled_inner_ref = xstrdup(inner_ref_str);
                         MangleVarRefString(mangled_inner_ref, strlen(mangled_inner_ref));
 
                         success++;
-                        switch (rval.type)
+                        switch (DataTypeToRvalType(value_type))
                         {
                         case RVAL_TYPE_LIST:
                             if (level > 0)
@@ -423,10 +424,10 @@ static void ExpandAndMapIteratorsFromScalar(EvalContext *ctx, const Bundle *bund
 
                             if (full_expansion)
                             {
-                                for (tmp = rval.item; tmp != NULL; tmp = tmp->next)
+                                for (const Rlist *rp = value; rp != NULL; rp = rp->next)
                                 {
                                     // append each slist item to each of full_expansion
-                                    RlistConcatInto(&tmp_list, *full_expansion, RlistScalarValue(tmp));
+                                    RlistConcatInto(&tmp_list, *full_expansion, RlistScalarValue(rp));
                                 }
                             }
                             break;
@@ -437,7 +438,7 @@ static void ExpandAndMapIteratorsFromScalar(EvalContext *ctx, const Bundle *bund
                             if (full_expansion)
                             {
                                 // append the scalar value to each of full_expansion
-                                RlistConcatInto(&tmp_list, *full_expansion, rval.item);
+                                RlistConcatInto(&tmp_list, *full_expansion, value);
                             }
                             break;
 
@@ -521,9 +522,11 @@ Rlist *ExpandList(EvalContext *ctx, const char *ns, const char *scope, const Rli
             {
                 VarRef *ref = VarRefParseFromScope(naked, scope);
 
-                if (EvalContextVariableGet(ctx, ref, &returnval, NULL))
+                DataType value_type = DATA_TYPE_NONE;
+                const void *value = EvalContextVariableGet(ctx, ref, &value_type);
+                if (value)
                 {
-                    returnval = ExpandPrivateRval(ctx, ns, scope, returnval.item, returnval.type);
+                    returnval = ExpandPrivateRval(ctx, ns, scope, value, DataTypeToRvalType(value_type));
                 }
                 else
                 {
@@ -640,7 +643,6 @@ static bool ExpandOverflow(const char *str1, const char *str2)
 
 bool ExpandScalar(const EvalContext *ctx, const char *ns, const char *scope, const char *string, char buffer[CF_EXPANDSIZE])
 {
-    Rval rval;
     int varstring = false;
     char currentitem[CF_EXPANDSIZE], temp[CF_BUFSIZE], name[CF_MAXVARSIZE];
     int increment, returnval = true;
@@ -734,14 +736,14 @@ bool ExpandScalar(const EvalContext *ctx, const char *ns, const char *scope, con
         if (!IsExpandable(currentitem))
         {
             DataType type = DATA_TYPE_NONE;
-            bool variable_found = false;
+            const void *value = NULL;
             {
                 VarRef *ref = VarRefParseFromNamespaceAndScope(currentitem, ns, scope, CF_NS, '.');
-                variable_found = EvalContextVariableGet(ctx, ref, &rval, &type);
+                value = EvalContextVariableGet(ctx, ref, &type);
                 VarRefDestroy(ref);
             }
 
-            if (variable_found)
+            if (value)
             {
                 switch (type)
                 {
@@ -749,12 +751,12 @@ bool ExpandScalar(const EvalContext *ctx, const char *ns, const char *scope, con
                 case DATA_TYPE_INT:
                 case DATA_TYPE_REAL:
 
-                    if (ExpandOverflow(buffer, (char *) rval.item))
+                    if (ExpandOverflow(buffer, value))
                     {
                         FatalError(ctx, "Can't expand varstring");
                     }
 
-                    strlcat(buffer, (char *) rval.item, CF_EXPANDSIZE);
+                    strlcat(buffer, value, CF_EXPANDSIZE);
                     break;
 
                 case DATA_TYPE_STRING_LIST:
@@ -831,7 +833,7 @@ bool ExpandScalar(const EvalContext *ctx, const char *ns, const char *scope, con
 /*********************************************************************/
 
 
-Rval EvaluateFinalRval(EvalContext *ctx, const char *ns, const char *scope, Rval rval, int forcelist, const Promise *pp)
+Rval EvaluateFinalRval(EvalContext *ctx, const char *ns, const char *scope, Rval rval, bool forcelist, const Promise *pp)
 {
     Rlist *rp;
     Rval returnval, newret;
@@ -844,14 +846,16 @@ Rval EvaluateFinalRval(EvalContext *ctx, const char *ns, const char *scope, Rval
         if (!IsExpandable(naked))
         {
             VarRef *ref = VarRefParseFromScope(naked, scope);
+            DataType value_type = DATA_TYPE_NONE;
+            const void *value = EvalContextVariableGet(ctx, ref, &value_type);
 
-            if (!EvalContextVariableGet(ctx, ref, &returnval, NULL) || returnval.type != RVAL_TYPE_LIST)
+            if (!value || DataTypeToRvalType(value_type) != RVAL_TYPE_LIST)
             {
                 returnval = ExpandPrivateRval(ctx, NULL, "this", rval.item, rval.type);
             }
             else
             {
-                returnval.item = ExpandList(ctx, ns, scope, returnval.item, true);
+                returnval.item = ExpandList(ctx, ns, scope, value, true);
                 returnval.type = RVAL_TYPE_LIST;
             }
 
@@ -947,35 +951,34 @@ static void CopyLocalizedReferencesToBundleScope(EvalContext *ctx, const Bundle 
         {
             VarRef *demangled_ref = VarRefParseFromBundle(demangled, bundle);
 
-            Rval retval;
-            DataType type;
-            if (!EvalContextVariableGet(ctx, demangled_ref, &retval, &type))
+            DataType value_type;
+            const void *value = EvalContextVariableGet(ctx, demangled_ref, &value_type);
+            if (!value)
             {
                 ProgrammingError("Couldn't find extracted variable '%s'", mangled);
             }
 
             VarRef *mangled_ref = VarRefParseFromBundle(mangled, bundle);
 
-            switch (retval.type)
+            switch (DataTypeToRvalType(value_type))
             {
             case RVAL_TYPE_LIST:
                 {
-
-                    Rlist *list = RvalCopy((Rval) {retval.item, RVAL_TYPE_LIST}).item;
+                    Rlist *list = RlistCopy(value);
                     RlistFlatten(ctx, &list);
 
-                    EvalContextVariablePut(ctx, mangled_ref, list, type, "source=agent");
+                    EvalContextVariablePut(ctx, mangled_ref, list, value_type, "source=agent");
                 }
                 break;
 
             case RVAL_TYPE_CONTAINER:
             case RVAL_TYPE_SCALAR:
-                EvalContextVariablePut(ctx, mangled_ref, retval.item, type, "source=agent");
+                EvalContextVariablePut(ctx, mangled_ref, value, value_type, "source=agent");
                 break;
 
             case RVAL_TYPE_FNCALL:
             case RVAL_TYPE_NOPROMISEE:
-                ProgrammingError("Illegal rval type in switch %d", retval.type);
+                ProgrammingError("Illegal rval type in switch %d", DataTypeToRvalType(value_type));
             }
 
             VarRefDestroy(mangled_ref);
@@ -1031,7 +1034,7 @@ static void ResolveVariablesPromises(EvalContext *ctx, PromiseType *pt)
     }
 }
 
-void BundleResolve(EvalContext *ctx, Bundle *bundle)
+void BundleResolve(EvalContext *ctx, const Bundle *bundle)
 {
     Log(LOG_LEVEL_VERBOSE, "Resolving variables in bundle '%s' '%s'", bundle->type, bundle->name);
 

--- a/libpromises/expand.h
+++ b/libpromises/expand.h
@@ -42,14 +42,14 @@ bool ExpandScalar(const EvalContext *ctx, const char *ns, const char *scope, con
 Rval ExpandBundleReference(EvalContext *ctx, const char *ns, const char *scope, Rval rval);
 Rval ExpandPrivateRval(EvalContext *ctx, const char *ns, const char *scope, const void *rval_item, RvalType rval_type);
 Rlist *ExpandList(EvalContext *ctx, const char *ns, const char *scope, const Rlist *list, int expandnaked);
-Rval EvaluateFinalRval(EvalContext *ctx, const char *ns, const char *scope, Rval rval, int forcelist, const Promise *pp);
+Rval EvaluateFinalRval(EvalContext *ctx, const char *ns, const char *scope, Rval rval, bool forcelist, const Promise *pp);
 
 /**
  * @brief BundleResolve
  * @param ctx
  * @param bundle
  */
-void BundleResolve(EvalContext *ctx, Bundle *bundle);
+void BundleResolve(EvalContext *ctx, const Bundle *bundle);
 void PolicyResolve(EvalContext *ctx, const Policy *policy, GenericAgentConfig *config);
 
 

--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -191,7 +191,7 @@ char *JoinSuffix(char *path, char *leaf)
     return path;
 }
 
-int IsAbsPath(char *path)
+int IsAbsPath(const char *path)
 {
     if (IsFileSep(*path))
     {

--- a/libpromises/files_names.h
+++ b/libpromises/files_names.h
@@ -41,7 +41,7 @@ int CompareCSVName(const char *s1, const char *s2);
 int IsDir(const char *path);
 char *JoinPath(char *path, const char *leaf);
 char *JoinSuffix(char *path, char *leaf);
-int IsAbsPath(char *path);
+int IsAbsPath(const char *path);
 void AddSlash(char *str);
 char *GetParentDirectoryCopy(const char *path);
 void DeleteSlash(char *str);

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1499,23 +1499,16 @@ void WritePID(char *filename)
 
 static bool VerifyBundleSequence(EvalContext *ctx, const Policy *policy, const GenericAgentConfig *config)
 {
-    char *name;
-    Rval retval;
-    int ok = true;
-    FnCall *fp;
-
-    if (!EvalContextVariableControlCommonGet(ctx, COMMON_CONTROL_BUNDLESEQUENCE, &retval))
+    const Rlist *bundlesequence = EvalContextVariableControlCommonGet(ctx, COMMON_CONTROL_BUNDLESEQUENCE);
+    if (!bundlesequence)
     {
         Log(LOG_LEVEL_ERR, " No bundlesequence in the common control body");
         return false;
     }
 
-    if (retval.type != RVAL_TYPE_LIST)
-    {
-        FatalError(ctx, "Promised bundlesequence was not a list");
-    }
-
-    for (Rlist *rp = RvalRlistValue(retval); rp != NULL; rp = rp->next)
+    const char *name;
+    int ok = true;
+    for (const Rlist *rp = bundlesequence; rp != NULL; rp = rp->next)
     {
         switch (rp->val.type)
         {
@@ -1524,8 +1517,7 @@ static bool VerifyBundleSequence(EvalContext *ctx, const Policy *policy, const G
             break;
 
         case RVAL_TYPE_FNCALL:
-            fp = RlistFnCallValue(rp);
-            name = fp->name;
+            name = RlistFnCallValue(rp)->name;
             break;
 
         default:

--- a/libpromises/ornaments.c
+++ b/libpromises/ornaments.c
@@ -139,7 +139,7 @@ void BannerSubPromiseType(const EvalContext *ctx, const char *bundlename, const 
     Log(LOG_LEVEL_VERBOSE, "\n");
 }
 
-void BannerBundle(Bundle *bp, Rlist *params)
+void BannerBundle(const Bundle *bp, const Rlist *params)
 {
     if (!LEGACY_OUTPUT)
     {

--- a/libpromises/ornaments.h
+++ b/libpromises/ornaments.h
@@ -38,6 +38,6 @@ void BannerSubBundle(const Bundle *bp, const Rlist *params);
 void BannerPromiseType(const char *bundlename, const char *type, int p);
 void BannerSubPromiseType(const EvalContext *ctx, const char *bundlename, const char *type);
 void Banner(const char *s);
-void BannerBundle(Bundle *bp, Rlist *params);
+void BannerBundle(const Bundle *bp, const Rlist *params);
 
 #endif

--- a/libpromises/prototypes3.h
+++ b/libpromises/prototypes3.h
@@ -41,7 +41,7 @@ void yyerror(const char *s);
 
 /* agent.c */
 
-int ScheduleAgentOperations(EvalContext *ctx, Bundle *bp);
+int ScheduleAgentOperations(EvalContext *ctx, const Bundle *bp);
 
 /* Only for agent.c */
 

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -155,30 +155,6 @@ JsonElement *RvalContainerValue(Rval rval)
     return rval.item;
 }
 
-/*******************************************************************/
-
-const char *RvalContainerPrimitiveAsString(const Rval rval, const size_t index)
-{
-    const char *jstring = NULL;
-
-    if (JsonGetElementType(RvalContainerValue(rval)) == JSON_ELEMENT_TYPE_CONTAINER)
-    {
-        if (index < JsonLength(RvalContainerValue(rval)))
-        {
-
-            const JsonElement* const jelement = JsonAt(RvalContainerValue(rval), index);
-
-            if (JsonGetElementType(jelement) == JSON_ELEMENT_TYPE_PRIMITIVE)
-            {
-                jstring = JsonPrimitiveGetAsString(jelement);
-            }
-        }
-    }
-
-    return jstring;
-}
-
-/*******************************************************************/
 
 Rlist *RlistKeyIn(Rlist *list, const char *key)
 {
@@ -1228,19 +1204,17 @@ void RlistFlatten(EvalContext *ctx, Rlist **list)
 
             if (!IsExpandable(naked))
             {
-                Rval rv;
                 VarRef *ref = VarRefParse(naked);
-
-                bool var_found = EvalContextVariableGet(ctx, ref, &rv, NULL);
-
+                DataType value_type = DATA_TYPE_NONE;
+                const void *value = EvalContextVariableGet(ctx, ref, &value_type);
                 VarRefDestroy(ref);
 
-                if (var_found)
+                if (value)
                 {
-                    switch (rv.type)
+                    switch (DataTypeToRvalType(value_type))
                     {
                     case RVAL_TYPE_LIST:
-                        for (const Rlist *srp = rv.item; srp != NULL; srp = srp->next)
+                        for (const Rlist *srp = value; srp != NULL; srp = srp->next)
                         {
                             RlistAppendRval(list, RvalCopy(srp->val));
                         }

--- a/libpromises/rlist.h
+++ b/libpromises/rlist.h
@@ -42,7 +42,6 @@ FnCall *RvalFnCallValue(Rval rval);
 Rlist *RvalRlistValue(Rval rval);
 
 JsonElement *RvalContainerValue(Rval rval);
-const char *RvalContainerPrimitiveAsString(const Rval rval, const size_t index);
 
 Rval RvalNew(const void *item, RvalType type);
 Rval RvalCopy(Rval rval);

--- a/libpromises/scope.c
+++ b/libpromises/scope.c
@@ -129,40 +129,41 @@ void ScopeAugment(EvalContext *ctx, const Bundle *bp, const Promise *pp, const R
 
         if (rpr->val.type == RVAL_TYPE_SCALAR && IsNakedVar(RlistScalarValue(rpr), '@'))
         {
-            DataType vtype;
+
             char naked[CF_BUFSIZE];
             
             GetNaked(naked, RlistScalarValue(rpr));
 
-            Rval retval;
+            DataType value_type = DATA_TYPE_NONE;
+            const void *value = NULL;
             if (pbp != NULL)
             {
                 VarRef *ref = VarRefParseFromBundle(naked, pbp);
-                EvalContextVariableGet(ctx, ref, &retval, &vtype);
+                value = EvalContextVariableGet(ctx, ref, &value_type);
                 VarRefDestroy(ref);
             }
             else
             {
                 VarRef *ref = VarRefParseFromBundle(naked, bp);
-                EvalContextVariableGet(ctx, ref, &retval, &vtype);
+                value = EvalContextVariableGet(ctx, ref, &value_type);
                 VarRefDestroy(ref);
             }
 
-            switch (vtype)
+            switch (value_type)
             {
             case DATA_TYPE_STRING_LIST:
             case DATA_TYPE_INT_LIST:
             case DATA_TYPE_REAL_LIST:
                 {
                     VarRef *ref = VarRefParseFromBundle(lval, bp);
-                    EvalContextVariablePut(ctx, ref, retval.item, DATA_TYPE_STRING_LIST, "source=promise");
+                    EvalContextVariablePut(ctx, ref, value, DATA_TYPE_STRING_LIST, "source=promise");
                     VarRefDestroy(ref);
                 }
                 break;
             case DATA_TYPE_CONTAINER:
                 {
                     VarRef *ref = VarRefParseFromBundle(lval, bp);
-                    EvalContextVariablePut(ctx, ref, retval.item, DATA_TYPE_CONTAINER, "source=promise");
+                    EvalContextVariablePut(ctx, ref, value, DATA_TYPE_CONTAINER, "source=promise");
                     VarRefDestroy(ref);
                 }
                 break;

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -405,10 +405,9 @@ SyntaxTypeMatch CheckConstraintTypeMatch(const char *lval, Rval rval, DataType d
 
 DataType StringDataType(EvalContext *ctx, const char *string)
 {
-    DataType dtype = DATA_TYPE_NONE;
-    Rval rval;
     int islist = false;
     char var[CF_BUFSIZE];
+    DataType dtype = DATA_TYPE_NONE;
 
 /*-------------------------------------------------------
 What happens if we embed vars in a literal string
@@ -431,10 +430,9 @@ vars:
             if (!IsExpandable(var))
             {
                 VarRef *ref = VarRefParse(var);
-
-                if (EvalContextVariableGet(ctx, ref, &rval, &dtype))
+                if (EvalContextVariableGet(ctx, ref, &dtype))
                 {
-                    if (rval.type == RVAL_TYPE_LIST)
+                    if (DataTypeToRvalType(dtype) == RVAL_TYPE_LIST)
                     {
                         if (!islist)
                         {

--- a/tests/unit/rlist_test.c
+++ b/tests/unit/rlist_test.c
@@ -513,7 +513,7 @@ int FullTextMatch(const char *regptr, const char *cmpptr)
     fail();
 }
 
-bool EvalContextVariableGet(const EvalContext *ctx, const VarRef *lval, Rval *rval_out, DataType *type_out)
+const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *lval, DataType *type_out)
 {
     fail();
 }

--- a/tests/unit/set_domainname_test.c
+++ b/tests/unit/set_domainname_test.c
@@ -52,11 +52,7 @@ ExpectedVars expected_vars[] =
 static void TestSysVar(EvalContext *ctx, const char *lval, const char *expected)
 {
     VarRef *ref = VarRefParseFromScope(lval, "sys");
-    Rval rval;
-
-    assert_true(EvalContextVariableGet(ctx, ref, &rval, NULL));
-    assert_string_equal(expected, RvalScalarValue(rval));
-
+    assert_string_equal(expected, EvalContextVariableGet(ctx, ref, NULL));
     VarRefDestroy(ref);
 }
 


### PR DESCRIPTION
This enforces that EvalContext owns the memory of variables.
