### PR TITLE
Use cfengine's syslog implementation on Android

### DIFF
--- a/libpromises/syslog_client.c
+++ b/libpromises/syslog_client.c
@@ -103,8 +103,7 @@ void RemoteSysLog(int log_priority, const char *log_string)
         }
         else
         {
-            const size_t rfc3164_len = 1024;
-            char message[rfc3164_len];
+            char message[RFC3164_LEN];
             char timebuffer[26];
             pid_t pid = getpid();
 

--- a/libpromises/syslog_client.h
+++ b/libpromises/syslog_client.h
@@ -27,6 +27,8 @@
 
 #include <platform.h>
 
+#define RFC3164_LEN 1024
+
 /*
  * This module provides implementation of UDP syslog protocol
  */

--- a/libpromises/verify_reports.c
+++ b/libpromises/verify_reports.c
@@ -128,7 +128,7 @@ static void ReportToLog(const char *message)
     syslog(LOG_NOTICE, "R: %s", message);
 #endif
 #ifdef __ANDROID__
-    char log_string[1024];
+    char log_string[RFC3164_LEN];
     snprintf(log_string, sizeof(log_string), "R: %s", message);
     RemoteSysLog(LOG_NOTICE, log_string);
 #endif


### PR DESCRIPTION
It is hard to use a syslog daemon on Android, moreover the syslog(3) implementation is bugged.
The easiest way is to rely only on cfengine implementation.
