### PR TITLE
remove non-existent failures and add failing acceptance tests

### DIFF
--- a/tests/acceptance/01_vars/03_lists/016.cf
+++ b/tests/acceptance/01_vars/03_lists/016.cf
@@ -23,7 +23,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "hpux|windows|sunos_5_11|sunos_5_10|sunos_5_9",
+      "test_suppress_fail" string => "hpux|windows|sunos_5_11|sunos_5_9",
         meta => { "redmine4745", "redmine4963" };
 
 files:

--- a/tests/acceptance/10_files/08_field_edits/set_empty_field_erroneous_message.cf
+++ b/tests/acceptance/10_files/08_field_edits/set_empty_field_erroneous_message.cf
@@ -15,6 +15,10 @@ body common control
 
 bundle agent check
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+        meta => { "redmine6469" };
+        
   methods:
       "" usebundle => file_make($(G.testfile), "root:sikrt:16104::::::");
       "" usebundle => dcs_passif_output("",

--- a/tests/acceptance/10_files/09_insert_lines/nothing_to_repeat_error.cf
+++ b/tests/acceptance/10_files/09_insert_lines/nothing_to_repeat_error.cf
@@ -15,6 +15,9 @@ body common control
 
 bundle agent check
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+        meta => { "redmine6470"};
   methods:
       "" usebundle => dcs_passif_output("",
                                         ".*nothing to repeat.*",

--- a/tests/acceptance/14_reports/00_output/002.cf
+++ b/tests/acceptance/14_reports/00_output/002.cf
@@ -20,7 +20,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "hpux|windows|sunos_5_11|sunos_5_10|sunos_5_9",
+      "test_suppress_fail" string => "hpux|windows|sunos_5_11|sunos_5_9",
         meta => { "redmine4745", "redmine4963" };
 
   vars:

--- a/tests/acceptance/16_cf-serverd/01_start/001.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/001.cf
@@ -8,6 +8,9 @@ body common control
 
 bundle agent test
 {
+meta:
+      "test_suppress_fail" string => "sunos_5_10",
+        meta => { "redmine6471" };
   methods:
       "any" usebundle => dcs_fini("$(G.testdir)/destination_file");
       "any" usebundle => file_make("$(G.testdir)/source_file",

--- a/tests/acceptance/16_cf-serverd/01_start/004.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/004.cf
@@ -8,6 +8,9 @@ body common control
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+        meta => { "redmine6472" };
   methods:
       "any" usebundle => dcs_fini("$(G.testdir)/destination_file");
       "any" usebundle => file_make("$(G.testdir)/source_file",

--- a/tests/acceptance/16_cf-serverd/01_start/008.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/008.cf
@@ -8,6 +8,9 @@ body common control
 
 bundle agent test
 {
+meta:
+      "test_suppress_fail" string => "sunos_5_10",
+        meta => { "redmine6473" };
   methods:
       "any" usebundle => dcs_fini("$(G.testdir)/destination_file");
       "any" usebundle => file_make("$(G.testdir)/source_file",

--- a/tests/acceptance/16_cf-serverd/01_start/011.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/011.cf
@@ -8,6 +8,9 @@ body common control
 
 bundle agent test
 {
+meta:
+      "test_suppress_fail" string => "sunos_5_10",
+        meta => { "redmine6474" };
   methods:
       "any" usebundle => dcs_fini("$(G.testdir)/destination_file");
       "any" usebundle => file_make("$(G.testdir)/source_file",

--- a/tests/acceptance/16_cf-serverd/01_start/allow_path1_then_deny_path2_b.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/allow_path1_then_deny_path2_b.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "freebsd|sunos_5_10",
+      "test_suppress_fail" string => "freebsd",
         meta => { "redmine6406" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different.cf
@@ -8,6 +8,9 @@ body common control
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+        meta => { "redmine6475" };
   methods:
       "any" usebundle => file_make("$(G.testdir)/source_file",
                                    "Source and Destination are DIFFERENT_A");

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_ip.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_ip.cf
@@ -8,6 +8,9 @@ body common control
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+       meta => { "redmine6476" };
   methods:
       "any" usebundle => file_make("$(G.testdir)/127.0.0.1.txt",
                                    "Source and Destination are different_A");

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_expand_ip_directory.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_expand_ip_directory.cf
@@ -15,6 +15,9 @@ bundle agent init
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_10",
+        meta => { "redmine6476" };
   methods:
       "any" usebundle => file_make("$(G.testdir)/127.0.0.1_DIR1/ADMIT_FILE",
                                    "ADMIT_FILE A CONTENTS");

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_md5_zero_length_file.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_md5_zero_length_file.cf
@@ -9,8 +9,8 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "freebsd",
-        meta => { "redmine6406" };
+      "test_suppress_fail" string => "freebsd|sunos_5_10",
+        meta => { "redmine6406", redmine6476 };
 
   methods:
       "any" usebundle => dcs_fini("$(G.testdir)/destination_file");

--- a/tests/acceptance/16_cf-serverd/01_start/simple_copy_from_deny_localhost.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/simple_copy_from_deny_localhost.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows|sunos_5_11|sunos_5_10|sunos_5_9",
+      "test_suppress_fail" string => "windows|sunos_5_11|sunos_5_9",
         meta => { "redmine6405", "redmine6406" };
 
   methods:


### PR DESCRIPTION
Re-enable acceptance tests which now pass and document those which fail on Solaris 10.
