### PR TITLE
Redmine #6370: Discard call collect connection.

### DIFF
--- a/cf-serverd/server_classic.c
+++ b/cf-serverd/server_classic.c
@@ -1519,7 +1519,6 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
         if ((len >= sizeof(out)) || (received != (len + CF_PROTO_OFFSET)))
         {
             Log(LOG_LEVEL_INFO, "Decrypt error CALL_ME_BACK");
-            RefuseAccess(conn, "decrypt error CALL_ME_BACK");
             return true;
         }
 
@@ -1529,14 +1528,12 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
         if (strncmp(recvbuffer, "CALL_ME_BACK collect_calls", strlen("CALL_ME_BACK collect_calls")) != 0)
         {
             Log(LOG_LEVEL_INFO, "CALL_ME_BACK protocol defect");
-            RefuseAccess(conn, "decryption failure");
             return false;
         }
 
         if (!LiteralAccessControl(ctx, recvbuffer, conn, true))
         {
             Log(LOG_LEVEL_INFO, "Query access failure");
-            RefuseAccess(conn, recvbuffer);
             return false;
         }
 

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -1029,7 +1029,6 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
         {
             Log(LOG_LEVEL_INFO,
                 "access denied to Call-Collect, check the ACL for class: collect_calls");
-            RefuseAccess(conn, recvbuffer);
             return false;
         }
 


### PR DESCRIPTION
Instead of sending "BAD: Unspecified server refusal
(see verbose server output)" message to the call collected client
which is not having access to call collect simply refuse connection.

Message sent to the client is interpreted as a call collect queue
length and client assumes that connection is valid.
