### PR TITLE
redmine6524: Fix for test of mustache's rendering of quotes.

### DIFF
--- a/tests/acceptance/10_files/templating/mustache_render_quote.cf.expected
+++ b/tests/acceptance/10_files/templating/mustache_render_quote.cf.expected
@@ -1,2 +1,6 @@
+# Escaped variable references by default:
+Something &quot;special&quot; with quotes
+Something 'special' with quotes
+# Unescaped variable references:
 Something "special" with quotes
 Something 'special' with quotes

--- a/tests/acceptance/10_files/templating/mustache_render_quote.cf.mustache
+++ b/tests/acceptance/10_files/templating/mustache_render_quote.cf.mustache
@@ -1,2 +1,6 @@
+# Escaped variable references by default:
 {{vars.init.variable_containing_double_quote}}
 {{vars.init.variable_containing_single_quote}}
+# Unescaped variable references:
+{{&vars.init.variable_containing_double_quote}}
+{{&vars.init.variable_containing_single_quote}}


### PR DESCRIPTION
The test expected variable expansion to be unescaped, but it's escaped
by default; it needs an & at the start of the variable name to
suppress escaping.  I've duly expanded the test to test both escaped
and unescaped variable expansion.

This is a fixup for PR #1898
