### PR TITLE
mark tests as test_suppress_fail

### DIFF
--- a/tests/acceptance/05_processes/01_matching/004.cf
+++ b/tests/acceptance/05_processes/01_matching/004.cf
@@ -23,6 +23,10 @@ bundle agent init
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+       meta => { "redmine6215" };
+      
   processes:
       "\bcf-agent\b"
       process_count => test_no_such;

--- a/tests/acceptance/05_processes/01_matching/006.cf
+++ b/tests/acceptance/05_processes/01_matching/006.cf
@@ -23,6 +23,9 @@ bundle agent init
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+       meta => { "redmine6216" };
   processes:
       "\bcf-agent\b"
       process_count => test_no_such;

--- a/tests/acceptance/05_processes/01_matching/100.cf
+++ b/tests/acceptance/05_processes/01_matching/100.cf
@@ -23,6 +23,9 @@ bundle agent init
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+      meta => { "redmine6217" };
   processes:
       "-agent"
       process_count => test_no_such;

--- a/tests/acceptance/05_processes/01_matching/201.cf
+++ b/tests/acceptance/05_processes/01_matching/201.cf
@@ -23,6 +23,10 @@ bundle agent init
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+      meta => { "redmine6218" };
+      
   processes:
       ".*"
       process_count => test_range,

--- a/tests/acceptance/10_files/02_maintain/changes_depth_search.cf
+++ b/tests/acceptance/10_files/02_maintain/changes_depth_search.cf
@@ -89,6 +89,10 @@ subfile.same,N,New file found");
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+       meta => { "redmine6220" };
+      
   commands:
       "$(sys.cf_agent) -Dpass1 -Kf $(this.promise_filename).sub";
       "$(sys.cf_agent) -Dpass2 -Kf $(this.promise_filename).sub";

--- a/tests/acceptance/10_files/templating/timed/expired_edit_line_locks.cf
+++ b/tests/acceptance/10_files/templating/timed/expired_edit_line_locks.cf
@@ -10,6 +10,10 @@ body common control
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+      meta => { "redmine6214" };
+      
   commands:
       # Note, no -K, we are testing locks.
       "$(sys.cf_agent) -v -D AUTO,DEBUG -f $(this.promise_filename).sub"

--- a/tests/acceptance/16_cf-serverd/01_start/001.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/001.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_suppress_fail" string => "windows|sunos_5_10",
         meta => { "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/allow_path1_then_deny_path2_a.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/allow_path1_then_deny_path2_a.cf
@@ -7,6 +7,10 @@ body common control
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+      meta => { "redmine6224" };
+      
   methods:
       "any" usebundle => dcs_fini("$(G.testdir)/destination_file1");
       "any" usebundle => dcs_fini("$(G.testdir)/destination_file2");

--- a/tests/acceptance/16_cf-serverd/01_start/allow_path1_then_deny_path2_b.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/allow_path1_then_deny_path2_b.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "freebsd",
+      "test_suppress_fail" string => "freebsd|sunos_5_10",
         meta => { "redmine5224" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_ip.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_ip.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_suppress_fail" string => "windows|sunos_5_10",
         meta => { "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_shortcut.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_shortcut.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_suppress_fail" string => "windows|sunos_5_10",
         meta => { "redmine4822" };
 
   methods:

--- a/tests/acceptance/18_examples/ouputs/check_outputs.cf
+++ b/tests/acceptance/18_examples/ouputs/check_outputs.cf
@@ -34,6 +34,8 @@ bundle agent test
 {
   meta:
       "test_skip_unsupported" string => "windows";
+      "test_suppress_fail" string => "sunos_5_10",
+       meta => { "redmine6225" };
 
   vars:
       "examples" slist => { @(init.all_examples) };


### PR DESCRIPTION
Re-submission of pull request to mark acceptance test as test_suppress_fail on solaris 10.
