### PR TITLE
Change log level for template rendering to INFO.

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -633,7 +633,7 @@ PromiseResult ScheduleEditOperation(EvalContext *ctx, char *filename, Attributes
                 HashFile(pp->promiser, rendered_output_digest, CF_DEFAULT_DIGEST);
                 if (!HashesMatch(existing_output_digest, rendered_output_digest, CF_DEFAULT_DIGEST))
                 {
-                    cfPS(ctx, LOG_LEVEL_NOTICE, PROMISE_RESULT_CHANGE, pp, a, "Updated rendering of '%s' from template mustache template '%s'",
+                    cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_CHANGE, pp, a, "Updated rendering of '%s' from template mustache template '%s'",
                          pp->promiser, a.edit_template);
                     result = PromiseResultUpdate(result, PROMISE_RESULT_CHANGE);
                 }


### PR DESCRIPTION
The promise is recorded as repaired, which uses INFO log level.

Redmine #5214
