### PR TITLE
Mark as unsupported — fields unavailable on Win

### DIFF
--- a/tests/acceptance/01_vars/02_functions/filestat.cf
+++ b/tests/acceptance/01_vars/02_functions/filestat.cf
@@ -70,6 +70,9 @@ bundle agent test
 
 bundle agent check
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "expected[size]" string => "42";
       "expected[mode]" string => "33152";


### PR DESCRIPTION
unavailable: type, permstr, dev_minor, dev_major, permoct
