### PR TITLE
variable ip_len breaks build on aix so switched it to len_ip

### DIFF
--- a/libpromises/item_lib.c
+++ b/libpromises/item_lib.c
@@ -524,13 +524,13 @@ size_t ItemList2CSV_bound(const Item *list, char *buf, size_t buf_size,
     for (ip = list; ip != NULL; ip = ip->next)
     {
         size_t space_left = buf_size - len;
-        size_t ip_len = strlen(ip->name);
+        size_t len_ip = strlen(ip->name);
 
         /* 2 bytes must be spared: one for separator, one for '\0' */
-        if (space_left >= ip_len - 2)
+        if (space_left >= len_ip - 2)
         {
-            memcpy(buf, ip->name, ip_len);
-            len += ip_len;
+            memcpy(buf, ip->name, len_ip);
+            len += len_ip;
         }
         else                                            /* we must truncate */
         {


### PR DESCRIPTION
The use of len_ip on AIX causes a compile error. len_ip is being replaced by len_ff, presumably because of a system define. Renaming to ip_len resolves this.
