### PR TITLE
Make lmdb recreate a file if it has an invalid format

### DIFF
--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -143,6 +143,10 @@ err:
         mdb_env_close(db->env);
     }
     free(db);
+    if (rc == MDB_INVALID)
+    {
+        return DB_PRIV_DATABASE_BROKEN;
+    }
     return NULL;
 }
 

--- a/tests/unit/db_test.c
+++ b/tests/unit/db_test.c
@@ -81,7 +81,7 @@ void test_iter_delete_entry(void)
     CloseDB(db);
 }
 
-#if defined(HAVE_LIBTOKYOCABINET) || defined(HAVE_LIBQDBM)
+#if defined(HAVE_LIBTOKYOCABINET) || defined(HAVE_LIBQDBM) || defined(HAVE_LIBLMDB)
 static void CreateGarbage(const char *filename)
 {
     FILE *fh = fopen(filename, "w");
@@ -106,6 +106,12 @@ void test_recreate(void)
     snprintf(qdbm_db, CF_BUFSIZE, "%s/cf_classes.qdbm", CFWORKDIR);
     CreateGarbage(qdbm_db);
 #endif
+#ifdef HAVE_LIBLMDB
+    char lmdb_db[CF_BUFSIZE];
+    snprintf(lmdb_db, CF_BUFSIZE, "%s/cf_classes.lmdb", CFWORKDIR);
+    CreateGarbage(lmdb_db);
+#endif
+
     CF_DB *db;
     assert_int_equal(OpenDB(&db, dbid_classes), true);
     CloseDB(db);


### PR DESCRIPTION
In response to https://cfengine.com/dev/issues/5486

LMDB is not as fragile as TCDB so this possibility can arise only when an external source has tampered with the DB file
