### PR TITLE
print evaluation pass, bundle, and (promise) type once again

### DIFF
--- a/libpromises/ornaments.c
+++ b/libpromises/ornaments.c
@@ -98,6 +98,7 @@ void BannerPromiseType(const char *bundlename, const char *type, int pass)
 {
     if (!LEGACY_OUTPUT)
     {
+        Log(LOG_LEVEL_VERBOSE, "/Pass:%d/Bundle:%s/PromiseType:%s", pass, bundlename, type);
         return;
     }
 


### PR DESCRIPTION
Cheap solution to re-introduce verbose printing of the CFEngine pass number, bundle, and promise type.

Log format is negotiable. I just went with the first thing that I thought would fit current formatting.

PR was opened mainly to solicit feedback and thoughts since printing of the pass number seems to be a feature that is missed by the community.
