### PR TITLE
Disable all renegotiation, resumption options and set safest defaults.

### DIFF
--- a/cf-serverd/tls_server.c
+++ b/cf-serverd/tls_server.c
@@ -67,10 +67,7 @@ bool ServerTLSInitialize()
         goto err1;
     }
 
-    /* Use only TLS v1 or later.
-       TODO option for SSL_OP_NO_TLSv{1,1_1} */
-    SSL_CTX_set_options(SSLSERVERCONTEXT,
-                        SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+    TLSSetDefaultOptions(SSLSERVERCONTEXT);
 
     /*
      * CFEngine is not a web server so we don't need many ciphers. We only
@@ -92,10 +89,6 @@ bool ServerTLSInitialize()
             "No valid ciphers in cipher list: %s",
             cipher_list);
     }
-
-    /* Never bother with retransmissions, SSL_write() should
-     * always either write the whole amount or fail. */
-    SSL_CTX_set_mode(SSLSERVERCONTEXT, SSL_MODE_AUTO_RETRY);
 
     if (PRIVKEY == NULL || PUBKEY == NULL)
     {
@@ -132,16 +125,6 @@ bool ServerTLSInitialize()
             ERR_reason_error_string(ERR_get_error()));
         goto err3;
     }
-
-    /* Set options to always request a certificate from the peer, either we
-     * are client or server. */
-    SSL_CTX_set_verify(SSLSERVERCONTEXT,
-                       SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
-                       NULL);
-    /* Always accept that certificate, we do proper checking after TLS
-     * connection is established since OpenSSL can't pass a connection
-     * specific pointer to the callback (so we would have to lock).  */
-    SSL_CTX_set_cert_verify_callback(SSLSERVERCONTEXT, TLSVerifyCallback, NULL);
 
     return true;
 

--- a/libcfnet/tls_client.c
+++ b/libcfnet/tls_client.c
@@ -74,14 +74,7 @@ bool TLSClientInitialize()
         goto err1;
     }
 
-    /* Use only TLS v1 or later.
-       TODO option for SSL_OP_NO_TLSv{1,1_1} */
-    SSL_CTX_set_options(SSLCLIENTCONTEXT,
-                        SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
-
-    /* Never bother with retransmissions, SSL_write() should
-     * always either write the whole amount or fail. */
-    SSL_CTX_set_mode(SSLCLIENTCONTEXT, SSL_MODE_AUTO_RETRY);
+    TLSSetDefaultOptions(SSLCLIENTCONTEXT);
 
     if (PRIVKEY == NULL || PUBKEY == NULL)
     {
@@ -123,14 +116,6 @@ bool TLSClientInitialize()
             ERR_reason_error_string(ERR_get_error()));
         goto err3;
     }
-
-    /* Set options to always request a certificate from the peer, either we
-     * are client or server. */
-    SSL_CTX_set_verify(SSLCLIENTCONTEXT, SSL_VERIFY_PEER, NULL);
-    /* Always accept that certificate, we do proper checking after TLS
-     * connection is established since OpenSSL can't pass a connection
-     * specific pointer to the callback (so we would have to lock).  */
-    SSL_CTX_set_cert_verify_callback(SSLCLIENTCONTEXT, TLSVerifyCallback, NULL);
 
     is_initialised = true;
     return true;

--- a/libcfnet/tls_generic.h
+++ b/libcfnet/tls_generic.h
@@ -35,7 +35,7 @@
 extern int CONNECTIONINFO_SSL_IDX;
 
 
-bool TLSGenericInitialize();
+bool TLSGenericInitialize(void);
 int TLSVerifyCallback(X509_STORE_CTX *ctx, void *arg);
 int TLSVerifyPeer(ConnectionInfo *conn_info, const char *remoteip, const char *username);
 X509 *TLSGenerateCertFromPrivKey(RSA *privkey);
@@ -43,5 +43,6 @@ void TLSLogError(SSL *ssl, LogLevel level, const char *prepend, int code);
 int TLSSend(SSL *ssl, const char *buffer, int length);
 int TLSRecv(SSL *ssl, char *buffer, int length);
 int TLSRecvLines(SSL *ssl, char *buf, size_t buf_size);
+void TLSSetDefaultOptions(SSL_CTX *ssl_ctx);
 
 #endif


### PR DESCRIPTION
Reason is we want to expose a minimal attack surface on the very complex
TLS protocol and its implementations.

To disable TLS renegotiation and session resumption we need to turn off
the server-side session cache _and_ disable session tickets (RFC 5077)
extension, see [1]. In the future we can always selectively re-enable
options in order to gain a performance boost.

[1] https://www.mail-archive.com/openssl-users@openssl.org/msg73185.html

Since we do not care about cross-browser compatibility and web, we also
disable all OpenSSL defaults that help with backwards compatibility.
