### PR TITLE
Redmine#4482: introduce cf-promises -T option to tag a release directory

### DIFF
--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -83,6 +83,7 @@ static const struct option OPTIONS[] =
     {"warn", optional_argument, 0, 'W'},
     {"legacy-output", no_argument, 0, 'l'},
     {"color", optional_argument, 0, 'C'},
+    {"tag-release", required_argument, 0, 'T'},
     {NULL, 0, 0, '\0'}
 };
 
@@ -109,6 +110,7 @@ static const char *const HINTS[] =
     "Pass comma-separated <warnings>|all to enable non-default warnings, or error=<warnings>|all",
     "Use legacy output format",
     "Enable colorized output. Possible values: 'always', 'auto', 'never'. If option is used, the default value is 'auto'",
+    "Tag a directory with promises.cf with cf_promises_validated and cf_promises_release_id",
     NULL
 };
 
@@ -128,6 +130,20 @@ int main(int argc, char *argv[])
     {
         Log(LOG_LEVEL_ERR, "Input files contain errors.");
         exit(EXIT_FAILURE);
+    }
+
+    if (config->tag_release_dir)
+    {
+        bool tagged = GenericAgentTagReleaseDirectory(config, config->tag_release_dir);
+        if (tagged)
+        {
+            Log(LOG_LEVEL_VERBOSE, "Release tagging done!");
+        }
+        else
+        {
+            Log(LOG_LEVEL_ERR, "The given directory could not be tagged, sorry.");
+            exit(EXIT_FAILURE);
+        }
     }
 
     if (SHOWREPORTS)
@@ -193,7 +209,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
     int c;
     GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_COMMON);
 
-    while ((c = getopt_long(argc, argv, "dvnIf:D:N:VSrxMb:i:p:s:cg:hW:lC::", OPTIONS, &optindex)) != EOF)
+    while ((c = getopt_long(argc, argv, "dvnIf:D:N:VSrxMb:i:p:s:cg:hW:lC::T:", OPTIONS, &optindex)) != EOF)
     {
         switch ((char) c)
         {
@@ -369,6 +385,12 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
             {
                 exit(EXIT_FAILURE);
             }
+            break;
+
+        case 'T':
+            GenericAgentConfigSetInputFile(config, optarg, "promises.cf");
+            MINUSF = true;
+            config->tag_release_dir = xstrdup(optarg);
             break;
 
         default:

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -39,6 +39,7 @@ typedef struct
     char *original_input_file;
     char *input_file;
     char *input_dir;
+    char *tag_release_dir;
 
     bool check_not_writable_by_others;
     bool check_runnable;
@@ -91,7 +92,7 @@ void GenericAgentWriteHelp(Writer *w, const char *comp, const struct option opti
 bool GenericAgentArePromisesValid(const GenericAgentConfig *config);
 time_t ReadTimestampFromPolicyValidatedMasterfiles(const GenericAgentConfig *config);
 
-bool GeneratePolicyReleaseIDFromMasterfiles(char release_id_out[CF_SHA1_LEN + 1]);
+bool GeneratePolicyReleaseID(char release_id_out[CF_SHA1_LEN + 1], const char *dirname);
 bool GenericAgentIsPolicyReloadNeeded(const GenericAgentConfig *config, const Policy *policy);
 
 void CloseLog(void);
@@ -111,5 +112,6 @@ void GenericAgentConfigApply(EvalContext *ctx, const GenericAgentConfig *config)
 
 void GenericAgentConfigSetInputFile(GenericAgentConfig *config, const char *inputdir, const char *input_file);
 void GenericAgentConfigSetBundleSequence(GenericAgentConfig *config, const Rlist *bundlesequence);
+bool GenericAgentTagReleaseDirectory(const GenericAgentConfig *config, const char *dirname);
 
 #endif


### PR DESCRIPTION
See https://cfengine.com/dev/issues/4482

Factored out some common functionality to make this work.

No new behavior was introduced, except:
- `-T DIR` tags that directory with `cf_promises_validated` and `cf_promises_release_id`
- `MINUSF` is not respected in `GetReleaseIdFile` but that's not relevant as far as I can tell
