### PR TITLE
Add acceptance test for reporting of nested variables

### DIFF
--- a/tests/acceptance/14_reports/00_output/report_nested_variable.cf
+++ b/tests/acceptance/14_reports/00_output/report_nested_variable.cf
@@ -1,0 +1,41 @@
+# Check that nested variables are reported (Redmine: https://cfengine.com/dev/issues/4247)
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+
+}
+
+
+bundle agent test
+{
+  vars:
+    !FAKE_PASS::
+      "subout" string => execresult("$(sys.cf_agent) -b runme -Kf $(this.promise_filename).sub", "noshell");
+    FAKE_PASS::
+      "subout" string => execresult("$(sys.cf_agent) -b runme -Kf $(this.promise_filename).sub -DFAKE_PASS", "noshell");
+}
+
+
+bundle agent check
+{
+  classes:
+      "ok" expression => regcmp(".*replaced-by=something_else.*", "$(test.subout)");
+
+  reports:
+    DEBUG::
+      "$(test.subout)";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}
+### PROJECT_ID: core
+### CATEGORY_ID: 2

--- a/tests/acceptance/14_reports/00_output/report_nested_variable.cf.sub
+++ b/tests/acceptance/14_reports/00_output/report_nested_variable.cf.sub
@@ -5,7 +5,6 @@ bundle agent old_bundle
                       "deprecated=3.6.0",
                       "deprecation-reason=Generic reimplementation",
                       "replaced-by=something_else",
-                      "deprecated",
                     };
 
 }

--- a/tests/acceptance/14_reports/00_output/report_nested_variable.cf.sub
+++ b/tests/acceptance/14_reports/00_output/report_nested_variable.cf.sub
@@ -1,0 +1,22 @@
+bundle agent old_bundle
+{
+  meta:
+    "tags" slist => {
+                      "deprecated=3.6.0",
+                      "deprecation-reason=Generic reimplementation",
+                      "replaced-by=something_else",
+                      "deprecated",
+                    };
+
+}
+bundle agent runme
+{
+  vars:
+    "deprecated" slist => bundlesmatching(".*", "deprecated.*");
+
+  reports:
+    !FAKE_PASS::
+      "$(deprecated): $($(deprecated)_meta.tags)";
+    FAKE_PASS::
+      "$(deprecated): $(old_bundle_meta.tags)";
+}


### PR DESCRIPTION
```
root@vagrant:/src/cfengine/core/tests/acceptance/14_reports/00_output# cf-agent -KIf ./report_nested_variable.cf -DAUTO,FAKE_PASS
R: /src/cfengine/core/tests/acceptance/14_reports/00_output/./report_nested_variable.cf Pass
```

```
root@vagrant:/src/cfengine/core/tests/acceptance/14_reports/00_output# cf-agent -KIf ./report_nested_variable.cf -DAUTO
R: /src/cfengine/core/tests/acceptance/14_reports/00_output/./report_nested_variable.cf FAIL
```