### PR TITLE
Pass the path to pcre.h to the compiler

### DIFF
--- a/cf-execd/Makefile.am
+++ b/cf-execd/Makefile.am
@@ -6,6 +6,7 @@ AM_CPPFLAGS = \
 	-I$(srcdir)/../libutils \
 	-I$(srcdir)/../libcfnet \
 	-I$(srcdir)/../libenv \
+	$(PCRE_CPPFLAGS) \
 	$(ENTERPRISE_CPPFLAGS)
 
 AM_CFLAGS = \

--- a/cf-monitord/Makefile.am
+++ b/cf-monitord/Makefile.am
@@ -6,6 +6,7 @@ AM_CPPFLAGS = \
 	-I$(srcdir)/../libcfnet \
 	-I$(srcdir)/../libenv \
 	-I$(srcdir)/../libpromises \
+	$(PCRE_CPPFLAGS) \
 	$(ENTERPRISE_CPPFLAGS)
 
 AM_CFLAGS = @CFLAGS@ \

--- a/cf-promises/Makefile.am
+++ b/cf-promises/Makefile.am
@@ -2,6 +2,7 @@ noinst_LTLIBRARIES = libcf-promises.la
 
 AM_CPPFLAGS = @CPPFLAGS@ -I$(srcdir)/../libpromises -I$(srcdir)/../libutils -I$(srcdir)/../libcfnet \
 	$(OPENSSL_CPPFLAGS) \
+	$(PCRE_CPPFLAGS) \
 	$(ENTERPRISE_CPPFLAGS)
 
 AM_CFLAGS = @CFLAGS@ -I$(srcdir) \

--- a/cf-runagent/Makefile.am
+++ b/cf-runagent/Makefile.am
@@ -3,6 +3,7 @@ noinst_LTLIBRARIES = libcf-runagent.la
 AM_CPPFLAGS = -I$(srcdir)/../libpromises -I$(srcdir)/../libutils \
 	-I$(srcdir)/../libcfnet \
 	$(OPENSSL_CPPFLAGS) \
+	$(PCRE_CPPFLAGS) \
 	$(ENTERPRISE_CPPFLAGS)
 
 AM_CFLAGS = @CFLAGS@ \

--- a/cf-serverd/Makefile.am
+++ b/cf-serverd/Makefile.am
@@ -4,6 +4,7 @@ AM_CPPFLAGS = -I$(srcdir)/../libpromises -I$(srcdir)/../libutils \
 	-I$(srcdir)/../libcfnet \
 	-I$(srcdir)/../libenv \
 	$(OPENSSL_CPPFLAGS) \
+	$(PCRE_CPPFLAGS) \
 	$(ENTERPRISE_CPPFLAGS)
 
 AM_CFLAGS = \

--- a/libcfnet/Makefile.am
+++ b/libcfnet/Makefile.am
@@ -1,6 +1,7 @@
 noinst_LTLIBRARIES = libcfnet.la
 
 AM_CPPFLAGS  = $(OPENSSL_CPPFLAGS)
+AM_CPPFLAGS  = $(PCRE_CPPFLAGS)
 AM_CPPFLAGS += -I$(top_srcdir)/libutils			    # platform.h
 AM_CPPFLAGS += -I$(top_srcdir)/libpromises		    # cf3.defs.h
 

--- a/libenv/Makefile.am
+++ b/libenv/Makefile.am
@@ -13,6 +13,7 @@ endif
 
 AM_CPPFLAGS  = -I$(top_srcdir)/libutils
 AM_CPPFLAGS += $(OPENSSL_CPPFLAGS)	     # because libutils needs it
+AM_CPPFLAGS += $(PCRE_CPPFLAGS)
 
 # Those dependencies are ought to go away ASAP
 AM_CPPFLAGS += -I$(top_srcdir)/libcfnet


### PR DESCRIPTION
This is necessary to build cfengine 3.6.1 on FreeBSD with the tarball provided on the source downloads page.

In the cfengine36 port on FreeBSD, we work around this by just adding the path to CPPFLAGS in the top level makefile but it would nice to be able to compile the port from source
