### PR TITLE
Avoid 100% CPU hang when process table has empty columns for some processes

### DIFF
--- a/src/processes_select.c
+++ b/src/processes_select.c
@@ -400,6 +400,11 @@ static int SplitProcLine(char *proc, char **names, int *start, int *end, char **
                 {
                     e--;
                 }
+
+                if(e == 0)
+                {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
observed on AIX with zombie processes

(cherry picked from commit ee9375f925aaac9f41aea659133b1a651d4c5aeb)

Redmine #5507
