### PR TITLE
classic protocol could not handle shortcuts. Is necessary for bootstrap

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ Cfengine Propulsion Lab
         - "ifvarclass" now has "if" as an alias
         - Fix error messages/ hanndling in process signalling which no longer allowed any signals to fail silently
         - Fix output format
+        - Also enable shortcut keyword for cf-serverd classic protocol, eg to simplify the  bootstrap process for clients that have
+          different sys.masterdir settings (Redmine #3697)
 
 3.6.1
         New features:

--- a/cf-serverd/server_classic.c
+++ b/cf-serverd/server_classic.c
@@ -1172,7 +1172,7 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
 
         zret = ShortcutsExpand(filename, sizeof(filename),
             SV.path_shortcuts,
-            conn->ipaddr, conn->revdns,
+            conn->ipaddr, conn->hostname,
             KeyPrintableHash(ConnectionInfoKey(conn->conn_info)));
 
         if (zret == (size_t) -1)
@@ -1240,7 +1240,7 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
 
         zret = ShortcutsExpand(filename, sizeof(filename),
             SV.path_shortcuts,
-            conn->ipaddr, conn->revdns,
+            conn->ipaddr, conn->hostname,
             KeyPrintableHash(ConnectionInfoKey(conn->conn_info)));
 
         if (zret == (size_t) -1)
@@ -1296,7 +1296,7 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
 
         zret = ShortcutsExpand(filename, sizeof(filename),
             SV.path_shortcuts,
-            conn->ipaddr, conn->revdns,
+            conn->ipaddr, conn->hostname,
             KeyPrintableHash(ConnectionInfoKey(conn->conn_info)));
 
         if (zret == (size_t) -1)
@@ -1321,7 +1321,7 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
 
         zret = ShortcutsExpand(filename, sizeof(filename),
             SV.path_shortcuts,
-            conn->ipaddr, conn->revdns,
+            conn->ipaddr, conn->hostname,
             KeyPrintableHash(ConnectionInfoKey(conn->conn_info)));
 
         if (zret == (size_t) -1)
@@ -1392,7 +1392,7 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
 
         zret = ShortcutsExpand(filename, sizeof(filename),
             SV.path_shortcuts,
-            conn->ipaddr, conn->revdns,
+            conn->ipaddr, conn->hostname,
             KeyPrintableHash(ConnectionInfoKey(conn->conn_info)));
 
         if (zret == (size_t) -1)
@@ -1454,7 +1454,7 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
 
         zret = ShortcutsExpand(filename, sizeof(filename),
             SV.path_shortcuts,
-            conn->ipaddr, conn->revdns,
+            conn->ipaddr, conn->hostname,
             KeyPrintableHash(ConnectionInfoKey(conn->conn_info)));
 
         if (zret == (size_t) -1)


### PR DESCRIPTION
see redmine: https://dev.cfengine.com/issues/3697
