### PR TITLE
remove xfail on acceptance test for solaris 11

### DIFF
--- a/tests/acceptance/18_examples/ouputs/check_outputs.cf
+++ b/tests/acceptance/18_examples/ouputs/check_outputs.cf
@@ -34,7 +34,7 @@ bundle agent test
 {
   meta:
       "test_skip_unsupported" string => "windows";
-      "test_suppress_fail" string => "solaris",
+      "test_suppress_fail" string => "sunos_5_10|sunos_5_9", # need to re-test on solaris 8 and 10 but now passing on solaris 11
        meta => { "redmine6225" };
 
   vars:


### PR DESCRIPTION
re-enable 18_examples/ouputs/check_outputs.cf for solaris 11
