### PR TITLE
improve regexp to avoid bogus fails on HPUX

### DIFF
--- a/tests/acceptance/00_basics/04_bundles/call_namespaced_bundle_from_namespace_without_specifying_namespace.cf
+++ b/tests/acceptance/00_basics/04_bundles/call_namespaced_bundle_from_namespace_without_specifying_namespace.cf
@@ -25,7 +25,7 @@ bundle agent check
 {
   classes:
       "OK_non_specified_namespace" expression => regcmp(".*OKI DOKI.*", $(test.agent_output));
-      "OK_specified_namespace" expression => regcmp(".*artichokie*", $(test.agent_output));
+      "OK_specified_namespace" expression => regcmp(".*artichokie.*", $(test.agent_output));
 
       "ok" and => {
                     "OK_non_specified_namespace",


### PR DESCRIPTION
While there, deal with three duplicates: nuke one with identical content, and rename the two others.
