### PR TITLE
Redmine#3454: rename string functions to string_*

### DIFF
--- a/examples/string_downcase.cf
+++ b/examples/string_downcase.cf
@@ -29,14 +29,14 @@ body common control
 bundle agent example
 {
   vars:
-      "length" int =>  strlen("abc"); # will contain "3"
+      "downcase" string => string_downcase("ABC"); # will contain "abc"
   reports:
-      "length of string abc = $(length)";
+      "downcased ABC = $(downcase)";
 }
 #+end_src
 ###############################################################################
 #+begin_src example_output
 #@ ```
-#@ 2013-12-20T13:44:35-0500   notice: /default/example: R: length of string abc = 3
+#@ 2013-12-20T13:44:29-0500   notice: /default/example: R: downcased ABC = abc
 #@ ```
 #+end_src

--- a/examples/string_head.cf
+++ b/examples/string_head.cf
@@ -29,15 +29,15 @@ body common control
 bundle agent example
 {
   vars:
-
-      "downcase" string =>  downcase("ABC"); # will contain "abc"
+      "start" string => string_head("abc", "1"); # will contain "a"
   reports:
-      "downcased ABC = $(downcase)";
+      "start of abc = $(start)";
+
 }
 #+end_src
 ###############################################################################
 #+begin_src example_output
 #@ ```
-#@ 2013-12-20T13:44:29-0500   notice: /default/example: R: downcased ABC = abc
+#@ 2013-12-20T13:44:30-0500   notice: /default/example: R: start of abc = a
 #@ ```
 #+end_src

--- a/examples/string_length.cf
+++ b/examples/string_length.cf
@@ -29,15 +29,14 @@ body common control
 bundle agent example
 {
   vars:
-
-      "upcase" string =>  upcase("abc"); # will contain "ABC"
+      "length" int =>  string_length("abc"); # will contain "3"
   reports:
-      "upcased abc: $(upcase)";
+      "length of string abc = $(length)";
 }
 #+end_src
 ###############################################################################
 #+begin_src example_output
 #@ ```
-#@ 2013-12-20T13:44:35-0500   notice: /default/example: R: upcased abc: ABC
+#@ 2013-12-20T13:44:35-0500   notice: /default/example: R: length of string abc = 3
 #@ ```
 #+end_src

--- a/examples/string_reverse.cf
+++ b/examples/string_reverse.cf
@@ -29,10 +29,8 @@ body common control
 bundle agent example
 {
   vars:
-
       "reversed"
-
-      string =>  reversestring("abc"); # will contain "cba"
+      string =>  string_reverse("abc"); # will contain "cba"
   reports:
       "reversed abs = $(reversed)";
 }

--- a/examples/string_tail.cf
+++ b/examples/string_tail.cf
@@ -29,8 +29,7 @@ body common control
 bundle agent example
 {
   vars:
-
-      "end" string =>  tail("abc", "1"); # will contain "c"
+      "end" string => string_tail("abc", "1"); # will contain "c"
   reports:
       "end of abc = $(end)";
 

--- a/examples/string_upcase.cf
+++ b/examples/string_upcase.cf
@@ -29,16 +29,14 @@ body common control
 bundle agent example
 {
   vars:
-
-      "start" string =>  head("abc", "1"); # will contain "a"
+      "upcase" string => string_upcase("abc"); # will contain "ABC"
   reports:
-      "start of abc = $(start)";
-
+      "upcased abc: $(upcase)";
 }
 #+end_src
 ###############################################################################
 #+begin_src example_output
 #@ ```
-#@ 2013-12-20T13:44:30-0500   notice: /default/example: R: start of abc = a
+#@ 2013-12-20T13:44:35-0500   notice: /default/example: R: upcased abc: ABC
 #@ ```
 #+end_src

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1200,7 +1200,7 @@ static FnCallResult FnCallTextXform(ARG_UNUSED EvalContext *ctx, FnCall *fp, Rli
     strncpy(buf, string, sizeof(buf) - 1);
     len = strlen(buf);
 
-    if (!strcmp(fp->name, "downcase"))
+    if (!strcmp(fp->name, "string_downcase"))
     {
         int pos = 0;
         for (pos = 0; pos < len; pos++)
@@ -1208,7 +1208,7 @@ static FnCallResult FnCallTextXform(ARG_UNUSED EvalContext *ctx, FnCall *fp, Rli
             buf[pos] = tolower(buf[pos]);
         }
     }
-    else if (!strcmp(fp->name, "upcase"))
+    else if (!strcmp(fp->name, "string_upcase"))
     {
         int pos = 0;
         for (pos = 0; pos < len; pos++)
@@ -1216,7 +1216,7 @@ static FnCallResult FnCallTextXform(ARG_UNUSED EvalContext *ctx, FnCall *fp, Rli
             buf[pos] = toupper(buf[pos]);
         }
     }
-    else if (!strcmp(fp->name, "reversestring"))
+    else if (!strcmp(fp->name, "string_reverse"))
     {
         int c, i, j;
         for (i = 0, j = len - 1; i < j; i++, j--)
@@ -1226,11 +1226,11 @@ static FnCallResult FnCallTextXform(ARG_UNUSED EvalContext *ctx, FnCall *fp, Rli
             buf[j] = c;
         }
     }
-    else if (!strcmp(fp->name, "strlen"))
+    else if (!strcmp(fp->name, "string_length"))
     {
         sprintf(buf, "%d", len);
     }
-    else if (!strcmp(fp->name, "head"))
+    else if (!strcmp(fp->name, "string_head"))
     {
         long max = IntFromString(RlistScalarValue(finalargs->next));
         if (max < sizeof(buf))
@@ -1238,7 +1238,7 @@ static FnCallResult FnCallTextXform(ARG_UNUSED EvalContext *ctx, FnCall *fp, Rli
             buf[max] = '\0';
         }
     }
-    else if (!strcmp(fp->name, "tail"))
+    else if (!strcmp(fp->name, "string_tail"))
     {
         long max = IntFromString(RlistScalarValue(finalargs->next));
         if (max < len)
@@ -6876,17 +6876,17 @@ const FnCallType CF_FNCALL_TYPES[] =
                   FNCALL_OPTION_VARARG, FNCALL_CATEGORY_UTILS, SYNTAX_STATUS_NORMAL),
 
     // Text xform functions
-    FnCallTypeNew("downcase", DATA_TYPE_STRING, XFORM_ARGS, &FnCallTextXform, "Convert a string to lowercase",
+    FnCallTypeNew("string_downcase", DATA_TYPE_STRING, XFORM_ARGS, &FnCallTextXform, "Convert a string to lowercase",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
-    FnCallTypeNew("head", DATA_TYPE_STRING, XFORM_SUBSTR_ARGS, &FnCallTextXform, "Extract characters from the head of the string",
+    FnCallTypeNew("string_head", DATA_TYPE_STRING, XFORM_SUBSTR_ARGS, &FnCallTextXform, "Extract characters from the head of the string",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
-    FnCallTypeNew("reversestring", DATA_TYPE_STRING, XFORM_ARGS, &FnCallTextXform, "Reverse a string",
+    FnCallTypeNew("string_reverse", DATA_TYPE_STRING, XFORM_ARGS, &FnCallTextXform, "Reverse a string",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
-    FnCallTypeNew("strlen", DATA_TYPE_INT, XFORM_ARGS, &FnCallTextXform, "Return the length of a string",
+    FnCallTypeNew("string_length", DATA_TYPE_INT, XFORM_ARGS, &FnCallTextXform, "Return the length of a string",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
-    FnCallTypeNew("tail", DATA_TYPE_STRING, XFORM_SUBSTR_ARGS, &FnCallTextXform, "Extract characters from the tail of the string",
+    FnCallTypeNew("string_tail", DATA_TYPE_STRING, XFORM_SUBSTR_ARGS, &FnCallTextXform, "Extract characters from the tail of the string",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
-    FnCallTypeNew("upcase", DATA_TYPE_STRING, XFORM_ARGS, &FnCallTextXform, "Convert a string to UPPERCASE",
+    FnCallTypeNew("string_upcase", DATA_TYPE_STRING, XFORM_ARGS, &FnCallTextXform, "Convert a string to UPPERCASE",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
 
     // List folding functions

--- a/tests/acceptance/01_vars/02_functions/text_xform.cf
+++ b/tests/acceptance/01_vars/02_functions/text_xform.cf
@@ -26,58 +26,58 @@ bundle agent test
   vars:
       "tests" slist => { "q1", "q2", "q3" };
       "offsets" ilist => { "0", "1", "20", "26", "27", "28" };
-      "fn1" slist => { "head", "tail" };
+      "fn1" slist => { "string_head", "string_tail" };
       "data[q1]" string => "this is the Question";
       "data[q2]" string => "";
       "data[q3]" string => "some text is not $(const.t) simple
 
 ";
 
-      "data[$(tests)_reversestring]" string => reversestring("$(data[$(tests)])");
-      "data[$(tests)_strlen]" int => strlen("$(data[$(tests)])");
-      "data[$(tests)_upcase]" string => upcase("$(data[$(tests)])");
-      "data[$(tests)_downcase]" string => downcase("$(data[$(tests)])");
-      "data[$(tests)_head_$(offsets)]" string => head("$(data[$(tests)])", $(offsets));
-      "data[$(tests)_tail_$(offsets)]" string => tail("$(data[$(tests)])", $(offsets));
+      "data[$(tests)_string_reverse]" string => string_reverse("$(data[$(tests)])");
+      "data[$(tests)_string_length]" int => string_length("$(data[$(tests)])");
+      "data[$(tests)_string_upcase]" string => string_upcase("$(data[$(tests)])");
+      "data[$(tests)_string_downcase]" string => string_downcase("$(data[$(tests)])");
+      "data[$(tests)_string_head_$(offsets)]" string => string_head("$(data[$(tests)])", $(offsets));
+      "data[$(tests)_string_tail_$(offsets)]" string => string_tail("$(data[$(tests)])", $(offsets));
 
-      "expected[q1_reversestring]" string => "noitseuQ eht si siht";
-      "expected[q1_strlen]" int => "20";
-      "expected[q1_upcase]" string => "THIS IS THE QUESTION";
-      "expected[q1_downcase]" string => "this is the question";
-      "expected[q1_head_0]" string => "";
-      "expected[q1_tail_0]" string => "";
-      "expected[q1_head_1]" string => "t";
-      "expected[q1_tail_1]" string => "n";
+      "expected[q1_string_reverse]" string => "noitseuQ eht si siht";
+      "expected[q1_string_length]" int => "20";
+      "expected[q1_string_upcase]" string => "THIS IS THE QUESTION";
+      "expected[q1_string_downcase]" string => "this is the question";
+      "expected[q1_string_head_0]" string => "";
+      "expected[q1_string_tail_0]" string => "";
+      "expected[q1_string_head_1]" string => "t";
+      "expected[q1_string_tail_1]" string => "n";
       "expected[q1_$(fn1)_20]" string => "$(data[q1])";
       "expected[q1_$(fn1)_26]" string => "$(data[q1])";
       "expected[q1_$(fn1)_27]" string => "$(data[q1])";
       "expected[q1_$(fn1)_28]" string => "$(data[q1])";
 
-      "expected[q2_reversestring]" string => "";
-      "expected[q2_strlen]" int => "0";
-      "expected[q2_upcase]" string => "";
-      "expected[q2_downcase]" string => "";
+      "expected[q2_string_reverse]" string => "";
+      "expected[q2_string_length]" int => "0";
+      "expected[q2_string_upcase]" string => "";
+      "expected[q2_string_downcase]" string => "";
       "expected[q2_$(fn1)_$(offsets)]" string => "";
 
-      "expected[q3_reversestring]" string => "
+      "expected[q3_string_reverse]" string => "
 
 elpmis $(const.t) ton si txet emos";
-      "expected[q3_strlen]" int => "27";
-      "expected[q3_upcase]" string => "SOME TEXT IS NOT $(const.t) SIMPLE
+      "expected[q3_string_length]" int => "27";
+      "expected[q3_string_upcase]" string => "SOME TEXT IS NOT $(const.t) SIMPLE
 
 ";
-      "expected[q3_downcase]" string => "$(data[q3])";
+      "expected[q3_string_downcase]" string => "$(data[q3])";
       "expected[q3_$(fn1)_0]" string => "";
-      "expected[q3_head_1]" string => "s";
-      "expected[q3_tail_1]" string => "
+      "expected[q3_string_head_1]" string => "s";
+      "expected[q3_string_tail_1]" string => "
 ";
-      "expected[q3_head_20]" string => "some text is not $(const.t) s";
-      "expected[q3_tail_20]" string => "xt is not $(const.t) simple
+      "expected[q3_string_head_20]" string => "some text is not $(const.t) s";
+      "expected[q3_string_tail_20]" string => "xt is not $(const.t) simple
 
 ";
-      "expected[q3_head_26]" string => "some text is not $(const.t) simple
+      "expected[q3_string_head_26]" string => "some text is not $(const.t) simple
 ";
-      "expected[q3_tail_26]" string => "ome text is not $(const.t) simple
+      "expected[q3_string_tail_26]" string => "ome text is not $(const.t) simple
 
 ";
       "expected[q3_$(fn1)_27]" string => "$(data[q3])";
@@ -90,7 +90,7 @@ bundle agent check
 {
   vars:
       "tests" slist => { @(test.tests) };
-      "fn0" slist => { "reversestring", "strlen", "upcase", "downcase" };
+      "fn0" slist => { "string_reverse", "string_length", "string_upcase", "string_downcase" };
       "fn1" slist => { @(test.fn1) };
       "offsets" ilist => { @(test.offsets) };
 
@@ -107,20 +107,20 @@ bundle agent check
       "not_ok_$(tests)_$(fn1)_$(offsets)" not => strcmp("$(test.expected[$(tests)_$(fn1)_$(offsets)])",
                                                         "$(test.data[$(tests)_$(fn1)_$(offsets)])");
 
-      "ok" and => { 'ok_q1_reversestring', 'ok_q2_reversestring', 'ok_q3_reversestring',
-                    'ok_q1_strlen', 'ok_q2_strlen', 'ok_q3_strlen',
-                    'ok_q1_upcase', 'ok_q2_upcase', 'ok_q3_upcase',
-                    'ok_q1_downcase', 'ok_q2_downcase', 'ok_q3_downcase',
+      "ok" and => { 'ok_q1_string_reverse', 'ok_q2_string_reverse', 'ok_q3_string_reverse',
+                    'ok_q1_string_length', 'ok_q2_string_length', 'ok_q3_string_length',
+                    'ok_q1_string_upcase', 'ok_q2_string_upcase', 'ok_q3_string_upcase',
+                    'ok_q1_string_downcase', 'ok_q2_string_downcase', 'ok_q3_string_downcase',
 
-                    'ok_q1_head_0', 'ok_q2_head_0', 'ok_q3_head_0', 'ok_q1_tail_0',
-                    'ok_q2_tail_0', 'ok_q3_tail_0', 'ok_q1_head_1', 'ok_q2_head_1',
-                    'ok_q3_head_1', 'ok_q1_tail_1', 'ok_q2_tail_1', 'ok_q3_tail_1',
-                    'ok_q1_head_20', 'ok_q2_head_20', 'ok_q3_head_20', 'ok_q1_tail_20',
-                    'ok_q2_tail_20', 'ok_q3_tail_20', 'ok_q1_head_26', 'ok_q2_head_26',
-                    'ok_q3_head_26', 'ok_q1_tail_26', 'ok_q2_tail_26', 'ok_q3_tail_26',
-                    'ok_q1_head_27', 'ok_q2_head_27', 'ok_q3_head_27', 'ok_q1_tail_27',
-                    'ok_q2_tail_27', 'ok_q3_tail_27', 'ok_q1_head_28', 'ok_q2_head_28',
-                    'ok_q3_head_28', 'ok_q1_tail_28', 'ok_q2_tail_28', 'ok_q3_tail_28'
+                    'ok_q1_string_head_0', 'ok_q2_string_head_0', 'ok_q3_string_head_0', 'ok_q1_string_tail_0',
+                    'ok_q2_string_tail_0', 'ok_q3_string_tail_0', 'ok_q1_string_head_1', 'ok_q2_string_head_1',
+                    'ok_q3_string_head_1', 'ok_q1_string_tail_1', 'ok_q2_string_tail_1', 'ok_q3_string_tail_1',
+                    'ok_q1_string_head_20', 'ok_q2_string_head_20', 'ok_q3_string_head_20', 'ok_q1_string_tail_20',
+                    'ok_q2_string_tail_20', 'ok_q3_string_tail_20', 'ok_q1_string_head_26', 'ok_q2_string_head_26',
+                    'ok_q3_string_head_26', 'ok_q1_string_tail_26', 'ok_q2_string_tail_26', 'ok_q3_string_tail_26',
+                    'ok_q1_string_head_27', 'ok_q2_string_head_27', 'ok_q3_string_head_27', 'ok_q1_string_tail_27',
+                    'ok_q2_string_tail_27', 'ok_q3_string_tail_27', 'ok_q1_string_head_28', 'ok_q2_string_head_28',
+                    'ok_q3_string_head_28', 'ok_q1_string_tail_28', 'ok_q2_string_tail_28', 'ok_q3_string_tail_28'
       };
 
   reports:


### PR DESCRIPTION
see https://cfengine.com/dev/issues/3454

documentation adjustments coming as well
