### PR TITLE
Fix potential hang in unit/logging_timestamp_test

### DIFF
--- a/tests/unit/logging_timestamp_test.c
+++ b/tests/unit/logging_timestamp_test.c
@@ -17,6 +17,7 @@ static void test_timestamp_regex(void)
     // Make stderr point to the pipe.
     assert_int_equal(dup2(pipe_fd[1], 2), 2);
     Log(LOG_LEVEL_ERR, "Test string");
+    fputc('\n', stderr); /* Make sure fgets() doesn't hang. */
     fflush(stderr);
     fflush(stdout);
     // Restore stdout.


### PR DESCRIPTION
If Log() fails to deliver even one newline, the fgets() later in the
test shall hang indefinitely.  So make sure we send a newline to
stderr after the Log(), to prevent that.  This shouldn't affect the
validity of the timestamp in what's sent before ...

This change is a pre-requisite for Mark's logging changes, but
is in any case desirable to make the test robust, so that it fails
promply rather than hanging a build slave if someone breaks it.
