### PR TITLE
Valgrind friendly openssl, if getenv("CFENGINE_TEST_PURIFY_OPENSSL")

### DIFF
--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -244,6 +244,11 @@ X509 *TLSGenerateCertFromPrivKey(RSA *privkey)
         goto err3;
     }
 
+    if (getenv("CFENGINE_TEST_PURIFY_OPENSSL") != NULL)
+    {
+        RSA_blinding_off(privkey);
+    }
+
     /* Not really needed since the other side does not
        verify the signature. */
     ret = X509_sign(x509, pkey, md);


### PR DESCRIPTION
Even if you compile your openssl with -DPURIFY and no-asm, valgrind
still outputs a very long list of uninitialised variable warnings. It
turns out that the "blinding" feature of openssl is the culprit.
