### PR TITLE
redmine6476: Aborting on low entropy is too drastic.

### DIFF
--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -133,8 +133,14 @@ static void RandomSeed(void)
 
         if (RAND_status() != 1)
         {
+#if 0 /* FIXME: We really are in trouble here !  But aborting is too drastic. */
             UnexpectedError("Low entropy! "
                             "Please report which platform you are using.");
+#else
+            Log(LOG_LEVEL_ERR,
+                "Failed to scavenge enough entropy! "
+                "Please report which platform you are using.");
+#endif
         }
     }
 }


### PR DESCRIPTION
Rather than reverting the whole commit involved, keep what we can of
it and Log() instead of UnexpectedError(), at least until Jimis can
invent some better way to respond to this.

Proposed as a less drastic alternative to #1887.
