### PR TITLE
Redmine#5986: fix to assume all non-specified return codes are failed

### DIFF
--- a/cf-agent/retcode.c
+++ b/cf-agent/retcode.c
@@ -69,9 +69,11 @@ int VerifyCommandRetcode(EvalContext *ctx, int retcode, Attributes a, const Prom
 
         if (!matched)
         {
-            Log(LOG_LEVEL_VERBOSE,
-                "Command related to promiser '%s' returned code %d -- did not match any failed, repaired or kept lists",
-                  pp->promiser, retcode);
+            cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_FAIL, pp, a,
+                 "Command related to promiser '%s' returned code not defined as promise kept, not kept or repaired; setting to failed: %d",
+                 pp->promiser, retcode);
+            *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
+            result_retcode = false;
         }
 
     }

--- a/tests/acceptance/00_basics/03_bodies/119.cf
+++ b/tests/acceptance/00_basics/03_bodies/119.cf
@@ -87,12 +87,12 @@ bundle agent check
   vars:
       "expect[promise_kept]" string        => "";
       "expect[promise_repaired]" string        => "";
-      "expect[repair_failed]" string        => "";
+      "expect[repair_failed]" string        => "ON";
       "expect[repair_denied]" string        => "";
       "expect[repair_timeout]" string        => "";
       "expect[cancel_kept]" string        => "ON";
       "expect[cancel_repaired]" string        => "ON";
-      "expect[cancel_notkept]" string        => "ON";
+      "expect[cancel_notkept]" string        => "";
 
       # Everything from here down is "boilerplate" to these 1xx.cf tests
       "lookfor" slist => {

--- a/tests/acceptance/00_basics/03_bodies/121.cf
+++ b/tests/acceptance/00_basics/03_bodies/121.cf
@@ -87,12 +87,12 @@ bundle agent check
   vars:
       "expect[promise_kept]" string        => "";
       "expect[promise_repaired]" string        => "";
-      "expect[repair_failed]" string        => "";
+      "expect[repair_failed]" string        => "ON";
       "expect[repair_denied]" string        => "";
       "expect[repair_timeout]" string        => "";
       "expect[cancel_kept]" string        => "ON";
       "expect[cancel_repaired]" string        => "ON";
-      "expect[cancel_notkept]" string        => "ON";
+      "expect[cancel_notkept]" string        => "";
 
       # Everything from here down is "boilerplate" to these 1xx.cf tests
       "lookfor" slist => {


### PR DESCRIPTION
see https://dev.cfengine.com/issues/5987

**When any of `kept/repaired/failed_returncodes` are specified**, any unspecified return codes are set to repaired.  This is the only way to preserve sanity, since in Unix convention there are far more error codes than success (which has only 0).
