### PR TITLE
partially revert a change intended to alter the log message - fixes 4038

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1397,7 +1397,7 @@ static void KeepAgentPromise(EvalContext *ctx, Promise *pp, ARG_UNUSED void *par
         }
         else
         {
-            Log(LOG_LEVEL_VERBOSE, "Skipping next promise '%s', as var-context '%s' is not relevant", pp->promiser, sp);
+            Log(LOG_LEVEL_VERBOSE, "Skipping next promise '%s', as var-context '%s' is not relevant", pp->promiser, pp->classes);
         }
         return;
     }


### PR DESCRIPTION
Log(LOG_LEVEL_VERBOSE, "Skipping next promise '%s', as context '%s' is not relevant", pp->promiser, pp->classes);

was changed to 

Log(LOG_LEVEL_VERBOSE, "Skipping next promise '%s', as var-context '%s' is not relevant", pp->promiser, sp);

by 4fa70ef078336f225740c17c7cdefb258d6a0ba3

When sp is NULL (if the classes list is empty), this results in segfault. If the change is partially reverted so that pp->classes is retained, the bug disappears.
