### PR TITLE
Set not-kept classes when promise should be repaired, but is warn-only

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -246,14 +246,14 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a,
 
     if (DONTDO && (!a.contain.preview))
     {
-        Log(LOG_LEVEL_ERR, "Would execute script '%s'", cmdline);
+        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a, "Would execute script '%s'", cmdline);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
         return ACTION_RESULT_OK;
     }
 
     if (a.transaction.action != cfa_fix)
     {
-        Log(LOG_LEVEL_ERR, "Command '%s' needs to be executed, but only warning was promised", cmdline);
+        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a, "Command '%s' needs to be executed, but only warning was promised", cmdline);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
         return ACTION_RESULT_OK;
     }

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -3523,7 +3523,7 @@ bool CfCreateFile(EvalContext *ctx, char *file, const Promise *pp, Attributes at
         }
         else
         {
-            Log(LOG_LEVEL_ERR, "Warning promised, need to create directory '%s'", file);
+            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "Warning promised, need to create directory '%s'", file);
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
             return false;
         }
@@ -3567,7 +3567,7 @@ bool CfCreateFile(EvalContext *ctx, char *file, const Promise *pp, Attributes at
         }
         else
         {
-            Log(LOG_LEVEL_ERR, "Warning promised, need to create file '%s'", file);
+            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "Warning promised, need to create file '%s'", file);
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
             return false;
         }

--- a/tests/acceptance/02_classes/01_basic/action_policy_warn_sets_classes.cf
+++ b/tests/acceptance/02_classes/01_basic/action_policy_warn_sets_classes.cf
@@ -23,11 +23,27 @@ bundle agent init
 
 bundle agent test
 {
+   files:
+      "/tmp/dont_create_me"
+         create  => 'true',
+         classes => classes_generic( "test_files" ),
+         action  => warnonly;
+
+   commands:
+      "$(G.echo) 'dont_print_me'"
+         classes =>  classes_generic( "test_commands" ),
+         action  => warnonly;
+
+   processes:
+      "cf-agent-x"
+         restart_class => "restart_cf_agent",
+         classes       => classes_generic( "test_processes" ),
+         action        => warnonly;
+
   reports:
-    cfengine::
       "Test output"
-      classes => if_else("kept", "needs_repair"),
-      action => warnonly;
+         classes => classes_generic("test_reports"),
+         action => warnonly;
 }
 
 body action warnonly
@@ -39,13 +55,24 @@ body action warnonly
 
 bundle agent check
 {
-  classes:
-      "ok" expression => "needs_repair";
+   vars:
+      "classes" slist => classesmatching( "test_.*" );
+
+   classes:
+      "ok" and => {
+         "test_files_not_kept",
+         "test_commands_not_kept",
+         "test_processes_not_kept",
+         "test_reports_not_kept" 
+      };
 
   reports:
     ok::
       "$(this.promise_filename) Pass";
     !ok::
       "$(this.promise_filename) FAIL";
+
+    debug::
+      "$(classes)";
 }
 


### PR DESCRIPTION
There are probably more cases where Log instead of cfPS is used and
that are not covered by this fix, but this covers the immedate
issues as reported and covered by the test case.

Test case originally submitted as https://github.com/cfengine/core/pull/1311,
but merging here with the already existing test case.

See Redmine #2359.
