### PR TITLE
fix failing acceptance test and remove suppression sol11

### DIFF
--- a/tests/acceptance/10_files/02_maintain/line_truncation_at_4096_chars.cf
+++ b/tests/acceptance/10_files/02_maintain/line_truncation_at_4096_chars.cf
@@ -44,8 +44,6 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "sunos_5_11",
-       meta => { "redmine6345" };
       "test_skip_unsupported" string => "windows";
 
   files:

--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -32,6 +32,7 @@ bundle common G
     solaris::
       "paths[usr_xpg4_bin]" string           => "/usr/xpg4/bin";
       "paths[usr_ucb_sparcv7]" string        => "/usr/ucb/sparcv7";
+      "paths[opt_csw_bin]" string            => "/opt/csw/bin";
     !windows::
       "paths[bin]" string                    => "/bin";
       "paths[usr_bin]" string                => "/usr/bin";


### PR DESCRIPTION
Add the path for /opt/csw/perl to dcf.cf.sub and comment out suppression of test 10_files/02_maintain/line_truncation_at_4096_chars.cf for solaris 11
