### PR TITLE
Fix Redmine #2971: issue with commands where SIGPIPE is necessary

### DIFF
--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -127,6 +127,12 @@ static pid_t CreatePipeAndFork(const char *type, int *pd)
 
     signal(SIGCHLD, SIG_DFL);
 
+    // Redmine #2971: reset SIGPIPE signal handler to have a sane behavior of piped commands within child
+    if (pid == 0)
+    {
+        signal(SIGPIPE, SIG_DFL);
+    }
+
     ALARM_PID = (pid != 0 ? pid : -1);
 
     return pid;


### PR DESCRIPTION
In CFEngine the SIGPIPE signal is ignored by default (look for `signal(SIGPIPE, SIG_IGN);`)

In subprocesses, this break the pipe paradigm when multiples commands are piped together. 
Since there is a subsequent exec*\* call, no need to restore anything :)

Comments are welcome !
