### PR TITLE
Removed MapName() call..

### DIFF
--- a/cf-agent/files_properties.c
+++ b/cf-agent/files_properties.c
@@ -150,6 +150,8 @@ bool ConsiderAbstractFile(const char *filename, const char *directory, FileCopy 
         return false;
     }
 
+    /* TODO this function should accept the joined path in the first place
+     * since it's joined elsewhere as well, if split needed do it here. */
     char buf[CF_BUFSIZE];
     int ret = snprintf(buf, sizeof(buf), "%s/%s", directory, filename);
     if (ret < 0 || ret >= sizeof(buf))
@@ -159,7 +161,6 @@ bool ConsiderAbstractFile(const char *filename, const char *directory, FileCopy 
             directory, filename);
         return false;
     }
-    MapName(buf);
 
     struct stat stat;
     if (cf_lstat(buf, &stat, fc, conn) == -1)

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -668,8 +668,8 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, char *from, char *to,
                                          const Promise *pp, dev_t rootdevice, CompressedArray **inode_cache, AgentConnection *conn)
 {
     struct stat sb, dsb;
-    char newfrom[CF_BUFSIZE];
-    char newto[CF_BUFSIZE];
+    /* TODO overflow check all these str*cpy()s in here! */
+    char newfrom[CF_BUFSIZE], newto[CF_BUFSIZE];
     Item *namecache = NULL;
     const struct dirent *dirp;
     AbstractDir *dirh;
@@ -687,7 +687,7 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, char *from, char *to,
 
     /* Check that dest dir exists before starting */
 
-    strncpy(newto, to, CF_BUFSIZE - 10);
+    strlcpy(newto, to, sizeof(newto) - 10);
     AddSlash(newto);
     strcat(newto, "dummy");
 
@@ -765,8 +765,8 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, char *from, char *to,
             AppendItem(&namecache, dirp->d_name, NULL);
         }
 
-        strncpy(newfrom, from, CF_BUFSIZE - 2); /* Assemble pathname */
-        strncpy(newto, to, CF_BUFSIZE - 2);
+        strlcpy(newfrom, from, sizeof(newfrom) - 2); /* Assemble pathname */
+        strlcpy(newto, to, sizeof(newto) - 2);
 
         if (!JoinPath(newfrom, dirp->d_name))
         {


### PR DESCRIPTION
...so that remote request from Windows boxes do not contain backslashes.

Also removed some possible overflows to the relevant safe calls, now they will
/only/ be truncated in case string is too long...
