### PR TITLE
Lower level of missing public/private key warnings for non-root/fakeroot

### DIFF
--- a/libcfnet/tls_client.c
+++ b/libcfnet/tls_client.c
@@ -84,12 +84,12 @@ bool TLSClientInitialize()
 
     if (PRIVKEY == NULL || PUBKEY == NULL)
     {
-        Log(LOG_LEVEL_WARNING,
+        Log(CryptoGetMissingKeyLogLevel(),
             "No public/private key pair is loaded, trying to reload");
         LoadSecretKeys();
         if (PRIVKEY == NULL || PUBKEY == NULL)
         {
-            Log(LOG_LEVEL_ERR,
+            Log(CryptoGetMissingKeyLogLevel(),
                 "No public/private key pair found");
             goto err2;
         }

--- a/libpromises/crypto.h
+++ b/libpromises/crypto.h
@@ -26,6 +26,7 @@
 #define CFENGINE_CRYPTO_H
 
 #include <platform.h>
+#include <logging.h>
 
 void CryptoInitialize(void);
 void CryptoDeInitialize(void);
@@ -41,5 +42,6 @@ void SavePublicKey(const char *username, const char *digest, const RSA *key);
 
 char *PublicKeyFile(const char *workdir);
 char *PrivateKeyFile(const char *workdir);
+LogLevel CryptoGetMissingKeyLogLevel();
 
 #endif


### PR DESCRIPTION
Quick workaround specifically for the messages about missing keys in situations where those keys are likely to be irrelevant.
