### PR TITLE
Make process_select by priority work on FreeBSD.

### DIFF
--- a/libpromises/mod_process.c
+++ b/libpromises/mod_process.c
@@ -42,7 +42,11 @@ static const ConstraintSyntax process_select_constraints[] =
     ConstraintSyntaxNewIntRange("pid", CF_VALRANGE, "Range of integers matching the process id of a process", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewIntRange("pgid", CF_VALRANGE, "Range of integers matching the parent group id of a process", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewIntRange("ppid", CF_VALRANGE, "Range of integers matching the parent process id of a process", SYNTAX_STATUS_NORMAL),
+#if defined (__FreeBSD__)
+    ConstraintSyntaxNewIntRange("priority", "-100,+155", "Range of integers matching the priority field (PRI/NI) of a process", SYNTAX_STATUS_NORMAL),
+#else
     ConstraintSyntaxNewIntRange("priority", "-20,+20", "Range of integers matching the priority field (PRI/NI) of a process", SYNTAX_STATUS_NORMAL),
+#endif
     ConstraintSyntaxNewStringList("process_owner", "", "List of regexes matching the user of a process", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("process_result",
      "[(process_owner|pid|ppid||pgid|rsize|vsize|status|command|ttime|stime|tty|priority|threads)[|&!.]*]*",

--- a/libpromises/systype.c
+++ b/libpromises/systype.c
@@ -94,7 +94,7 @@ const char *const VPSOPTS[] =
     [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss:9,nlwp,stime,time,args",        /* linux */
     [PLATFORM_CONTEXT_SOLARIS] = "auxww",     /* solaris >= 11 */
     [PLATFORM_CONTEXT_SUN_SOLARIS] = "auxww", /* solaris < 11 */
-    [PLATFORM_CONTEXT_FREEBSD] = "auxw",              /* freebsd */
+    [PLATFORM_CONTEXT_FREEBSD] = "axwwo user,pid,ppid,pgid,pcpu,pmem,vsz,pri,rss,nlwp,start,time,args",  /* freebsd */
     [PLATFORM_CONTEXT_NETBSD] = "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,start,time,args",   /* netbsd */
     [PLATFORM_CONTEXT_CRAYOS] = "-elyf",              /* cray */
     [PLATFORM_CONTEXT_WINDOWS_NT] = "-aW",            /* NT */


### PR DESCRIPTION
  Ref: http://lkc.me/5P

Wanted something like and (auto-nice daemon), but would also operate on processes owned by root.  So, tried to have a CFEngine policy, additional had it make some things even nicer by moving them into the idle priority class.  Which meant looking at PRI, since NI isn't meaningful for processes above or below the normal user range.

IE: the processes's NI value stayed the same after it is moved into the idle priority class, so the promise to move matching processes into the idle priority class would never converge.  Opted to not expose and parse the rtprio field from ps....  but rather have process_priority() work on PRI.