### PR TITLE
Only respect CFENGINE_COLOR environment if we are on a console.

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1409,7 +1409,7 @@ GenericAgentConfig *GenericAgentConfigNewDefault(AgentType agent_type)
     config->tty_interactive = isatty(0) && isatty(1);
 
     const char *color_env = getenv("CFENGINE_COLOR");
-    config->color = (color_env && 0 == strcmp(color_env, "1"));
+    config->color = config->tty_interactive && (color_env && 0 == strcmp(color_env, "1"));
 
     config->bundlesequence = NULL;
 


### PR DESCRIPTION
Otherwise we spam syslog and other targets with ANSI codes.

Redmine #5388
