### PR TITLE
Changelog36 leakfixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,7 +18,7 @@
         - port argument in readtcp() and selectservers() may be a
           service name (e.g. "http", "pop3").
         - Enable source file in agent copy_from promises to be a relative path.
-	    - file "changes" reporting now reports with log level "notice", instead of "error".
+            - file "changes" reporting now reports with log level "notice", instead of "error".
         - process_results default to AND'ing of set attributes if not specified (Redmine #3224)
         - interface is now canonified in sys.hardware_mac[interface] to align with
           sys.ipv4[interface] (Redmine #3418)
@@ -29,8 +29,8 @@
         - including the same file multiple times in 'body control inputs' is not an error
         - portnumber in body copy_from now supports service names like
           "cfengine", "pop3" etc, check /etc/services for more.
-    	- The failsafe.cf policy, run on bootstrap and in some other
-    	  unusual cases, has been extracted from C code into libpromises/failsafe.cf
+        - The failsafe.cf policy, run on bootstrap and in some other
+          unusual cases, has been extracted from C code into libpromises/failsafe.cf
         - masterfiles
             - cf_promises_validated is now in JSON format
             - timestamp key is timestamp (sec since unix epoch) of last time validated
@@ -93,7 +93,7 @@
               "deny_keys". 
             - New "shortcut" attribute in bundle server access_rules used to
               dynamically expand non-absolute request paths.
-    	- masterfiles
+        - masterfiles
                 - standard library split: lib/3.5 (compatibility) and lib/3.6 (mainline)
                 - many standard library bundles and bodies, especially packages- and file-related,
                   were revised and fixed
@@ -103,15 +103,15 @@
                 - cf_promises_release_id contains the policy release ID which is the GIT HEAD SHA
                   if available or hash of tree
                 - a bunch'o'bundles to make starting with CFEngine easier:
-    		- file-related: file_mustache, file_mustache_jsonstring, file_tidy, dir_sync, file_copy,
+                - file-related: file_mustache, file_mustache_jsonstring, file_tidy, dir_sync, file_copy,
               file_link, file_hardlink, file_empty, file_make
-    		- packages-related: package_absent, package_present, package_latest,
+                - packages-related: package_absent, package_present, package_latest,
               package_specific_present, package_specific_absent, package_specific_latest, package_specific
-    		- XML-related: xml_insert_tree_nopath, xml_insert_tree, xml_set_value, xml_set_attribute
-    		- VCS-related: git_init, git_add, git_checkout, git_checkout_new_branch,
+                - XML-related: xml_insert_tree_nopath, xml_insert_tree, xml_set_value, xml_set_attribute
+                - VCS-related: git_init, git_add, git_checkout, git_checkout_new_branch,
               git_clean, git_stash, git_stash_and_clean, git_commit, git
-    		- process-related: process_kill
-    		- other: cmerge, url_ping, logrotate, prunedir
+                - process-related: process_kill
+                - other: cmerge, url_ping, logrotate, prunedir
         - New command line options for agent binaries
             - New options to cf-promises
                 - '--show-classes' and '--show-vars'
@@ -142,7 +142,7 @@
                 - 'getvariablemetatags' - returns list of meta tags for a variable
             - 'body file control' has an 'inputs' attribute to include library files and other
               dependencies
-	    - bundlesequences can be built with bundlesmatching() based on bundle name and tags
+            - bundlesequences can be built with bundlesmatching() based on bundle name and tags
         - New attributes in existing promise types and bodies
             - New option 'preserve_all_lines' for insert_type in insert_lines promises
             - Caching of expensive system functions to avoid multiple executions of
@@ -197,15 +197,15 @@
 
         Deprecations:
         - 'splitstring' - deprecated by 'string_split'
-    	- 'track_value'
-    	- 'skipverify'
+        - 'track_value'
+        - 'skipverify'
 
         Bug fixes: for a complete list of fixed bugs, see Redmine at https://cfengine.com/dev
         - various fixes in evaluation and variable resolution
         - Improve performance of list iteration (Redmine #1875)
         - Removed limitation of input length to internal buffer sizes
-	    - directories ending with "/" are not ignored
-	    - lsdir() always return a list now, never a scalar
+            - directories ending with "/" are not ignored
+            - lsdir() always return a list now, never a scalar
         - 'abortclasses' fixed to work in common bundles and other cases
         - namespaced 'edit_line' bundles now work (Redmine#3781)
         - lists are interpolated in correct order (Redmine#3122)


### PR DESCRIPTION
Record 3.6.0's copious leak fixes.
Also fix some hspace irregularity (using emacs M-x untabify).
Note that this is against 3.6.x, not master.
