### PR TITLE
libpromises/syntax.c: include function argument descriptions too

### DIFF
--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -1198,6 +1198,7 @@ static JsonElement *FnCallTypeToJson(const FnCallType *fn_syntax)
             JsonElement *json_param = JsonObjectCreate(2);
             JsonObjectAppendString(json_param, "type", DataTypeToString(param->dtype));
             JsonObjectAppendString(json_param, "range", param->pattern);
+            JsonObjectAppendString(json_param, "description", param->description);
             JsonArrayAppendObject(params, json_param);
         }
         JsonObjectAppendArray(json_fn, "parameters", params);


### PR DESCRIPTION
I can't think of a reason not to include the description of the function parameter, so I hope this is OK to merge.

@sigurdteigen @vohi this would make the function doc pages a bit nicer and has no downsides AFAIK
