### PR TITLE
[3.5.x] Use a dynamically allocated buffer to remove size restriction on templat...

### DIFF
--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -283,9 +283,7 @@ static void ExpandAndMapIteratorsFromScalar(EvalContext *ctx, const char *scopei
     }
 
     /* No return calls in this function, so free at the end */
-    buffer = xcalloc(length+1,sizeof(char));
-    strncpy(buffer, string, length);
-    buffer[length] = '\0';
+    buffer = xstrndup(string, length);
 
     for (sp = buffer; (*sp != '\0'); sp++)
     {


### PR DESCRIPTION
...e files
It looks like you can just calloc the buffer, and only one free needed at the end.
