### PR TITLE
libpromises: limit readstringarrayidx() tokens to CF_MAXVARSIZE

### DIFF
--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -960,7 +960,9 @@ Rlist *RlistFromSplitRegex(const char *string, const char *regex, int max, bool 
         }
 
         memset(node, 0, CF_MAXVARSIZE);
-        strncpy(node, sp, start);
+        /* silently drop tokens longer than CF_MAXVARSIZE,
+         * we don't want to propagate larger buffers down the Rlist */
+        strncpy(node, sp, MIN(start, CF_MAXVARSIZE-1));
 
         if (blanks || strlen(node) > 0)
         {


### PR DESCRIPTION
Note: this bug may apply to earlier versions, 3.5 etc.

A very strange case: my system scripts did append mount options to
nfs mounts on /etc/mtab , causing some lines to have >2.5k fields!

Then, new promise:
   => readstringarrayidx("mounts",.., "\s_#[^\n]_", "\s+",..)
of inventory/any.cf:147 borked, because the mount-options column
did have >2k length.

In my case SILENTLY dropping the rest of the token works.
