### PR TITLE
tests/unit: fix file_writer test on Mac OS X (Darwin) because of clang

### DIFF
--- a/m4/cf3_platforms.m4
+++ b/m4/cf3_platforms.m4
@@ -7,6 +7,7 @@
 # Bad example: use LINUX to select code which parses output of coreutils' ps(1).
 #
 AM_CONDITIONAL([LINUX], [test -n "`echo ${target_os} | grep linux`"])
+AM_CONDITIONAL([MACOSX], [test -n "`echo ${target_os} | grep darwin`"])
 AM_CONDITIONAL([SOLARIS], [test -n "`(echo ${target_os} | egrep 'solaris|sunos')`"])
 AM_CONDITIONAL([NT], [test -n "`(echo ${target_os} | egrep 'mingw|cygwin')`"])
 AM_CONDITIONAL([CYGWIN], [test -n "`(echo ${target_os} | egrep 'cygwin')`"])

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -207,8 +207,14 @@ endif
 # file_writer_test overrides fclose(3) which causes gcov to fail as gcov
 # instrumentation code uses fclose(3).
 #
-file_writer_test_SOURCES = file_writer_test.c gcov-stub.c
+
+if MACOSX
+file_writer_test_CFLAGS = $(AM_CFLAGS)
+else
 file_writer_test_CFLAGS = $(AM_CFLAGS) -fno-profile-arcs -fno-test-coverage
+endif
+
+file_writer_test_SOURCES = file_writer_test.c gcov-stub.c
 file_writer_test_LDADD = libstr.la
 file_writer_test_LDFLAGS =
 


### PR DESCRIPTION
those flags don't work with clang... so maybe this fix should be for clang, not Mac OS X specifically...
