### PR TITLE
provide a wrapper for obtaining solaris zoneid

### DIFF
--- a/libenv/zones.c
+++ b/libenv/zones.c
@@ -86,4 +86,18 @@ bool ForeignZone(char *s)
     return false;
 }
 
+int  CurrentZoneName(char *s)
+{
+    zoneid_t zid;
+    int ok = -1;
+
+    if ((zid = getzoneid()) < 0)
+    {
+        return ok;
+    }
+# ifdef HAVE_GETZONEID
+    ok = getzonenamebyid(zid, s, ZONENAME_MAX);
+# endif
+    return ok;
+}
 #endif // !__MINGW32__

--- a/libenv/zones.h
+++ b/libenv/zones.h
@@ -30,6 +30,7 @@
 #ifndef __MINGW32__
 bool IsGlobalZone();
 bool ForeignZone(char *s);
+int  CurrentZoneName(char *s);
 #endif
 
 #endif // ZONES_H


### PR DESCRIPTION
Part implementation of the changes required to provide a resolution to https://dev.cfengine.com/issues/3974
Small wrapper function to fill the zone name and provide a status on a solaris host. This change should be cherry-picked for 3.6.1 as this is the target version.
