### PR TITLE
libpromises: non-literal strings must use fputs(), not fprintf()

### DIFF
--- a/libpromises/bootstrap.c
+++ b/libpromises/bootstrap.c
@@ -298,7 +298,7 @@ bool WriteBuiltinFailsafePolicyToPath(const char *filename)
         return false;
     }
 
-    fprintf(fout, bootstrap_content);
+    fputs(bootstrap_content, fout);
     fclose(fout);
 
     if (chmod(filename, S_IRUSR | S_IWUSR) == -1)


### PR DESCRIPTION
Previous take of commit 023f3d7629d041a had gcc with -Wformat-security
throw an error.
