### PR TITLE
redmine#3034: Increase precision of the final outcome report by 2 decimal places.

### DIFF
--- a/libpromises/enterprise_stubs.c
+++ b/libpromises/enterprise_stubs.c
@@ -100,7 +100,7 @@ ENTERPRISE_VOID_FUNC_2ARG_DEFINE_STUB(void, LogTotalCompliance, const char *, ve
     char string[CF_BUFSIZE] = { 0 };
 
     snprintf(string, CF_BUFSIZE,
-             "Outcome of version %s (" CF_AGENTC "-%d): Promises observed to be kept %.0f%%, Promises repaired %.0f%%, Promises not repaired %.0f%%",
+             "Outcome of version %s (" CF_AGENTC "-%d): Promises observed to be kept %.2f%%, Promises repaired %.2f%%, Promises not repaired %.2f%%",
              version, background_tasks,
              (double) PR_KEPT / total,
              (double) PR_REPAIRED / total,


### PR DESCRIPTION
I can hardly take much credit for this but found it scouraging redmine, [#3034](https://dev.cfengine.com/issues/3034). Please consider backporting the change.

Final outcome now reads as:

```
2014-05-16T08:18:51-0500  verbose: Logging total compliance, total 'Outcome of version CFEngine Promises.cf 3.7.0 (agent-0): Promises observed to be kept 95.97%, Promises repaired 4.03%, Promises not repaired 0.00%'
```
