### PR TITLE
port of fix from 3.5.x for issue #3408 - getprocs64 on aix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -847,6 +847,8 @@ AC_REPLACE_FUNCS(inet_ntop inet_pton)
 
 AC_CHECK_FUNCS(getifaddrs)
 
+AC_CHECK_FUNCS(getprocs64)
+
 AC_CHECK_FUNC(lchown, AC_DEFINE(HAVE_LCHOWN, 1, [Whether to use lchown(3) to change ownerships]))
 
 AC_CHECK_DECLS(pthread_attr_setstacksize, [], [], [[#include <pthread.h>]])

--- a/libpromises/process_aix.c
+++ b/libpromises/process_aix.c
@@ -33,8 +33,9 @@
 /*
  * AIX 5.3 is missing this declaration
  */
+#ifndef HAVE_GETPROCS64
 int getprocs64(struct procentry64 *, int, struct fdsinfo64 *, int, pid_t *, int);
-
+#endif
 static bool FillProcEntry(struct procentry64* pe, pid_t pid)
 {
     pid_t nextpid = pid;

--- a/tests/unit/aix_process_test.c
+++ b/tests/unit/aix_process_test.c
@@ -10,6 +10,7 @@
 /*
  * AIX 5.3 is missing this declaration
  */
+#ifndef GETPROCS64
 int getprocs64(struct procentry64 *, int, struct fdsinfo64 *, int, pid_t *, int);
 
 int getprocs64(struct procentry64* pe, int process_size, struct fdsinfo64 *fi, int files_size, pid_t* pid, int count)
@@ -56,7 +57,7 @@ int getprocs64(struct procentry64* pe, int process_size, struct fdsinfo64 *fi, i
         return 0;
     }
 }
-
+#endif
 static void test_get_start_time_process1(void)
 {
     time_t t = GetProcessStartTime(1);


### PR DESCRIPTION
This ports a change made to 3.5.x (ecf826e0b150d445ab3c942424291181b099f09f) into master - configure checks if getprocs64 exists and either enables or disables function delaration of getprocs64 in process_aix and a unit test.
