### PR TITLE
verify_services: bail out with error if some service cannot be resolved

### DIFF
--- a/cf-agent/verify_services.c
+++ b/cf-agent/verify_services.c
@@ -201,7 +201,7 @@ static PromiseResult DoVerifyServices(EvalContext *ctx, Attributes a, const Prom
 
     if (!service_bundle)
     {
-        cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_FAIL, pp, a, "Service '%s' cannmot be resolved as a bundle", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_FAIL, pp, a, "Service '%s' cannot be resolved as a bundle", pp->promiser);
         return PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
     }
 


### PR DESCRIPTION
Please, can you tell me /why/ this promise failed to resolve, at all?

Rather than the assertion (which can even be no-oped in compile time),
which would kill cf-agent, exit the promise with a failure.
