### PR TITLE
Use MapAddress() early on, so that conn->ipaddr is never a v4-to-v6 mapped

### DIFF
--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -706,7 +706,9 @@ void StartServer(EvalContext *ctx, Policy **policy, GenericAgentConfig *config)
                             ipaddr, sizeof(ipaddr),
                             NULL, 0, NI_NUMERICHOST);
 
-                ServerEntryPoint(ctx, ipaddr, info);
+                /* IPv4 mapped addresses (e.g. "::ffff:192.168.1.2") are
+                 * hereby represented with their IPv4 counterpart. */
+                ServerEntryPoint(ctx, MapAddress(ipaddr), info);
             }
         }
     }

--- a/cf-serverd/server.h
+++ b/cf-serverd/server.h
@@ -133,7 +133,7 @@ typedef struct
 
 
 /* Used in cf-serverd-functions.c. */
-void ServerEntryPoint(EvalContext *ctx, char *ipaddr, ConnectionInfo *info);
+void ServerEntryPoint(EvalContext *ctx, const char *ipaddr, ConnectionInfo *info);
 
 
 AgentConnection *ExtractCallBackChannel(ServerConnectionState *conn);

--- a/cf-serverd/server_access.c
+++ b/cf-serverd/server_access.c
@@ -4,7 +4,6 @@
 
 #include <cf3.defs.h>                                     /* FILE_SEPARATOR */
 #include <addr_lib.h>                                     /* FuzzySetMatch */
-#include <conversion.h>                                   /* MapAddress */
 #include <string_lib.h>                      /* StringMatchFull TODO REMOVE */
 #include <misc_lib.h>
 
@@ -53,12 +52,9 @@ bool access_CheckResource(const struct resource_acl *acl,
         const char *rule = NULL;
         for (int i = 0; i < StrList_Len(acl->admit.ips); i++)
         {
-            if (FuzzySetMatch(StrList_At(acl->admit.ips, i),
-                              MapAddress(ipaddr))
-                == 0 ||
+            if (FuzzySetMatch(StrList_At(acl->admit.ips, i), ipaddr) == 0 ||
                 /* Legacy regex matching, TODO DEPRECATE */
-                StringMatchFull(StrList_At(acl->admit.ips, i),
-                                MapAddress(ipaddr)))
+                StringMatchFull(StrList_At(acl->admit.ips, i), ipaddr))
             {
                 rule = StrList_At(acl->admit.ips, i);
                 break;
@@ -124,12 +120,9 @@ bool access_CheckResource(const struct resource_acl *acl,
         const char *rule = NULL;
         for (int i = 0; i < StrList_Len(acl->deny.ips); i++)
         {
-            if (FuzzySetMatch(StrList_At(acl->deny.ips, i),
-                              MapAddress(ipaddr))
-                == 0 ||
+            if (FuzzySetMatch(StrList_At(acl->deny.ips, i), ipaddr) == 0 ||
                 /* Legacy regex matching, TODO DEPRECATE */
-                StringMatchFull(StrList_At(acl->deny.ips, i),
-                                MapAddress(ipaddr)))
+                StringMatchFull(StrList_At(acl->deny.ips, i), ipaddr))
             {
                 rule = StrList_At(acl->deny.ips, i);
                 break;

--- a/cf-serverd/server_classic.c
+++ b/cf-serverd/server_classic.c
@@ -2,7 +2,6 @@
 
 #include <cf3.defs.h>
 #include <item_lib.h>                 /* IsMatchItemIn */
-#include <conversion.h>               /* MapAddress */
 #include <matching.h>                 /* IsRegexItemIn */
 #include <net.h>                      /* ReceiveTransaction,SendTransaction */
 #include <signals.h>
@@ -213,14 +212,14 @@ static int AccessControl(EvalContext *ctx, const char *req_path, ServerConnectio
             {
                 Log(LOG_LEVEL_DEBUG, "Checking whether to map root privileges..");
 
-                if ((IsMatchItemIn(ap->maproot, MapAddress(conn->ipaddr))) ||
+                if ((IsMatchItemIn(ap->maproot, conn->ipaddr)) ||
                     (IsRegexItemIn(ctx, ap->maproot, conn->hostname)))
                 {
                     conn->maproot = true;
                     Log(LOG_LEVEL_VERBOSE, "Mapping root privileges to access non-root files");
                 }
 
-                if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)))
+                if ((IsMatchItemIn(ap->accesslist, conn->ipaddr))
                     || (IsRegexItemIn(ctx, ap->accesslist, conn->hostname)))
                 {
                     access = true;
@@ -247,7 +246,7 @@ static int AccessControl(EvalContext *ctx, const char *req_path, ServerConnectio
             /* or if it's an exact match */
             (strcmp(transpath, transrequest) == 0))
         {
-            if ((IsMatchItemIn(dp->accesslist, MapAddress(conn->ipaddr))) ||
+            if ((IsMatchItemIn(dp->accesslist, conn->ipaddr)) ||
                 (IsRegexItemIn(ctx, dp->accesslist, conn->hostname)))
             {
                 access = false;
@@ -327,7 +326,7 @@ static int LiteralAccessControl(EvalContext *ctx, char *in, ServerConnectionStat
             {
                 Log(LOG_LEVEL_DEBUG, "Checking whether to map root privileges");
 
-                if ((IsMatchItemIn(ap->maproot, MapAddress(conn->ipaddr))) ||
+                if ((IsMatchItemIn(ap->maproot, conn->ipaddr)) ||
                     (IsRegexItemIn(ctx, ap->maproot, conn->hostname)))
                 {
                     conn->maproot = true;
@@ -338,7 +337,7 @@ static int LiteralAccessControl(EvalContext *ctx, char *in, ServerConnectionStat
                     Log(LOG_LEVEL_VERBOSE, "No root privileges granted");
                 }
 
-                if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)))
+                if ((IsMatchItemIn(ap->accesslist, conn->ipaddr))
                     || (IsRegexItemIn(ctx, ap->accesslist, conn->hostname)))
                 {
                     access = true;
@@ -352,7 +351,7 @@ static int LiteralAccessControl(EvalContext *ctx, char *in, ServerConnectionStat
     {
         if (strcmp(ap->path, name) == 0)
         {
-            if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)))
+            if ((IsMatchItemIn(ap->accesslist, conn->ipaddr))
                 || (IsRegexItemIn(ctx, ap->accesslist, conn->hostname)))
             {
                 access = false;
@@ -426,7 +425,7 @@ static Item *ContextAccessControl(EvalContext *ctx, char *in, ServerConnectionSt
                     {
                         Log(LOG_LEVEL_DEBUG, "Checking whether to map root privileges");
 
-                        if ((IsMatchItemIn(ap->maproot, MapAddress(conn->ipaddr)))
+                        if ((IsMatchItemIn(ap->maproot, conn->ipaddr))
                             || (IsRegexItemIn(ctx, ap->maproot, conn->hostname)))
                         {
                             conn->maproot = true;
@@ -437,7 +436,7 @@ static Item *ContextAccessControl(EvalContext *ctx, char *in, ServerConnectionSt
                             Log(LOG_LEVEL_VERBOSE, "No root privileges granted");
                         }
 
-                        if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)))
+                        if ((IsMatchItemIn(ap->accesslist, conn->ipaddr))
                             || (IsRegexItemIn(ctx, ap->accesslist, conn->hostname)))
                         {
                             access = true;
@@ -451,7 +450,7 @@ static Item *ContextAccessControl(EvalContext *ctx, char *in, ServerConnectionSt
             {
                 if (strcmp(ap->path, ip->name) == 0)
                 {
-                    if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr)))
+                    if ((IsMatchItemIn(ap->accesslist, conn->ipaddr))
                         || (IsRegexItemIn(ctx, ap->accesslist, conn->hostname)))
                     {
                         access = false;
@@ -550,7 +549,7 @@ static int CheckStoreKey(ServerConnectionState *conn, RSA *key)
     const char *udigest = KeyPrintableHash(ConnectionInfoKey(conn->conn_info));
     assert(udigest != NULL);
 
-    if ((savedkey = HavePublicKey(conn->username, MapAddress(conn->ipaddr), udigest)))
+    if ((savedkey = HavePublicKey(conn->username, conn->ipaddr, udigest)))
     {
         Log(LOG_LEVEL_VERBOSE, "A public key was already known from %s/%s - no trust required", conn->hostname,
               conn->ipaddr);
@@ -568,7 +567,7 @@ static int CheckStoreKey(ServerConnectionState *conn, RSA *key)
      * directory): Allow access only if host is listed in "trustkeysfrom" body
      * server control option. */
 
-    if ((SV.trustkeylist != NULL) && (IsMatchItemIn(SV.trustkeylist, MapAddress(conn->ipaddr))))
+    if ((SV.trustkeylist != NULL) && (IsMatchItemIn(SV.trustkeylist, conn->ipaddr)))
     {
         Log(LOG_LEVEL_VERBOSE, "Host %s/%s was found in the list of hosts to trust", conn->hostname, conn->ipaddr);
         SendTransaction(conn->conn_info, "OK: unknown key was accepted on trust", 0, CF_DONE);

--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -314,7 +314,7 @@ static int AuthorizeRoles(EvalContext *ctx, ServerConnectionState *conn, char *a
             if (StringMatchFull(ap->path, RlistScalarValue(rp)))
             {
                 /* We have a pattern covering this class - so are we allowed to activate it? */
-                if ((IsMatchItemIn(ap->accesslist, MapAddress(conn->ipaddr))) ||
+                if ((IsMatchItemIn(ap->accesslist, conn->ipaddr)) ||
                     (IsRegexItemIn(ctx, ap->accesslist, conn->hostname)) ||
                     (IsRegexItemIn(ctx, ap->accesslist, userid1)) ||
                     (IsRegexItemIn(ctx, ap->accesslist, userid2)) ||

--- a/cf-serverd/tls_server.c
+++ b/cf-serverd/tls_server.c
@@ -469,7 +469,7 @@ int ServerTLSSessionEstablish(ServerConnectionState *conn)
         if (ret == 0)                                  /* untrusted key */
         {
             if ((SV.trustkeylist != NULL) &&
-                (IsMatchItemIn(SV.trustkeylist, MapAddress(conn->ipaddr))))
+                (IsMatchItemIn(SV.trustkeylist, conn->ipaddr)))
             {
                 Log(LOG_LEVEL_VERBOSE,
                     "Peer was found in \"trustkeysfrom\" list");


### PR DESCRIPTION
By calling MapAddress() in the main loop (inside StartServer()) we avoid
the need for calling MapAddress tens of times later. We lose the
information that 192.168.1.2 might originate from ::ffff:192.168.1.2,
but shouldn't matter, all access controls in that case are written in
pure v4 style anyway.
