### PR TITLE
Redmine#4694: fix prefixing public client key file in cf-serverd by user name

### DIFF
--- a/cf-serverd/tls_server.c
+++ b/cf-serverd/tls_server.c
@@ -468,7 +468,7 @@ int ServerTLSSessionEstablish(ServerConnectionState *conn)
                     "%s: Explicitly trusting this key from now on.",
                     KeyPrintableHash(ConnectionInfoKey(conn->conn_info)));
 
-                SavePublicKey("root", KeyPrintableHash(ConnectionInfoKey(conn->conn_info)),
+                SavePublicKey(conn->username, KeyPrintableHash(ConnectionInfoKey(conn->conn_info)),
                               KeyRSA(ConnectionInfoKey(conn->conn_info)));
             }
             else


### PR DESCRIPTION
Removing hard-coded "root" as a user-name of while storing public agent key in TLS connection.
