### PR TITLE
Revert recent dependency on libutils, use a simple ifdef instead

### DIFF
--- a/cf-upgrade/Makefile.am
+++ b/cf-upgrade/Makefile.am
@@ -2,12 +2,12 @@ sbin_PROGRAMS = cf-upgrade
 
 LIBS=
 CORE_LIBS=
-cf_upgrade_CPPFLAGS= -I$(top_srcdir)/libutils
+cf_upgrade_CPPFLAGS=
 cf_upgrade_CFLAGS = $(CORE_CFLAGS)
 cf_upgrade_LDFLAGS = $(LIBS) $(CORE_LIBS)
 
 
-cf_upgrade_SOURCES = $(top_srcdir)/libutils/platform.h \
+cf_upgrade_SOURCES = \
     alloc-mini.c alloc-mini.h \
     command_line.c command_line.h \
     configuration.c configuration.h \

--- a/cf-upgrade/log.c
+++ b/cf-upgrade/log.c
@@ -22,8 +22,6 @@
   included file COSL.txt.
 */
 
-#include <platform.h>
-
 #include <log.h>
 #include <alloc-mini.h>
 #include <time.h>
@@ -83,7 +81,11 @@ static void private_log_init()
     int log_fd = -1;
 
     strftime(path, sizeof(path), "cf-upgrade-%Y%m%d-%H%M%S.log", now_tm);
+#ifndef __MINGW32__
     log_fd = open(path, O_WRONLY|O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
+#else
+    log_fd = open(path, O_WRONLY|O_CREAT, S_IRUSR|S_IWUSR);
+#endif
     if (log_fd < 0)
     {
         puts("Could not initialize log file, only console messages will be printed");


### PR DESCRIPTION
Proper dependency tracking in our Makefiles needs re-organisation of
configure.ac and all makefiles, to be done.
