### PR TITLE
Coalesce Dituri's author names in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -13,4 +13,5 @@ Sigurd Teigen <sigurd.teigen@cfengine.com> <sigurd.teigen@gmail.com>
 Geir Nygård <geir.nygard@cfengine.com>
 Mark Burgess <mark@cfengine.com>
 Bas van der Vlies <basv@sara.nl> <root@test3.irc.sara.nl.irc.sara.nl>
-
+Chris Dituri <csdituri@gmail.com> chris.dituri
+Chris Dituri <csdituri@gmail.com> chris dituri


### PR DESCRIPTION
nitpick:  fixes my own shortlog output :-S

```
git shortlog --email -s | sort -k 2 -n | grep dituri -i
    17        chris.dituri <csdituri@gmail.com>
     1        chris dituri <csdituri@gmail.com>
```
