### PR TITLE
Redmine#4096: teach mergedata() how to merge classic CFE arrays

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -2400,15 +2400,65 @@ static FnCallResult FnCallMergeData(EvalContext *ctx, ARG_UNUSED const Policy *p
             SeqAppend(containers, (void *)value);
             break;
         default:
-            Log(LOG_LEVEL_ERR, "%s: argument '%s' does not resolve to a container or a list", fp->name, RlistScalarValue(arg));
-            SeqDestroy(containers);
-            VarRefDestroy(ref);
-            SeqDestroy(toremove);
-            return FnFailure();
-        }
+        {
+            VariableTableIterator *iter = EvalContextVariableTableIteratorNew(ctx, ref->ns, ref->scope, ref->lval);
+            JsonElement *convert = JsonObjectCreate(10);
+            Variable *var;
+            while ((var = VariableTableIteratorNext(iter)))
+            {
+                if (var->ref->num_indices != 1)
+                {
+                    continue;
+                }
+
+                switch (var->rval.type)
+                {
+                case RVAL_TYPE_SCALAR:
+                    JsonObjectAppendString(convert, var->ref->indices[0], xstrdup(var->rval.item));
+                    break;
+
+                case RVAL_TYPE_LIST:
+                {
+                    JsonElement *array = JsonArrayCreate(10);
+                    for (const Rlist *rp = RvalRlistValue(var->rval); rp != NULL; rp = rp->next)
+                    {
+                        if (rp->val.type == RVAL_TYPE_SCALAR &&
+                            strcmp(RlistScalarValue(rp), CF_NULL_VALUE) != 0)
+                        {
+                            JsonArrayAppendString(array, RlistScalarValue(rp));
+                        }
+                    }
+                    JsonObjectAppendArray(convert, var->ref->indices[0], array);
+                }
+                break;
+
+                default:
+                    break;
+                }
+            }
+
+            VariableTableIteratorDestroy(iter);
+
+            if (JsonLength(convert) < 1)
+            {
+                Log(LOG_LEVEL_ERR, "%s: argument '%s' does not resolve to a container or a list", fp->name, RlistScalarValue(arg));
+                SeqDestroy(containers);
+                VarRefDestroy(ref);
+                SeqDestroy(toremove);
+                return FnFailure();
+            }
+            else
+            {
+                SeqAppend(containers, convert);
+                SeqAppend(toremove, convert);
+            }
+            break;
+        } // end of default case
+
+        } // end of data type switch
 
         VarRefDestroy(ref);
-    }
+    } // end of args loop
 
     if (SeqLength(containers) == 1)
     {

--- a/tests/acceptance/01_vars/02_functions/mergedata.cf
+++ b/tests/acceptance/01_vars/02_functions/mergedata.cf
@@ -1,6 +1,7 @@
 #######################################################
 #
 # Test mergedata()
+# This test is unstable until we have canonical JSON output
 #
 #######################################################
 
@@ -26,8 +27,11 @@ bundle agent test
       "load2" slist => { "element1", "element2", "element3" };
       "load3" data => parsejson('{ "x": "y" }');
       "load4" slist => { };
+      "load5[mykey]" slist => { "myvalue" };
+      "load5[anotherkey]" string => "anothervalue";
+      "load5[lastkey!]" slist => {};
 
-      "X" slist => { "1", "2", "3", "4" };
+      "X" slist => { "1", "2", "3", "4", "5" };
       "Y" slist => { @(X) };
 
       "load_$(X)" data => mergedata("load$(X)");
@@ -46,22 +50,32 @@ bundle agent check
       "expected_2" string => '["element1","element2","element3"]';
       "expected_3" string => '{"x":"y"}';
       "expected_4" string => '[]';
+      "expected_5" string => '{"lastkey!":[],"anotherkey":"anothervalue","mykey":["myvalue"]}';
       "expected_1_1" string => '[1,2,3,1,2,3]';
       "expected_1_2" string => '[1,2,3,"element1","element2","element3"]';
       "expected_1_3" string => '{"x":"y","0":1,"1":2,"2":3}';
       "expected_1_4" string => '[1,2,3]';
+      "expected_1_5" string => '{"lastkey!":[],"anotherkey":"anothervalue","mykey":["myvalue"],"0":1,"1":2,"2":3}';
       "expected_2_1" string => '["element1","element2","element3",1,2,3]';
       "expected_2_2" string => '["element1","element2","element3","element1","element2","element3"]';
       "expected_2_3" string => '{"x":"y","0":"element1","1":"element2","2":"element3"}';
       "expected_2_4" string => '["element1","element2","element3"]';
+      "expected_2_5" string => '{"lastkey!":[],"anotherkey":"anothervalue","mykey":["myvalue"],"0":"element1","1":"element2","2":"element3"}';
       "expected_3_1" string => '{"x":"y","0":1,"1":2,"2":3}';
       "expected_3_2" string => '{"x":"y","0":"element1","1":"element2","2":"element3"}';
       "expected_3_3" string => '{"x":"y"}';
       "expected_3_4" string => '{"x":"y"}';
+      "expected_3_5" string => '{"x":"y","lastkey!":[],"anotherkey":"anothervalue","mykey":["myvalue"]}';
       "expected_4_1" string => '[1,2,3]';
       "expected_4_2" string => '["element1","element2","element3"]';
       "expected_4_3" string => '{"x":"y"}';
       "expected_4_4" string => '[]';
+      "expected_4_5" string => '{"lastkey!":[],"anotherkey":"anothervalue","mykey":["myvalue"]}';
+      "expected_5_1" string => '{"lastkey!":[],"anotherkey":"anothervalue","mykey":["myvalue"],"0":1,"1":2,"2":3}';
+      "expected_5_2" string => '{"lastkey!":[],"anotherkey":"anothervalue","mykey":["myvalue"],"0":"element1","1":"element2","2":"element3"}';
+      "expected_5_3" string => '{"lastkey!":[],"anotherkey":"anothervalue","mykey":["myvalue"],"x":"y"}';
+      "expected_5_4" string => '{"lastkey!":[],"anotherkey":"anothervalue","mykey":["myvalue"]}';
+      "expected_5_5" string => '{"lastkey!":[],"anotherkey":"anothervalue","mykey":["myvalue"]}';
 
       "actual_$(X)_$(Y)" string => format("%S", "test.load_$(X)_$(Y)");
       "actual_$(X)" string => format("%S", "test.load_$(X)");
@@ -77,10 +91,10 @@ bundle agent check
 
   reports:
     DEBUG::
-      "$(X): $(actual_$(X)) != $(X) $(expected_$(X))"
+      "$(X): actual $(actual_$(X)) != $(X) expected $(expected_$(X))"
        ifvarclass => "not_ok_$(X)";
 
-      "$(X)+$(Y): $(actual_$(X)_$(Y)) != $(X)+$(Y) $(expected_$(X)_$(Y))"
+      "$(X)+$(Y): actual $(actual_$(X)_$(Y)) != $(X)+$(Y) expected $(expected_$(X)_$(Y))"
        ifvarclass => "not_ok_$(X)_$(Y)";
 
     ok::


### PR DESCRIPTION
See https://cfengine.com/dev/issues/4096

Simply converts an array, if found, to a data container so it can be merged with other data containers if the variable name is not a data container or list.

With acceptance test that depends on VarTable iteration order, until we have canonical JSON output (sorted keys).
