### PR TITLE
Redmine#4791: AND body perms mode with S_IFMT as per POSIX 2001

### DIFF
--- a/libpromises/modes.c
+++ b/libpromises/modes.c
@@ -153,6 +153,13 @@ int ParseModeString(const char *modestring, mode_t *plusmask, mode_t *minusmask)
             state = which;
             affected = 07777;   /* TODO: Hard-coded; see below */
             sscanf(sp, "%o", &value);
+
+            /* stat() returns the file types in the mode, but they
+             * can't be set.  So we clear the file-type as per POSIX
+             * 2001 instead of erroring out, leaving just the
+             * permissions. */
+            value &= ~S_IFMT;
+            
             if (value > 07777)  /* TODO: Hardcoded !
                                    Is this correct for all sorts of Unix ?
                                    What about NT ?

--- a/tests/acceptance/10_files/01_create/perms-mode.cf
+++ b/tests/acceptance/10_files/01_create/perms-mode.cf
@@ -1,0 +1,72 @@
+#######################################################
+#
+# Redmine #4791: body perms mode
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "modes" slist => { "1", "333", "100", "200", "777", "1111", "1010", "13400" };
+
+  files:
+      "$(G.testdir)/$(modes)"
+      create => "true",
+      perms => test_mode($(modes));
+}
+
+body perms test_mode(m)
+{
+      mode => "$(m)";
+}
+
+bundle agent check
+{
+  vars:
+      "modes" slist => { @(test.modes) };
+      "expected" data => parsejson('
+{
+  "1": "100001",
+  "333": "100333",
+  "100": "100100",
+  "200": "100200",
+  "777": "100777",
+  "1111": "101111",
+  "1010": "101010",
+  "13400": "103400",
+}');
+
+      "actual[$(modes)]" string => filestat("$(G.testdir)/$(modes)", "modeoct");
+
+  classes:
+      "ok_$(modes)" expression => strcmp("$(expected[$(modes)])",
+                                         "$(actual[$(modes)])");
+      "ok" and => { "ok_1", "ok_333", "ok_100", "ok_200", "ok_777", "ok_1111", "ok_1010", "ok_13400" };
+
+  reports:
+    DEBUG::
+      "Permission $(modes) worked, got $(expected[$(modes)])" ifvarclass => "ok_$(modes)";
+      "Permission $(modes) failed, expected $(expected[$(modes)]) != actual $(actual[$(modes)])" ifvarclass => "!ok_$(modes)";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 27


### PR DESCRIPTION
Simple fix.  Don't know if it works on all our platforms.

see https://cfengine.com/dev/issues/4791
