### PR TITLE
Correction to: Record which promise set each variable.

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1592,8 +1592,8 @@ bool EvalContextVariablePut(EvalContext *ctx,
     }
 
     VariableTable *table = GetVariableTableForScope(ctx, ref->ns, ref->scope);
-    VariableTablePut(table, ref, &rval, type, tags, EvalContextStackCurrentPromise(ctx));
-    /* FIXME: we really shouldn't be ignoring the return from that ... */
+    const Promise *pp = EvalContextStackCurrentPromise(ctx);
+    VariableTablePut(table, ref, &rval, type, tags, pp ? pp->org_pp : pp);
     return true;
 }
 


### PR DESCRIPTION
Our current Promise may be a copy, that'll be free()d at the end of
the current convergence pass; comparing this to the Promise of a later
assignment won't be equal even if it's the original (or another copy
of it); and dereferencing it during reporting shall be regrettable.
Fortunately, a Promise's .org_pp records the original in any copies,
so we can record that instead, bypassing both problems.

I also deleted FIXME that I recently added and someone explained in review why it was misguided.
