### PR TITLE
Don't link dl on FreeBSD

### DIFF
--- a/cf-agent/Makefile.am
+++ b/cf-agent/Makefile.am
@@ -21,9 +21,11 @@ AM_LDFLAGS = \
 	$(MYSQL_LDFLAGS) \
 	$(LIBXML2_LDFLAGS)
 
+if !FREEBSD
 if HAVE_AVAHI_COMMON
 if HAVE_AVAHI_CLIENT
 AM_LDFLAGS += -ldl
+endif
 endif
 endif
 


### PR DESCRIPTION
The dlopen/dlsym functions are built into libc on FreeBSD, so libdl doesn't exist and causes the linking to fail
