### PR TITLE
Clarifications for --show-classes --show-vars

### DIFF
--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -89,8 +89,8 @@ static const struct option OPTIONS[] =
 static const char *const HINTS[] =
 {
     [PROMISES_OPTION_EVAL_FUNCTIONS] = "Evaluate functions during syntax checking (may catch more run-time errors). Possible values: 'yes', 'no'. Default is 'yes'",
-    [PROMISES_OPTION_SHOW_CLASSES] = "Show discovered classes, including those defined in policy",
-    [PROMISES_OPTION_SHOW_VARIABLES] = "Show discovered variables, including those defined in policy",
+    [PROMISES_OPTION_SHOW_CLASSES] = "Show discovered classes, including those defined in common bundles in policy",
+    [PROMISES_OPTION_SHOW_VARIABLES] = "Show discovered variables, including those defined anywhere in policy",
     "Print the help message",
     "Use the specified bundlesequence for verification",
     "Enable debugging output",


### PR DESCRIPTION
Improve help text to include exactly which types of classes and variables are shown.
They don't take arguments, fix this too.
