### PR TITLE
Redmine #5637: increase the maximal mapsize for DB files with a lot of activity or a lot of expected data

### DIFF
--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -156,8 +156,9 @@ const char *DBPrivGetFileExtension(void)
     return "lmdb";
 }
 
+/* Corresponds to a maximum of 50000 pages */
 #ifndef LMDB_MAXSIZE
-#define LMDB_MAXSIZE    104857600
+#define LMDB_MAXSIZE    204800000
 #endif
 
 /* Lastseen default number of maxreaders = 4x the default lmdb maxreaders */
@@ -185,7 +186,15 @@ DBPriv *DBPrivOpenDB(const char *dbpath, dbid id)
               dbpath, mdb_strerror(rc));
         goto err;
     }
-    rc = mdb_env_set_mapsize(db->env, LMDB_MAXSIZE);
+    if (id == dbid_locks || id == dbid_history || id == dbid_observations ||
+        id == dbid_classes || id == dbid_variables)
+    {
+        rc = mdb_env_set_mapsize(db->env, LMDB_MAXSIZE * 2);
+    }
+    else
+    {
+        rc = mdb_env_set_mapsize(db->env, LMDB_MAXSIZE);
+    }
     if (rc)
     {
         Log(LOG_LEVEL_ERR, "Could not set mapsize for database %s: %s",


### PR DESCRIPTION
There are two ways to reach the maximum number of pages used : 
1. Too much data (the obvious one)
2. Too much long transactions (readers or writers). These tend to reserve special dirty pages for them that don't get reused until they are freed. (This can be triggered for example by a bug where a read operation takes a long time to commit or is stuck somewhere)

Unfortunately and unlike maxreaders, it is hard to modify the max mapsize after the creation of the DB file (although the lmdb documentation hints to the opposite).

Note that setting this to the maximum does not imply that the DB file will ever reach even the half of it.
