### PR TITLE
Generate runtime warning if code assumes that repaired classes are set by default

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -109,6 +109,10 @@ PromiseResult VerifyExecPromise(EvalContext *ctx, const Promise *pp)
     if (result == PROMISE_RESULT_CHANGE && !(a.classes.retcode_repaired))
     {
         result = PROMISE_RESULT_NOOP;
+        if (a.classes.change)
+        {
+            Log(LOG_LEVEL_WARNING, "Commands promises will set kept, not repaired classes from 3.7 on. Set repaired_returncodes explicitly");
+        }
     }
 
     YieldCurrentLock(thislock);


### PR DESCRIPTION
In 3.7, a command executing with exit-code 0 implies kept, not repaired. Use
repaired_returncodes from body classes to keep old behavior.
