### PR TITLE
Log messages from reports promises to event log on Windows.

### DIFF
--- a/libpromises/verify_reports.c
+++ b/libpromises/verify_reports.c
@@ -33,6 +33,7 @@
 #include <attributes.h>
 #include <communication.h>
 #include <locks.h>
+#include <logging.h>
 #include <string_lib.h>
 #include <misc_lib.h>
 #include <file_lib.h>
@@ -122,10 +123,14 @@ PromiseResult VerifyReportPromise(EvalContext *ctx, const Promise *pp)
 
 static void ReportToLog(const char *message)
 {
-    fprintf(stdout, "R: %s\n", message);
-#ifndef __MINGW32__
-    syslog(LOG_NOTICE, "R: %s", message);
-#endif
+    int report_size = strlen(message) + 4;
+    char *report_message = malloc(report_size);
+    xsnprintf(report_message, report_size, "R: %s", message);
+
+    fprintf(stdout, "%s\n", report_message);
+    LogToSystemLog(report_message, LOG_LEVEL_NOTICE);
+
+    free(report_message);
 }
 
 static void ReportToFile(const char *logfile, const char *message)

--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -43,8 +43,6 @@ typedef struct
 
 static LogLevel global_level = LOG_LEVEL_NOTICE; /* GLOBAL_X */
 
-static void LogToSystemLog(const char *msg, LogLevel level);
-
 static pthread_once_t log_context_init_once = PTHREAD_ONCE_INIT; /* GLOBAL_T */
 static pthread_key_t log_context_key; /* GLOBAL_T, initialized by pthread_key_create */
 
@@ -209,7 +207,7 @@ static int LogLevelToSyslogPriority(LogLevel level)
 
 }
 
-static void LogToSystemLog(const char *msg, LogLevel level)
+void LogToSystemLog(const char *msg, LogLevel level)
 {
     syslog(LogLevelToSyslogPriority(level), "%s", msg);
 }

--- a/libutils/logging.h
+++ b/libutils/logging.h
@@ -65,6 +65,11 @@ LogLevel LogGetGlobalLevel(void);
 void LoggingSetColor(bool enabled);
 
 /*
+ * Portable syslog()
+ */
+void LogToSystemLog(const char *msg, LogLevel level);
+
+/*
  * Portable strerror(errno)
  */
 const char *GetErrorStr(void);


### PR DESCRIPTION
Use portable LogToSystemLog function to that end.

Fixes Redmine #6315
