### PR TITLE
Set BOOTSTRAP_MODE global flag to indicate that cf-agent was executed

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -393,6 +393,8 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                                                "promises.cf");
                 config->agent_specific.agent.bootstrap_policy_server =
                     xstrdup(mapped_policy_server);
+
+                BOOTSTRAP_MODE = true;
             }
             break;
 

--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -52,6 +52,7 @@ extern char VUQNAME[];
 
 extern bool DONTDO;
 extern bool MINUSF;
+extern bool BOOTSTRAP_MODE;
 
 extern const char *const VPSCOMM[];
 extern const char *const VPSOPTS[];

--- a/libpromises/cf3globals.c
+++ b/libpromises/cf3globals.c
@@ -154,6 +154,13 @@ char BINDINTERFACE[CF_MAXVARSIZE]; /* GLOBAL_P */
 */
 bool MINUSF = false; /* GLOBAL_A */
 
+/*
+  Set in cf-agent.c:CheckOpts.
+
+  Utilized in enterprise report generation.
+*/
+bool BOOTSTRAP_MODE = false; /* GLOBAL_A */
+
 /* Set in libenv/sysinfo.c::DetectEnvironment (called every time environment
    reload is performed).
 


### PR DESCRIPTION
with bootstrap argument. (Used in enterprise plugin)
