### PR TITLE
Add 2 functions to DB API

### DIFF
--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -170,6 +170,7 @@ void CloseAllDBExit()
                 Log(LOG_LEVEL_ERR,
                     "Database %s refcount is still not zero (%d), forcing CloseDB()!",
                     db_handles[i].filename, db_handles[i].refcount);
+                DBPrivCommit(db_handles[i].priv);
                 DBPrivCloseDB(db_handles[i].priv);
             }
         }
@@ -256,6 +257,23 @@ void CloseDB(DBHandle *handle)
     pthread_mutex_unlock(&handle->lock);
 }
 
+void CloseDBCommit(DBHandle *handle)
+{
+    pthread_mutex_lock(&handle->lock);
+
+    DBPrivCommit(handle->priv);
+    if (handle->refcount < 1)
+    {
+        Log(LOG_LEVEL_ERR, "Trying to close database %s which is not open", handle->filename);
+    }
+    else if (--handle->refcount == 0)
+    {
+        DBPrivCloseDB(handle->priv);
+    }
+
+    pthread_mutex_unlock(&handle->lock);
+}
+
 /*****************************************************************************/
 
 bool ReadComplexKeyDB(DBHandle *handle, const char *key, int key_size,
@@ -283,6 +301,11 @@ bool ReadDB(DBHandle *handle, const char *key, void *dest, int destSz)
 bool WriteDB(DBHandle *handle, const char *key, const void *src, int srcSz)
 {
     return DBPrivWrite(handle->priv, key, strlen(key) + 1, src, srcSz);
+}
+
+bool WriteDBNoCommit(DBHandle *handle, const char *key, const void *src, int srcSz)
+{
+    return DBPrivWriteNoCommit(handle->priv, key, strlen(key) + 1, src, srcSz);
 }
 
 bool HasKeyDB(DBHandle *handle, const char *key, int key_size)

--- a/libpromises/dbm_api.h
+++ b/libpromises/dbm_api.h
@@ -60,6 +60,7 @@ typedef DBCursor CF_DBC;
 
 bool OpenDB(CF_DB **dbp, dbid db);
 void CloseDB(CF_DB *dbp);
+void CloseDBCommit(CF_DB *dbp);
 
 bool HasKeyDB(CF_DB *dbp, const char *key, int key_size);
 int ValueSizeDB(CF_DB *dbp, const char *key, int key_size);
@@ -68,6 +69,7 @@ bool WriteComplexKeyDB(CF_DB *dbp, const char *key, int keySz, const void *src, 
 bool DeleteComplexKeyDB(CF_DB *dbp, const char *key, int size);
 bool ReadDB(CF_DB *dbp, const char *key, void *dest, int destSz);
 bool WriteDB(CF_DB *dbp, const char *key, const void *src, int srcSz);
+bool WriteDBNoCommit(CF_DB *dbp, const char *key, const void *src, int srcSz);
 bool DeleteDB(CF_DB *dbp, const char *key);
 
 /*

--- a/libpromises/dbm_priv.h
+++ b/libpromises/dbm_priv.h
@@ -48,6 +48,7 @@ const char *DBPrivGetFileExtension(void);
  */
 DBPriv *DBPrivOpenDB(const char *dbpath);
 void DBPrivCloseDB(DBPriv *hdbp);
+void DBPrivCommit(DBPriv *hdbp);
 
 bool DBPrivHasKey(DBPriv *db, const void *key, int key_size);
 int DBPrivGetValueSize(DBPriv *db, const void *key, int key_size);
@@ -56,6 +57,9 @@ bool DBPrivRead(DBPriv *db, const void *key, int key_size,
             void *dest, int dest_size);
 
 bool DBPrivWrite(DBPriv *db, const void *key, int key_size,
+             const void *value, int value_size);
+
+bool DBPrivWriteNoCommit(DBPriv *db, const void *key, int key_size,
              const void *value, int value_size);
 
 bool DBPrivDelete(DBPriv *db, const void *key, int key_size);

--- a/libpromises/dbm_quick.c
+++ b/libpromises/dbm_quick.c
@@ -174,6 +174,10 @@ void DBPrivCloseDB(DBPriv *db)
     free(db);
 }
 
+void DBPrivCommit(ARG_UNUSED DBPriv *db)
+{
+}
+
 bool DBPrivRead(DBPriv *db, const void *key, int key_size, void *dest, int dest_size)
 {
     if (!Lock(db))
@@ -215,6 +219,11 @@ bool DBPrivWrite(DBPriv *db, const void *key, int key_size, const void *value, i
 
     Unlock(db);
     return true;
+}
+
+bool DBPrivWriteNoCommit(DBPriv *db, const void *key, int key_size, const void *value, int value_size)
+{
+    return DBPrivWriteNoCommit(db, key, key_size, value, value_size);
 }
 
 bool DBPrivHasKey(DBPriv *db, const void *key, int key_size)

--- a/libpromises/dbm_tokyocab.c
+++ b/libpromises/dbm_tokyocab.c
@@ -213,6 +213,10 @@ void DBPrivCloseDB(DBPriv *db)
     free(db);
 }
 
+void DBPrivCommit(ARG_UNUSED DBPriv *db)
+{
+}
+
 bool DBPrivHasKey(DBPriv *db, const void *key, int key_size)
 {
     // FIXME: distinguish between "entry not found" and "error occured"
@@ -273,6 +277,11 @@ bool DBPrivWrite(DBPriv *db, const void *key, int key_size, const void *value, i
     int ret = Write(db->hdb, key, key_size, value, value_size);
 
     return ret;
+}
+
+bool DBPrivWriteNoCommit(DBPriv *db, const void *key, int key_size, const void *value, int value_size)
+{
+    return DBPrivWrite(db, key, key_size, value, value_size);
 }
 
 /*


### PR DESCRIPTION
- WriteNoCommit : write to DB without committing the last transaction
- CloseCommit   : commit current transaction before closing DB conn

These two functions will allow us to solve one specific performance problem when we need to open a DB, batch insert a set of records and close the DB afterwords
