### PR TITLE
Make use of preprocessor macros for static known_dirs.c functions

### DIFF
--- a/libpromises/known_dirs.c
+++ b/libpromises/known_dirs.c
@@ -46,9 +46,9 @@ GET_DEFAULT_DIRECTORY_DEFINE(Master, MASTERDIR)
 
 #elif !defined(__MINGW32__)
 
-#define MAX_WORKDIR_LENGTH (CF_BUFSIZE / 2)
+#define MAX_DIR_LENGTH (CF_BUFSIZE / 2)
 
-static const char *GetDefaultDir_helper(char dir[MAX_WORKDIR_LENGTH], const char *root_dir, const char *append_dir)
+static const char *GetDefaultDir_helper(char dir[MAX_DIR_LENGTH], const char *root_dir, const char *append_dir)
 {
     if (getuid() > 0)
     {
@@ -58,14 +58,14 @@ static const char *GetDefaultDir_helper(char dir[MAX_WORKDIR_LENGTH], const char
 
             if ( append_dir == NULL )
             {
-                if (snprintf(dir, MAX_WORKDIR_LENGTH, "%s/.cfagent", mpw->pw_dir) >= MAX_WORKDIR_LENGTH)
+                if (snprintf(dir, MAX_DIR_LENGTH, "%s/.cfagent", mpw->pw_dir) >= MAX_DIR_LENGTH)
                 {
                     return NULL;
                 }
             }
             else
             {
-                if (snprintf(dir, MAX_WORKDIR_LENGTH, "%s/.cfagent/%s", mpw->pw_dir, append_dir) >= MAX_WORKDIR_LENGTH)
+                if (snprintf(dir, MAX_DIR_LENGTH, "%s/.cfagent/%s", mpw->pw_dir, append_dir) >= MAX_DIR_LENGTH)
                 {
                     return NULL;
                 }
@@ -79,12 +79,12 @@ static const char *GetDefaultDir_helper(char dir[MAX_WORKDIR_LENGTH], const char
     }
 }
 
-#define GET_DEFAULT_DIRECTORY_DEFINE(FUNC, STATIC, GLOBAL, FOLDER)    \
-static const char *GetDefault##FUNC##Dir(void)                        \
-{                                                                     \
-    static char STATIC##dir[MAX_WORKDIR_LENGTH] = ""; /* GLOBAL_C */  \
-    return GetDefaultDir_helper(STATIC##dir, GLOBAL, FOLDER);         \
-}                                                                     \
+#define GET_DEFAULT_DIRECTORY_DEFINE(FUNC, STATIC, GLOBAL, FOLDER)  \
+static const char *GetDefault##FUNC##Dir(void)                      \
+{                                                                   \
+    static char STATIC##dir[MAX_DIR_LENGTH] = ""; /* GLOBAL_C */    \
+    return GetDefaultDir_helper(STATIC##dir, GLOBAL, FOLDER);       \
+}                                                                   \
 
 GET_DEFAULT_DIRECTORY_DEFINE(Work, work, WORKDIR, NULL)
 GET_DEFAULT_DIRECTORY_DEFINE(Log, log, LOGDIR, NULL)


### PR DESCRIPTION
Preprocessor macros are used to expand the static functions in `known_dirs.c`, and since they are restricted to the implementation, I believe this not to be preprocessor abuse. Overall readability goes up IMHO, repetition goes down, and no grepability is lost.

Cherry-picked from another one of my endeavors... love it or hate it?
