### PR TITLE
add space for terminating null to fix AIX memory corruption

### DIFF
--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -532,7 +532,7 @@ Policy *LoadPolicy(EvalContext *ctx, GenericAgentConfig *config)
         const char *release_id = JsonObjectGetAsString(validated_doc, "releaseId");
         if (release_id)
         {
-            policy->release_id = xstrndup(release_id, 2 * CF_SHA256_LEN);
+            policy->release_id = xstrndup(release_id, (2 * CF_SHA256_LEN) + 1);
         }
         JsonDestroy(validated_doc);
     }


### PR DESCRIPTION
Fixes https://dev.cfengine.com/issues/4776 - xstrndup was not allocating enough space to store the releaseId on AIX. 
