### PR TITLE
Restore pre-3.6 compliance behavior for commands promises.

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -85,10 +85,14 @@ PromiseResult VerifyExecPromise(EvalContext *ctx, const Promise *pp)
     PromiseBanner(pp);
 
     PromiseResult result = PROMISE_RESULT_NOOP;
+    /* See VerifyCommandRetcode for interpretation of return codes.
+     * Unless overridden by attributes in body classes, an exit code 0 means
+     * reparied (PROMISE_RESULT_CHANGE), an exit code != 0 means failure.
+     */
     switch (RepairExec(ctx, a, pp, &result))
     {
     case ACTION_RESULT_OK:
-        result = PromiseResultUpdate(result, PROMISE_RESULT_NOOP);
+        result = PromiseResultUpdate(result, PROMISE_RESULT_CHANGE);
         break;
 
     case ACTION_RESULT_TIMEOUT:
@@ -101,14 +105,6 @@ PromiseResult VerifyExecPromise(EvalContext *ctx, const Promise *pp)
 
     default:
         ProgrammingError("Unexpected ActionResult value");
-    }
-
-    // explicitly set commands promises that end up changing to KEPT. This is because commands promises
-    // shares code with packages promises (VerifyCommandRetcode), so we enforce this condition here,
-    // unless a body classes explicitly defines return codes for the REPAIRED state.
-    if (result == PROMISE_RESULT_CHANGE && !(a.classes.retcode_repaired))
-    {
-        result = PROMISE_RESULT_NOOP;
     }
 
     YieldCurrentLock(thislock);


### PR DESCRIPTION
Commands that exit with 0 result in a repaired promise, unless the
return code interpretation is explicitly overriden via body classes
attributes.

This effectively reverts ce463506e4795f1007a31720afd3300de9bca18e,
adds commentary for generations to come.

Redmine #5761
