### PR TITLE
re-enable acceptance tests now they are passing

### DIFF
--- a/tests/acceptance/05_processes/01_matching/004.cf
+++ b/tests/acceptance/05_processes/01_matching/004.cf
@@ -23,10 +23,7 @@ bundle agent init
 
 bundle agent test
 {
-  meta:
-      "test_suppress_fail" string => "sunos_5_10",
-       meta => { "redmine6215" };
-      
+        
   processes:
       "\bcf-agent\b"
       process_count => test_no_such;

--- a/tests/acceptance/05_processes/01_matching/006.cf
+++ b/tests/acceptance/05_processes/01_matching/006.cf
@@ -23,9 +23,7 @@ bundle agent init
 
 bundle agent test
 {
-  meta:
-      "test_suppress_fail" string => "sunos_5_10",
-       meta => { "redmine6216" };
+
   processes:
       "\bcf-agent\b"
       process_count => test_no_such;

--- a/tests/acceptance/05_processes/01_matching/100.cf
+++ b/tests/acceptance/05_processes/01_matching/100.cf
@@ -23,9 +23,7 @@ bundle agent init
 
 bundle agent test
 {
-  meta:
-      "test_suppress_fail" string => "sunos_5_10",
-      meta => { "redmine6217" };
+  
   processes:
       "-agent"
       process_count => test_no_such;

--- a/tests/acceptance/05_processes/01_matching/201.cf
+++ b/tests/acceptance/05_processes/01_matching/201.cf
@@ -23,10 +23,7 @@ bundle agent init
 
 bundle agent test
 {
-  meta:
-      "test_suppress_fail" string => "sunos_5_10",
-      meta => { "redmine6218" };
-      
+        
   processes:
       ".*"
       process_count => test_range,

--- a/tests/acceptance/05_processes/01_matching/202.cf
+++ b/tests/acceptance/05_processes/01_matching/202.cf
@@ -23,10 +23,11 @@ bundle agent init
 
 bundle agent test
 {
+  
   meta:
       "test_suppress_fail" string => "windows",
         meta => { "redmine4747" };
-
+        
   processes:
       ".*"
       process_count => test_range,

--- a/tests/acceptance/10_files/02_maintain/changes_depth_search.cf
+++ b/tests/acceptance/10_files/02_maintain/changes_depth_search.cf
@@ -89,10 +89,7 @@ subfile.same,N,New file found");
 
 bundle agent test
 {
-  meta:
-      "test_suppress_fail" string => "sunos_5_10",
-       meta => { "redmine6220" };
-      
+        
   commands:
       "$(sys.cf_agent) -Dpass1 -Kf $(this.promise_filename).sub";
       "$(sys.cf_agent) -Dpass2 -Kf $(this.promise_filename).sub";

--- a/tests/acceptance/10_files/templating/timed/expired_edit_line_locks.cf
+++ b/tests/acceptance/10_files/templating/timed/expired_edit_line_locks.cf
@@ -10,10 +10,7 @@ body common control
 
 bundle agent test
 {
-  meta:
-      "test_suppress_fail" string => "sunos_5_10",
-      meta => { "redmine6214" };
-      
+        
   commands:
       # Note, no -K, we are testing locks.
       "$(sys.cf_agent) -v -D AUTO,DEBUG -f $(this.promise_filename).sub"

--- a/tests/acceptance/16_cf-serverd/01_start/001.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/001.cf
@@ -9,9 +9,9 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows|sunos_5_10",
+      "test_suppress_fail" string => "windows",
         meta => { "redmine4822" };
-
+        
   methods:
       "any" usebundle => dcs_fini("$(G.testdir)/destination_file");
       "any" usebundle => file_make("$(G.testdir)/source_file",

--- a/tests/acceptance/16_cf-serverd/01_start/008.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/008.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "solaris|windows",
+      "test_suppress_fail" string => "windows",
         meta => { "redmine5224", "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/011.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/011.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "solaris|windows",
+      "test_suppress_fail" string => "windows",
         meta => { "redmine5224", "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_ip.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_ip.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows|sunos_5_10",
+      "test_suppress_fail" string => "windows",
         meta => { "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_shortcut.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_shortcut.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows|sunos_5_10",
+      "test_suppress_fail" string => "windows",
         meta => { "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_md5_zero_length_file.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_md5_zero_length_file.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "freebsd|solaris|windows",
+      "test_suppress_fail" string => "freebsd|windows",
         meta => { "redmine5224", "redmine4822" };
 
   methods:


### PR DESCRIPTION
Various acceptance tests which had been marked as expected to fail are now passing. Removed the solaris meta tag from the - now - passing tests.
