### PR TITLE
We should call FindLock() inside AcquireLock() regardless of boolean ignoreProcesses

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -704,9 +704,9 @@ CfLock AcquireLock(EvalContext *ctx, const char *operand, const char *host, time
     }
 
     // Look for existing (current) processes
+    lastcompleted = FindLock(cflock);
     if (!ignoreProcesses)
     {
-        lastcompleted = FindLock(cflock);
         elapsedtime = (time_t) (now - lastcompleted) / 60;
 
         if (lastcompleted != 0)


### PR DESCRIPTION
- FindLock(cflock) does not only look for the existence of the cflock lock but also creates it if it does not exist.
- This is independent from whether ignoreProcesses is set or not
- It also affects yielding of locks because cflock needs to exist in order to be yielded
