### PR TITLE
re enable mon_processes_test for solaris

### DIFF
--- a/tests/unit/mon_processes_test.c
+++ b/tests/unit/mon_processes_test.c
@@ -78,10 +78,6 @@ static bool GetSysUsers( int *userListSz, int *numRootProcs, int *numOtherProcs)
 
 void test_processes_monitor(void)
 {
-#if defined(__sun)
-    // Redmine #6316.
-    return;
-#endif
 
     double cf_this[100] = { 0.0 };
     MonProcessesGatherData(cf_this);


### PR DESCRIPTION
This test is now passing after changes to the ps options for solaris.
