### PR TITLE
use variables for grep and egrep to enable Solaris 11 acceptance tests

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -56,6 +56,16 @@ GREP_OPTIONS=
 export GREP_OPTIONS
 
 #
+# Specify GNU grep and egrep for solaris 11 to support the options being used in those
+#
+if [ `uname` == "SunOS" ] && [ `uname -v` == "11.0" ]; then
+  GREP=ggrep
+  EGREP=gegrep
+else
+  GREP=grep
+  EGREP=egrep
+fi
+
 # Defaults (overridden by command-line arguments)
 #
 LOG=test.log
@@ -90,7 +100,7 @@ TESTS_TIMED_REMAINING=0
 
 case "$OSTYPE" in
   msys)
-    if "$WHOAMI" -priv | grep SeTakeOwnershipPrivilege > /dev/null; then
+    if "$WHOAMI" -priv | $GREP SeTakeOwnershipPrivilege > /dev/null; then
       # Don't use elevate if we already have the privileges. It is slower and
       # pops up a flashing window for every single test.
       DEFAULT_GAINROOT=
@@ -120,7 +130,7 @@ SKIPPED_TESTS=0
 # and find Perl for the unix_seconds() routine below. (Mantis #1254)
 #
 HAVE_DATE_PCT_S=
-date +%s | grep %s >/dev/null 2>&1
+date +%s | $GREP %s >/dev/null 2>&1
 if [ $? -ne 0 ] ; then
   HAVE_DATE_PCT_S=1
 fi
@@ -258,7 +268,7 @@ runtest() {
     printf "$TEST "
   fi
 
-  if echo "$TEST" | grep -F -e .x.cf > /dev/null; then
+  if echo "$TEST" | $GREP -F -e .x.cf > /dev/null; then
     EXPECTED_CRASH=1
   else
     EXPECTED_CRASH=
@@ -267,16 +277,16 @@ runtest() {
   if [ "x$CRASHING_TESTS" = "x0" ] && [ "x$EXPECTED_CRASH" = "x1" ]; then
     SKIP=1
     SKIPREASON="${COLOR_WARNING}Crashing tests are disabled${COLOR_NORMAL}"
-  elif [ "x$STAGING_TESTS" = "x0" ] && echo "$TEST" | grep -e '/staging/' > /dev/null; then
+  elif [ "x$STAGING_TESTS" = "x0" ] && echo "$TEST" | $GREP -e '/staging/' > /dev/null; then
     SKIP=1
     SKIPREASON="${COLOR_WARNING}Staging tests are disabled${COLOR_NORMAL}"
-  elif [ "x$UNSAFE_TESTS" != "x1" ] && echo "$TEST" | grep -e '/unsafe/' > /dev/null; then
+  elif [ "x$UNSAFE_TESTS" != "x1" ] && echo "$TEST" | $GREP -e '/unsafe/' > /dev/null; then
     SKIP=1
     SKIPREASON="${COLOR_WARNING}Unsafe tests are disabled${COLOR_NORMAL}"
-  elif [ "x$NETWORK_TESTS" = "x0" ] && echo "$TEST" | grep -e '/network/' > /dev/null; then
+  elif [ "x$NETWORK_TESTS" = "x0" ] && echo "$TEST" | $GREP -e '/network/' > /dev/null; then
     SKIP=1
     SKIPREASON="${COLOR_WARNING}Network-dependent tests are disabled${COLOR_NORMAL}"
-  elif [ "x$LIBXML2_TESTS" = "x0" ] && echo "$TEST" | grep -e '/11_xml_edits/' > /dev/null; then
+  elif [ "x$LIBXML2_TESTS" = "x0" ] && echo "$TEST" | $GREP -e '/11_xml_edits/' > /dev/null; then
     SKIP=1
     SKIPREASON="XML file editing tests are disabled"
   else
@@ -316,7 +326,7 @@ runtest() {
         $LN_CMD "$CF_KEY" "$WORKDIR/bin"
       fi
     fi
-    if uname | grep MINGW > /dev/null; then
+    if uname | $GREP MINGW > /dev/null; then
         PLATFORM_WORKDIR="$(echo $WORKDIR | sed -e 's%^/\([a-cA-Z]\)/%\1:/%' | sed -e 's%/%\\%g')"
         DS="\\"
     else
@@ -333,14 +343,14 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
 " > "$WORKDIR/runtest"
 
     if [ "$GDB" = 1 ]; then
-      if grep libtool < "$AGENT" > /dev/null; then
+      if $GREP libtool < "$AGENT" > /dev/null; then
         printf "\"$LIBTOOL\" --mode=execute " >> "$WORKDIR/runtest"
       fi
       printf "gdb --args " >> "$WORKDIR/runtest"
     fi
 
     if [ -n "$USE_VALGRIND" ] && [ x"$EXPECTED_CRASH" = "x" ]; then
-      if grep libtool < "$AGENT" > /dev/null; then
+      if $GREP libtool < "$AGENT" > /dev/null; then
         printf "\"$LIBTOOL\" --mode=execute " >> "$WORKDIR/runtest"
       fi
       printf "valgrind ${VALGRIND_OPTS} \"$AGENT\" $VERBOSE -Kf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES} 2>&1\n" >> "$WORKDIR/runtest"
@@ -379,36 +389,36 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
       # Some states are output by dcs.cf.sub, therefore check for both TEST
       # prefix and dcs.cf.sub prefix.
       ESCAPED_TEST="$(echo "($TEST|dcs.cf.sub)" | sed -e 's/\./\\./g')"
-      if egrep -e "R: .*$ESCAPED_TEST XFAIL" $OUTFILE > /dev/null; then
+      if $EGREP -e "R: .*$ESCAPED_TEST XFAIL" $OUTFILE > /dev/null; then
         # Check for other test case outcomes than fail. Should not happen.
-        if egrep -e "R: .*$ESCAPED_TEST " $OUTFILE | egrep -v -e "R: .*$ESCAPED_TEST X?FAIL" > /dev/null; then
+        if $EGREP -e "R: .*$ESCAPED_TEST " $OUTFILE | $EGREP -v -e "R: .*$ESCAPED_TEST X?FAIL" > /dev/null; then
           RESULT=FAIL
           RESULT_MSG="${COLOR_FAILURE}FAIL (Tried to suppress nonexistent failure)${COLOR_NORMAL}"
         else
-          REDMINE="$(egrep -e "R: .*$ESCAPED_TEST XFAIL" $OUTFILE | sed -e "s,.*XFAIL/redmine\([0-9][0-9]*\).*,\1,")"
+          REDMINE="$($EGREP -e "R: .*$ESCAPED_TEST XFAIL" $OUTFILE | sed -e "s,.*XFAIL/redmine\([0-9][0-9]*\).*,\1,")"
           RESULT=XFAIL
           RESULT_MSG="${COLOR_WARNING}FAIL (Suppressed, Redmine #$REDMINE)${COLOR_NORMAL}"
         fi
-      elif egrep -e "R: .*$ESCAPED_TEST FAIL/no_redmine_number" $OUTFILE > /dev/null; then
+      elif $EGREP -e "R: .*$ESCAPED_TEST FAIL/no_redmine_number" $OUTFILE > /dev/null; then
         RESULT=FAIL
         RESULT_MSG="${COLOR_FAILURE}FAIL (Tried to suppress failure, but no Redmine issue number is provided)${COLOR_NORMAL}"
-      elif egrep -e "R: .*$ESCAPED_TEST Wait/[0-9]+" $OUTFILE > /dev/null; then
+      elif $EGREP -e "R: .*$ESCAPED_TEST Wait/[0-9]+" $OUTFILE > /dev/null; then
         if [ -z "$NEXT_TIMEOUT_VAR" ]; then
           RESULT=FAIL
           RESULT_MSG="${COLOR_FAILURE}FAIL (Test tried to wait but is not in \"timed\" directory)${COLOR_NORMAL}"
         else
-          WAIT_TIME=$(egrep -e "R: .*$ESCAPED_TEST Wait/[0-9]+" $OUTFILE | sed -e 's,.*Wait/\([0-9][0-9]*\).*,\1,')
+          WAIT_TIME=$($EGREP -e "R: .*$ESCAPED_TEST Wait/[0-9]+" $OUTFILE | sed -e 's,.*Wait/\([0-9][0-9]*\).*,\1,')
           eval $NEXT_TIMEOUT_VAR=$(($TEST_END_TIME+$WAIT_TIME))
           RESULT=Wait
           RESULT_MSG="Awaiting ($WAIT_TIME seconds)..."
         fi
-      elif egrep -e "R: .*$ESCAPED_TEST Pass" $OUTFILE > /dev/null; then
+      elif $EGREP -e "R: .*$ESCAPED_TEST Pass" $OUTFILE > /dev/null; then
         RESULT=Pass
         RESULT_MSG="${COLOR_SUCCESS}Pass${COLOR_NORMAL}"
-      elif egrep -e "R: .*$ESCAPED_TEST Skip/unsupported" $OUTFILE > /dev/null; then
+      elif $EGREP -e "R: .*$ESCAPED_TEST Skip/unsupported" $OUTFILE > /dev/null; then
         RESULT=Skip
         RESULT_MSG="${COLOR_WARNING}Skipped (No platform support)${COLOR_NORMAL}"
-      elif egrep -e "R: .*$ESCAPED_TEST Skip/needs_work" $OUTFILE > /dev/null; then
+      elif $EGREP -e "R: .*$ESCAPED_TEST Skip/needs_work" $OUTFILE > /dev/null; then
         RESULT=Skip
         RESULT_MSG="${COLOR_WARNING}Skipped (Test needs work)${COLOR_NORMAL}"
       else
@@ -573,7 +583,7 @@ while true; do
 done
 
 if [ "$OSTYPE" = "msys" ] && [ "$TESTALL_DO_NOT_RECURSE" != 1 ] &&
-    ! "$WHOAMI" -priv | grep SeTakeOwnershipPrivilege > /dev/null; then
+    ! "$WHOAMI" -priv | $GREP SeTakeOwnershipPrivilege > /dev/null; then
   # On Windows we run the entire test run under GAINROOT, because doing it for
   # each test is horribly slow.
   echo "export GAINROOT=" > runtests.sh
@@ -661,7 +671,7 @@ else
 fi
 
 for addtest in $ADDTESTS; do
-  if echo "$addtest" | grep -F "/timed/" > /dev/null; then
+  if echo "$addtest" | $GREP -F "/timed/" > /dev/null; then
     if [ "$TIMED_TESTS" = 1 ]; then
       eval TESTS_TIMED_$TEST_TIMED_INDEX="$addtest"
       eval TESTS_TIMEOUT_$TEST_TIMED_INDEX=0


### PR DESCRIPTION
Solaris 11 doesn't understand the grep options used in the test script. It doesn't have the posix xpg tools. Use GREP and EGREP variables and on Solaris 11, use the gnu tools.
