### PR TITLE
Mark hash.cf as needing work on win

### DIFF
--- a/tests/acceptance/01_vars/02_functions/hash.cf
+++ b/tests/acceptance/01_vars/02_functions/hash.cf
@@ -34,6 +34,9 @@ the hash function!";';
 
 bundle agent test
 {
+  meta:
+      "test_skip_needs_work" string => "windows";
+
   vars:
       "algos" slist => { "md5", "sha1", "sha256", "sha384", "sha512" };
 


### PR DESCRIPTION
hash() being what it is, there isn't an easy way to work around the
problem of newlines in the cross-platform world. Tc needs to be
substantially changed.
