### PR TITLE
Show supressed test in Fail results

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -445,11 +445,11 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
   fi
 
 
-  if [ "$RESULT" != Wait ] && [ "$RESULT" = "XFAIL" ]; then
+  if [ "$RESULT" = "XFAIL" ]; then
     echo "    <testcase name=\"$(basename $TEST)\"" >> "$XMLTMP"
     echo "              classname=\"$TEST $RESULT_MSG\"" >> "$XMLTMP"
     echo "              time=\"$(($TEST_END_TIME - $TEST_START_TIME)) seconds\">" >> "$XMLTMP"
-  else
+  elif [ "$RESULT" != Wait ]; then
     echo "    <testcase name=\"$(basename $TEST)\"" >> "$XMLTMP"
     echo "              classname=\"$TEST\"" >> "$XMLTMP"
     echo "              time=\"$(($TEST_END_TIME - $TEST_START_TIME)) seconds\">" >> "$XMLTMP"


### PR DESCRIPTION
add extra message in test classname , so that it visibly indicate the test that was failing was suppressed to go ahead for compilation, to be used by Junit extractor in jenkins as Junit-4 xdd used by jenkins does not have suppressed categories for test.
