### PR TITLE
Call service methods even in dry-run mode.

### DIFF
--- a/cf-agent/verify_services.c
+++ b/cf-agent/verify_services.c
@@ -264,10 +264,7 @@ static PromiseResult DoVerifyServices(EvalContext *ctx, Attributes a, const Prom
     }
 
     PromiseResult result = PROMISE_RESULT_NOOP;
-    if (!DONTDO)
-    {
-        result = PromiseResultUpdate(result, VerifyMethod(ctx, call, a, pp));  // Send list of classes to set privately?
-    }
+    result = PromiseResultUpdate(result, VerifyMethod(ctx, call, a, pp));  // Send list of classes to set privately?
 
     RvalDestroy(call);
 


### PR DESCRIPTION
Otherwise the promises inside the method are not evaluated at all,
and no insight is provided into whether cf-agent would have modified
the system.

Since the promises then respect DRYRUN mode, nothing will changed
on the system.

If action_policy is set to warn_only, the methods promise will
respect that and not evaluate the bundle.

This follows up on commit 65c15626992d608eaa51ca3d47b6ccf4e8058576.

See Redmine #5924
