### PR TITLE
No longer ignore Linux virtual interfaces. Fixes redmine #1490, #3420

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -359,7 +359,7 @@ void GetInterfacesInfo(EvalContext *ctx)
             continue;
         }
 
-        /* Skip virtual network interfaces listed in ignore_interfaces.rx */
+        /* Skip network interfaces listed in ignore_interfaces.rx */
 
         if (IgnoreInterface(ifp->ifr_name))
         {


### PR DESCRIPTION
This fixes red mine bugs [#1490](https://dev.cfengine.com/issues/1490) and [#3420](https://dev.cfengine.com/issues/3420).

Regarding [this help-cfengine discussion about missing interfaces](https://groups.google.com/forum/m/#!topic/help-cfengine/3jEu9Jc3wek), and [Mark's comment](https://dev.cfengine.com/issues/1490#note-14) that there's no longer any reason to keep this.
