### PR TITLE
Fix a segmentation fault if the private key file is corrupted

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -899,6 +899,12 @@ void GenericAgentInitialize(EvalContext *ctx, GenericAgentConfig *config)
     if (config->agent_type != AGENT_TYPE_KEYGEN)
     {
         LoadSecretKeys();
+        if (PRIVKEY == NULL)
+        {
+            char *secretkeyfile = PrivateKeyFile(GetWorkDir());
+            FatalError(ctx, "Couldn't read private key from file %s\n", secretkeyfile);
+        }
+
         char *bootstrapped_policy_server = ReadPolicyServerFile(CFWORKDIR);
         PolicyHubUpdateKeys(bootstrapped_policy_server);
         free(bootstrapped_policy_server);


### PR DESCRIPTION
When the private key file is corrupted, cf-promises and cf-agent generate a segmentation fault:
Without the patch:

```
$ cf-promises 
2014-01-29T07:29:57+0100    error: Error reading private key. (PEM_read_RSAPrivateKey: too long)
Segmentation fault
```

With the patch:

```
$ cf-promises 
2014-01-29T07:25:22+0100    error: Error reading private key. (PEM_read_RSAPrivateKey: too long)
2014-01-29T07:25:22+0100    error: Fatal CFEngine error: Couldn't read private key from file /home/loic/.cfagent/ppkeys/localhost.priv
```

Feedback is welcome :-)
