### PR TITLE
cf-upgrade should not close STDOUT of all forked commands

### DIFF
--- a/cf-upgrade/tests/good.sh
+++ b/cf-upgrade/tests/good.sh
@@ -1,3 +1,13 @@
-#!/bin/true
+#!/bin/sh
+
+# Exit with error on any failed command
+set -e
 
 
+echo running inside $0, arguments are: $@
+
+echo good.sh STDOUT
+echo good.sh STDERR >&2
+
+
+return 0

--- a/cf-upgrade/tests/pm.sh
+++ b/cf-upgrade/tests/pm.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 
+# Exit with error on any failed command
+set -e
+
+
+echo running inside $0, arguments are: $@
+
+echo pm.sh STDOUT
+echo pm.sh STDERR >&2
+
 FOLDER=$1
-mv $FOLDER/cf-upgrade-test $FOLDER/cf-upgrade-done
+# mv $FOLDER/cf-upgrade-test $FOLDER/cf-upgrade-done
+
 
 exit 0


### PR DESCRIPTION
Now both STDOUT and STDERR of forked commands go to STDOUT and STDERR of
cf-upgrade. Previously it was just closed and e.g. dpkg was failing
because of that.

Modify the test scripts to actually test that.
