### PR TITLE
When deleting, entry not found should not be logged as an error

### DIFF
--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -372,6 +372,11 @@ bool DBPrivDelete(DBPriv *db, const void *key, int key_size)
                     Log(LOG_LEVEL_ERR, "Could not commit: %s", mdb_strerror(rc));
                 }
             }
+            else if (rc == MDB_NOTFOUND)
+            {
+                Log(LOG_LEVEL_DEBUG, "Entry not found: %s", mdb_strerror(rc));
+                mdb_txn_abort(txn);
+            }
             else
             {
                 Log(LOG_LEVEL_ERR, "Could not delete: %s", mdb_strerror(rc));


### PR DESCRIPTION
DeleteDB() returns the error and HasKeyDB() should be called before DeleteDB() if we are not sure that a key already exists in the database.
