### PR TITLE
check for EINTR to avoid spinning in an empty file

### DIFF
--- a/libutils/csv_parser.c
+++ b/libutils/csv_parser.c
@@ -335,8 +335,9 @@ char *GetCsvLineNext(FILE *fp)
 
     for (;;)
     {
-        char current = fgetc(fp);
-        if (current == EOF)
+        int current = fgetc(fp);
+
+        if (current == EOF || feof(fp))
         {
             break;
         }


### PR DESCRIPTION
This appears to prevent the long spin loop encountered when a file is empty at least on AIX. 
