### PR TITLE
Tc broken on Win — see issue #4720

### DIFF
--- a/tests/acceptance/01_vars/02_functions/countlinesmatching.cf
+++ b/tests/acceptance/01_vars/02_functions/countlinesmatching.cf
@@ -23,6 +23,13 @@ bundle agent test
                                            $(this.promise_filename));
       "nullgrep" int => countlinesmatching("blue hippo, purple elephant, yellow submarine",
                                            $(this.promise_filename));
+
+      "test_suppress_fail" string => "windows";
+      "failure_issue_number" int => "4720";
+
+  meta:
+      "tags" slist => { "test_suppress_fail" };
+
 }
 
 bundle agent check


### PR DESCRIPTION
coutlinesmatching() should eat CRLF on Win before it performs any
regexp matching magic
