### PR TITLE
remove extraneous output from ps on solaris

### DIFF
--- a/libpromises/systype.c
+++ b/libpromises/systype.c
@@ -92,8 +92,8 @@ const char *const VPSOPTS[] =
     [PLATFORM_CONTEXT_HP] = "-ef",                    /* hpux */
     [PLATFORM_CONTEXT_AIX] =  "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args",       /* aix */
     [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss:9,nlwp,stime,time,args",        /* linux */
-    [PLATFORM_CONTEXT_SOLARIS] = "auxww",     /* solaris >= 11 */
-    [PLATFORM_CONTEXT_SUN_SOLARIS] = "auxww", /* solaris < 11 */
+    [PLATFORM_CONTEXT_SOLARIS] = "axww",     /* solaris >= 11 */
+    [PLATFORM_CONTEXT_SUN_SOLARIS] = "axww", /* solaris < 11 */
     [PLATFORM_CONTEXT_FREEBSD] = "auxw",              /* freebsd */
     [PLATFORM_CONTEXT_NETBSD] = "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,start,time,args",   /* netbsd */
     [PLATFORM_CONTEXT_CRAYOS] = "-elyf",              /* cray */


### PR DESCRIPTION
ps output columns are used to generate column indices on the ps output. the ucb ps command doesn't do a very good job of separating numeric strings that are too long, with the consequence that the column count is screwed up as columns with adjacent long digit strings are concatenated into one, resulting in incorrect matching (the assumption is made that at least a space is separating columns). This patch eliminates the unused columns, retaining PID and COMMAND, as used by cf-agent with processes promises. ps axww is now the argument string for ps on Solaris.
