### PR TITLE
Special handling of signals for cf-key.

### DIFF
--- a/cf-key/cf-key-functions.c
+++ b/cf-key/cf-key-functions.c
@@ -129,6 +129,8 @@ int TrustKey(const char* pubkey)
     return (ok? 0 : 1);
 }
 
+extern bool cf_key_interrupted;
+
 bool ShowHost(const char *hostkey, const char *address, bool incoming,
                      const KeyHostSeen *quality, void *ctx)
 {
@@ -144,7 +146,7 @@ bool ShowHost(const char *hostkey, const char *address, bool incoming,
            address, (ret != -1) ? hostname : "-",
            cf_strtimestamp_local(quality->lastseen, timebuf), hostkey);
 
-    return true;
+    return !cf_key_interrupted;
 }
 
 void ShowLastSeenHosts()

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -97,14 +97,20 @@ static const char *const HINTS[] =
 };
 
 /*****************************************************************************/
+
+bool cf_key_interrupted = false;
+
+static void handleSignal(int signum)
+{
+    cf_key_interrupted = true;
+
+    signal(signum, handleSignal);
+}
+
 static void ThisAgentInit(void)
 {
-    signal(SIGINT, HandleSignalsForAgent);
-    signal(SIGTERM, HandleSignalsForAgent);
-    signal(SIGHUP, SIG_IGN);
-    signal(SIGPIPE, SIG_IGN);
-    signal(SIGUSR1, HandleSignalsForAgent);
-    signal(SIGUSR2, HandleSignalsForAgent);
+    signal(SIGINT, handleSignal);
+    signal(SIGTERM, handleSignal);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Handle SIGINT and SIGTERM to set gobal flag that makes the
ShowHost callback return false, thus causing ScanLastSeenQuality break
out of the while loop and return cleanly.
