### PR TITLE
Fix for: Destroy policy object at end of run.

### DIFF
--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -162,7 +162,6 @@ int main(int argc, char *argv[])
         StartServer(ctx, policy, config, &execd_config, &exec_config);
     }
 
-    PolicyDestroy(policy);
     ExecConfigDestroy(exec_config);
     ExecdConfigDestroy(execd_config);
     GenericAgentConfigDestroy(config);


### PR DESCRIPTION
I managed to add two calls to PolicyDestroy() where there should only
have been one - resulting in a double free.
