### PR TITLE
Redmine#4683: ensure dynamic inputs from data containers work

### DIFF
--- a/tests/acceptance/15_control/01_common/dynamic.sub
+++ b/tests/acceptance/15_control/01_common/dynamic.sub
@@ -1,0 +1,3 @@
+bundle agent dummy
+{
+}

--- a/tests/acceptance/15_control/01_common/staging/inputs_from_json.cf
+++ b/tests/acceptance/15_control/01_common/staging/inputs_from_json.cf
@@ -1,0 +1,29 @@
+# Redmine#4683: dynamic inputs should work from a data container
+
+body common control
+{
+      #ignore_missing_inputs => "true";
+      inputs => { "../../default.cf.sub", "$(config.myfile)" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+}
+
+bundle common config
+{
+  vars:
+      "c" data => parsejson('{ "file": "dynamic.sub" }');
+      "myfile" string => "$(c[file])";
+}
+
+bundle agent init
+{
+}
+
+bundle agent test
+{
+}
+
+bundle agent check
+{
+  reports:
+      "$(this.promise_filename) Pass";
+}


### PR DESCRIPTION
see https://cfengine.com/dev/issues/4683

Test is in staging.

Current output:

```
2014-02-24T16:54:00-0500    error: Can't parse directory './15_control/01_common/'.
2014-02-24T16:54:00-0500    error: Policy failed validation with command '"/home/tzz/source/cfengine/core/tests/acceptance/workdir/__15_control_01_common_inputs_from_json_cf/bin/cf-promises" -c "./15_control/01_common/inputs_from_json.cf"'
```
