### PR TITLE
findfiles() broken — #4730. Limit tc scope on win

### DIFF
--- a/tests/acceptance/01_vars/02_functions/findfiles.cf
+++ b/tests/acceptance/01_vars/02_functions/findfiles.cf
@@ -14,6 +14,10 @@ body common control
 bundle common findfiles
 {
   vars:
+    # * in filenames not allowed on win
+    windows::
+      "names" slist => { "a", "bc", "d/e/f", "g/h/i/j", "klm/nop/qrs" };
+    !windows::
       "names" slist => { "a", "bc", "d/e/f", "g/h/i/j", "klm/nop/qrs", "tu/*" };
 }
 
@@ -35,18 +39,26 @@ bundle agent init
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "windows",
+        meta => { "redmine4730" };
+
   vars:
       "patterns[a]" string => "$(G.testdir)/?";
       "patterns[b]" string => "$(G.testdir)/*";
       "patterns[c]" string => "$(G.testdir)/?/*";
       "patterns[d]" string => "$(G.testdir)/[ab]*";
       "patterns[e]" string => "$(G.testdir)/nosuch/*";
+
+    !windows::
       "patterns[f]" string => "$(G.testdir)/tu/\\*";
 
+    any::
       "pnames" slist => getindices("patterns");
 
       "found[$(pnames)]" slist => findfiles("$(patterns[$(pnames)])");
       "found_string[$(pnames)]" string => join(",", "found[$(pnames)]");
+    
 
   reports:
     DEBUG::
@@ -60,12 +72,20 @@ bundle agent check
 {
   vars:
       "expected[a]" string => "$(G.testdir)/a,$(G.testdir)/d,$(G.testdir)/g";
+    windows::
+      "expected[b]" string => "$(G.testdir)/a,$(G.testdir)/bc,$(G.testdir)/d,$(G.testdir)/g,$(G.testdir)/klm";
+    !windows::
       "expected[b]" string => "$(G.testdir)/a,$(G.testdir)/bc,$(G.testdir)/d,$(G.testdir)/g,$(G.testdir)/klm,$(G.testdir)/tu";
+
+    any::
       "expected[c]" string => "$(G.testdir)/d/e,$(G.testdir)/g/h";
       "expected[d]" string => "$(G.testdir)/a,$(G.testdir)/bc";
       "expected[e]" string => "";
+
+    !windows::
       "expected[f]" string => "$(G.testdir)/tu/*";
 
+    any::
       "expects" slist => getindices("expected");
 
       "fstring" slist => getindices("test.found_string");


### PR DESCRIPTION
This tc has multiple problems:

```
1. findfiles() doesn't process anything, including regular
expressions in say, paths, but instead throws the argument back.

2. "*" is verboten in filenames on Win. Add conditionals
throughout the tc to avoid processing the last list element
which contains this character.
```
