### PR TITLE
Redmine#5667 - address ps -axo shift on FreeBSD 10.0-RELEASE and later

### DIFF
--- a/libpromises/classes.c
+++ b/libpromises/classes.c
@@ -81,7 +81,7 @@ const char *const VPSOPTS[] =
     [PLATFORM_CONTEXT_AIX] =  "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args", /* aix */
     [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* linux */
     [PLATFORM_CONTEXT_SOLARIS] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,pri,rss,nlwp,stime,time,args",  /* solaris */
-    [PLATFORM_CONTEXT_FREEBSD] = "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,start,time,args",  /* freebsd */
+    [PLATFORM_CONTEXT_FREEBSD] = "auxw",                    /* freebsd */
     [PLATFORM_CONTEXT_NETBSD] = "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,start,time,args",  /* netbsd */
     [PLATFORM_CONTEXT_CRAYOS] = "-elyf",                    /* cray */
     [PLATFORM_CONTEXT_WINDOWS_NT] = "-aW",                      /* NT */


### PR DESCRIPTION
See https://dev.cfengine.com/issues/5667 - There's an inevitable creep to the right going on in FreeBSD 10 and later which has been demonstrated to break bootstrapping in a severe fashion. Going with the most elegant fix, which is to just say 'auxw' in line with Darwin, which is closest for these purposes. Output and column starts do not change, just guarantees getting complete lines regardless of terminal width. Quick test shows no impact.
Note that columns with -axo DO variably shift now on 10 and later, so systems with long runtimes trying to bootstrap are likely to encounter the described bug.
