### PR TITLE
Redmine#5882: add INFORM message when the given permissions will be filtered

### DIFF
--- a/libpromises/modes.c
+++ b/libpromises/modes.c
@@ -154,6 +154,12 @@ int ParseModeString(const char *modestring, mode_t *plusmask, mode_t *minusmask)
             affected = 07777;   /* TODO: Hard-coded; see below */
             sscanf(sp, "%o", &value);
 
+            if (value & S_IFMT)
+            {
+                Log(LOG_LEVEL_INFO, "Mode-Value is not entirely within the system's allowed permissions (octal %o) and will be filtered accordingly : %s",
+                    S_IFMT, modestring);
+            }
+
             /* stat() returns the file types in the mode, but they
              * can't be set.  So we clear the file-type as per POSIX
              * 2001 instead of erroring out, leaving just the


### PR DESCRIPTION
see https://dev.cfengine.com/issues/5882

output with patch from `VERBOSE=-I testall --printlog ./10_files/01_create/perms-mode.cf`:

```
2014-05-27T09:41:27-0400     info: /default/default/methods/'any'/default/test_run/methods/'any'/default/test/files/'/home/tzz/source/cfengine/core/tests/acceptance/workdir/__10_files_01_create_perms-mode_cf/tmp/TEST.cfengine/13400'[7]: Mode-Value is not entirely within the system's allowed permissions (octal 170000) and will be filtered accordingly : 13400
2014-05-27T09:41:27-0400     info: /default/default/methods/'any'/default/test_run/methods/'any'/default/test/files/'/home/tzz/source/cfengine/core/tests/acceptance/workdir/__10_files_01_create_perms-mode_cf/tmp/TEST.cfengine/22222'[8]: Mode-Value is not entirely within the system's allowed permissions (octal 170000) and will be filtered accordingly : 22222
```
