### PR TITLE
Redmine#3514: allow non-absolute paths for returnszero()

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -6421,7 +6421,7 @@ static const FnCallArg REMOTECLASSESMATCHING_ARGS[] =
 
 static const FnCallArg RETURNSZERO_ARGS[] =
 {
-    {CF_ABSPATHRANGE, DATA_TYPE_STRING, "Fully qualified command path"},
+    {CF_PATHRANGE, DATA_TYPE_STRING, "Command path"},
     {"noshell,useshell,powershell", DATA_TYPE_OPTION, "Shell encapsulation option"},
     {NULL, DATA_TYPE_NONE, NULL}
 };

--- a/tests/acceptance/02_classes/02_functions/returnszero.cf
+++ b/tests/acceptance/02_classes/02_functions/returnszero.cf
@@ -7,7 +7,7 @@
 body common control
 {
       inputs => { "../../default.cf.sub" };
-      bundlesequence  => { default("$(this.promise_filename)") };   
+      bundlesequence  => { default("$(this.promise_filename)") };
       version => "1.0";
 }
 
@@ -57,6 +57,9 @@ bundle agent check
       "nxe_abs" string => "/xbin/nosuchprogramexists";
 
   classes:
+      "rawshell_no_prefix" expression => returnszero("ls /", "useshell");
+      "rawnoshell_no_prefix" expression => returnszero("ls /", "noshell");
+
       "zero_noshell_rel" expression => returnszero("$(zero_rel)", "noshell");
       "zero_useshell_rel" expression => returnszero("$(zero_rel)", "useshell");
       "zero_noshell_abs" expression => returnszero("$(zero_abs)", "noshell");


### PR DESCRIPTION
See https://cfengine.com/dev/issues/3514

With acceptance test.  The basis for making the change is that `execresult` already allows non-absolute paths, so it must have simply been an oversight.
