### PR TITLE
Introduce const.dirsep and use it in tests

### DIFF
--- a/libenv/constants.c
+++ b/libenv/constants.c
@@ -33,5 +33,6 @@ void LoadSystemConstants(EvalContext *ctx)
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_CONST, "r", "\r", CF_DATA_TYPE_STRING, "source=agent");
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_CONST, "t", "\t", CF_DATA_TYPE_STRING, "source=agent");
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_CONST, "endl", "\n", CF_DATA_TYPE_STRING, "source=agent");
+    EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_CONST, "dirsep", FILE_SEPARATOR_STR, CF_DATA_TYPE_STRING, "source=agent");
     /* NewScalar("const","0","\0",cf_str);  - this cannot work */
 }

--- a/tests/acceptance/01_vars/01_basic/sysvars.cf
+++ b/tests/acceptance/01_vars/01_basic/sysvars.cf
@@ -10,13 +10,13 @@ body common control
 bundle agent init
 {
   vars:
-      "expected[bindir]" string => "$(sys.workdir)$(G.DS)bin";
-      "expected[failsafe_policy_path]" string => "$(sys.workdir)$(G.DS)inputs$(G.DS)failsafe.cf";
-      "expected[inputdir]" string => "$(sys.workdir)$(G.DS)inputs";
-      "expected[libdir]" string => "$(sys.workdir)$(G.DS)inputs$(G.DS)lib$(G.DS)$(sys.cf_version_major).$(sys.cf_version_minor)";
-      "expected[local_libdir]" string => "lib$(G.DS)$(sys.cf_version_major).$(sys.cf_version_minor)";
-      "expected[masterdir]" string => "$(sys.workdir)$(G.DS)masterfiles";
-      "expected[update_policy_path]" string => "$(sys.workdir)$(G.DS)inputs$(G.DS)update.cf";
+      "expected[bindir]" string => "$(sys.workdir)$(const.dirsep)bin";
+      "expected[failsafe_policy_path]" string => "$(sys.workdir)$(const.dirsep)inputs$(const.dirsep)failsafe.cf";
+      "expected[inputdir]" string => "$(sys.workdir)$(const.dirsep)inputs";
+      "expected[libdir]" string => "$(sys.workdir)$(const.dirsep)inputs$(const.dirsep)lib$(const.dirsep)$(sys.cf_version_major).$(sys.cf_version_minor)";
+      "expected[local_libdir]" string => "lib$(const.dirsep)$(sys.cf_version_major).$(sys.cf_version_minor)";
+      "expected[masterdir]" string => "$(sys.workdir)$(const.dirsep)masterfiles";
+      "expected[update_policy_path]" string => "$(sys.workdir)$(const.dirsep)inputs$(const.dirsep)update.cf";
 
       "sysvars" slist => getindices("expected");
 }

--- a/tests/acceptance/01_vars/02_functions/execresult.cf
+++ b/tests/acceptance/01_vars/02_functions/execresult.cf
@@ -41,21 +41,21 @@ bundle agent check
       "cwd" string => dirname("$(this.promise_filename)");
 
     windows::
-      "zero_rel" string => "type $(cwd)$(G.DS)text.txt";
-      "one_rel" string => "type $(cwd)$(G.DS)text.txt.doesnotexist";
+      "zero_rel" string => "type $(cwd)$(const.dirsep)text.txt";
+      "one_rel" string => "type $(cwd)$(const.dirsep)text.txt.doesnotexist";
       "nxe_rel" string => "nosuchprogramexists";
-      "zero_abs" string => "c:\windows\system32\cmd.exe /C type $(cwd)$(G.DS)text.txt";
-      "one_abs" string => "c:\windows\system32\cmd.exe /C type $(cwd)$(G.DS)text.txt.doesnotexist";
+      "zero_abs" string => "c:\windows\system32\cmd.exe /C type $(cwd)$(const.dirsep)text.txt";
+      "one_abs" string => "c:\windows\system32\cmd.exe /C type $(cwd)$(const.dirsep)text.txt.doesnotexist";
       "nxe_abs" string => "c:\xbin\nosuchprogramexists";
-      "zero_powershell" string => "Get-Content $(cwd)$(G.DS)text.txt";
-      "one_powershell" string => "Get-Content $(cwd)$(G.DS)text.txt.doesnotexist";
+      "zero_powershell" string => "Get-Content $(cwd)$(const.dirsep)text.txt";
+      "one_powershell" string => "Get-Content $(cwd)$(const.dirsep)text.txt.doesnotexist";
       "nxe_powershell" string => "nosuchprogramexists";
     !windows::
-      "zero_rel" string => "cat $(cwd)$(G.DS)text.txt";
-      "one_rel" string => "cat $(cwd)$(G.DS)text.txt.doesnotexist";
+      "zero_rel" string => "cat $(cwd)$(const.dirsep)text.txt";
+      "one_rel" string => "cat $(cwd)$(const.dirsep)text.txt.doesnotexist";
       "nxe_rel" string => "nosuchprogramexists";
-      "zero_abs" string => "/bin/cat $(cwd)$(G.DS)text.txt";
-      "one_abs" string => "/bin/cat $(cwd)$(G.DS)text.txt.doesnotexist";
+      "zero_abs" string => "/bin/cat $(cwd)$(const.dirsep)text.txt";
+      "one_abs" string => "/bin/cat $(cwd)$(const.dirsep)text.txt.doesnotexist";
       "nxe_abs" string => "/xbin/nosuchprogramexists";
 
   classes:

--- a/tests/acceptance/02_classes/03_os/powershell.cf
+++ b/tests/acceptance/02_classes/03_os/powershell.cf
@@ -34,7 +34,7 @@ bundle agent check
   classes:
       "ok" and => { "!windows", "!powershell" };
       # This relies on powershell being in the path, which it should be for a standard install.
-      "detected_powershell" expression => regcmp(".*Succeeded.*", execresult("powershell Get-Content $(G.cwd)$(G.DS)text.txt", "useshell"));
+      "detected_powershell" expression => regcmp(".*Succeeded.*", execresult("powershell Get-Content $(G.cwd)$(const.dirsep)text.txt", "useshell"));
       "ok" and => { "windows", "powershell", "detected_powershell" };
       "ok" and => { "windows", "!powershell", "!detected_powershell" };
 

--- a/tests/acceptance/08_commands/03_shells/shelltypes.cf
+++ b/tests/acceptance/08_commands/03_shells/shelltypes.cf
@@ -35,7 +35,7 @@ bundle agent init
 bundle agent test
 {
   classes:
-      "$(init.shelltypes)" expression => regcmp(".*(Succeeded|Powershell is only supported on Windows).*", execresult("$(sys.cf_agent) -D $(init.shelltypes) -Kf $(init.origtestdir)$(G.DS)tryshell.cf.sub", "noshell"));
+      "$(init.shelltypes)" expression => regcmp(".*(Succeeded|Powershell is only supported on Windows).*", execresult("$(sys.cf_agent) -D $(init.shelltypes) -Kf $(init.origtestdir)$(const.dirsep)tryshell.cf.sub", "noshell"));
 
       "ok" and => { "@(init.shelltypes)" };
 

--- a/tests/acceptance/08_commands/03_shells/tryshell.cf.sub
+++ b/tests/acceptance/08_commands/03_shells/tryshell.cf.sub
@@ -64,7 +64,7 @@ bundle agent test
 
   commands:
     shell_specified::
-      "$(shellcmd) $(init.origtestdir)$(G.DS)text.txt"
+      "$(shellcmd) $(init.origtestdir)$(const.dirsep)text.txt"
         contain => shelltype;
 
   reports:

--- a/tests/acceptance/10_files/12_acl/acl.cf
+++ b/tests/acceptance/10_files/12_acl/acl.cf
@@ -25,7 +25,7 @@ bundle agent init
       "cmd" string => "/usr/bin/getfacl";
 
   files:
-      "$(G.testdir)$(G.DS)file"
+      "$(G.testdir)$(const.dirsep)file"
       create => "true",
       acl => acl_sanity_check;
 }
@@ -42,7 +42,7 @@ bundle agent test
 {
   vars:
     linux::
-      "sanity_perms" string => execresult("$(init.cmd) $(G.testdir)$(G.DS)file 2>&1 | $(G.grep) -v 'Removing leading'", "noshell");
+      "sanity_perms" string => execresult("$(init.cmd) $(G.testdir)$(const.dirsep)file 2>&1 | $(G.grep) -v 'Removing leading'", "noshell");
   classes:
     linux::
       # Some filesystems don't have ACL capability, so we do this sanity check.
@@ -75,7 +75,7 @@ bundle agent check
       "$(this.promise_filename) FAIL";
 
   files:
-      "$(G.testdir)$(G.DS)file"
+      "$(G.testdir)$(const.dirsep)file"
       acl => acl_sanity_check_reset;
 }
 

--- a/tests/acceptance/10_files/12_acl/acl.cf.sub
+++ b/tests/acceptance/10_files/12_acl/acl.cf.sub
@@ -219,7 +219,7 @@ bundle agent init
                        };
 
   files:
-    "$(G.testdir)$(G.DS)file"
+    "$(G.testdir)$(const.dirsep)file"
       create => "true";
 }
 
@@ -241,8 +241,8 @@ bundle agent test_and_check(testname)
       "any" usebundle => test_exec("$(testname)", "$(G.testdir)");
       "any" usebundle => test_check("$(testname)", "$(G.testdir)");
     !use_dir::
-      "any" usebundle => test_exec("$(testname)", "$(G.testdir)$(G.DS)file");
-      "any" usebundle => test_check("$(testname)", "$(G.testdir)$(G.DS)file");
+      "any" usebundle => test_exec("$(testname)", "$(G.testdir)$(const.dirsep)file");
+      "any" usebundle => test_check("$(testname)", "$(G.testdir)$(const.dirsep)file");
 }
 
 bundle agent test_exec(testname, file)

--- a/tests/acceptance/10_files/12_acl/file_copy_acl.cf
+++ b/tests/acceptance/10_files/12_acl/file_copy_acl.cf
@@ -77,12 +77,12 @@ body copy_from source_ext_no_preserve
 bundle agent check
 {
   vars:
-      "destination_ext_preserve_output" string => execresult("$(init.cmd) $(G.testdir)$(G.DS)destination_ext_preserve", "noshell");
-      "destination_ext_no_preserve_output" string => execresult("$(init.cmd) $(G.testdir)$(G.DS)destination_ext_no_preserve", "noshell");
+      "destination_ext_preserve_output" string => execresult("$(init.cmd) $(G.testdir)$(const.dirsep)destination_ext_preserve", "noshell");
+      "destination_ext_no_preserve_output" string => execresult("$(init.cmd) $(G.testdir)$(const.dirsep)destination_ext_no_preserve", "noshell");
 
     !windows::
-      "destination_plain_output" string => execresult("/bin/ls -lZ $(G.testdir)$(G.DS)destination_plain", "noshell");
-      "source_ext_output" string => execresult("$(init.cmd) $(G.testdir)$(G.DS)source_ext", "noshell");
+      "destination_plain_output" string => execresult("/bin/ls -lZ $(G.testdir)$(const.dirsep)destination_plain", "noshell");
+      "source_ext_output" string => execresult("$(init.cmd) $(G.testdir)$(const.dirsep)source_ext", "noshell");
 
   classes:
     !windows::

--- a/tests/acceptance/10_files/12_acl/file_edit_acl.cf
+++ b/tests/acceptance/10_files/12_acl/file_edit_acl.cf
@@ -68,11 +68,11 @@ bundle edit_line file_edit
 bundle agent check
 {
   vars:
-      "file_ext_output" string => execresult("$(init.cmd) $(G.testdir)$(G.DS)file_ext", "noshell");
+      "file_ext_output" string => execresult("$(init.cmd) $(G.testdir)$(const.dirsep)file_ext", "noshell");
 
     !windows::
-      "file_plain_output" string => execresult("/bin/ls -lZ $(G.testdir)$(G.DS)file_plain", "noshell");
-      "basetest_ext_output" string => execresult("$(init.cmd) $(G.testdir)$(G.DS)basetest_ext", "noshell");
+      "file_plain_output" string => execresult("/bin/ls -lZ $(G.testdir)$(const.dirsep)file_plain", "noshell");
+      "basetest_ext_output" string => execresult("$(init.cmd) $(G.testdir)$(const.dirsep)basetest_ext", "noshell");
 
   classes:
     !windows::

--- a/tests/acceptance/17_users/unsafe/add_user_with_shell.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_shell.cf
@@ -40,7 +40,7 @@ bundle agent check
 
   classes:
     !windows::
-      "ok" expression => regcmp(".*Succeeded.*", execresult("sudo su johndoe $(currentdir)$(G.DS)add_user_with_shell.txt", "useshell"));
+      "ok" expression => regcmp(".*Succeeded.*", execresult("sudo su johndoe $(currentdir)$(const.dirsep)add_user_with_shell.txt", "useshell"));
 
   reports:
     ok|windows::

--- a/tests/acceptance/default.cf.sub
+++ b/tests/acceptance/default.cf.sub
@@ -4,7 +4,6 @@ vars:
   windows::
     "cwd" string => execresult("C:\windows\system32\cmd.exe /C cd", "noshell");
     # Dir separator
-    "DS" string => "\\";
     "exeext" slist => { ".exe", ".bat" };
   !windows::
     "cwd" string => execresult("/bin/pwd 2>/dev/null || /usr/bin/pwd", "useshell");


### PR DESCRIPTION
Simply add `$(const.dirsep)` equivalent to the platform's directory separator.  Parallels `translatepath`; mainly useful for tests.

Suggested in #1469
