### PR TITLE
Get rid of the 'failed to crash' oddity on win

### DIFF
--- a/tests/acceptance/10_files/02_maintain/406.x.cf
+++ b/tests/acceptance/10_files/02_maintain/406.x.cf
@@ -42,15 +42,8 @@ body delete init_delete
 bundle agent test
 {
   files:
-    windows::
       "$(G.testfile)"
-      repository => "/var/tmp",	# Intentionally wrong
-      move_obstructions => "true",
-      copy_from => test_copy;
-
-    !windows::
-      "$(G.testfile)"
-      repository => "c:\var\tmp",	# Intentionally wrong
+      repository => "non-absolute-path",	# Intentionally wrong
       move_obstructions => "true",
       copy_from => test_copy;
 }


### PR DESCRIPTION
Nuke. Asphalt over.

Change the path for nix to non-absolute.
