### PR TITLE
Add stubs for Nova_NoteAgentExecutionPerformance

### DIFF
--- a/cf-agent/cf-agent-enterprise-stubs.c
+++ b/cf-agent/cf-agent-enterprise-stubs.c
@@ -77,3 +77,9 @@ ENTERPRISE_VOID_FUNC_1ARG_DEFINE_STUB(void, Nova_TrackExecution, ARG_UNUSED cons
 ENTERPRISE_VOID_FUNC_1ARG_DEFINE_STUB(void, GenerateDiffReports, ARG_UNUSED const char *, input_file)
 {
 }
+
+ENTERPRISE_VOID_FUNC_2ARG_DEFINE_STUB(void, Nova_NoteAgentExecutionPerformance,
+                                      ARG_UNUSED const char *, input_file,
+                                      ARG_UNUSED struct timespec, start)
+{
+}

--- a/cf-agent/cf-agent-enterprise-stubs.h
+++ b/cf-agent/cf-agent-enterprise-stubs.h
@@ -64,6 +64,8 @@ ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, Nova_NoteVarUsageDB, EvalContext *, ctx)
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, Nova_NoteClassUsage, EvalContext *, ctx);
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, Nova_TrackExecution, const char *, input_file);
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, GenerateDiffReports, const char *, input_file);
+ENTERPRISE_VOID_FUNC_2ARG_DECLARE(void, Nova_NoteAgentExecutionPerformance, const char *,
+                                  input_file, struct timespec, start);
 
 #endif
 

--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -226,6 +226,7 @@ static const char *const HINTS[] =
 int main(int argc, char *argv[])
 {
     int ret = 0;
+    struct timespec start = BeginMeasure();
 
     EvalContext *ctx = EvalContextNew();
 
@@ -280,6 +281,8 @@ int main(int argc, char *argv[])
     EvalContextDestroy(ctx);
 
     GenerateDiffReports(config->input_file);
+    Nova_NoteAgentExecutionPerformance(config->input_file, start);
+
     GenericAgentConfigDestroy(config);
 
     return ret;


### PR DESCRIPTION
This is adding hooks for measuring cf-agent execution time for benchmark report.
