### PR TITLE
Make db_concurrent_test work again

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -221,7 +221,7 @@ file_writer_test_LDFLAGS =
 db_test_SOURCES = db_test.c
 db_test_LDADD = libdb.la
 
-db_concurrent_test_SOURCES = db_test.c
+db_concurrent_test_SOURCES = db_concurrent_test.c
 db_concurrent_test_LDADD = libdb.la
 
 lastseen_test_SOURCES = lastseen_test.c ../../libpromises/item_lib.c  ../../libpromises/lastseen.c ../../libutils/statistics.c

--- a/tests/unit/db_concurrent_test.c
+++ b/tests/unit/db_concurrent_test.c
@@ -138,23 +138,3 @@ void FatalError(char *s, ...)
     exit(42);
 }
 
-void Log(LogLevel level, const char *fmt, ...)
-{
-    fprintf(stderr, "CFOUT<%d>: ", level);
-    va_list ap;
-    va_start(ap, fmt);
-    vfprintf(stderr, fmt, ap);
-    va_end(ap);
-    fprintf(stderr, "\n");
-}
-
-const char *GetErrorStr(void)
-{
-    return strerror(errno);
-}
-
-const char *DAY_TEXT[] = {};
-const char *MONTH_TEXT[] = {};
-
-
-


### PR DESCRIPTION
Tested in private branch and works for all platforms.
Although it works for me under lmdb 0.9.11, it is (like db_test) best suitable to run it under lmdb 0.9.7 to 0.9.10.
