### PR TITLE
[3.5.x] fix for #3482 sys.flavor and sys.arch are empty

### DIFF
--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -77,7 +77,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <limits.h>
-#if defined (HAVE_UNAME) && !defined (__hpux)
+#if defined (HAVE_UNAME)
 # include <sys/utsname.h>
 #else
 # define _LOC_NMLN       257


### PR DESCRIPTION
This fixes the empty sys.arch and sys.flavour problem on hp-ux
