### PR TITLE
Disallow no-lock and file-input options in cf-agent when called via cfruncommand

### DIFF
--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -454,7 +454,7 @@ void DoExec(EvalContext *ctx, ServerConnectionState *conn, char *args)
         }
     }
 
-    snprintf(ebuff, CF_BUFSIZE, "%s --inform", CFRUNCOMMAND);
+    snprintf(ebuff, CF_BUFSIZE, "%s --Dcfruncommand --inform", CFRUNCOMMAND);
 
     if (strlen(ebuff) + strlen(args) + 6 > CF_BUFSIZE)
     {


### PR DESCRIPTION
This hardens the already existing limitation, which is enforced in
cf-runagent and cf-serverd, but has holes. Ie. --no-loc is accepted by
cf-runagent and cf-serverd, and interpreted by cf-agent as --no-lock
as is standard for unix command line tools.
