### PR TITLE
Change: Update test to use alternate unescape form

### DIFF
--- a/tests/acceptance/10_files/templating/mustache_render_quote.cf.expected
+++ b/tests/acceptance/10_files/templating/mustache_render_quote.cf.expected
@@ -1,2 +1,8 @@
+# Escaped variable references by default:
+Something &quot;special&quot; with quotes
+Something 'special' with quotes
+# Unescaped variable references:
+Something "special" with quotes
+Something 'special' with quotes
 Something "special" with quotes
 Something 'special' with quotes

--- a/tests/acceptance/10_files/templating/mustache_render_quote.cf.mustache
+++ b/tests/acceptance/10_files/templating/mustache_render_quote.cf.mustache
@@ -1,2 +1,8 @@
+# Escaped variable references by default:
 {{vars.init.variable_containing_double_quote}}
 {{vars.init.variable_containing_single_quote}}
+# Unescaped variable references:
+{{&vars.init.variable_containing_double_quote}}
+{{&vars.init.variable_containing_single_quote}}
+{{{vars.init.variable_containing_double_quote}}}
+{{{vars.init.variable_containing_single_quote}}}


### PR DESCRIPTION
The mustache spec allows variables to be inside of `{{{`. This extends the
test to cover that style in addition to including the characters to not
escape.
