### PR TITLE
cf-serverd: fix file-access path calculation, after symlink expansion

### DIFF
--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -941,6 +941,7 @@ static void KeepFileAccessPromise(const EvalContext *ctx, const Promise *pp)
     {
         /* If it's a directory append trailing '/'. */
         int is_dir = IsDirReal(path);
+        path_len = ret;
         if (is_dir == 1 && path[path_len - 1] != FILE_SEPARATOR)
         {
             if (path_len + 2 > sizeof(path))


### PR DESCRIPTION
If we define an access rule to some symlink, like:
 "/var/cfengine/masterfiles" -> "/var/lib/cfengine/masterfiles"
then, pre-processing of the path will expand it to a longer string,
and thus "path_len" will be invalid.
