### PR TITLE
Only ignore existing matches if preserve_all_lines is used

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -1648,9 +1648,10 @@ static int InsertCompoundLineAtLocation(EvalContext *ctx, char *chunk, Item **st
     bool retval = false;
     char buf[CF_EXPANDSIZE];
     char *sp;
-    int preserve_block = a.sourcetype && (strcmp(a.sourcetype, "preserve_all_lines") == 0 || strcmp(a.sourcetype, "preserve_block") == 0 || strcmp(a.sourcetype, "file_preserve_block") == 0);
+    int preserve_all_lines = a.sourcetype && strcmp(a.sourcetype, "preserve_all_lines") == 0;
+    int preserve_block = a.sourcetype && (preserve_all_lines || strcmp(a.sourcetype, "preserve_block") == 0 || strcmp(a.sourcetype, "file_preserve_block") == 0);
 
-    if (!preserve_block && MatchRegion(ctx, chunk, location, NULL, false))
+    if (!preserve_all_lines && MatchRegion(ctx, chunk, location, NULL, false))
     {
         cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a, "Promised chunk '%s' exists within selected region of %s (promise kept)", pp->promiser, edcontext->filename);
         return false;

--- a/tests/acceptance/10_files/09_insert_lines/block_insert_duplicate.cf
+++ b/tests/acceptance/10_files/09_insert_lines/block_insert_duplicate.cf
@@ -1,0 +1,73 @@
+#######################################################
+#
+# Insert lines at the top of file a multi-line header, 
+# verify that insertion is convergent - Redmine #1525
+#
+#######################################################
+
+body common control
+{
+	inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "header" string => "###############
+### This file is managed by CFEngine 
+### Do not update it manually, oh no
+### do not
+###############";
+
+  files:
+      "$(G.testfile).expected"
+      create => "true",
+      edit_line => insert_header;
+
+  commands:
+     !windows::
+      "$(G.echo)"
+        args    => "\"${init.header}\" > \"$(G.testfile).actual\"",
+        contain => in_shell;
+     windows:: # newlines in shell are not handled properly on Windows...
+      "$(G.printf)"
+        args => '"###############\n### This file is managed by CFEngine\n### Do not update it manually, oh no\n### do not\n###############\n" > "$(G.testfile).actual"',
+        contain => in_shell;
+}
+
+#######################################################
+
+bundle agent test
+{
+  files:
+      "$(G.testfile).actual"
+      create => "true",
+      edit_line => insert_header;
+}
+
+bundle edit_line insert_header
+{
+  insert_lines:
+    "${init.header}"
+      location => start,
+      insert_type => "preserve_block";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => dcs_check_diff("$(G.testfile).actual",
+                                        "$(G.testfile).expected",
+                                        "$(this.promise_filename)");
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 27
+


### PR DESCRIPTION
That option is documented to disable convergence, while preserve_block
should respect existing occurances of the promiser within the selected
region.

Redmine #1525
