### PR TITLE
disable acceptance tests failing on solaris

### DIFF
--- a/tests/acceptance/01_vars/03_lists/016.cf
+++ b/tests/acceptance/01_vars/03_lists/016.cf
@@ -23,7 +23,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "hpux|windows",
+      "test_suppress_fail" string => "hpux|windows|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine4745", "redmine4963" };
 
 files:

--- a/tests/acceptance/05_processes/01_matching/004.cf
+++ b/tests/acceptance/05_processes/01_matching/004.cf
@@ -23,6 +23,9 @@ bundle agent init
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_11|sunos_5_10|sunos_5_9",
+        meta => { "redmine6340" };
         
   processes:
       "\bcf-agent\b"

--- a/tests/acceptance/05_processes/01_matching/006.cf
+++ b/tests/acceptance/05_processes/01_matching/006.cf
@@ -23,7 +23,10 @@ bundle agent init
 
 bundle agent test
 {
-
+  meta:
+      "test_suppress_fail" string => "sunos_5_11|sunos_5_10|sunos_5_9",
+        meta => { "redmine6341" };
+        
   processes:
       "\bcf-agent\b"
       process_count => test_no_such;

--- a/tests/acceptance/05_processes/01_matching/100.cf
+++ b/tests/acceptance/05_processes/01_matching/100.cf
@@ -23,7 +23,10 @@ bundle agent init
 
 bundle agent test
 {
-  
+  meta:
+      "test_suppress_fail" string => "sunos_5_11|sunos_5_10|sunos_5_9",
+        meta => { "redmine6342" };
+        
   processes:
       "-agent"
       process_count => test_no_such;

--- a/tests/acceptance/05_processes/01_matching/201.cf
+++ b/tests/acceptance/05_processes/01_matching/201.cf
@@ -23,7 +23,9 @@ bundle agent init
 
 bundle agent test
 {
-        
+  meta:
+      "test_suppress_fail" string => "sunos_5_11|sunos_5_10|sunos_5_9",
+        meta => { "redmine6343" };
   processes:
       ".*"
       process_count => test_range,

--- a/tests/acceptance/06_storage/01_local/001.cf
+++ b/tests/acceptance/06_storage/01_local/001.cf
@@ -24,7 +24,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "sunos_5_10",
+      "test_suppress_fail" string => "sunos_5_10|sunos_5_11",
         meta => { "redmine5234" };
 
   vars:

--- a/tests/acceptance/10_files/02_maintain/changes_depth_search.cf
+++ b/tests/acceptance/10_files/02_maintain/changes_depth_search.cf
@@ -89,7 +89,9 @@ subfile.same,N,New file found");
 
 bundle agent test
 {
-        
+  meta:
+      "test_suppress_fail" string => "sunos_5_11",
+        meta => { "redmine6344" };  
   commands:
       "$(sys.cf_agent) -Dpass1 -Kf $(this.promise_filename).sub";
       "$(sys.cf_agent) -Dpass2 -Kf $(this.promise_filename).sub";

--- a/tests/acceptance/10_files/02_maintain/line_truncation_at_4096_chars.cf
+++ b/tests/acceptance/10_files/02_maintain/line_truncation_at_4096_chars.cf
@@ -44,6 +44,8 @@ bundle agent init
 bundle agent test
 {
   meta:
+      "test_suppress_fail" string => "sunos_5_11",
+       meta => { "redmine6345" };
       "test_skip_unsupported" string => "windows";
 
   files:

--- a/tests/acceptance/14_reports/00_output/002.cf
+++ b/tests/acceptance/14_reports/00_output/002.cf
@@ -20,7 +20,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "hpux|windows",
+      "test_suppress_fail" string => "hpux|windows|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine4745", "redmine4963" };
 
   vars:

--- a/tests/acceptance/16_cf-serverd/01_start/007.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/007.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_suppress_fail" string => "windows|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/010.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/010.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "freebsd|windows",
+      "test_suppress_fail" string => "freebsd|windows|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine5224", "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_ip_and_shortcut.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_ip_and_shortcut.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_suppress_fail" string => "windows|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_shortcut.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_shortcut.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_suppress_fail" string => "windows|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_encrypted_md5_zero_length_file.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_encrypted_md5_zero_length_file.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_suppress_fail" string => "windows|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/simple_copy_from_admit_localhost.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/simple_copy_from_admit_localhost.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_suppress_fail" string => "windows|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine4822" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/simple_copy_from_deny_localhost.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/simple_copy_from_deny_localhost.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_suppress_fail" string => "windows|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine4822" };
 
   methods:


### PR DESCRIPTION
Disable remaining acceptance tests which still fail when tested on solaris.
