### PR TITLE
Move policy loading out of generic_agent.h into loading.h

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -73,6 +73,7 @@
 #include <bootstrap.h>
 #include <misc_lib.h>
 #include <buffer.h>
+#include <loading.h>
 
 #include <mod_common.h>
 
@@ -239,7 +240,7 @@ int main(int argc, char *argv[])
     Policy *policy = NULL;
     if (GenericAgentCheckPolicy(config, ALWAYS_VALIDATE, true))
     {
-        policy = GenericAgentLoadPolicy(ctx, config);
+        policy = LoadPolicy(ctx, config);
     }
     else if (config->tty_interactive)
     {
@@ -250,7 +251,7 @@ int main(int argc, char *argv[])
         Log(LOG_LEVEL_ERR, "CFEngine was not able to get confirmation of promises from cf-promises, so going to failsafe");
         EvalContextClassPutHard(ctx, "failsafe_fallback", "attribute_name=Errors,source=agent");
         GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
-        policy = GenericAgentLoadPolicy(ctx, config);
+        policy = LoadPolicy(ctx, config);
     }
     assert(policy);
 

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -36,6 +36,7 @@
 #include <sysinfo.h>
 #include <timeout.h>
 #include <time_classes.h>
+#include <loading.h>
 
 #include <cf-windows-functions.h>
 
@@ -130,7 +131,7 @@ int main(int argc, char *argv[])
     Policy *policy = NULL;
     if (GenericAgentCheckPolicy(config, false, false))
     {
-        policy = GenericAgentLoadPolicy(ctx, config);
+        policy = LoadPolicy(ctx, config);
     }
     else if (config->tty_interactive)
     {
@@ -141,7 +142,7 @@ int main(int argc, char *argv[])
         Log(LOG_LEVEL_ERR, "CFEngine was not able to get confirmation of promises from cf-promises, so going to failsafe");
         EvalContextClassPutHard(ctx, "failsafe_fallback", "attribute_name=Errors,source=agent");
         GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
-        policy = GenericAgentLoadPolicy(ctx, config);
+        policy = LoadPolicy(ctx, config);
     }
 
     ThisAgentInit();
@@ -541,7 +542,7 @@ static bool ScheduleRun(EvalContext *ctx, Policy **policy, GenericAgentConfig *c
 
         GenericAgentConfigSetBundleSequence(config, NULL);
 
-        *policy = GenericAgentLoadPolicy(ctx, config);
+        *policy = LoadPolicy(ctx, config);
         ExecConfigDestroy(*exec_config);
         ExecdConfigDestroy(*execd_config);
 

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -36,6 +36,7 @@
 #include <bootstrap.h>
 #include <timeout.h>
 #include <time_classes.h>
+#include <loading.h>
 
 typedef enum
 {
@@ -117,7 +118,7 @@ int main(int argc, char *argv[])
     GenericAgentConfigApply(ctx, config);
 
     GenericAgentDiscoverContext(ctx, config);
-    Policy *policy = GenericAgentLoadPolicy(ctx, config);
+    Policy *policy = LoadPolicy(ctx, config);
 
     ThisAgentInit(ctx);
     KeepPromises(ctx, policy);

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -33,6 +33,7 @@
 #include <man.h>
 #include <bootstrap.h>
 #include <string_lib.h>
+#include <loading.h>
 
 #include <time.h>
 
@@ -125,7 +126,7 @@ int main(int argc, char *argv[])
     GenericAgentConfigApply(ctx, config);
 
     GenericAgentDiscoverContext(ctx, config);
-    Policy *policy = GenericAgentLoadPolicy(ctx, config);
+    Policy *policy = LoadPolicy(ctx, config);
     if (!policy)
     {
         Log(LOG_LEVEL_ERR, "Input files contain errors.");

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -44,6 +44,7 @@
 #include <man.h>
 #include <connection_info.h>
 #include <addr_lib.h>
+#include <loading.h>
 
 typedef enum
 {
@@ -158,7 +159,7 @@ int main(int argc, char *argv[])
     GenericAgentConfigApply(ctx, config);
 
     GenericAgentDiscoverContext(ctx, config);
-    Policy *policy = GenericAgentLoadPolicy(ctx, config);
+    Policy *policy = LoadPolicy(ctx, config);
 
     ThisAgentInit();
     KeepControlPromises(ctx, policy);      // Set RUNATTR using copy

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -43,6 +43,7 @@
 #include <time_classes.h>
 #include <connection_info.h>
 #include <file_lib.h>
+#include <loading.h>
 
 #include "server_access.h"
 
@@ -674,7 +675,7 @@ void CheckFileChanges(EvalContext *ctx, Policy **policy, GenericAgentConfig *con
 
             time_t t = SetReferenceTime();
             UpdateTimeClasses(ctx, t);
-            *policy = GenericAgentLoadPolicy(ctx, config);
+            *policy = LoadPolicy(ctx, config);
             KeepPromises(ctx, *policy, config);
             Summarize();
         }

--- a/cf-serverd/cf-serverd.c
+++ b/cf-serverd/cf-serverd.c
@@ -23,9 +23,10 @@
 */
 
 #include <cf-serverd-functions.h>
-#include <known_dirs.h>
 
+#include <known_dirs.h>
 #include <server_transform.h>
+#include <loading.h>
 
 int main(int argc, char *argv[])
 {
@@ -38,7 +39,7 @@ int main(int argc, char *argv[])
     Policy *policy = NULL;
     if (GenericAgentCheckPolicy(config, false, false))
     {
-        policy = GenericAgentLoadPolicy(ctx, config);
+        policy = LoadPolicy(ctx, config);
     }
     else if (config->tty_interactive)
     {
@@ -49,7 +50,7 @@ int main(int argc, char *argv[])
         Log(LOG_LEVEL_ERR, "CFEngine was not able to get confirmation of promises from cf-promises, so going to failsafe");
         EvalContextClassPutHard(ctx, "failsafe_fallback", "attribute_name=Errors,source=agent");
         GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
-        policy = GenericAgentLoadPolicy(ctx, config);
+        policy = LoadPolicy(ctx, config);
     }
 
     ThisAgentInit();

--- a/libpromises/Makefile.am
+++ b/libpromises/Makefile.am
@@ -64,6 +64,7 @@ libpromises_la_SOURCES = \
         keyring.c keyring.h\
 	known_dirs.c known_dirs.h \
         lastseen.c lastseen.h \
+        loading.c loading.h \
         locks.c locks.h \
         logic_expressions.c logic_expressions.h \
         matching.c matching.h \

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -67,17 +67,12 @@ static pthread_once_t pid_cleanup_once = PTHREAD_ONCE_INIT; /* GLOBAL_T */
 
 static char PIDFILE[CF_BUFSIZE] = ""; /* GLOBAL_C */
 
-static void VerifyPromises(EvalContext *ctx, const Policy *policy, GenericAgentConfig *config);
 static void CheckWorkingDirectories(EvalContext *ctx);
 
-static Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_path);
-
-static Policy *LoadPolicyFile(EvalContext *ctx, GenericAgentConfig *config, const char *policy_file, StringSet *parsed_files_and_checksums, StringSet *failed_files);
 static bool WritePolicyValidatedFileToMasterfiles(const GenericAgentConfig *config);
 static void GetPromisesValidatedFileFromMasterfiles(char *filename, size_t max_size, const GenericAgentConfig *config, const char *maybe_dirname);
 static bool WriteReleaseIdFileToMasterfiles(void);
 static bool WriteReleaseIdFile(const char *filename, const char *dirname);
-static void GetReleaseIdFile(const char *base_path, char *filename, size_t max_size);
 bool GeneratePolicyReleaseIDFromTree(char release_id_out[GENERIC_AGENT_CHECKSUM_SIZE], const char *policy_dir);
 char* ReadChecksumFromPolicyValidatedMasterfiles(const GenericAgentConfig *config, const char *maybe_dirname);
 
@@ -86,7 +81,6 @@ static bool MissingInputFile(const char *input_file);
 #if !defined(__MINGW32__)
 static void OpenLog(int facility);
 #endif
-static bool VerifyBundleSequence(EvalContext *ctx, const Policy *policy, const GenericAgentConfig *config);
 
 /*****************************************************************************/
 
@@ -387,32 +381,6 @@ static bool WritePolicyValidatedFileToMasterfiles(const GenericAgentConfig *conf
 }
 
 /**
- * @brief Reads the release_id file from inputs and return a JsonElement.
- */
-static JsonElement *ReadReleaseIdFileFromInputs()
-{
-    char filename[CF_MAXVARSIZE];
-
-    GetReleaseIdFile(GetInputDir(), filename, sizeof(filename));
-
-    struct stat sb;
-    if (stat(filename, &sb) == -1)
-    {
-        return NULL;
-    }
-
-    JsonElement *validated_doc = NULL;
-    JsonParseError err = JsonParseFile(filename, 4096, &validated_doc);
-    if (err != JSON_PARSE_OK)
-    {
-        Log(LOG_LEVEL_WARNING, "Could not read release ID: '%s' did not contain valid JSON data. "
-            "(JsonParseFile: '%s')", filename, JsonParseErrorToString(err));
-    }
-
-    return validated_doc;
-}
-
-/**
  * @brief Writes a file with a contained release ID based on git SHA,
  *        or file checksum if git SHA is not available.
  * @return True if successful or if no release ID is needed (-f specified).
@@ -526,326 +494,8 @@ bool GenericAgentArePromisesValid(const GenericAgentConfig *config)
     return true;
 }
 
-static void ShowContext(EvalContext *ctx)
-{
-    Seq *hard_contexts = SeqNew(1000, NULL);
-    Seq *soft_contexts = SeqNew(1000, NULL);
-
-    {
-        ClassTableIterator *iter = EvalContextClassTableIteratorNewGlobal(ctx, NULL, true, true);
-        Class *cls = NULL;
-        while ((cls = ClassTableIteratorNext(iter)))
-        {
-            if (cls->is_soft)
-            {
-                SeqAppend(soft_contexts, cls->name);
-            }
-            else
-            {
-                SeqAppend(hard_contexts, cls->name);
-            }
-        }
-
-        ClassTableIteratorDestroy(iter);
-    }
-
-    SeqSort(soft_contexts, (SeqItemComparator)strcmp, NULL);
-    SeqSort(hard_contexts, (SeqItemComparator)strcmp, NULL);
 
 
-    {
-        Writer *w = NULL;
-        if (LEGACY_OUTPUT)
-        {
-            w = FileWriter(stdout);
-            WriterWriteF(w, "%s>  -> Hard classes = {", VPREFIX);
-        }
-        else
-        {
-            w = StringWriter();
-            WriterWrite(w, "Discovered hard classes:");
-        }
-
-        for (size_t i = 0; i < SeqLength(hard_contexts); i++)
-        {
-            const char *context = SeqAt(hard_contexts, i);
-            WriterWriteF(w, " %s", context);
-        }
-
-        if (LEGACY_OUTPUT)
-        {
-            WriterWrite(w, "}\n");
-            FileWriterDetach(w);
-        }
-        else
-        {
-            Log(LOG_LEVEL_VERBOSE, "%s", StringWriterData(w));
-            WriterClose(w);
-        }
-    }
-
-    {
-        Writer *w = NULL;
-        if (LEGACY_OUTPUT)
-        {
-            w = FileWriter(stdout);
-            WriterWriteF(w, "%s>  -> Additional classes = {", VPREFIX);
-        }
-        else
-        {
-            w = StringWriter();
-            WriterWrite(w, "Additional classes:");
-        }
-
-        for (size_t i = 0; i < SeqLength(soft_contexts); i++)
-        {
-            const char *context = SeqAt(soft_contexts, i);
-            WriterWriteF(w, " %s", context);
-        }
-
-        if (LEGACY_OUTPUT)
-        {
-            WriterWrite(w, "}\n");
-            FileWriterDetach(w);
-        }
-        else
-        {
-            if (SeqLength(soft_contexts) > 0)
-            {
-                Log(LOG_LEVEL_VERBOSE, "%s", StringWriterData(w));
-            }
-            WriterClose(w);
-        }
-    }
-
-    SeqDestroy(hard_contexts);
-    SeqDestroy(soft_contexts);
-}
-
-static Policy *LoadPolicyInputFiles(EvalContext *ctx, GenericAgentConfig *config, const Rlist *inputs, StringSet *parsed_files_and_checksums, StringSet *failed_files)
-{
-    Policy *policy = PolicyNew();
-
-    for (const Rlist *rp = inputs; rp; rp = rp->next)
-    {
-        if (rp->val.type != RVAL_TYPE_SCALAR)
-        {
-            Log(LOG_LEVEL_ERR, "Non-file object in inputs list");
-            continue;
-        }
-
-        const char *unresolved_input = RlistScalarValue(rp);
-
-        if (strcmp(CF_NULL_VALUE, unresolved_input) == 0)
-        {
-            continue;
-        }
-
-        if (IsExpandable(unresolved_input))
-        {
-            PolicyResolve(ctx, policy, config);
-        }
-
-        Rval resolved_input = EvaluateFinalRval(ctx, policy, NULL, "sys", rp->val, true, NULL);
-
-        Policy *aux_policy = NULL;
-        switch (resolved_input.type)
-        {
-        case RVAL_TYPE_SCALAR:
-            if (IsCf3VarString(RvalScalarValue(resolved_input)))
-            {
-                Log(LOG_LEVEL_ERR, "Unresolved variable '%s' in input list, cannot parse", RvalScalarValue(resolved_input));
-                break;
-            }
-
-            aux_policy = LoadPolicyFile(ctx, config, GenericAgentResolveInputPath(config, RvalScalarValue(resolved_input)), parsed_files_and_checksums, failed_files);
-            break;
-
-        case RVAL_TYPE_LIST:
-            aux_policy = LoadPolicyInputFiles(ctx, config, RvalRlistValue(resolved_input), parsed_files_and_checksums, failed_files);
-            break;
-
-        default:
-            ProgrammingError("Unknown type in input list for parsing: %d", resolved_input.type);
-            break;
-        }
-
-        if (aux_policy)
-        {
-            policy = PolicyMerge(policy, aux_policy);
-        }
-
-        RvalDestroy(resolved_input);
-    }
-
-    return policy;
-}
-
-static Policy *LoadPolicyFile(EvalContext *ctx, GenericAgentConfig *config, const char *policy_file, StringSet *parsed_files_and_checksums, StringSet *failed_files)
-{
-    Policy *policy = NULL;
-    unsigned char digest[EVP_MAX_MD_SIZE + 1] = { 0 };
-    char hashbuffer[EVP_MAX_MD_SIZE * 4] = { 0 };
-    char hashprintbuffer[CF_BUFSIZE] = { 0 };
-
-    HashFile(policy_file, digest, CF_DEFAULT_DIGEST);
-    snprintf(hashprintbuffer, CF_BUFSIZE - 1, "{checksum}%s",
-             HashPrintSafe(CF_DEFAULT_DIGEST, true, digest, hashbuffer));
-
-    Log(LOG_LEVEL_DEBUG, "Hashed policy file %s to %s", policy_file, hashprintbuffer);
-
-    if (StringSetContains(parsed_files_and_checksums, policy_file))
-    {
-        Log(LOG_LEVEL_VERBOSE, "Skipping loading of duplicate policy file %s", policy_file);
-        return NULL;
-    }
-    else if (StringSetContains(parsed_files_and_checksums, hashprintbuffer))
-    {
-        Log(LOG_LEVEL_VERBOSE, "Skipping loading of duplicate (detected by hash) policy file %s", policy_file);
-        return NULL;
-    }
-    else
-    {
-        Log(LOG_LEVEL_DEBUG, "Loading policy file %s", policy_file);
-    }
-
-    policy = Cf3ParseFile(config, policy_file);
-    // we keep the checksum and the policy file name to help debugging
-    StringSetAdd(parsed_files_and_checksums, xstrdup(policy_file));
-    StringSetAdd(parsed_files_and_checksums, xstrdup(hashprintbuffer));
-
-    if (policy)
-    {
-        Seq *errors = SeqNew(10, free);
-        if (!PolicyCheckPartial(policy, errors))
-        {
-            Writer *writer = FileWriter(stderr);
-            for (size_t i = 0; i < errors->length; i++)
-            {
-                PolicyErrorWrite(writer, errors->data[i]);
-            }
-            WriterClose(writer);
-            SeqDestroy(errors);
-
-            StringSetAdd(failed_files, xstrdup(policy_file));
-            return NULL;
-        }
-
-        SeqDestroy(errors);
-    }
-    else
-    {
-        StringSetAdd(failed_files, xstrdup(policy_file));
-        return NULL;
-    }
-
-    PolicyResolve(ctx, policy, config);
-
-    Body *body_common_control = PolicyGetBody(policy, NULL, "common", "control");
-    Body *body_file_control = PolicyGetBody(policy, NULL, "file", "control");
-
-    if (body_common_control)
-    {
-        Seq *potential_inputs = BodyGetConstraint(body_common_control, "inputs");
-        Constraint *cp = EffectiveConstraint(ctx, potential_inputs);
-        SeqDestroy(potential_inputs);
-
-        if (cp)
-        {
-            Policy *aux_policy = LoadPolicyInputFiles(ctx, config, RvalRlistValue(cp->rval), parsed_files_and_checksums, failed_files);
-            if (aux_policy)
-            {
-                policy = PolicyMerge(policy, aux_policy);
-                PolicyResolve(ctx, policy, config);
-            }
-        }
-    }
-
-    if (body_file_control)
-    {
-        Seq *potential_inputs = BodyGetConstraint(body_file_control, "inputs");
-        Constraint *cp = EffectiveConstraint(ctx, potential_inputs);
-        SeqDestroy(potential_inputs);
-
-        if (cp)
-        {
-            Policy *aux_policy = LoadPolicyInputFiles(ctx, config, RvalRlistValue(cp->rval), parsed_files_and_checksums, failed_files);
-            if (aux_policy)
-            {
-                policy = PolicyMerge(policy, aux_policy);
-                PolicyResolve(ctx, policy, config);
-            }
-        }
-    }
-
-    return policy;
-}
-
-Policy *GenericAgentLoadPolicy(EvalContext *ctx, GenericAgentConfig *config)
-{
-    StringSet *parsed_files_and_checksums = StringSetNew();
-    StringSet *failed_files = StringSetNew();
-
-    Policy *policy = LoadPolicyFile(ctx, config, config->input_file, parsed_files_and_checksums, failed_files);
-
-    if (StringSetSize(failed_files) > 0)
-    {
-        Log(LOG_LEVEL_ERR, "There are syntax errors in policy files");
-        exit(EXIT_FAILURE);
-    }
-
-    StringSetDestroy(parsed_files_and_checksums);
-    StringSetDestroy(failed_files);
-
-    {
-        Seq *errors = SeqNew(100, PolicyErrorDestroy);
-
-        if (PolicyCheckPartial(policy, errors))
-        {
-            if (!config->bundlesequence && (PolicyIsRunnable(policy) || config->check_runnable))
-            {
-                Log(LOG_LEVEL_VERBOSE, "Running full policy integrity checks");
-                PolicyCheckRunnable(ctx, policy, errors, config->ignore_missing_bundles);
-            }
-        }
-
-        if (SeqLength(errors) > 0)
-        {
-            Writer *writer = FileWriter(stderr);
-            for (size_t i = 0; i < errors->length; i++)
-            {
-                PolicyErrorWrite(writer, errors->data[i]);
-            }
-            WriterClose(writer);
-            exit(EXIT_FAILURE); // TODO: do not exit
-        }
-
-        SeqDestroy(errors);
-    }
-
-    if (LogGetGlobalLevel() >= LOG_LEVEL_VERBOSE)
-    {
-        ShowContext(ctx);
-    }
-
-    if (policy)
-    {
-        VerifyPromises(ctx, policy, config);
-    }
-
-    JsonElement *validated_doc = ReadReleaseIdFileFromInputs();
-    if (validated_doc)
-    {
-        const char *release_id = JsonObjectGetAsString(validated_doc, "releaseId");
-        if (release_id)
-        {
-            policy->release_id = xstrndup(release_id, 2 * CF_SHA256_LEN);
-        }
-        JsonDestroy(validated_doc);
-    }
-
-    return policy;
-}
 
 /*****************************************************************************/
 
@@ -1140,7 +790,7 @@ static void GetPromisesValidatedFileFromMasterfiles(char *filename, size_t max_s
 /**
  * @brief Gets the release_id file name in the given base_path.
  */
-static void GetReleaseIdFile(const char *base_path, char *filename, size_t max_size)
+void GetReleaseIdFile(const char *base_path, char *filename, size_t max_size)
 {
     snprintf(filename, max_size, "%s/cf_promises_release_id", base_path);
     MapName(filename);
@@ -1270,89 +920,6 @@ bool GenericAgentIsPolicyReloadNeeded(const GenericAgentConfig *config, const Po
     }
 
     return false;
-}
-
-/*
- * The difference between filename and input_input file is that the latter is the file specified by -f or
- * equivalently the file containing body common control. This will hopefully be squashed in later refactoring.
- */
-static Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_path)
-{
-    struct stat statbuf;
-
-    if (stat(input_path, &statbuf) == -1)
-    {
-        if (config->ignore_missing_inputs)
-        {
-            return PolicyNew();
-        }
-
-        Log(LOG_LEVEL_ERR, "Can't stat file '%s' for parsing. (stat: %s)", input_path, GetErrorStr());
-        exit(EXIT_FAILURE);
-    }
-    else if (S_ISDIR(statbuf.st_mode))
-    {
-        if (config->ignore_missing_inputs)
-        {
-            return PolicyNew();
-        }
-
-        Log(LOG_LEVEL_ERR, "Can't parse directory '%s'.", input_path);
-        exit(EXIT_FAILURE);
-    }
-
-#ifndef _WIN32
-    if (config->check_not_writable_by_others && (statbuf.st_mode & (S_IWGRP | S_IWOTH)))
-    {
-        Log(LOG_LEVEL_ERR, "File %s (owner %ju) is writable by others (security exception)", input_path, (uintmax_t)statbuf.st_uid);
-        exit(EXIT_FAILURE);
-    }
-#endif
-
-    Log(LOG_LEVEL_VERBOSE, "Parsing file '%s'", input_path);
-
-    if (!FileCanOpen(input_path, "r"))
-    {
-        Log(LOG_LEVEL_ERR, "Can't open file '%s' for parsing", input_path);
-        exit(EXIT_FAILURE);
-    }
-
-    Policy *policy = NULL;
-    if (StringEndsWith(input_path, ".json"))
-    {
-        Writer *contents = FileRead(input_path, SIZE_MAX, NULL);
-        if (!contents)
-        {
-            Log(LOG_LEVEL_ERR, "Error reading JSON input file '%s'", input_path);
-            return NULL;
-        }
-        JsonElement *json_policy = NULL;
-        const char *data = StringWriterData(contents);
-        if (JsonParse(&data, &json_policy) != JSON_PARSE_OK)
-        {
-            Log(LOG_LEVEL_ERR, "Error parsing JSON input file '%s'", input_path);
-            WriterClose(contents);
-            return NULL;
-        }
-
-        policy = PolicyFromJson(json_policy);
-
-        JsonDestroy(json_policy);
-        WriterClose(contents);
-    }
-    else
-    {
-        if (config->agent_type == AGENT_TYPE_COMMON)
-        {
-            policy = ParserParseFile(config->agent_type, input_path, config->agent_specific.common.parser_warnings, config->agent_specific.common.parser_warnings_error);
-        }
-        else
-        {
-            policy = ParserParseFile(config->agent_type, input_path, 0, 0);
-        }
-    }
-
-    return policy;
 }
 
 /*******************************************************************/
@@ -1561,50 +1128,6 @@ const char *GenericAgentResolveInputPath(const GenericAgentConfig *config, const
     return MapName(input_path);
 }
 
-static void VerifyPromises(EvalContext *ctx, const Policy *policy, GenericAgentConfig *config)
-{
-
-/* Now look once through ALL the bundles themselves */
-
-    for (size_t i = 0; i < SeqLength(policy->bundles); i++)
-    {
-        Bundle *bp = SeqAt(policy->bundles, i);
-        EvalContextStackPushBundleFrame(ctx, bp, NULL, false);
-
-        for (size_t j = 0; j < SeqLength(bp->promise_types); j++)
-        {
-            PromiseType *sp = SeqAt(bp->promise_types, j);
-            EvalContextStackPushPromiseTypeFrame(ctx, sp);
-
-            for (size_t ppi = 0; ppi < SeqLength(sp->promises); ppi++)
-            {
-                Promise *pp = SeqAt(sp->promises, ppi);
-                ExpandPromise(ctx, pp, CommonEvalPromise, NULL);
-            }
-
-            EvalContextStackPopFrame(ctx);
-        }
-
-        EvalContextStackPopFrame(ctx);
-    }
-
-    PolicyResolve(ctx, policy, config);
-
-    // TODO: need to move this inside PolicyCheckRunnable eventually.
-    if (!config->bundlesequence && config->check_runnable)
-    {
-        // only verify policy-defined bundlesequence for cf-agent, cf-promises
-        if ((config->agent_type == AGENT_TYPE_AGENT) ||
-            (config->agent_type == AGENT_TYPE_COMMON))
-        {
-            if (!VerifyBundleSequence(ctx, policy, config))
-            {
-                FatalError(ctx, "Errors in promise bundles: could not verify bundlesequence");
-            }
-        }
-    }
-}
-
 void GenericAgentWriteHelp(Writer *w, const char *component, const struct option options[], const char *const hints[], bool accepts_file_argument)
 {
     WriterWriteF(w, "Usage: %s [OPTION]...%s\n", component, accepts_file_argument ? " [FILE]" : "");
@@ -1686,59 +1209,6 @@ void WritePID(char *filename)
 
     fclose(fp);
 }
-
-static bool VerifyBundleSequence(EvalContext *ctx, const Policy *policy, const GenericAgentConfig *config)
-{
-    const Rlist *bundlesequence = EvalContextVariableControlCommonGet(ctx, COMMON_CONTROL_BUNDLESEQUENCE);
-    if (!bundlesequence)
-    {
-        Log(LOG_LEVEL_ERR, " No bundlesequence in the common control body");
-        return false;
-    }
-
-    const char *name;
-    int ok = true;
-    for (const Rlist *rp = bundlesequence; rp != NULL; rp = rp->next)
-    {
-        switch (rp->val.type)
-        {
-        case RVAL_TYPE_SCALAR:
-            name = RlistScalarValue(rp);
-            break;
-
-        case RVAL_TYPE_FNCALL:
-            name = RlistFnCallValue(rp)->name;
-            break;
-
-        default:
-            name = NULL;
-            ok = false;
-            {
-                Writer *w = StringWriter();
-                WriterWrite(w, "Illegal item found in bundlesequence '");
-                RvalWrite(w, rp->val);
-                WriterWrite(w, "'");
-                Log(LOG_LEVEL_ERR, "%s", StringWriterData(w));
-                WriterClose(w);
-            }
-            continue;
-        }
-
-        if (strcmp(name, CF_NULL_VALUE) == 0)
-        {
-            continue;
-        }
-
-        if (!config->ignore_missing_bundles && !PolicyGetBundle(policy, NULL, NULL, name))
-        {
-            Log(LOG_LEVEL_ERR, "Bundle '%s' listed in the bundlesequence is not a defined bundle", name);
-            ok = false;
-        }
-    }
-
-    return ok;
-}
-
 
 bool GenericAgentConfigParseArguments(GenericAgentConfig *config, int argc, char **argv)
 {

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -86,7 +86,6 @@ ENTERPRISE_VOID_FUNC_2ARG_DECLARE(void, GenericAgentSetDefaultDigest, HashMethod
 const char *GenericAgentResolveInputPath(const GenericAgentConfig *config, const char *input_file);
 void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config);
 bool GenericAgentCheckPolicy(GenericAgentConfig *config, bool force_validation, bool write_validated_file);
-Policy *GenericAgentLoadPolicy(EvalContext *ctx, GenericAgentConfig *config);
 
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, GenericAgentAddEditionClasses, EvalContext *, ctx);
 void GenericAgentInitialize(EvalContext *ctx, GenericAgentConfig *config);
@@ -117,4 +116,5 @@ void GenericAgentConfigSetInputFile(GenericAgentConfig *config, const char *inpu
 void GenericAgentConfigSetBundleSequence(GenericAgentConfig *config, const Rlist *bundlesequence);
 bool GenericAgentTagReleaseDirectory(const GenericAgentConfig *config, const char *dirname);
 
+void GetReleaseIdFile(const char *base_path, char *filename, size_t max_size);
 #endif

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -1,0 +1,543 @@
+#include <loading.h>
+
+#include <eval_context.h>
+#include <files_hashes.h>
+#include <file_lib.h>
+#include <string_lib.h>
+#include <parser.h>
+#include <expand.h>
+#include <rlist.h>
+#include <misc_lib.h>
+#include <class.h>
+#include <fncall.h>
+#include <known_dirs.h>
+
+// TODO: remove
+#include <vars.h>
+#include <audit.h>
+
+
+static Policy *LoadPolicyFile(EvalContext *ctx, GenericAgentConfig *config, const char *policy_file,
+                              StringSet *parsed_files_and_checksums, StringSet *failed_files);
+
+
+
+
+/*
+ * The difference between filename and input_input file is that the latter is the file specified by -f or
+ * equivalently the file containing body common control. This will hopefully be squashed in later refactoring.
+ */
+static Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_path)
+{
+    struct stat statbuf;
+
+    if (stat(input_path, &statbuf) == -1)
+    {
+        if (config->ignore_missing_inputs)
+        {
+            return PolicyNew();
+        }
+
+        Log(LOG_LEVEL_ERR, "Can't stat file '%s' for parsing. (stat: %s)", input_path, GetErrorStr());
+        exit(EXIT_FAILURE);
+    }
+    else if (S_ISDIR(statbuf.st_mode))
+    {
+        if (config->ignore_missing_inputs)
+        {
+            return PolicyNew();
+        }
+
+        Log(LOG_LEVEL_ERR, "Can't parse directory '%s'.", input_path);
+        exit(EXIT_FAILURE);
+    }
+
+#ifndef _WIN32
+    if (config->check_not_writable_by_others && (statbuf.st_mode & (S_IWGRP | S_IWOTH)))
+    {
+        Log(LOG_LEVEL_ERR, "File %s (owner %ju) is writable by others (security exception)", input_path, (uintmax_t)statbuf.st_uid);
+        exit(EXIT_FAILURE);
+    }
+#endif
+
+    Log(LOG_LEVEL_VERBOSE, "Parsing file '%s'", input_path);
+
+    if (!FileCanOpen(input_path, "r"))
+    {
+        Log(LOG_LEVEL_ERR, "Can't open file '%s' for parsing", input_path);
+        exit(EXIT_FAILURE);
+    }
+
+    Policy *policy = NULL;
+    if (StringEndsWith(input_path, ".json"))
+    {
+        Writer *contents = FileRead(input_path, SIZE_MAX, NULL);
+        if (!contents)
+        {
+            Log(LOG_LEVEL_ERR, "Error reading JSON input file '%s'", input_path);
+            return NULL;
+        }
+        JsonElement *json_policy = NULL;
+        const char *data = StringWriterData(contents);
+        if (JsonParse(&data, &json_policy) != JSON_PARSE_OK)
+        {
+            Log(LOG_LEVEL_ERR, "Error parsing JSON input file '%s'", input_path);
+            WriterClose(contents);
+            return NULL;
+        }
+
+        policy = PolicyFromJson(json_policy);
+
+        JsonDestroy(json_policy);
+        WriterClose(contents);
+    }
+    else
+    {
+        if (config->agent_type == AGENT_TYPE_COMMON)
+        {
+            policy = ParserParseFile(config->agent_type, input_path, config->agent_specific.common.parser_warnings, config->agent_specific.common.parser_warnings_error);
+        }
+        else
+        {
+            policy = ParserParseFile(config->agent_type, input_path, 0, 0);
+        }
+    }
+
+    return policy;
+}
+
+static Policy *LoadPolicyInputFiles(EvalContext *ctx, GenericAgentConfig *config, const Rlist *inputs, StringSet *parsed_files_and_checksums, StringSet *failed_files)
+{
+    Policy *policy = PolicyNew();
+
+    for (const Rlist *rp = inputs; rp; rp = rp->next)
+    {
+        if (rp->val.type != RVAL_TYPE_SCALAR)
+        {
+            Log(LOG_LEVEL_ERR, "Non-file object in inputs list");
+            continue;
+        }
+
+        const char *unresolved_input = RlistScalarValue(rp);
+
+        if (strcmp(CF_NULL_VALUE, unresolved_input) == 0)
+        {
+            continue;
+        }
+
+        if (IsExpandable(unresolved_input))
+        {
+            PolicyResolve(ctx, policy, config);
+        }
+
+        Rval resolved_input = EvaluateFinalRval(ctx, policy, NULL, "sys", rp->val, true, NULL);
+
+        Policy *aux_policy = NULL;
+        switch (resolved_input.type)
+        {
+        case RVAL_TYPE_SCALAR:
+            if (IsCf3VarString(RvalScalarValue(resolved_input)))
+            {
+                Log(LOG_LEVEL_ERR, "Unresolved variable '%s' in input list, cannot parse", RvalScalarValue(resolved_input));
+                break;
+            }
+
+            aux_policy = LoadPolicyFile(ctx, config, GenericAgentResolveInputPath(config, RvalScalarValue(resolved_input)), parsed_files_and_checksums, failed_files);
+            break;
+
+        case RVAL_TYPE_LIST:
+            aux_policy = LoadPolicyInputFiles(ctx, config, RvalRlistValue(resolved_input), parsed_files_and_checksums, failed_files);
+            break;
+
+        default:
+            ProgrammingError("Unknown type in input list for parsing: %d", resolved_input.type);
+            break;
+        }
+
+        if (aux_policy)
+        {
+            policy = PolicyMerge(policy, aux_policy);
+        }
+
+        RvalDestroy(resolved_input);
+    }
+
+    return policy;
+}
+
+// TODO: should be replaced by something not complected with loading
+static void ShowContext(EvalContext *ctx)
+{
+    Seq *hard_contexts = SeqNew(1000, NULL);
+    Seq *soft_contexts = SeqNew(1000, NULL);
+
+    {
+        ClassTableIterator *iter = EvalContextClassTableIteratorNewGlobal(ctx, NULL, true, true);
+        Class *cls = NULL;
+        while ((cls = ClassTableIteratorNext(iter)))
+        {
+            if (cls->is_soft)
+            {
+                SeqAppend(soft_contexts, cls->name);
+            }
+            else
+            {
+                SeqAppend(hard_contexts, cls->name);
+            }
+        }
+
+        ClassTableIteratorDestroy(iter);
+    }
+
+    SeqSort(soft_contexts, (SeqItemComparator)strcmp, NULL);
+    SeqSort(hard_contexts, (SeqItemComparator)strcmp, NULL);
+
+
+    {
+        Writer *w = NULL;
+        if (LEGACY_OUTPUT)
+        {
+            w = FileWriter(stdout);
+            WriterWriteF(w, "%s>  -> Hard classes = {", VPREFIX);
+        }
+        else
+        {
+            w = StringWriter();
+            WriterWrite(w, "Discovered hard classes:");
+        }
+
+        for (size_t i = 0; i < SeqLength(hard_contexts); i++)
+        {
+            const char *context = SeqAt(hard_contexts, i);
+            WriterWriteF(w, " %s", context);
+        }
+
+        if (LEGACY_OUTPUT)
+        {
+            WriterWrite(w, "}\n");
+            FileWriterDetach(w);
+        }
+        else
+        {
+            Log(LOG_LEVEL_VERBOSE, "%s", StringWriterData(w));
+            WriterClose(w);
+        }
+    }
+
+    {
+        Writer *w = NULL;
+        if (LEGACY_OUTPUT)
+        {
+            w = FileWriter(stdout);
+            WriterWriteF(w, "%s>  -> Additional classes = {", VPREFIX);
+        }
+        else
+        {
+            w = StringWriter();
+            WriterWrite(w, "Additional classes:");
+        }
+
+        for (size_t i = 0; i < SeqLength(soft_contexts); i++)
+        {
+            const char *context = SeqAt(soft_contexts, i);
+            WriterWriteF(w, " %s", context);
+        }
+
+        if (LEGACY_OUTPUT)
+        {
+            WriterWrite(w, "}\n");
+            FileWriterDetach(w);
+        }
+        else
+        {
+            if (SeqLength(soft_contexts) > 0)
+            {
+                Log(LOG_LEVEL_VERBOSE, "%s", StringWriterData(w));
+            }
+            WriterClose(w);
+        }
+    }
+
+    SeqDestroy(hard_contexts);
+    SeqDestroy(soft_contexts);
+}
+
+static Policy *LoadPolicyFile(EvalContext *ctx, GenericAgentConfig *config, const char *policy_file, StringSet *parsed_files_and_checksums, StringSet *failed_files)
+{
+    Policy *policy = NULL;
+    unsigned char digest[EVP_MAX_MD_SIZE + 1] = { 0 };
+    char hashbuffer[EVP_MAX_MD_SIZE * 4] = { 0 };
+    char hashprintbuffer[CF_BUFSIZE] = { 0 };
+
+    HashFile(policy_file, digest, CF_DEFAULT_DIGEST);
+    snprintf(hashprintbuffer, CF_BUFSIZE - 1, "{checksum}%s",
+             HashPrintSafe(CF_DEFAULT_DIGEST, true, digest, hashbuffer));
+
+    Log(LOG_LEVEL_DEBUG, "Hashed policy file %s to %s", policy_file, hashprintbuffer);
+
+    if (StringSetContains(parsed_files_and_checksums, policy_file))
+    {
+        Log(LOG_LEVEL_VERBOSE, "Skipping loading of duplicate policy file %s", policy_file);
+        return NULL;
+    }
+    else if (StringSetContains(parsed_files_and_checksums, hashprintbuffer))
+    {
+        Log(LOG_LEVEL_VERBOSE, "Skipping loading of duplicate (detected by hash) policy file %s", policy_file);
+        return NULL;
+    }
+    else
+    {
+        Log(LOG_LEVEL_DEBUG, "Loading policy file %s", policy_file);
+    }
+
+    policy = Cf3ParseFile(config, policy_file);
+    // we keep the checksum and the policy file name to help debugging
+    StringSetAdd(parsed_files_and_checksums, xstrdup(policy_file));
+    StringSetAdd(parsed_files_and_checksums, xstrdup(hashprintbuffer));
+
+    if (policy)
+    {
+        Seq *errors = SeqNew(10, free);
+        if (!PolicyCheckPartial(policy, errors))
+        {
+            Writer *writer = FileWriter(stderr);
+            for (size_t i = 0; i < errors->length; i++)
+            {
+                PolicyErrorWrite(writer, errors->data[i]);
+            }
+            WriterClose(writer);
+            SeqDestroy(errors);
+
+            StringSetAdd(failed_files, xstrdup(policy_file));
+            return NULL;
+        }
+
+        SeqDestroy(errors);
+    }
+    else
+    {
+        StringSetAdd(failed_files, xstrdup(policy_file));
+        return NULL;
+    }
+
+    PolicyResolve(ctx, policy, config);
+
+    Body *body_common_control = PolicyGetBody(policy, NULL, "common", "control");
+    Body *body_file_control = PolicyGetBody(policy, NULL, "file", "control");
+
+    if (body_common_control)
+    {
+        Seq *potential_inputs = BodyGetConstraint(body_common_control, "inputs");
+        Constraint *cp = EffectiveConstraint(ctx, potential_inputs);
+        SeqDestroy(potential_inputs);
+
+        if (cp)
+        {
+            Policy *aux_policy = LoadPolicyInputFiles(ctx, config, RvalRlistValue(cp->rval), parsed_files_and_checksums, failed_files);
+            if (aux_policy)
+            {
+                policy = PolicyMerge(policy, aux_policy);
+                PolicyResolve(ctx, policy, config);
+            }
+        }
+    }
+
+    if (body_file_control)
+    {
+        Seq *potential_inputs = BodyGetConstraint(body_file_control, "inputs");
+        Constraint *cp = EffectiveConstraint(ctx, potential_inputs);
+        SeqDestroy(potential_inputs);
+
+        if (cp)
+        {
+            Policy *aux_policy = LoadPolicyInputFiles(ctx, config, RvalRlistValue(cp->rval), parsed_files_and_checksums, failed_files);
+            if (aux_policy)
+            {
+                policy = PolicyMerge(policy, aux_policy);
+                PolicyResolve(ctx, policy, config);
+            }
+        }
+    }
+
+    return policy;
+}
+
+static bool VerifyBundleSequence(EvalContext *ctx, const Policy *policy, const GenericAgentConfig *config)
+{
+    const Rlist *bundlesequence = EvalContextVariableControlCommonGet(ctx, COMMON_CONTROL_BUNDLESEQUENCE);
+    if (!bundlesequence)
+    {
+        Log(LOG_LEVEL_ERR, " No bundlesequence in the common control body");
+        return false;
+    }
+
+    const char *name;
+    int ok = true;
+    for (const Rlist *rp = bundlesequence; rp != NULL; rp = rp->next)
+    {
+        switch (rp->val.type)
+        {
+        case RVAL_TYPE_SCALAR:
+            name = RlistScalarValue(rp);
+            break;
+
+        case RVAL_TYPE_FNCALL:
+            name = RlistFnCallValue(rp)->name;
+            break;
+
+        default:
+            name = NULL;
+            ok = false;
+            {
+                Writer *w = StringWriter();
+                WriterWrite(w, "Illegal item found in bundlesequence '");
+                RvalWrite(w, rp->val);
+                WriterWrite(w, "'");
+                Log(LOG_LEVEL_ERR, "%s", StringWriterData(w));
+                WriterClose(w);
+            }
+            continue;
+        }
+
+        if (strcmp(name, CF_NULL_VALUE) == 0)
+        {
+            continue;
+        }
+
+        if (!config->ignore_missing_bundles && !PolicyGetBundle(policy, NULL, NULL, name))
+        {
+            Log(LOG_LEVEL_ERR, "Bundle '%s' listed in the bundlesequence is not a defined bundle", name);
+            ok = false;
+        }
+    }
+
+    return ok;
+}
+
+/**
+ * @brief Reads the release_id file from inputs and return a JsonElement.
+ */
+static JsonElement *ReadReleaseIdFileFromInputs()
+{
+    char filename[CF_MAXVARSIZE];
+
+    GetReleaseIdFile(GetInputDir(), filename, sizeof(filename));
+
+    struct stat sb;
+    if (stat(filename, &sb) == -1)
+    {
+        return NULL;
+    }
+
+    JsonElement *validated_doc = NULL;
+    JsonParseError err = JsonParseFile(filename, 4096, &validated_doc);
+    if (err != JSON_PARSE_OK)
+    {
+        Log(LOG_LEVEL_WARNING, "Could not read release ID: '%s' did not contain valid JSON data. "
+            "(JsonParseFile: '%s')", filename, JsonParseErrorToString(err));
+    }
+
+    return validated_doc;
+}
+
+Policy *LoadPolicy(EvalContext *ctx, GenericAgentConfig *config)
+{
+    StringSet *parsed_files_and_checksums = StringSetNew();
+    StringSet *failed_files = StringSetNew();
+
+    Policy *policy = LoadPolicyFile(ctx, config, config->input_file, parsed_files_and_checksums, failed_files);
+
+    if (StringSetSize(failed_files) > 0)
+    {
+        Log(LOG_LEVEL_ERR, "There are syntax errors in policy files");
+        exit(EXIT_FAILURE);
+    }
+
+    StringSetDestroy(parsed_files_and_checksums);
+    StringSetDestroy(failed_files);
+
+    {
+        Seq *errors = SeqNew(100, PolicyErrorDestroy);
+
+        if (PolicyCheckPartial(policy, errors))
+        {
+            if (!config->bundlesequence && (PolicyIsRunnable(policy) || config->check_runnable))
+            {
+                Log(LOG_LEVEL_VERBOSE, "Running full policy integrity checks");
+                PolicyCheckRunnable(ctx, policy, errors, config->ignore_missing_bundles);
+            }
+        }
+
+        if (SeqLength(errors) > 0)
+        {
+            Writer *writer = FileWriter(stderr);
+            for (size_t i = 0; i < errors->length; i++)
+            {
+                PolicyErrorWrite(writer, errors->data[i]);
+            }
+            WriterClose(writer);
+            exit(EXIT_FAILURE); // TODO: do not exit
+        }
+
+        SeqDestroy(errors);
+    }
+
+    if (LogGetGlobalLevel() >= LOG_LEVEL_VERBOSE)
+    {
+        ShowContext(ctx);
+    }
+
+    if (policy)
+    {
+        for (size_t i = 0; i < SeqLength(policy->bundles); i++)
+        {
+            Bundle *bp = SeqAt(policy->bundles, i);
+            EvalContextStackPushBundleFrame(ctx, bp, NULL, false);
+
+            for (size_t j = 0; j < SeqLength(bp->promise_types); j++)
+            {
+                PromiseType *sp = SeqAt(bp->promise_types, j);
+                EvalContextStackPushPromiseTypeFrame(ctx, sp);
+
+                for (size_t ppi = 0; ppi < SeqLength(sp->promises); ppi++)
+                {
+                    Promise *pp = SeqAt(sp->promises, ppi);
+                    ExpandPromise(ctx, pp, CommonEvalPromise, NULL);
+                }
+
+                EvalContextStackPopFrame(ctx);
+            }
+
+            EvalContextStackPopFrame(ctx);
+        }
+
+        PolicyResolve(ctx, policy, config);
+
+        // TODO: need to move this inside PolicyCheckRunnable eventually.
+        if (!config->bundlesequence && config->check_runnable)
+        {
+            // only verify policy-defined bundlesequence for cf-agent, cf-promises
+            if ((config->agent_type == AGENT_TYPE_AGENT) ||
+                (config->agent_type == AGENT_TYPE_COMMON))
+            {
+                if (!VerifyBundleSequence(ctx, policy, config))
+                {
+                    FatalError(ctx, "Errors in promise bundles: could not verify bundlesequence");
+                }
+            }
+        }
+    }
+
+    JsonElement *validated_doc = ReadReleaseIdFileFromInputs();
+    if (validated_doc)
+    {
+        const char *release_id = JsonObjectGetAsString(validated_doc, "releaseId");
+        if (release_id)
+        {
+            policy->release_id = xstrndup(release_id, 2 * CF_SHA256_LEN);
+        }
+        JsonDestroy(validated_doc);
+    }
+
+    return policy;
+}

--- a/libpromises/loading.h
+++ b/libpromises/loading.h
@@ -1,0 +1,33 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#ifndef CFENGINE_LOADING_H
+#define CFENGINE_LOADING_H
+
+#include <policy.h>
+#include <generic_agent.h>
+
+Policy *LoadPolicy(EvalContext *ctx, GenericAgentConfig *config);
+
+#endif

--- a/tests/unit/exec-config-test.c
+++ b/tests/unit/exec-config-test.c
@@ -7,7 +7,7 @@
 #include <eval_context.h>
 #include <expand.h>
 
-static Policy *LoadPolicy(const char *filename)
+static Policy *TestParsePolicy(const char *filename)
 {
     char path[1024];
     sprintf(path, "%s/%s", TESTDATADIR, filename);
@@ -22,7 +22,7 @@ static void run_test_in_policy(const char *policy_filename, TestFn fn)
     GenericAgentConfig *agent_config = GenericAgentConfigNewDefault(
         AGENT_TYPE_EXECUTOR);
     EvalContext *ctx = EvalContextNew();
-    Policy *policy = LoadPolicy(policy_filename);
+    Policy *policy = TestParsePolicy(policy_filename);
     PolicyResolve(ctx, policy, agent_config);
 
     /* Setup global environment */

--- a/tests/unit/generic_agent_test.c
+++ b/tests/unit/generic_agent_test.c
@@ -4,6 +4,7 @@
 #include <known_dirs.h>
 #include <eval_context.h>
 #include <sysinfo_priv.h>
+#include <loading.h>
 
 void test_load_masterfiles(void)
 {
@@ -15,7 +16,7 @@ void test_load_masterfiles(void)
     GenericAgentConfigSetInputFile(config, NULL,
                                    ABS_TOP_SRCDIR "/masterfiles/promises.cf");
 
-    Policy *masterfiles = GenericAgentLoadPolicy(ctx, config);
+    Policy *masterfiles = LoadPolicy(ctx, config);
     assert_true(masterfiles);
 
     PolicyDestroy(masterfiles);

--- a/tests/unit/parser_test.c
+++ b/tests/unit/parser_test.c
@@ -3,7 +3,7 @@
 #include <policy.h>
 #include <parser.h>
 
-static Policy *LoadPolicy(const char *filename)
+static Policy *TestParsePolicy(const char *filename)
 {
     char path[1024];
     sprintf(path, "%s/%s", TESTDATADIR, filename);
@@ -13,205 +13,205 @@ static Policy *LoadPolicy(const char *filename)
 
 void test_benchmark(void)
 {
-    Policy *p = LoadPolicy("benchmark.cf");
+    Policy *p = TestParsePolicy("benchmark.cf");
     assert_true(p);
     PolicyDestroy(p);
 }
 
 void test_no_bundle_or_body_keyword(void)
 {
-    assert_false(LoadPolicy("no_bundle_or_body_keyword.cf"));
+    assert_false(TestParsePolicy("no_bundle_or_body_keyword.cf"));
 }
 
 void test_bundle_invalid_type(void)
 {
-    assert_false(LoadPolicy("bundle_invalid_type.cf"));
+    assert_false(TestParsePolicy("bundle_invalid_type.cf"));
 }
 
 void test_body_invalid_type(void)
 {
-    assert_false(LoadPolicy("body_invalid_type.cf"));
+    assert_false(TestParsePolicy("body_invalid_type.cf"));
 }
 
 void test_constraint_ifvarclass_invalid(void)
 {
-    Policy *p = LoadPolicy("constraint_ifvarclass_invalid.cf");
+    Policy *p = TestParsePolicy("constraint_ifvarclass_invalid.cf");
     assert_false(p);
 }
 
 void test_bundle_args_invalid_type(void)
 {
-    assert_false(LoadPolicy("bundle_args_invalid_type.cf"));
+    assert_false(TestParsePolicy("bundle_args_invalid_type.cf"));
 }
 
 void test_bundle_args_forgot_cp(void)
 {
-    assert_false(LoadPolicy("bundle_args_forgot_cp.cf"));
+    assert_false(TestParsePolicy("bundle_args_forgot_cp.cf"));
 }
 
 void test_bundle_body_forgot_ob(void)
 {
-    assert_false(LoadPolicy("bundle_body_forgot_ob.cf"));
+    assert_false(TestParsePolicy("bundle_body_forgot_ob.cf"));
 }
 
 void test_bundle_invalid_promise_type(void)
 {
-    assert_false(LoadPolicy("bundle_invalid_promise_type.cf"));
+    assert_false(TestParsePolicy("bundle_invalid_promise_type.cf"));
 }
 
 void test_bundle_body_wrong_promise_type_token(void)
 {
-    assert_false(LoadPolicy("bundle_body_wrong_promise_type_token.cf"));
+    assert_false(TestParsePolicy("bundle_body_wrong_promise_type_token.cf"));
 }
 
 void test_bundle_body_wrong_statement(void)
 {
-    assert_false(LoadPolicy("bundle_body_wrong_statement.cf"));
+    assert_false(TestParsePolicy("bundle_body_wrong_statement.cf"));
 }
 
 void test_bundle_body_forgot_semicolon(void)
 {
-    assert_false(LoadPolicy("bundle_body_forgot_semicolon.cf"));
+    assert_false(TestParsePolicy("bundle_body_forgot_semicolon.cf"));
 }
 
 void test_bundle_body_promiser_statement_contains_colon(void)
 {
-    assert_false(LoadPolicy("bundle_body_promiser_statement_contains_colon.cf"));
+    assert_false(TestParsePolicy("bundle_body_promiser_statement_contains_colon.cf"));
 }
 
 void test_bundle_body_promiser_statement_missing_assign(void)
 {
-    assert_false(LoadPolicy("bundle_body_promiser_statement_missing_assign.cf"));
+    assert_false(TestParsePolicy("bundle_body_promiser_statement_missing_assign.cf"));
 }
 
 void test_bundle_body_promisee_missing_arrow(void)
 {
-    assert_false(LoadPolicy("bundle_body_promise_missing_arrow.cf"));
+    assert_false(TestParsePolicy("bundle_body_promise_missing_arrow.cf"));
 }
 
 void test_bundle_body_promiser_wrong_constraint_token(void)
 {
-    assert_false(LoadPolicy("bundle_body_promiser_wrong_constraint_token.cf"));
+    assert_false(TestParsePolicy("bundle_body_promiser_wrong_constraint_token.cf"));
 }
 
 void test_bundle_body_promiser_unknown_constraint_id(void)
 {
-    assert_false(LoadPolicy("bundle_body_promiser_unknown_constraint_id.cf"));
+    assert_false(TestParsePolicy("bundle_body_promiser_unknown_constraint_id.cf"));
 }
 
 void test_body_edit_line_common_constraints(void)
 {
-    assert_true(LoadPolicy("body_edit_line_common_constraints.cf"));
+    assert_true(TestParsePolicy("body_edit_line_common_constraints.cf"));
 }
 
 void test_body_edit_xml_common_constraints(void)
 {
-    assert_true(LoadPolicy("body_edit_xml_common_constraints.cf"));
+    assert_true(TestParsePolicy("body_edit_xml_common_constraints.cf"));
 }
 
 void test_promise_promiser_nonscalar(void)
 {
-    assert_false(LoadPolicy("promise_promiser_nonscalar.cf"));
+    assert_false(TestParsePolicy("promise_promiser_nonscalar.cf"));
 }
 
 void test_bundle_body_promiser_forgot_colon(void)
 {
-    assert_false(LoadPolicy("bundle_body_promiser_forgot_colon.cf"));
+    assert_false(TestParsePolicy("bundle_body_promiser_forgot_colon.cf"));
 }
 
 void test_bundle_body_promisee_no_colon_allowed(void)
 {
-    assert_false(LoadPolicy("bundle_body_promisee_no_colon_allowed.cf"));
+    assert_false(TestParsePolicy("bundle_body_promisee_no_colon_allowed.cf"));
 }
 
 void test_bundle_body_forget_cb_eof(void)
 {
-    assert_false(LoadPolicy("bundle_body_forget_cb_eof.cf"));
+    assert_false(TestParsePolicy("bundle_body_forget_cb_eof.cf"));
 }
 
 void test_bundle_body_forget_cb_body(void)
 {
-    assert_false(LoadPolicy("bundle_body_forget_cb_body.cf"));
+    assert_false(TestParsePolicy("bundle_body_forget_cb_body.cf"));
 }
 
 void test_bundle_body_forget_cb_bundle(void)
 {
-    assert_false(LoadPolicy("bundle_body_forget_cb_bundle.cf"));
+    assert_false(TestParsePolicy("bundle_body_forget_cb_bundle.cf"));
 }
 
 void test_body_selection_wrong_token(void)
 {
-    assert_false(LoadPolicy("body_selection_wrong_token.cf"));
+    assert_false(TestParsePolicy("body_selection_wrong_token.cf"));
 }
 
 void test_body_selection_forgot_semicolon(void)
 {
-    assert_false(LoadPolicy("body_selection_forgot_semicolon.cf"));
+    assert_false(TestParsePolicy("body_selection_forgot_semicolon.cf"));
 }
 
 void test_body_selection_unknown_selection_id(void)
 {
-    assert_false(LoadPolicy("body_selection_unknown_selection_id.cf"));
+    assert_false(TestParsePolicy("body_selection_unknown_selection_id.cf"));
 }
 
 void test_body_body_forget_cb_eof(void)
 {
-    assert_false(LoadPolicy("body_body_forget_cb_eof.cf"));
+    assert_false(TestParsePolicy("body_body_forget_cb_eof.cf"));
 }
 
 void test_body_body_forget_cb_body(void)
 {
-    assert_false(LoadPolicy("body_body_forget_cb_body.cf"));
+    assert_false(TestParsePolicy("body_body_forget_cb_body.cf"));
 }
 
 void test_body_body_forget_cb_bundle(void)
 {
-    assert_false(LoadPolicy("body_body_forget_cb_bundle.cf"));
+    assert_false(TestParsePolicy("body_body_forget_cb_bundle.cf"));
 }
 
 void test_rval_list_forgot_colon(void)
 {
-    assert_false(LoadPolicy("rval_list_forgot_colon.cf"));
+    assert_false(TestParsePolicy("rval_list_forgot_colon.cf"));
 }
 
 void test_rval_list_wrong_input_type(void)
 {
-    assert_false(LoadPolicy("rval_list_wrong_input_type.cf"));
+    assert_false(TestParsePolicy("rval_list_wrong_input_type.cf"));
 }
 
 void test_rval_function_forgot_colon(void)
 {
-    assert_false(LoadPolicy("rval_function_forgot_colon.cf"));
+    assert_false(TestParsePolicy("rval_function_forgot_colon.cf"));
 }
 
 void test_rval_function_wrong_input_type(void)
 {
-    assert_false(LoadPolicy("rval_function_wrong_input_type.cf"));
+    assert_false(TestParsePolicy("rval_function_wrong_input_type.cf"));
 }
 
 void test_rval_wrong_input_type(void)
 {
-    assert_false(LoadPolicy("rval_wrong_input_type.cf"));
+    assert_false(TestParsePolicy("rval_wrong_input_type.cf"));
 }
 
 void test_rval_list_forgot_cb_semicolon(void)
 {
-    assert_false(LoadPolicy("rval_list_forgot_cb_semicolon.cf"));
+    assert_false(TestParsePolicy("rval_list_forgot_cb_semicolon.cf"));
 }
 
 void test_rval_list_forgot_cb_colon(void)
 {
-    assert_false(LoadPolicy("rval_list_forgot_cb_colon.cf"));
+    assert_false(TestParsePolicy("rval_list_forgot_cb_colon.cf"));
 }
 
 void test_rval_function_forgot_cp_semicolon(void)
 {
-    assert_false(LoadPolicy("rval_function_forgot_cp_semicolon.cf"));
+    assert_false(TestParsePolicy("rval_function_forgot_cp_semicolon.cf"));
 }
 
 void test_rval_function_forgot_cp_colon(void)
 {
-    assert_false(LoadPolicy("rval_function_forgot_cp_colon.cf"));
+    assert_false(TestParsePolicy("rval_function_forgot_cp_colon.cf"));
 }
 
 int main()

--- a/tests/unit/policy_test.c
+++ b/tests/unit/policy_test.c
@@ -8,7 +8,7 @@
 #include <item_lib.h>
 #include <bootstrap.h>
 
-static Policy *LoadPolicy(const char *filename)
+static Policy *TestParsePolicy(const char *filename)
 {
     char path[1024];
     sprintf(path, "%s/%s", TESTDATADIR, filename);
@@ -31,7 +31,7 @@ static void DumpErrors(Seq *errs)
 
 static Seq *LoadAndCheck(const char *filename)
 {
-    Policy *p = LoadPolicy(filename);
+    Policy *p = TestParsePolicy(filename);
 
     Seq *errs = SeqNew(10, PolicyErrorDestroy);
     PolicyCheckPartial(p, errs);
@@ -162,7 +162,7 @@ static void test_policy_json_to_from(void)
     EvalContext *ctx = EvalContextNew();
     Policy *policy = NULL;
     {
-        Policy *original = LoadPolicy("benchmark.cf");
+        Policy *original = TestParsePolicy("benchmark.cf");
         JsonElement *json = PolicyToJson(original);
         PolicyDestroy(original);
         policy = PolicyFromJson(json);
@@ -273,7 +273,7 @@ static void test_policy_json_offsets(void)
 {
     JsonElement *json = NULL;
     {
-        Policy *original = LoadPolicy("benchmark.cf");
+        Policy *original = TestParsePolicy("benchmark.cf");
         json = PolicyToJson(original);
         PolicyDestroy(original);
     }


### PR DESCRIPTION
This basically a bulk move of generic_agent:GenericAgentLoadPolicy to loading:LoadPolicy

I need to do a bit of reworking of this, and I want to isolate policy loading (as opposed to parsing and verification) as a concept. 
