### PR TITLE
suppress failing and unsuppress now passing acceptance tests

### DIFF
--- a/tests/acceptance/16_cf-serverd/01_start/007.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/007.cf
@@ -7,11 +7,7 @@ body common control
 }
 
 bundle agent test
-{
-  meta:
-      "test_suppress_fail" string => "sunos_5_11|sunos_5_10|sunos_5_9",
-        meta => { "redmine6406" };
-
+{ 
   methods:
       "any" usebundle => dcs_fini("$(G.testdir)/destination_file");
       "any" usebundle => file_make("$(G.testdir)/source_file",

--- a/tests/acceptance/16_cf-serverd/01_start/allow_path1_then_deny_path2_a.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/allow_path1_then_deny_path2_a.cf
@@ -7,6 +7,9 @@ body common control
 
 bundle agent test
 {
+  meta:
+      "test_suppress_fail" string => "sunos_5_11|sunos_5_10|sunos_5_9",
+        meta => { "redmine6406" };   
         
   methods:
       "any" usebundle => dcs_fini("$(G.testdir)/destination_file1");

--- a/tests/acceptance/16_cf-serverd/01_start/allow_path1_then_deny_path2_b.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/allow_path1_then_deny_path2_b.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "freebsd",
+      "test_suppress_fail" string => "freebsd|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine6406" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_ip_and_shortcut.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_ip_and_shortcut.cf
@@ -8,7 +8,10 @@ body common control
 
 bundle agent test
 {
-  
+  meta:
+      "test_suppress_fail" string => "sunos_5_11|sunos_5_10|sunos_5_9",
+        meta => { "redmine6406" };
+        
   methods:
       "any" usebundle => file_make("$(G.testdir)/127.0.0.1.txt",
                                    "Source and Destination are different_A");

--- a/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_shortcut.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/copy_from_digest_different_expand_shortcut.cf
@@ -8,10 +8,7 @@ body common control
 
 bundle agent test
 {
-  meta:
-      "test_suppress_fail" string => "sunos_5_11|sunos_5_10|sunos_5_9",
-        meta => { "redmine6406" };
-
+ 
   methods:
       "any" usebundle => file_make("$(G.testdir)/source_file",
                                    "Source and Destination are DIFFERENT_A");

--- a/tests/acceptance/16_cf-serverd/01_start/simple_copy_from_admit_localhost.cf
+++ b/tests/acceptance/16_cf-serverd/01_start/simple_copy_from_admit_localhost.cf
@@ -9,7 +9,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_suppress_fail" string => "windows|sunos_5_11|sunos_5_10|sunos_5_9",
         meta => { "redmine6405", "redmine6406" };
 
   methods:


### PR DESCRIPTION
Redmine #6406
16_serverd/01_start/007.cf is now unsuppressed as it now passes
16_serverd/01_start/010.cf is still failing so is still suppressed
16_serverd/01_start/allow_path1_then_deny_path2_a.cf was not suppressed and is still failing so has now been suppressed
16_serverd/01_start/allow_path1_then_deny_path2_b.cf was not suppressed and is still failing so has now been suppressed
16_serverd/01_start/copy_from_digest_different_expand_ip_and_shortcut.cf is failing and has now been suppressed
16_serverd/01_start/copy_from_digest_different_expand_shortcut.cf is now unsuppressed as it now passes
16_serverd/01_start/copy_from_encrypted_md5_zero_length_file.cf is still failing so is still suppressed
16_serverd/01_start/simple_copy_from_admit_localhost.cf is now failing so has been suppressed
16_serverd/01_start/16_serverd/01_start/simple_copy_from_deny_localhost.cf is passing and is not suppressed
