### PR TITLE
Leak-fix in FnCallRegExtract().

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -4875,6 +4875,7 @@ static FnCallResult FnCallRegExtract(EvalContext *ctx, ARG_UNUSED const Policy *
     if (!s || SeqLength(s) == 0)
     {
         SeqDestroy(s);
+        free(arrayname);
         return FnReturnContext(false);
     }
 


### PR DESCRIPTION
One of its premature returns neglected to free the arrayname.
