### PR TITLE
Include type definitions when declaring functions that use them.

### DIFF
--- a/libpromises/prototypes3.h
+++ b/libpromises/prototypes3.h
@@ -25,6 +25,7 @@
 #ifndef CFENGINE_PROTOTYPES3_H
 #define CFENGINE_PROTOTYPES3_H
 
+#include <cf3.defs.h>
 #include <compiler.h>
 #include <enterprise_extension.h>
 


### PR DESCRIPTION
A header should not reference a type for which it doesn't provide a
declaration, ideally via the appropriate other header.  I wanted to
call cf_closesocket but pulling in the header that provides it gave me
compiler errors because of references to undefined types in functions
I wasn't interested in.
