### PR TITLE
fix --enable-debug option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -192,7 +192,7 @@ AC_ARG_ENABLE(debug,
 AM_CONDITIONAL([NDEBUG], [test x"$debug" = x"no"])
 
 if test x"$debug" = x"yes"; then
-   CFLAGS="-g3 -O0 $CFLAGS"
+   CFLAGS="$CFLAGS -g3 -O0"
 else
    CFLAGS="-O2 -DNDEBUG $CFLAGS"
 fi


### PR DESCRIPTION
[f37d8506e0cd769acd026517074ab79a86cfd8a4] Make CFLAGS overridable
borked --enable-debug[=yes] by causing builds to always compile with `std=gnu99 -g3 -O0 -pthread -g -O2 -g -Wall`.

Debug symbols are indeed included but the binary is always built optimized.
