### PR TITLE
Separate cursors operations from ordinary operations and remove migration for LMDB

### DIFF
--- a/libpromises/dbm_migration.c
+++ b/libpromises/dbm_migration.c
@@ -35,6 +35,12 @@ static const DBMigrationFunction *const dbm_migration_plans[dbid_max] = {
     [dbid_lastseen] = dbm_migration_plan_lastseen
 };
 
+#ifdef LMDB
+bool DBMigrate(ARG_UNUSED DBHandle *db, ARG_UNUSED  dbid id)
+{
+    return true;
+}
+#else
 static size_t DBVersion(DBHandle *db)
 {
     char version[64];
@@ -66,6 +72,6 @@ bool DBMigrate(DBHandle *db, dbid id)
             }
         }
     }
-
     return true;
 }
+#endif

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -515,7 +515,13 @@ bool ScanLastSeenQuality(LastSeenQualityCallback callback, void *ctx)
     }
 
     DeleteDBCursor(cursor);
-    
+    CloseDB(db);
+
+    if (!OpenDB(&db, dbid_lastseen))
+    {
+        Log(LOG_LEVEL_ERR, "Unable to re-open lastseen database");
+        return false;
+    }
     for (int i = 0; i < SeqLength(hostkeys); ++i)
     {
         const char *hostkey = SeqAt(hostkeys, i);

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -955,8 +955,15 @@ void PurgeLocks(void)
             return;
         }
     }
+    CloseLock(dbp);
 
     Log(LOG_LEVEL_VERBOSE, "Looking for stale locks to purge");
+
+    dbp = OpenLock();
+    if(!dbp)
+    {
+        return;
+    }
 
     if (!NewDBCursor(dbp, &dbcp))
     {
@@ -988,7 +995,13 @@ void PurgeLocks(void)
 
     entry.time = now;
     DeleteDBCursor(dbcp);
+    CloseLock(dbp);
 
+    dbp = OpenLock();
+    if(!dbp)
+    {
+        return;
+    }
     WriteDB(dbp, "lock_horizon", &entry, sizeof(entry));
     CloseLock(dbp);
 }


### PR DESCRIPTION
I went through all cursor usage in cfengine and separated direct DB operations from pure cursor operations.
The aim is to distinguish read-only cursors from write cursors.

Corresponding enterprise pull request --> https://github.com/cfengine/enterprise/pull/177

Also removed DB migration support for LMDB.
