### PR TITLE
pass the exact length of release_id to xstrndup 

### DIFF
--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -532,7 +532,7 @@ Policy *LoadPolicy(EvalContext *ctx, GenericAgentConfig *config)
         const char *release_id = JsonObjectGetAsString(validated_doc, "releaseId");
         if (release_id)
         {
-            policy->release_id = xstrndup(release_id, (2 * CF_SHA256_LEN) + 1);
+            policy->release_id = xstrdup(release_id);
         }
         JsonDestroy(validated_doc);
     }


### PR DESCRIPTION
This passes the correct length into xstrndup to avoid memory corruption on aix. This was tested to ensure cf-promises did not segfault - see https://dev.cfengine.com/issues/4776 - this platform is known to have issues with strndup if the length is incorrect and it seems that if the length passed is greater than the actual length of the string, this causes problems as the destination buffer may or may not have been zeroed.
