### PR TITLE
Disable nix num permission tests on Windows

### DIFF
--- a/tests/acceptance/10_files/01_create/001.cf
+++ b/tests/acceptance/10_files/01_create/001.cf
@@ -30,6 +30,8 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
 
   files:
       "$(G.testfile)"

--- a/tests/acceptance/10_files/01_create/002.cf
+++ b/tests/acceptance/10_files/01_create/002.cf
@@ -30,6 +30,9 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "mode" int => "0641";
 

--- a/tests/acceptance/10_files/01_create/003.cf
+++ b/tests/acceptance/10_files/01_create/003.cf
@@ -30,6 +30,9 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "mode" int => "0146";
 

--- a/tests/acceptance/10_files/01_create/004.cf
+++ b/tests/acceptance/10_files/01_create/004.cf
@@ -30,6 +30,9 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "mode" int => "01010";
 

--- a/tests/acceptance/10_files/01_create/005.cf
+++ b/tests/acceptance/10_files/01_create/005.cf
@@ -30,6 +30,9 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "mode" int => "02001";
 

--- a/tests/acceptance/10_files/01_create/006.cf
+++ b/tests/acceptance/10_files/01_create/006.cf
@@ -30,6 +30,9 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "mode" int => "04777";
 

--- a/tests/acceptance/10_files/01_create/007.cf
+++ b/tests/acceptance/10_files/01_create/007.cf
@@ -30,6 +30,9 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "mode" int => "0644";
 

--- a/tests/acceptance/10_files/01_create/008.cf
+++ b/tests/acceptance/10_files/01_create/008.cf
@@ -31,6 +31,9 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "mode" int => "0644";
 

--- a/tests/acceptance/10_files/01_create/009.cf
+++ b/tests/acceptance/10_files/01_create/009.cf
@@ -31,6 +31,9 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "mode" int => "0644";
 

--- a/tests/acceptance/10_files/01_create/010.cf
+++ b/tests/acceptance/10_files/01_create/010.cf
@@ -11,13 +11,6 @@ body common control
       version => "1.0";
 }
 
-bundle common g
-{
-  vars:
-      # This extracts the octal mode, and decimal nlink, uid, gid, size
-      "command" string => 'printf "%o" . " %d" x 4, (stat("$(G.testfile)"))[2]&07777, (stat(_))[3..5,7]';
-}
-
 #######################################################
 
 bundle agent init
@@ -37,6 +30,9 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "mode" int => "0644";
 
@@ -61,8 +57,8 @@ bundle agent check
       "expect" string => "$(test.mode) 1 3 3 0";
 
       "result" string => execresult(
-				     "$(G.perl) -le '$(g.command)'",
-				     "noshell");
+	     "$(G.perl) -l $(this.promise_dirname)$(const.dirsep)..$(const.dirsep)stat.pl $(G.testfile)",
+	     "noshell");
 
   classes:
       "ok" expression => strcmp("$(expect)", "$(result)");

--- a/tests/acceptance/10_files/01_create/directory_with_trailing_slash.cf
+++ b/tests/acceptance/10_files/01_create/directory_with_trailing_slash.cf
@@ -30,8 +30,12 @@ body delete init_delete
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "windows";
+
   vars:
       "mode" string => "751";
+
   methods:
       "1" usebundle => test1; # create the directory
       "1" usebundle => test2($(mode)); # promise the directory with a trailing slash


### PR DESCRIPTION
Win ACLs are speficially tested for tested elsewhere. These tests will
always return something different than expected, as Win ACLs do not map
to nix permissions as the tests expect to. Mark all as unsupported.

While here, edit 010.cf missed in the fcdb6e commit, i.e. remove the 'g'
bundle and amend the execresult() to take a new script into account.
