### PR TITLE
Correct vzps usage

### DIFF
--- a/cf-monitord/mon_processes.c
+++ b/cf-monitord/mon_processes.c
@@ -74,7 +74,7 @@ static bool GatherProcessUsers(Item **userList, int *userListSz, int *numRootPro
     char pscomm[CF_BUFSIZE];
     char user[CF_MAXVARSIZE];
 
-    snprintf(pscomm, CF_BUFSIZE, "%s %s", VPSCOMM[VSYSTEMHARDCLASS], VPSOPTS[VSYSTEMHARDCLASS]);
+    snprintf(pscomm, CF_BUFSIZE, "%s %s", VPSCOMM[VPSHARDCLASS], VPSOPTS[VPSHARDCLASS]);
 
     if ((pp = cf_popen(pscomm, "r", true)) == NULL)
     {

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -471,6 +471,7 @@ static void GetNameInfo3(EvalContext *ctx)
                     found = true;
 
                     VSYSTEMHARDCLASS = (PlatformContext) i;
+                    VPSHARDCLASS = (PlatformContext) i; /* this one can be overriden at vz detection */
                     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "class", CLASSTEXT[i], CF_DATA_TYPE_STRING, "inventory,source=agent,attribute_name=OS type");
                     break;
                 }
@@ -2340,6 +2341,7 @@ static void OpenVZ_Detect(EvalContext *ctx)
 /* path to the vzps binary */
 #define OPENVZ_VZPS_FILE "/bin/vzps"
     struct stat statbuf;
+    int i;
 
     /* The file /proc/bc/0 is present on host
        The file /proc/vz is present on guest
@@ -2354,6 +2356,15 @@ static void OpenVZ_Detect(EvalContext *ctx)
         if (stat(OPENVZ_VZPS_FILE, &statbuf) != -1)
         {
             EvalContextClassPutHard(ctx, "virt_host_vz_vzps", "inventory,attribute_name=Virtual host,source=agent");
+            /* here we must redefine the value of VPSHARDCLASS */
+            for (i = 0; i < PLATFORM_CONTEXT_MAX; i++)
+            {
+                if (!strcmp(CLASSATTRIBUTES[i][0], "virt_host_vz_vzps"))
+                {
+                   VPSHARDCLASS = (PlatformContext) i;
+                   break;
+                }
+            }
         }
         else
         {

--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -48,6 +48,7 @@ extern char VPREFIX[];
 
 extern char VDOMAIN[CF_MAXVARSIZE];
 extern PlatformContext VSYSTEMHARDCLASS;
+extern PlatformContext VPSHARDCLASS; /* used to define which ps command to use*/
 extern char VFQNAME[];
 extern char VUQNAME[];
 

--- a/libpromises/cf3globals.c
+++ b/libpromises/cf3globals.c
@@ -168,3 +168,4 @@ bool MINUSF = false; /* GLOBAL_A */
    call external utility
 */
 PlatformContext VSYSTEMHARDCLASS; /* GLOBAL_E?, initialized_later */
+PlatformContext VPSHARDCLASS; /* used to define which ps command to use*/

--- a/libpromises/classes.c
+++ b/libpromises/classes.c
@@ -76,7 +76,7 @@ const char *const VPSCOMM[] =
 const char *const VPSOPTS[] =
 {
     [PLATFORM_CONTEXT_UNKNOWN] = "",
-    [PLATFORM_CONTEXT_OPENVZ] = "-E 0 -o user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* virt_host_vz_vzps (with vzps, the -E 0 replace the -e) */
+    [PLATFORM_CONTEXT_OPENVZ] = "-E 0 -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* virt_host_vz_vzps (with vzps, the -E 0 replace the -e) */
     [PLATFORM_CONTEXT_HP] = "-ef",                      /* hpux */
     [PLATFORM_CONTEXT_AIX] =  "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args", /* aix */
     [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* linux */

--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -683,7 +683,7 @@ static const char *GetProcessOptions(void)
 
     if (IsGlobalZone())
     {
-        snprintf(psopts, CF_BUFSIZE, "%s,zone", VPSOPTS[VSYSTEMHARDCLASS]);
+        snprintf(psopts, CF_BUFSIZE, "%s,zone", VPSOPTS[VPSHARDCLASS]);
         return psopts;
     }
 
@@ -696,7 +696,7 @@ static const char *GetProcessOptions(void)
 
 # endif
 
-    return VPSOPTS[VSYSTEMHARDCLASS];
+    return VPSOPTS[VPSHARDCLASS];
 }
 #endif
 
@@ -761,7 +761,7 @@ int LoadProcessTable(Item **procdata)
 
     const char *psopts = GetProcessOptions();
 
-    snprintf(pscomm, CF_MAXLINKSIZE, "%s %s", VPSCOMM[VSYSTEMHARDCLASS], psopts);
+    snprintf(pscomm, CF_MAXLINKSIZE, "%s %s", VPSCOMM[VPSHARDCLASS], psopts);
 
     Log(LOG_LEVEL_VERBOSE, "Observe process table with %s", pscomm);
 


### PR DESCRIPTION
This PR fixes what was introduced in https://github.com/cfengine/core/pull/956
Indeed, the classes were correctly defined, but I made a mistake in the implementation, and the vzps command was not used.

Here it is fixed by introducing the VPSHARDCLASS PlatformContext, used for the PS commands and parameters.
By default, its value is the same as VSYSTEMHARDCLASS, but on *vz system with vzps, it gets a new value

The benefit of this new variable is that we can use as many PS command as we need on different system (and not only copying the one from linux), without the risk of changing VSYSTEMHARDCLASS, which as a lot lot lot lot of impacts everywhere in the code
