### PR TITLE
Log messages improvements

### DIFF
--- a/cf-agent/acl_posix.c
+++ b/cf-agent/acl_posix.c
@@ -121,7 +121,7 @@ static int CheckPosixLinuxDefaultACEs(EvalContext *ctx, Rlist *aces, AclMethod m
         break;
 
     default:                   // unknown inheritance policy
-        Log(LOG_LEVEL_ERR, "Unknown inheritance policy - shouldn't happen");
+        Log(LOG_LEVEL_ERR, "Unknown ACL inheritance policy - shouldn't happen");
         retval = false;
         break;
     }
@@ -161,7 +161,7 @@ static int CheckPosixLinuxACEs(EvalContext *ctx, Rlist *aces, AclMethod method, 
 
     if ((acl_existing = acl_get_file(file_path, acl_type)) == NULL)
     {
-        Log(LOG_LEVEL_VERBOSE, "No ACL for '%s' could be read. (acl_get_file: %s)", file_path, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "No ACL for '%s' could be read. (acl_get_file: %s)", file_path, GetErrorStr());
         return false;
     }
 
@@ -211,7 +211,7 @@ static int CheckPosixLinuxACEs(EvalContext *ctx, Rlist *aces, AclMethod method, 
 
         if (!ParseEntityPosixLinux(&cf_ace, ace_parsed, &has_mask))
         {
-            Log(LOG_LEVEL_ERR, "Error parsing entity in 'cf_ace'.");
+            Log(LOG_LEVEL_ERR, "ACL: Error parsing entity in 'cf_ace'.");
             acl_free((void *) acl_existing);
             acl_free((void *) acl_tmp);
             acl_free((void *) acl_new);
@@ -250,7 +250,7 @@ static int CheckPosixLinuxACEs(EvalContext *ctx, Rlist *aces, AclMethod method, 
             // loop iteration to be taken into account when applying mode below
             if ((acl_get_permset(ace_current, &perms) != 0))
             {
-                Log(LOG_LEVEL_ERR, "Error obtaining permset for 'ace_current' (acl_get_permset: %s)", GetErrorStr());
+                Log(LOG_LEVEL_ERR, "Error obtaining permission set for 'ace_current' (acl_get_permset: %s)", GetErrorStr());
                 acl_free((void *) acl_existing);
                 acl_free((void *) acl_tmp);
                 acl_free((void *) acl_new);
@@ -259,7 +259,7 @@ static int CheckPosixLinuxACEs(EvalContext *ctx, Rlist *aces, AclMethod method, 
 
             if (acl_clear_perms(perms) != 0)
             {
-                Log(LOG_LEVEL_ERR, "Error clearing permset for 'ace_current'. (acl_clear_perms: %s)", GetErrorStr());
+                Log(LOG_LEVEL_ERR, "Error clearing permission set for 'ace_current'. (acl_clear_perms: %s)", GetErrorStr());
                 acl_free((void *) acl_existing);
                 acl_free((void *) acl_tmp);
                 acl_free((void *) acl_new);
@@ -271,7 +271,7 @@ static int CheckPosixLinuxACEs(EvalContext *ctx, Rlist *aces, AclMethod method, 
 
         if (*cf_ace != ':')
         {
-            Log(LOG_LEVEL_ERR, "No separator before mode-string in 'cf_ace'");
+            Log(LOG_LEVEL_ERR, "ACL: No separator before mode-string in 'cf_ace'");
             acl_free((void *) acl_existing);
             acl_free((void *) acl_tmp);
             acl_free((void *) acl_new);
@@ -282,7 +282,7 @@ static int CheckPosixLinuxACEs(EvalContext *ctx, Rlist *aces, AclMethod method, 
 
         if (acl_get_permset(ace_current, &perms) != 0)
         {
-            Log(LOG_LEVEL_ERR, "Error obtaining permset for 'cf_ace'");
+            Log(LOG_LEVEL_ERR, "ACL: Error obtaining permission set for 'cf_ace'. (acl_get_permset: %s)", GetErrorStr());
             acl_free((void *) acl_existing);
             acl_free((void *) acl_tmp);
             acl_free((void *) acl_new);
@@ -291,7 +291,7 @@ static int CheckPosixLinuxACEs(EvalContext *ctx, Rlist *aces, AclMethod method, 
 
         if (!ParseModePosixLinux(cf_ace, perms))
         {
-            Log(LOG_LEVEL_ERR, "Error parsing mode-string in 'cf_ace'");
+            Log(LOG_LEVEL_ERR, "ACL: Error parsing mode-string in 'cf_ace'");
             acl_free((void *) acl_existing);
             acl_free((void *) acl_tmp);
             acl_free((void *) acl_new);
@@ -307,7 +307,7 @@ static int CheckPosixLinuxACEs(EvalContext *ctx, Rlist *aces, AclMethod method, 
     {
         if (acl_calc_mask(&acl_new) != 0)
         {
-            Log(LOG_LEVEL_ERR, "Error calculating new acl mask");
+            Log(LOG_LEVEL_ERR, "Error calculating new ACL mask");
             acl_free((void *) acl_existing);
             acl_free((void *) acl_tmp);
             acl_free((void *) acl_new);
@@ -428,7 +428,7 @@ static int CheckDefaultEqualsAccessACL(EvalContext *ctx, const char *file_path, 
             {
                 if ((acl_set_file(file_path, ACL_TYPE_DEFAULT, acl_access)) != 0)
                 {
-                    Log(LOG_LEVEL_ERR, "Could not set default ACL to access");
+                    Log(LOG_LEVEL_ERR, "Could not set default ACL to access on '%s'. (acl_set_file: %s)", file_path, GetErrorStr());
                     acl_free(acl_access);
                     acl_free(acl_default);
                     return false;
@@ -451,7 +451,7 @@ static int CheckDefaultEqualsAccessACL(EvalContext *ctx, const char *file_path, 
 
     default:
         retval = false;
-        Log(LOG_LEVEL_ERR, "Unable to compare access and default ACEs");
+        Log(LOG_LEVEL_ERR, "ACL: Unable to compare access and default ACEs");
     }
 
     acl_free(acl_access);
@@ -485,7 +485,7 @@ int CheckDefaultClearACL(EvalContext *ctx, const char *file_path, Attributes a, 
     switch (retv)
     {
     case -1:
-        Log(LOG_LEVEL_VERBOSE, "Couldn't retrieve ACE for '%s'. (acl_get_entry: %s)", file_path, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "Couldn't retrieve ACE for '%s'. (acl_get_entry: %s)", file_path, GetErrorStr());
         retval = false;
         break;
 
@@ -517,7 +517,7 @@ int CheckDefaultClearACL(EvalContext *ctx, const char *file_path, Attributes a, 
             {
                 if (acl_set_file(file_path, ACL_TYPE_DEFAULT, acl_empty) != 0)
                 {
-                    Log(LOG_LEVEL_ERR, "Could not reset ACL for %s", file_path);
+                    Log(LOG_LEVEL_ERR, "Could not reset ACL for '%s'. (acl_set_file: %s)", file_path, GetErrorStr());
                     retval = false;
                     break;
                 }
@@ -568,7 +568,7 @@ static acl_entry_t FindACE(acl_t acl, acl_entry_t ace_find)
 
     if (more_aces == -1)
     {
-        Log(LOG_LEVEL_ERR, "Error reading acl. (acl_get_entry: %s)", GetErrorStr());
+        Log(LOG_LEVEL_ERR, "Error reading ACL. (acl_get_entry: %s)", GetErrorStr());
         return NULL;
     }
     else if (more_aces == 0)
@@ -661,13 +661,13 @@ static int ACLEquals(acl_t first, acl_t second)
 
     if ((first_cnt = ACECount(first)) == -1)
     {
-        Log(LOG_LEVEL_VERBOSE, "Couldn't count ACEs");
+        Log(LOG_LEVEL_ERR, "Couldn't count ACEs while comparing ACLs");
         return -1;
     }
 
     if ((second_cnt = ACECount(second)) == -1)
     {
-        Log(LOG_LEVEL_VERBOSE, "Couldn't count ACEs");
+        Log(LOG_LEVEL_ERR, "Couldn't count ACEs while comparing ACLs");
         return -1;
     }
 
@@ -914,7 +914,7 @@ static int ParseEntityPosixLinux(char **str, acl_entry_t ace, int *is_mask)
     }
     else
     {
-        Log(LOG_LEVEL_ERR, "ace does not start with user:/group:/all:/mask:");
+        Log(LOG_LEVEL_ERR, "ACE does not start with user:/group:/all:/mask:");
         return false;
     }
 
@@ -960,7 +960,7 @@ static int ParseModePosixLinux(char *mode, acl_permset_t perms)
     {
         if (acl_clear_perms(perms) != 0)
         {
-            Log(LOG_LEVEL_ERR, "Error clearing perms. (acl_clear_perms: %s)", GetErrorStr());
+            Log(LOG_LEVEL_ERR, "Error clearing permissions. (acl_clear_perms: %s)", GetErrorStr());
             return false;
         }
         else
@@ -1023,7 +1023,7 @@ static int ParseModePosixLinux(char *mode, acl_permset_t perms)
                 break;
 
             default:
-                Log(LOG_LEVEL_ERR, "No linux support for generic permission flag '%c'", *mode);
+                Log(LOG_LEVEL_ERR, "No Linux support for generic permission flag '%c'", *mode);
                 return false;
             }
 
@@ -1038,7 +1038,7 @@ static int ParseModePosixLinux(char *mode, acl_permset_t perms)
 
             if (retv != 0)
             {
-                Log(LOG_LEVEL_ERR, "Could not change ACE permission. (acl_[add|delete]_perms: %s)", GetErrorStr());
+                Log(LOG_LEVEL_ERR, "Could not change ACE permission. (acl_[add|delete]_perm: %s)", GetErrorStr());
                 return false;
             }
             mode++;
@@ -1067,7 +1067,7 @@ static int ParseModePosixLinux(char *mode, acl_permset_t perms)
                     break;
 
                 default:
-                    Log(LOG_LEVEL_ERR, "No linux support for native permission flag '%c'", *mode);
+                    Log(LOG_LEVEL_ERR, "No Linux support for native permission flag '%c'", *mode);
                     return false;
                 }
 

--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -609,7 +609,7 @@ static void ThisAgentInit(void)
     char filename[CF_BUFSIZE];
 
 #ifdef HAVE_SETSID
-    Log(LOG_LEVEL_VERBOSE, "Setting session ID, becoming process group leader");
+    Log(LOG_LEVEL_DEBUG, "Setting session ID, becoming process group leader");
     setsid();
 #endif
 
@@ -883,7 +883,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy)
             if (strcmp(cp->lval, CFA_CONTROLBODY[AGENT_CONTROL_REPOSITORY].lval) == 0)
             {
                 SetRepositoryLocation(value);
-                Log(LOG_LEVEL_VERBOSE, "SET repository = %s", (const char *)value);
+                Log(LOG_LEVEL_VERBOSE, "Setting repository to '%s'", (const char *)value);
                 continue;
             }
 
@@ -947,7 +947,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy)
             if (strcmp(cp->lval, CFA_CONTROLBODY[AGENT_CONTROL_TIMEOUT].lval) == 0)
             {
                 CONNTIMEOUT = IntFromString(value);
-                Log(LOG_LEVEL_VERBOSE, "Setting timeout = %jd", (intmax_t) CONNTIMEOUT);
+                Log(LOG_LEVEL_VERBOSE, "Setting timeout to %jd", (intmax_t) CONNTIMEOUT);
                 continue;
             }
 
@@ -1007,7 +1007,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy)
         if (!SetSyslogHost(value))
         {
             Log(LOG_LEVEL_ERR,
-                  "FAILed to set syslog_host, '%s' too long", (const char *)value);
+                  "Failed to set syslog_host to '%s', too long", (const char *)value);
         }
         else
         {
@@ -1157,7 +1157,7 @@ static void AllClassesReport(const EvalContext *ctx)
     FILE *fp = NULL;
     if ((fp = fopen(context_report_file, "w")) == NULL)
     {
-        Log(LOG_LEVEL_INFO, "Could not open allclasses cache file");
+        Log(LOG_LEVEL_INFO, "Could not open allclasses cache file '%s' (fopen: %s)", context_report_file, GetErrorStr());
     }
     else
     {
@@ -1524,7 +1524,7 @@ static int NewTypeContext(TypeSequence type)
 
         if (!LoadProcessTable(&PROCESSTABLE))
         {
-            Log(LOG_LEVEL_ERR, "Unable to read the process table - cannot keep process promises");
+            Log(LOG_LEVEL_ERR, "Unable to read the process table - cannot keep processes: type promises");
             return false;
         }
         break;

--- a/cf-agent/verify_acl.c
+++ b/cf-agent/verify_acl.c
@@ -163,7 +163,7 @@ static int CheckACLSyntax(const char *file, Acl acl, const Promise *pp)
 
         if (!valid)             // wrong syntax in this ace
         {
-            Log(LOG_LEVEL_ERR, "The ACE '%s' contains errors", RlistScalarValue(rp));
+            Log(LOG_LEVEL_ERR, "ACL: The ACE '%s' contains errors", RlistScalarValue(rp));
             PromiseRef(LOG_LEVEL_ERR, pp);
             break;
         }
@@ -175,7 +175,7 @@ static int CheckACLSyntax(const char *file, Acl acl, const Promise *pp)
 
         if (!valid)             // wrong syntax in this ace
         {
-            Log(LOG_LEVEL_ERR, "The ACE '%s' contains errors", RlistScalarValue(rp));
+            Log(LOG_LEVEL_ERR, "ACL: The ACE '%s' contains errors", RlistScalarValue(rp));
             PromiseRef(LOG_LEVEL_ERR, pp);
             break;
         }
@@ -298,7 +298,7 @@ static int CheckACESyntax(char *ace, char *valid_ops, char *valid_nperms, int de
     }
     else
     {
-        Log(LOG_LEVEL_ERR, "ACE '%s' does not start with user:/group:/all", ace);
+        Log(LOG_LEVEL_ERR, "ACL: ACE '%s' does not start with user:/group:/all", ace);
         PromiseRef(LOG_LEVEL_ERR, pp);
         return false;
     }
@@ -307,7 +307,7 @@ static int CheckACESyntax(char *ace, char *valid_ops, char *valid_nperms, int de
     {
         if (*str == ':')
         {
-            Log(LOG_LEVEL_ERR, "ACE '%s': id cannot be empty or contain ':'", ace);
+            Log(LOG_LEVEL_ERR, "ACL: ACE '%s': id cannot be empty or contain ':'", ace);
             return false;
         }
 
@@ -323,7 +323,7 @@ static int CheckACESyntax(char *ace, char *valid_ops, char *valid_nperms, int de
             }
             else if (*str == '\0')
             {
-                Log(LOG_LEVEL_ERR, "Nothing following id string in ACE '%s'", ace);
+                Log(LOG_LEVEL_ERR, "ACL: Nothing following id string in ACE '%s'", ace);
                 return false;
             }
         }
@@ -334,7 +334,7 @@ static int CheckACESyntax(char *ace, char *valid_ops, char *valid_nperms, int de
 
     if (!valid_mode)
     {
-        Log(LOG_LEVEL_ERR, "Malformed mode-string in ACE '%s'", ace);
+        Log(LOG_LEVEL_ERR, "ACL: Malformed mode-string in ACE '%s'", ace);
         PromiseRef(LOG_LEVEL_ERR, pp);
         return false;
     }
@@ -351,7 +351,7 @@ static int CheckACESyntax(char *ace, char *valid_ops, char *valid_nperms, int de
 
     if (!valid_permt)
     {
-        Log(LOG_LEVEL_ERR, "Malformed perm_type syntax in ACE '%s'", ace);
+        Log(LOG_LEVEL_ERR, "ACL: Malformed perm_type syntax in ACE '%s'", ace);
         return false;
     }
 
@@ -396,7 +396,7 @@ static int CheckModeSyntax(char **mode_p, char *valid_ops, char *valid_nperms, c
             }
             else
             {
-                Log(LOG_LEVEL_ERR, "Invalid native permission '%c', or missing native end separator", *mode);
+                Log(LOG_LEVEL_ERR, "ACL: Invalid native permission '%c', or missing native end separator", *mode);
                 PromiseRef(LOG_LEVEL_ERR, pp);
                 valid = false;
                 break;
@@ -414,7 +414,7 @@ static int CheckModeSyntax(char **mode_p, char *valid_ops, char *valid_nperms, c
         }
         else
         {
-            Log(LOG_LEVEL_ERR, "Mode string contains invalid characters");
+            Log(LOG_LEVEL_ERR, "ACL: Mode string contains invalid characters");
             PromiseRef(LOG_LEVEL_ERR, pp);
             valid = false;
             break;

--- a/cf-agent/verify_files_hashes.c
+++ b/cf-agent/verify_files_hashes.c
@@ -144,7 +144,10 @@ int FileHashChanged(EvalContext *ctx, const char *filename, unsigned char digest
 
     if (!OpenDB(&dbp, dbid_checksums))
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr, "Unable to open the hash database!");
+        char *db_path = DBIdToPath(WORKDIR, dbid_checksums);
+        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr,
+            "Unable to open the checksums database '%s'", db_path);
+        free(db_path);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
         return false;
     }

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -582,7 +582,7 @@ static PackageItem *GetCachedPackageList(EvalContext *ctx, PackageManager *manag
 
     if ((fin = fopen(name, "r")) == NULL)
     {
-        Log(LOG_LEVEL_INFO, "Cannot open the source log '%s' - you need to run a package discovery promise to create it in cf-agent. (fopen: %s)",
+        Log(LOG_LEVEL_ERR, "Cannot open the source log '%s' - you need to run a package discovery promise to create it in cf-agent. (fopen: %s)",
               name, GetErrorStr());
         return NULL;
     }

--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -534,7 +534,7 @@ static void MailResult(const ExecConfig *config, const char *file)
     FILE *fp = fopen(file, "r");
     if (!fp)
     {
-        Log(LOG_LEVEL_INFO, "Couldn't open file '%s'. (fopen: %s)", file, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "Couldn't open file '%s'. (fopen: %s)", file, GetErrorStr());
         return;
     }
 
@@ -560,7 +560,7 @@ static void MailResult(const ExecConfig *config, const char *file)
 
     if ((fp = fopen(file, "r")) == NULL)
     {
-        Log(LOG_LEVEL_INFO, "Couldn't open file '%s'. (fopen: %s)", file, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "Couldn't open file '%s'. (fopen: %s)", file, GetErrorStr());
         return;
     }
 

--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -208,7 +208,7 @@ static void LoadHistogram(void)
 
     if ((fp = fopen(filename, "r")) == NULL)
     {
-        Log(LOG_LEVEL_VERBOSE, "Unable to load histogram data. (fopen: %s)", GetErrorStr());
+        Log(LOG_LEVEL_ERR, "Unable to load histogram data from '%s' (fopen: %s)", filename, GetErrorStr());
         return;
     }
 
@@ -817,7 +817,7 @@ static void UpdateDistributions(EvalContext *ctx, char *timekey, Averages *av)
 
         if ((fp = fopen(filename, "w")) == NULL)
         {
-            Log(LOG_LEVEL_ERR, "Unable to save histograms. (fopen: %s)", GetErrorStr());
+            Log(LOG_LEVEL_ERR, "Unable to save histograms to '%s' (fopen: %s)", filename, GetErrorStr());
             return;
         }
 

--- a/cf-monitord/mon_cpu.c
+++ b/cf-monitord/mon_cpu.c
@@ -50,7 +50,7 @@ void MonCPUGatherData(double *cf_this)
 
     if ((fp = fopen("/proc/stat", "r")) == NULL)
     {
-        Log(LOG_LEVEL_VERBOSE, "Didn't find proc data");
+        Log(LOG_LEVEL_ERR, "Could not open /proc/stat while gathering CPU data (fopen: %s)", GetErrorStr());
         return;
     }
 

--- a/cf-monitord/mon_network_sniffer.c
+++ b/cf-monitord/mon_network_sniffer.c
@@ -429,7 +429,7 @@ static void SaveTCPEntropyData(Item *list, int i, char *inout)
 
     if ((fp = fopen(filename, "w")) == NULL)
     {
-        Log(LOG_LEVEL_VERBOSE, "Unable to write datafile '%s'", filename);
+        Log(LOG_LEVEL_ERR, "Couldn't save TCP entropy to '%s' (fopen: %s)", filename, GetErrorStr());
         return;
     }
 

--- a/cf-monitord/mon_temp.c
+++ b/cf-monitord/mon_temp.c
@@ -124,7 +124,7 @@ static bool GetAcpi(double *cf_this)
 
         if ((fp = fopen(path, "r")) == NULL)
         {
-            Log(LOG_LEVEL_ERR, "Couldn't open '%s'", path);
+            Log(LOG_LEVEL_ERR, "Couldn't open '%s' to gather temperature data (fopen: %s)", path, GetErrorStr());
             continue;
         }
 

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -780,7 +780,7 @@ static FILE *NewStream(char *name)
 
         if ((fp = fopen(filename, "w")) == NULL)
         {
-            Log(LOG_LEVEL_ERR, "Unable to open file '%s'", filename);
+            Log(LOG_LEVEL_ERR, "Unable to open file '%s' (fopen: %s)", filename, GetErrorStr());
             fp = stdout;
         }
     }

--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -98,14 +98,20 @@ Item *ListPersistentClasses()
 
     CF_DB *dbp;
     CF_DBC *dbcp;
+
     if (!OpenDB(&dbp, dbid_state))
     {
-        Log(LOG_LEVEL_ERR, "Unable to open state database");
+        char *db_path = DBIdToPath(WORKDIR, dbid_state);
+        Log(LOG_LEVEL_ERR, "Unable to open persistent classes database '%s'", db_path);
+        free(db_path);
         return NULL;
     }
+
     if (!NewDBCursor(dbp, &dbcp))
     {
-        Log(LOG_LEVEL_ERR, "Unable to scan state database");
+        char *db_path = DBIdToPath(WORKDIR, dbid_state);
+        Log(LOG_LEVEL_ERR, "Unable to get cursor for persistent classes database '%s'", db_path);
+        free(db_path);
         CloseDB(dbp);
         return NULL;
     }

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -775,7 +775,7 @@ static void Get3Environment(EvalContext *ctx)
 
     if (stat(env, &statbuf) == -1)
     {
-        Log(LOG_LEVEL_VERBOSE, "Unable to detect environment from cf-monitord");
+        Log(LOG_LEVEL_ERR, "Unable to detect environment from cf-monitord");
         return;
     }
 

--- a/libpromises/acl_tools_posix.c
+++ b/libpromises/acl_tools_posix.c
@@ -54,7 +54,7 @@ int CopyACLs(const char *src, const char *dst)
         }
         else
         {
-            Log(LOG_LEVEL_INFO, "Can't copy ACLs from '%s'. (acl_get_file: %s)", src, GetErrorStr());
+            Log(LOG_LEVEL_ERR, "Can't copy ACLs from '%s'. (acl_get_file: %s)", src, GetErrorStr());
             return false;
         }
     }
@@ -68,14 +68,14 @@ int CopyACLs(const char *src, const char *dst)
         }
         else
         {
-            Log(LOG_LEVEL_INFO, "Can't copy ACLs to '%s'. (acl_set_file: %s)", dst, GetErrorStr());
+            Log(LOG_LEVEL_ERR, "Can't copy ACLs to '%s'. (acl_set_file: %s)", dst, GetErrorStr());
             return false;
         }
     }
 
     if (stat(src, &statbuf) != 0)
     {
-        Log(LOG_LEVEL_INFO, "Can't copy ACLs from '%s'. (stat: %s)", src, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "Can't copy ACLs from '%s'. (stat: %s)", src, GetErrorStr());
         return false;
     }
     if (!S_ISDIR(statbuf.st_mode))
@@ -87,14 +87,14 @@ int CopyACLs(const char *src, const char *dst)
     acls = acl_get_file(src, ACL_TYPE_DEFAULT);
     if (!acls)
     {
-        Log(LOG_LEVEL_INFO, "Can't copy ACLs from '%s'. (acl_get_file: %s)", src, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "Can't copy ACLs from '%s'. (acl_get_file: %s)", src, GetErrorStr());
         return false;
     }
     ret = acl_set_file(dst, ACL_TYPE_DEFAULT, acls);
     acl_free(acls);
     if (ret != 0)
     {
-        Log(LOG_LEVEL_INFO, "Can't copy ACLs to '%s'. (acl_set_file: %s)", dst, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "Can't copy ACLs to '%s'. (acl_set_file: %s)", dst, GetErrorStr());
         return false;
     }
 

--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -406,7 +406,7 @@ static void DBPathMoveBroken(const char *filename)
 
     if(rename(filename, filename_broken) != 0)
     {
-        Log(LOG_LEVEL_ERR, "Failed moving broken db out of the way");
+        Log(LOG_LEVEL_ERR, "Failed moving broken db out of the way '%s'", filename);
     }
 
     free(filename_broken);

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -474,7 +474,7 @@ void EvalContextHeapPersistentSave(const char *context, const char *ns, unsigned
         {
             if (now < state.expires)
             {
-                Log(LOG_LEVEL_VERBOSE, "Persisent state '%s' is already in a preserved state --  %jd minutes to go",
+                Log(LOG_LEVEL_VERBOSE, "Persistent state '%s' is already in a preserved state --  %jd minutes to go",
                       name, (intmax_t)((state.expires - now) / 60));
                 CloseDB(dbp);
                 return;

--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -573,7 +573,7 @@ int HashDirectoryTreeCallback(const char *filename, ARG_UNUSED const struct stat
     FILE *file = fopen(filename, "rb");
     if (!file)
     {
-        Log(LOG_LEVEL_INFO, "Cannot open file for hashing '%s'. (fopen: %s)", filename, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "Cannot open file for hashing '%s'. (fopen: %s)", filename, GetErrorStr());
         return -1;
     }
 

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -254,7 +254,9 @@ bool IsLastSeenCoherent(void)
 
     if (!OpenDB(&db, dbid_lastseen))
     {
-        Log(LOG_LEVEL_ERR, "Unable to open lastseen database");
+        char *db_path = DBIdToPath(WORKDIR, dbid_lastseen);
+        Log(LOG_LEVEL_ERR, "Unable to open lastseen database '%s'", db_path);
+        free(db_path);
         return false;
     }
 
@@ -368,7 +370,9 @@ bool DeleteIpFromLastSeen(const char *ip, char *digest)
 
     if (!OpenDB(&db, dbid_lastseen))
     {
-        Log(LOG_LEVEL_ERR, "Unable to open lastseen database");
+        char *db_path = DBIdToPath(WORKDIR, dbid_lastseen);
+        Log(LOG_LEVEL_ERR, "Unable to open lastseen database '%s'", db_path);
+        free(db_path);
         return false;
     }
 
@@ -433,7 +437,9 @@ bool DeleteDigestFromLastSeen(const char *key, char *ip)
 
     if (!OpenDB(&db, dbid_lastseen))
     {
-        Log(LOG_LEVEL_ERR, "Unable to open lastseen database");
+        char *db_path = DBIdToPath(WORKDIR, dbid_lastseen);
+        Log(LOG_LEVEL_ERR, "Unable to open lastseen database '%s'", db_path);
+        free(db_path);
         return false;
     }
     char bufkey[CF_BUFSIZE + 1];

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -985,6 +985,9 @@ void PurgeLocks(void)
 
     if (!NewDBCursor(dbp, &dbcp))
     {
+        char *db_path = DBIdToPath(WORKDIR, dbid_locks);
+        Log(LOG_LEVEL_ERR, "Unable to get cursor for locks database '%s'", db_path);
+        free(db_path);
         CloseLock(dbp);
         return;
     }


### PR DESCRIPTION
I'm trying to improve log messages on the following points:
  * Messages added where they were missing in case of error
  * Log level: adjust some level (ERR, DEBUG, ...) to be consistent with the other ones
  * Context: sometimes messages are not easy to understand without any context, for example ```Error parsing entity in 'cf_ace'``` Not easy to figure out this is from ACL stuff, so I prefix the message with ACL:
  * Consistent reporting of underlying functions errors (fopen, acl_set_perm, ...)
  * Cosmetic changes to be more consistent across messages from a same feature

I will issue several commits, one per domain (acl, xml, db, and so on), with more details in the commit message.

Please do not merge at the moment, many commits are on the way :)