### PR TITLE
extend Solaris ps output to include unrestricted command length and append zone info 

### DIFF
--- a/libenv/zones.c
+++ b/libenv/zones.c
@@ -52,7 +52,7 @@ bool ForeignZone(char *s)
 {
 // We want to keep the banner
 
-    if (strstr(s, "%CPU"))
+    if (strstr(s, "PID"))
     {
         return false;
     }
@@ -86,4 +86,18 @@ bool ForeignZone(char *s)
     return false;
 }
 
+int  CurrentZoneName(char *s)
+{
+    int ok = -1; 
+# ifdef HAVE_GETZONEID
+    zoneid_t zid;
+    if ((zid = getzoneid()) < 0)
+    {
+        return ok;
+    }
+
+    ok = getzonenamebyid(zid, s, ZONENAME_MAX);
+# endif
+    return ok;
+}
 #endif // !__MINGW32__

--- a/libenv/zones.h
+++ b/libenv/zones.h
@@ -30,6 +30,7 @@
 #ifndef __MINGW32__
 bool IsGlobalZone();
 bool ForeignZone(char *s);
+int  CurrentZoneName(char *s);
 #endif
 
 #endif // ZONES_H

--- a/libpromises/classes.c
+++ b/libpromises/classes.c
@@ -54,7 +54,7 @@ const char *const VPSCOMM[] =
     [PLATFORM_CONTEXT_HP] = "/bin/ps",                  /* hpux */
     [PLATFORM_CONTEXT_AIX] = "/bin/ps",                  /* aix */
     [PLATFORM_CONTEXT_LINUX] = "/bin/ps",                  /* linux */
-    [PLATFORM_CONTEXT_SOLARIS] = "/bin/ps",                  /* solaris */
+    [PLATFORM_CONTEXT_SOLARIS] = "/usr/ucb/ps",                  /* solaris */
     [PLATFORM_CONTEXT_FREEBSD] = "/bin/ps",                  /* freebsd */
     [PLATFORM_CONTEXT_NETBSD] = "/bin/ps",                  /* netbsd */
     [PLATFORM_CONTEXT_CRAYOS] = "/bin/ps",                  /* cray */
@@ -80,7 +80,7 @@ const char *const VPSOPTS[] =
     [PLATFORM_CONTEXT_HP] = "-ef",                      /* hpux */
     [PLATFORM_CONTEXT_AIX] =  "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args", /* aix */
     [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* linux */
-    [PLATFORM_CONTEXT_SOLARIS] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,pri,rss,nlwp,stime,time,args",  /* solaris */
+    [PLATFORM_CONTEXT_SOLARIS] = "auxlww",  /* solaris */
     [PLATFORM_CONTEXT_FREEBSD] = "auxw",                    /* freebsd */
     [PLATFORM_CONTEXT_NETBSD] = "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,start,time,args",  /* netbsd */
     [PLATFORM_CONTEXT_CRAYOS] = "-elyf",                    /* cray */

--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -29,12 +29,17 @@
 #include <conversion.h>
 #include <matching.h>
 #include <string_lib.h>
+#include <string.h>
 #include <item_lib.h>
 #include <pipes.h>
 #include <files_interfaces.h>
 #include <rlist.h>
 #include <policy.h>
 #include <zones.h>
+
+# ifdef HAVE_GETZONEID
+#define MAX_ZONENAME_SIZE 64
+# endif
 
 static int SelectProcRangeMatch(char *name1, char *name2, int min, int max, char **names, char **line);
 static bool SelectProcRegexMatch(const char *name1, const char *name2, const char *regex, char **colNames, char **line);
@@ -686,13 +691,6 @@ static void GetProcessColumnNames(char *proc, char **names, int *start, int *end
 #ifndef __MINGW32__
 static const char *GetProcessOptions(void)
 {
-    static char psopts[CF_BUFSIZE]; /* GLOBAL_R, no initialization needed */
-
-    if (IsGlobalZone())
-    {
-        snprintf(psopts, CF_BUFSIZE, "%s,zone", VPSOPTS[VSYSTEMHARDCLASS]);
-        return psopts;
-    }
 
 # ifdef __linux__
     if (strncmp(VSYSNAME.release, "2.4", 3) == 0)
@@ -753,6 +751,40 @@ static int ExtractPid(char *psentry, char **names, int *end)
 }
 
 #ifndef __MINGW32__
+int AppendZoneInfoSolaris(char **vbuff, int *max_size)
+{
+    size_t len = strlen(*vbuff) + MAX_ZONENAME_SIZE + 2;
+    if (len > *max_size)
+    {
+      char * new_buf = realloc(*vbuff, len);
+      if (!new_buf)
+      {
+	Log(LOG_LEVEL_ERR, "AppendZoneInfoSolaris(char **vbuff, int *max_size): Unable to reallocate vbuff.");
+	return -1;
+      }
+      *vbuff = new_buf;
+    }
+    
+    memmove(*vbuff + MAX_ZONENAME_SIZE + 1, *vbuff, strlen(*vbuff) + 1);
+      
+    if (strstr(*vbuff, "PID"))
+    {
+      sprintf(*vbuff, "%-*s", MAX_ZONENAME_SIZE, "ZONE");
+    }   
+    else
+    {
+       char zone[MAX_ZONENAME_SIZE];
+       if (CurrentZoneName(zone) < 0)
+       {
+           Log(LOG_LEVEL_ERR, "Unable to obtain zone name. (fread: %s)", GetErrorStr());
+	   return -1;
+       } 
+       sprintf(*vbuff, "%-*s", MAX_ZONENAME_SIZE, zone);     
+    }
+    
+    (*vbuff)[MAX_ZONENAME_SIZE] = ' '; 
+    return 0;
+}
 int LoadProcessTable(Item **procdata)
 {
     FILE *prp;
@@ -768,7 +800,14 @@ int LoadProcessTable(Item **procdata)
 
     const char *psopts = GetProcessOptions();
 
-    snprintf(pscomm, CF_MAXLINKSIZE, "%s %s", VPSCOMM[VSYSTEMHARDCLASS], psopts);
+    if ((strncmp(VSYSNAME.release, "5.11", 4) == 0) && (strncmp(VSYSNAME.sysname, "SunOS", 5) == 0 ))
+    {
+        snprintf(pscomm, CF_MAXLINKSIZE, "%s %s", "/usr/bin/ps", psopts);
+    }
+    else
+    {
+        snprintf(pscomm, CF_MAXLINKSIZE, "%s %s", VPSCOMM[VSYSTEMHARDCLASS], psopts);
+    }
 
     Log(LOG_LEVEL_VERBOSE, "Observe process table with %s", pscomm);
 
@@ -780,7 +819,7 @@ int LoadProcessTable(Item **procdata)
 
     size_t vbuff_size = CF_BUFSIZE;
     char *vbuff = xmalloc(vbuff_size);
-
+  
     for (;;)
     {
         ssize_t res = CfReadLine(&vbuff, &vbuff_size, prp);
@@ -791,24 +830,32 @@ int LoadProcessTable(Item **procdata)
                 Log(LOG_LEVEL_ERR, "Unable to read process list with command '%s'. (fread: %s)", pscomm, GetErrorStr());
                 cf_pclose(prp);
                 free(vbuff);
-                return false;
+                return -1;
             }
             else
             {
                 break;
             }
         }
-
-        for (sp = vbuff + strlen(vbuff) - 1; (sp > vbuff) && (isspace((int)*sp)); sp--)
+# ifdef HAVE_GETZONEID
+        if (IsGlobalZone())
         {
-            *sp = '\0';
+            if (AppendZoneInfoSolaris(&vbuff, &vbuff_size) < 0)
+            {
+                Log(LOG_LEVEL_ERR, "Unable to prepend Solaris Zone info");
+                return -1;
+            }
         }
 
         if (ForeignZone(vbuff))
         {
             continue;
         }
-
+# endif
+        for (sp = vbuff + strlen(vbuff) - 1; (sp > vbuff) && (isspace((int)*sp)); sp--)
+        {
+            *sp = '\0';
+        }
         AppendItem(procdata, vbuff, "");
     }
 


### PR DESCRIPTION
Commit contains these squashed commits:

commit 81f19834f5a8c889a3ca00e8054188253bc73c10
Author: Matthew Cattell matthew.cattell@cfengine.com
Date:   Fri Jun 20 00:43:27 2014 +0200

```
make sure zone header shows and ensure zone name appended to end of line
```

commit de8518c7fb75582063a26bcc4d6c5160d6ede1ac
Author: Matthew Cattell matthew.cattell@cfengine.com
Date:   Fri Jun 20 00:31:26 2014 +0200

```
add zones wrapper to get zone name
```

commit 8687a20ebd3750fff66c77e683b29138e1e60d10
Author: Matthew Cattell matthew.cattell@cfengine.com
Date:   Fri Jun 20 00:27:41 2014 +0200

```
add zone column to end of ps output
```
