### PR TITLE
Fix sscanf return in StringItemNumberLess.

### DIFF
--- a/libpromises/sort.c
+++ b/libpromises/sort.c
@@ -224,17 +224,17 @@ static bool StringItemNumberLess(const char *lhs, const char *rhs, ARG_UNUSED vo
     double left;
     double right;
 
-    int matched_left = sscanf(lhs, "%lf", &left);
-    int matched_right = sscanf(rhs, "%lf", &right);
+    bool matched_left = sscanf(lhs, "%lf", &left) > 0;
+    bool matched_right = sscanf(rhs, "%lf", &right) > 0;
 
     if (!matched_left)
     {
-        matched_left = sscanf(lhs, "%lf%s", &left, remainder);
+        matched_left = sscanf(lhs, "%lf%s", &left, remainder) > 0;
     }
 
     if (!matched_right)
     {
-        matched_right = sscanf(rhs, "%lf%s", &right, remainder);
+        matched_right = sscanf(rhs, "%lf%s", &right, remainder) > 0;
     }
 
     if (matched_left && matched_right)

--- a/tests/acceptance/01_vars/02_functions/fold.cf
+++ b/tests/acceptance/01_vars/02_functions/fold.cf
@@ -140,7 +140,7 @@ bundle agent check
       "expected[a][realmin]" string => "a";
       "expected[b][realmin]" string => "9";
       "expected[c][realmin]" string => "-1";
-      "expected[d][realmin]" string => "a";
+      "expected[d][realmin]" string => "";
       "expected[e][realmin]" string => "a";
       "expected[f][realmin]" string => "100";
       "expected[g][realmin]" string => "-3.33";
@@ -166,7 +166,7 @@ bundle agent check
       "expected[a][realmax]" string => "c";
       "expected[b][realmax]" string => "100";
       "expected[c][realmax]" string => "-1";
-      "expected[d][realmax]" string => "";
+      "expected[d][realmax]" string => "b";
       "expected[e][realmax]" string => "1";
       "expected[f][realmax]" string => "300";
       "expected[g][realmax]" string => "1.11";

--- a/tests/acceptance/01_vars/02_functions/sort.cf
+++ b/tests/acceptance/01_vars/02_functions/sort.cf
@@ -94,7 +94,7 @@ bundle agent check
 
       "$(sort)_check_c" string => "";
 
-      "$(numerics)_check_d" string => "a,b,,";
+      "$(numerics)_check_d" string => ",,a,b";
       "$(non_numerics)_check_d" string => ",,a,b";
 
       "$(numerics)_check_e" string => "a,b,1";
@@ -105,11 +105,11 @@ bundle agent check
       "real_check_f" string => "0,0.1,3.2,100.0";
 
       "$(non_numerics)_check_g" string => ",-2.1,0.88,00.88,b";
-      "$(numerics)_check_g" string => "b,-2.1,,00.88,0.88";
+      "$(numerics)_check_g" string => ",b,-2.1,00.88,0.88";
 
       "lex_check_ip" string => ",-1,1.2.3.4,100.200.100.0,9,9.7,9.7.5,9.7.5.1,where are the IP addresses?";
-      "int_check_ip" string => "where are the IP addresses?,-1,,1.2.3.4,9.7.5,9.7,9,9.7.5.1,100.200.100.0";
-      "real_check_ip" string => "where are the IP addresses?,-1,,1.2.3.4,9,9.7.5,9.7,9.7.5.1,100.200.100.0";
+      "int_check_ip" string => ",where are the IP addresses?,-1,1.2.3.4,9.7.5,9.7,9,9.7.5.1,100.200.100.0";
+      "real_check_ip" string => ",where are the IP addresses?,-1,1.2.3.4,9.7.5,9.7,9,9.7.5.1,100.200.100.0";
       "IP_check_ip" string => ",-1,9,9.7,9.7.5,where are the IP addresses?,1.2.3.4,9.7.5.1,100.200.100.0";
       "MAC_check_ip" string => $(lex_check_ip);
 


### PR DESCRIPTION
sscanf may return -1. reported by valgrind.
