### PR TITLE
mon_network.c: only free vbuff after we're done using it

### DIFF
--- a/cf-monitord/mon_network.c
+++ b/cf-monitord/mon_network.c
@@ -369,7 +369,6 @@ void MonNetworkGatherData(double *cf_this)
         }
     }
 
-    free(vbuff);
     cf_pclose(pp);
 
 /* Now save the state for ShowState() 
@@ -422,4 +421,6 @@ void MonNetworkGatherData(double *cf_this)
         Log(LOG_LEVEL_DEBUG, "Saved out netstat data in '%s'", vbuff);
         DeleteItemList(out[i]);
     }
+
+    free(vbuff);
 }


### PR DESCRIPTION
These two 'for' loops are still using 'vbuff' after it was free()d.

Fixed persistent crash of cf-monitord
