### PR TITLE
Introduce PRINTSIZE macro to help declare right-sized buffers.

### DIFF
--- a/cf-agent/retcode.c
+++ b/cf-agent/retcode.c
@@ -24,19 +24,19 @@
 
 #include <retcode.h>
 
+#include <printsize.h>
 #include <actuator.h>
 #include <rlist.h>
 
 int VerifyCommandRetcode(EvalContext *ctx, int retcode, int fallback, Attributes a, const Promise *pp, PromiseResult *result)
 {
-    char retcodeStr[128] = { 0 };
     bool result_retcode = true;
-    int matched = false;
 
     if ((a.classes.retcode_kept) || (a.classes.retcode_repaired) || (a.classes.retcode_failed))
     {
-
-        snprintf(retcodeStr, sizeof(retcodeStr), "%d", retcode);
+        int matched = false;
+        char retcodeStr[PRINTSIZE(retcode)];
+        sprintf(retcodeStr, "%d", retcode);
 
         if (RlistKeyIn(a.classes.retcode_kept, retcodeStr))
         {

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -37,6 +37,7 @@
 #include <timeout.h>
 #include <time_classes.h>
 #include <loading.h>
+#include <printsize.h>
 
 #include <cf-windows-functions.h>
 
@@ -421,8 +422,8 @@ static void Apoptosis(void)
 
     if (LoadProcessTable(&PROCESSTABLE))
     {
-        char myuid[32];
-        snprintf(myuid, 32, "%d", (int)getuid());
+        char myuid[PRINTSIZE(unsigned)];
+        sprintf(myuid, "%u", (unsigned)getuid());
 
         Rlist *owners = NULL;
         RlistPrepend(&owners, myuid, RVAL_TYPE_SCALAR);

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -44,6 +44,7 @@
 #include <connection_info.h>
 #include <file_lib.h>
 #include <loading.h>
+#include <printsize.h>
 
 #include "server_access.h"
 
@@ -492,8 +493,8 @@ int OpenReceiverChannel(void)
         ptr = BINDINTERFACE;
     }
 
-    char servname[10];
-    snprintf(servname, 10, "%d", CFENGINE_PORT);
+    char servname[PRINTSIZE(CFENGINE_PORT)];
+    sprintf(servname, "%d", CFENGINE_PORT);
 
     /* Resolve listening interface. */
     if (getaddrinfo(ptr, servname, &query, &response) != 0)

--- a/cf-serverd/server.c
+++ b/cf-serverd/server.c
@@ -45,6 +45,7 @@
 #include <connection_info.h>
 #include <cf-windows-functions.h>
 #include <logging_priv.h>                          /* LoggingPrivSetContext */
+#include <printsize.h>
 
 #include "server_classic.h"                    /* BusyWithClassicConnection */
 
@@ -89,7 +90,6 @@ static void DeleteConn(ServerConnectionState *conn);
 
 void ServerEntryPoint(EvalContext *ctx, char *ipaddr, ConnectionInfo *info)
 {
-    char intime[64];
     time_t now;
 
     Log(LOG_LEVEL_VERBOSE,
@@ -146,7 +146,8 @@ void ServerEntryPoint(EvalContext *ctx, char *ipaddr, ConnectionInfo *info)
         ThreadUnlock(cft_count);
     }
 
-    snprintf(intime, 63, "%d", (int) now);
+    char intime[PRINTSIZE(now)];
+    sprintf(intime, "%jd", (intmax_t) now);
 
     if (!ThreadLock(cft_count))
     {

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -41,9 +41,9 @@
 #include <files_lib.h>                               /* FullWrite,safe_open */
 #include <string_lib.h>                           /* MemSpan,MemSpanInverse */
 #include <misc_lib.h>                                   /* ProgrammingError */
+#include <printsize.h>                                         /* PRINTSIZE */
 
-#include <lastseen.h>                                           /* LastSaw */
-
+#include <lastseen.h>                                            /* LastSaw */
 
 typedef struct
 {
@@ -137,6 +137,8 @@ char CFENGINE_PORT_STR[16] = "5308";
 void DetermineCfenginePort()
 {
     struct servent *server;
+    assert(sizeof(CFENGINE_PORT_STR) >= PRINTSIZE(CFENGINE_PORT));
+    /* ... but we leave more space, as service names can be longer */
 
     errno = 0;
     if ((server = getservbyname(CFENGINE_SERVICE, "tcp")) != NULL)

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -46,6 +46,7 @@
 #include <ring_buffer.h>
 #include <logging_priv.h>
 #include <known_dirs.h>
+#include <printsize.h>
 
 static bool BundleAborted(const EvalContext *ctx);
 static void SetBundleAborted(EvalContext *ctx);
@@ -1231,14 +1232,14 @@ void EvalContextStackPushPromiseFrame(EvalContext *ctx, const Promise *owner, bo
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promise_linenumber", number, CF_DATA_TYPE_STRING, "source=promise");
     }
 
-    char v[CF_MAXVARSIZE];
-    snprintf(v, CF_MAXVARSIZE, "%d", (int) ctx->uid);
+    char v[PRINTSIZE(int)];
+    sprintf(v, "%d", (int) ctx->uid);
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promiser_uid", v, CF_DATA_TYPE_INT, "source=agent");
-    snprintf(v, CF_MAXVARSIZE, "%d", (int) ctx->gid);
+    sprintf(v, "%d", (int) ctx->gid);
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promiser_gid", v, CF_DATA_TYPE_INT, "source=agent");
-    snprintf(v, CF_MAXVARSIZE, "%d", (int) ctx->pid);
+    sprintf(v, "%d", (int) ctx->pid);
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promiser_pid", v, CF_DATA_TYPE_INT, "source=agent");
-    snprintf(v, CF_MAXVARSIZE, "%d", (int) ctx->ppid);
+    sprintf(v, "%d", (int) ctx->ppid);
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promiser_ppid", v, CF_DATA_TYPE_INT, "source=agent");
 
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "bundle", PromiseGetBundle(owner)->name, CF_DATA_TYPE_STRING, "source=promise");

--- a/libutils/json.c
+++ b/libutils/json.c
@@ -27,9 +27,9 @@
 #include <sequence.h>
 #include <string_lib.h>
 #include <file_lib.h>
+#include <printsize.h>
 
 #include <json.h>
-
 
 static const int SPACES_PER_INDENT = 2;
 static const int DEFAULT_CONTAINER_CAPACITY = 64;
@@ -1132,8 +1132,8 @@ JsonElement *JsonStringCreate(const char *value)
 
 JsonElement *JsonIntegerCreate(int value)
 {
-    char *buffer = xcalloc(32, sizeof(char));
-    snprintf(buffer, 32, "%d", value);
+    char *buffer = xmalloc(PRINTSIZE(value));
+    sprintf(buffer, "%d", value);
 
     return JsonElementCreatePrimitive(JSON_PRIMITIVE_TYPE_INTEGER, buffer);
 }

--- a/libutils/printsize.h
+++ b/libutils/printsize.h
@@ -1,0 +1,68 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+#ifndef CFENGINE_PRINTSIZE_H
+#define CFENGINE_PRINTSIZE_H
+
+/** Size of buffer needed to sprintf() an integral value.
+ *
+ * The constant 53/22 is a (very slightly) high approximation to
+ * log(256)/log(10), the number of decimal digits needed per byte of
+ * the value.  The offset of 3 accounts for: rounding details, the
+ * '\0' you need at the end of the buffer and the sign.  The last is a
+ * wasted byte when using "%u", but it's simpler this way !
+ *
+ * This macro should be preferred over using a char [64] buffer (or
+ * 128 or 32 or whatever guess you've made at "big enough") and
+ * trusting that your integer shall fit - for now it saves wasting
+ * stack space; one day it may even (when we have bigger integral
+ * types) save us a buffer over-run.  Limitation: if CHAR_BIT ever
+ * isn't 8, we should change the / 22 to * CHAR_BIT / 176.
+ *
+ * This deals with the simple case of a "%d", possibly with type
+ * modifiers (jhzl, etc.) or sign (%+d).  If you're using fancier
+ * modifiers (e.g. field-width), you need to think about what effect
+ * they have on the print width (max of field-width and this macro);
+ * if there is other text in your format, you need to allow space for
+ * it, too.
+ *
+ * If you are casting the value to be formatted (e.g. because there's
+ * no modifier for its type), applying this macro to the value shall
+ * get the maximum size that a %d-based format can produce for it (its
+ * value can't be any bigger, even if it's cast to a huge type); but,
+ * if you're using a %u-based format and the value is signed, you
+ * should call this macro on the type to which you're casting it
+ * (because, if it's negative, it'll wrap to a huge value of the cast
+ * type).
+ *
+ * @param #what The integral expression or its type.  Is not evaluated
+ * at run-time, only passed to sizeof() at compile-time.
+ *
+ * @return The size for a buffer big enough to hold sprintf()'s
+ * representation of an integer of this type.  This is a compile-time
+ * constant, so can be used in static array declarations or struct
+ * member array declarations.
+ */
+#define PRINTSIZE(what) (3 + 53 * sizeof(what) / 22)
+
+#endif /* CFENGINE_PRINTSIZE_H */


### PR DESCRIPTION
A pair of macros I keep wanting ...

The size of a buffer needed to safely sprintf() an integral type can
be computed from the sizeof() the type.  Doing so ensures we don't
waste stack space declaring "big enough" buffers that are way bigger
than we actually need; and shall ensure, if we ever port to systems
with bigger integral types, that "big enough" really is.

Made assorted variables more local in the process
