### PR TITLE
remove xfail from acceptance test

### DIFF
--- a/tests/acceptance/01_vars/02_functions/network/008.cf
+++ b/tests/acceptance/01_vars/02_functions/network/008.cf
@@ -23,9 +23,6 @@ bundle agent init
 
 bundle agent test
 {
-  meta:
-      "test_suppress_fail" string => "sunos_5_10",
-        meta => { "redmine5222" };
 
   vars:
       # Neither of these are likely to change...


### PR DESCRIPTION
This test is now passing on Solaris 10. Removed xfail.
