### PR TITLE
Add note about cf-promises partial check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,7 @@
             - output from 'reports' promises has nothing prefixed except 'R: '
         - process_results default to AND'ing of set attributes if not specified (Redmine #3224)
         - interface is now canonified in sys.hardware_mac[interface] to align with sys.ipv4[interface] (Redmine #3418)
+        - cf-promises when run without --full-check (-c) no longer errors on missing bodies
 
         - Linux flavor "SUSE" now correctly spelled with all uppercase in variables and class names
         (Redmine #3734).


### PR DESCRIPTION
Partial checks no longer complain about missing bodies.
