### PR TITLE
Update verify_users_pam.c

### DIFF
--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -74,6 +74,8 @@ static const char *GetPlatformSpecificExpirationDate()
     return "0102000070";
 #elif defined(__hpux) || defined(__SVR4)
     return "02/01/70";
+#elif defined(__NetBSD__)
+    return "January 02 1970";
 #elif defined(__linux__)
     return "1970-01-02";
 #else


### PR DESCRIPTION
Updated for bug https://cfengine.com/dev/issues/5485 as requested by Volker Hilsheimer. 
This will allow compile on NetBSD.
Tested on NetBSD i386 version 6.1.3.
