### PR TITLE
Fix quoting issues on windows

### DIFF
--- a/tests/acceptance/10_files/01_create/001.cf
+++ b/tests/acceptance/10_files/01_create/001.cf
@@ -11,13 +11,6 @@ body common control
       version => "1.0";
 }
 
-bundle common g
-{
-  vars:
-      # This extracts the octal mode, and decimal nlink, uid, gid, size
-      "command" string => 'printf "%o" . " %d" x 4, (stat("$(G.testfile)"))[2]&07777, (stat(_))[3..5,7]';
-}
-
 #######################################################
 
 bundle agent init
@@ -52,8 +45,8 @@ bundle agent check
       "expect" string => "600 1 \d+ \d+ 0";
 
       "result" string => execresult(
-				     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
-				     "noshell");
+	     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
+	     "noshell");
 
   classes:
       "ok" expression => regcmp("$(expect)", "$(result)");

--- a/tests/acceptance/10_files/01_create/002.cf
+++ b/tests/acceptance/10_files/01_create/002.cf
@@ -11,13 +11,6 @@ body common control
       version => "1.0";
 }
 
-bundle common g
-{
-  vars:
-      # This extracts the octal mode, and decimal nlink, uid, gid, size
-      "command" string => 'printf "%o" . " %d" x 4, (stat("$(G.testfile)"))[2]&07777, (stat(_))[3..5,7]';
-}
-
 #######################################################
 
 bundle agent init
@@ -59,8 +52,8 @@ bundle agent check
       "expect" string => "$(test.mode) 1 \d+ \d+ 0";
 
       "result" string => execresult(
-				     "$(G.perl) -le '$(g.command)'",
-				     "noshell");
+	     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
+	     "noshell");
 
   classes:
       "ok" expression => regcmp("$(expect)", "$(result)");

--- a/tests/acceptance/10_files/01_create/003.cf
+++ b/tests/acceptance/10_files/01_create/003.cf
@@ -11,13 +11,6 @@ body common control
       version => "1.0";
 }
 
-bundle common g
-{
-  vars:
-      # This extracts the octal mode, and decimal nlink, uid, gid, size
-      "command" string => 'printf "%o" . " %d" x 4, (stat("$(G.testfile)"))[2]&07777, (stat(_))[3..5,7]';
-}
-
 #######################################################
 
 bundle agent init
@@ -59,8 +52,8 @@ bundle agent check
       "expect" string => "$(test.mode) 1 \d+ \d+ 0";
 
       "result" string => execresult(
-				     "$(G.perl) -le '$(g.command)'",
-				     "noshell");
+	     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
+	     "noshell");
 
   classes:
       "ok" expression => regcmp("$(expect)", "$(result)");

--- a/tests/acceptance/10_files/01_create/004.cf
+++ b/tests/acceptance/10_files/01_create/004.cf
@@ -11,13 +11,6 @@ body common control
       version => "1.0";
 }
 
-bundle common g
-{
-  vars:
-      # This extracts the octal mode, and decimal nlink, uid, gid, size
-      "command" string => 'printf "%o" . " %d" x 4, (stat("$(G.testfile)"))[2]&07777, (stat(_))[3..5,7]';
-}
-
 #######################################################
 
 bundle agent init
@@ -59,8 +52,8 @@ bundle agent check
       "expect" string => "$(test.mode) 1 \d+ \d+ 0";
 
       "result" string => execresult(
-				     "$(G.perl) -le '$(g.command)'",
-				     "noshell");
+	     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
+	     "noshell");
 
   classes:
       "ok" expression => regcmp("$(expect)", "$(result)");

--- a/tests/acceptance/10_files/01_create/005.cf
+++ b/tests/acceptance/10_files/01_create/005.cf
@@ -11,13 +11,6 @@ body common control
       version => "1.0";
 }
 
-bundle common g
-{
-  vars:
-      # This extracts the octal mode, and decimal nlink, uid, gid, size
-      "command" string => 'printf "%o" . " %d" x 4, (stat("$(G.testfile)"))[2]&07777, (stat(_))[3..5,7]';
-}
-
 #######################################################
 
 bundle agent init
@@ -59,8 +52,8 @@ bundle agent check
       "expect" string => "$(test.mode) 1 \d+ \d+ 0";
 
       "result" string => execresult(
-				     "$(G.perl) -le '$(g.command)'",
-				     "noshell");
+	     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
+	     "noshell");
 
   classes:
       "ok" expression => regcmp("$(expect)", "$(result)");

--- a/tests/acceptance/10_files/01_create/006.cf
+++ b/tests/acceptance/10_files/01_create/006.cf
@@ -11,13 +11,6 @@ body common control
       version => "1.0";
 }
 
-bundle common g
-{
-  vars:
-      # This extracts the octal mode, and decimal nlink, uid, gid, size
-      "command" string => 'printf "%o" . " %d" x 4, (stat("$(G.testfile)"))[2]&07777, (stat(_))[3..5,7]';
-}
-
 #######################################################
 
 bundle agent init
@@ -59,8 +52,8 @@ bundle agent check
       "expect" string => "$(test.mode) 1 \d+ \d+ 0";
 
       "result" string => execresult(
-				     "$(G.perl) -le '$(g.command)'",
-				     "noshell");
+	     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
+	     "noshell");
 
   classes:
       "ok" expression => regcmp("$(expect)", "$(result)");

--- a/tests/acceptance/10_files/01_create/007.cf
+++ b/tests/acceptance/10_files/01_create/007.cf
@@ -11,13 +11,6 @@ body common control
       version => "1.0";
 }
 
-bundle common g
-{
-  vars:
-      # This extracts the octal mode, and decimal nlink, uid, gid, size
-      "command" string => 'printf "%o" . " %d" x 4, (stat("$(G.testfile)"))[2]&07777, (stat(_))[3..5,7]';
-}
-
 #######################################################
 
 bundle agent init
@@ -61,8 +54,8 @@ bundle agent check
       "expect" string => "$(test.mode) 1 0 0 0";
 
       "result" string => execresult(
-				     "$(G.perl) -le '$(g.command)'",
-				     "noshell");
+	     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
+	     "noshell");
 
   classes:
       "ok" expression => strcmp("$(expect)", "$(result)");

--- a/tests/acceptance/10_files/01_create/008.cf
+++ b/tests/acceptance/10_files/01_create/008.cf
@@ -12,13 +12,6 @@ body common control
       version => "1.0";
 }
 
-bundle common g
-{
-  vars:
-      # This extracts the octal mode, and decimal nlink, uid, gid, size
-      "command" string => 'printf "%o" . " %d" x 4, (stat("$(G.testfile)"))[2]&07777, (stat(_))[3..5,7]';
-}
-
 #######################################################
 
 bundle agent init
@@ -62,8 +55,8 @@ bundle agent check
       "expect" string => "$(test.mode) 1 0 0 0";
 
       "result" string => execresult(
-				     "$(G.perl) -le '$(g.command)'",
-				     "noshell");
+	     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
+	     "noshell");
 
   classes:
       "ok" expression => strcmp("$(expect)", "$(result)");

--- a/tests/acceptance/10_files/01_create/009.cf
+++ b/tests/acceptance/10_files/01_create/009.cf
@@ -12,13 +12,6 @@ body common control
       version => "1.0";
 }
 
-bundle common g
-{
-  vars:
-      # This extracts the octal mode, and decimal nlink, uid, gid, size
-      "command" string => 'printf "%o" . " %d" x 4, (stat("$(G.testfile)"))[2]&07777, (stat(_))[3..5,7]';
-}
-
 #######################################################
 
 bundle agent init
@@ -66,8 +59,8 @@ bundle agent check
       "expect" string => "$(test.mode) 1 3 3 0";
 
       "result" string => execresult(
-				     "$(G.perl) -le '$(g.command)'",
-				     "noshell");
+	     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
+	     "noshell");
 
   classes:
       "ok" expression => strcmp("$(expect)", "$(result)");

--- a/tests/acceptance/10_files/stat.pl
+++ b/tests/acceptance/10_files/stat.pl
@@ -1,1 +1,2 @@
+# extracts the octal mode, and decimal nlink, uid, gid, size
 printf "%o" . " %d" x 4, (stat("$ARGV[0]"))[2]&07777, (stat(_))[3..5,7]


### PR DESCRIPTION
Windows expects a different order of quotes for perl, and given that the
command evaluated already featured several double quotes, the entire
enchilada had to be outsourced into a perl script.

```
1. Add a comment to that file, moved from the original
testcases, so that it's not a mystery as to what it does.

2. Given that, remove the 'g' bundle from all relevant testcases.

3. Edit the argument to execresult() in all relevant tests, to
make use of the new script file

4. reindent 001.cf
```
