### PR TITLE
A fix and an improvement to contrib/reindent.pl

### DIFF
--- a/contrib/reindent.pl
+++ b/contrib/reindent.pl
@@ -56,6 +56,7 @@ foreach my $f (@ARGV)
                '--eval' => "(set-variable 'indent-tabs-mode nil)",
                # '--eval' => '(untabify (point-min) (point-max))',
                '--eval' => '(indent-region (point-min) (point-max) nil)',
+               '--eval' => '(delete-trailing-whitespace)',
                '--eval' => '(save-some-buffers t)');
     }
     else


### PR DESCRIPTION
I found myself adding tabs as indentation, which wasn't what I wanted; so fixed the script to disable indent-tabs-mode.  I was tempted to also untabify everywhere, but decided to leave that as a comment.
Purging dangling hspace at the same time seems a sensible bonus feature for this script, so I added it.
Hoping @tzz can still review this ...
