### PR TITLE
fix failing acceptance test by fixing ps opts

### DIFF
--- a/libpromises/systype.c
+++ b/libpromises/systype.c
@@ -92,8 +92,8 @@ const char *const VPSOPTS[] =
     [PLATFORM_CONTEXT_HP] = "-ef",                    /* hpux */
     [PLATFORM_CONTEXT_AIX] =  "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args",       /* aix */
     [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",        /* linux */
-    [PLATFORM_CONTEXT_SOLARIS] = "auxlww",     /* solaris >= 11 */
-    [PLATFORM_CONTEXT_SUN_SOLARIS] = "auxlww", /* solaris < 11 */
+    [PLATFORM_CONTEXT_SOLARIS] = "auxww",     /* solaris >= 11 */
+    [PLATFORM_CONTEXT_SUN_SOLARIS] = "auxww", /* solaris < 11 */
     [PLATFORM_CONTEXT_FREEBSD] = "auxw",              /* freebsd */
     [PLATFORM_CONTEXT_NETBSD] = "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,start,time,args",   /* netbsd */
     [PLATFORM_CONTEXT_CRAYOS] = "-elyf",              /* cray */


### PR DESCRIPTION
Make solaris ps options bsd compliant so that the user field is present in ps output.
