### PR TITLE
Correctly report repaired compliance for commands promises.

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -104,8 +104,9 @@ PromiseResult VerifyExecPromise(EvalContext *ctx, const Promise *pp)
     }
 
     // explicitly set commands promises that end up changing to KEPT. This is because commands promises
-    // shares code with packages promises (VerifyCommandRetcode), so we enforce this condition here.
-    if (result == PROMISE_RESULT_CHANGE)
+    // shares code with packages promises (VerifyCommandRetcode), so we enforce this condition here,
+    // unless a body classes explicitly defines return codes for the REPAIRED state.
+    if (result == PROMISE_RESULT_CHANGE && !(a.classes.retcode_repaired))
     {
         result = PROMISE_RESULT_NOOP;
     }


### PR DESCRIPTION
For compliance, commands promises are interpreted to have been KEPT
for 0 returns status, and NOTKEPT for non-zero. In order to maintain
compatibility with repaired classes set via body classes, a REPAIRED
state from VerifyCommandRetcode is overwritten with KEPT.

If the body classes also defines return codes for which the compliance
should be REPAIRED, then honour this and don't overwrite with KEPT.

Fixes: #5489
