### PR TITLE
fix unit test compile error

### DIFF
--- a/tests/unit/mon_processes_test.c
+++ b/tests/unit/mon_processes_test.c
@@ -1,5 +1,5 @@
 #include "test.h"
-
+#include "systype.h"
 #include "generic_agent.h"
 #include "item_lib.h"
 #include "mon.h"


### PR DESCRIPTION
include systype.h to fix compile error
