### PR TITLE
Add an extra path to reflect current Win defaults

### DIFF
--- a/tests/acceptance/default.cf.sub
+++ b/tests/acceptance/default.cf.sub
@@ -24,8 +24,9 @@ vars:
     "paths[usr_contrib_bin]" string        => "/usr/contrib/bin";
   windows::
     "paths[mingw_msys_1_0_bin]" string     => "c:\\mingw\\msys\\1.0\\bin";
+    "paths[msys_1_0_bin]" string           => "c:\\msys\\1.0\\bin";
     "paths[msys_bin]" string               => "c:\\msys\\bin";
-    "paths[pstools]" string               => "c:\\PSTools";
+    "paths[pstools]" string                => "c:\\PSTools";
 
   any::
   "paths_indices" slist => getindices("paths");


### PR DESCRIPTION
The current version of msys requires a specific path, which was missing
thus far, resulting in the shell being unable to find executables such
as grep(1), in turn causing tests to fail.
