### PR TITLE
Report methods promises as repaired to CFEngine Enterprise.

### DIFF
--- a/cf-agent/verify_methods.c
+++ b/cf-agent/verify_methods.c
@@ -65,13 +65,6 @@ PromiseResult VerifyMethodsPromise(EvalContext *ctx, const Promise *pp)
     }
 
     PromiseResult result = VerifyMethod(ctx, cp->rval, a, pp);
-    switch (result)
-    {
-    case PROMISE_RESULT_CHANGE:
-        result = PROMISE_RESULT_NOOP;
-    default:
-        break;
-    }
 
     return result;
 }


### PR DESCRIPTION
see https://cfengine.com/dev/issues/5625

While methods promises are not making any changes to the system
themselves, they provide the means of abstraction that is relevant
for compliance reporting. Otherwise, users of bundles need to
know about the details of the bundles in order to correctly evaluate
compliance.
