### PR TITLE
Change: Add alternate unescape form to mustache render quotes test

### DIFF
--- a/tests/acceptance/10_files/templating/mustache_render_quote.cf.expected
+++ b/tests/acceptance/10_files/templating/mustache_render_quote.cf.expected
@@ -4,3 +4,5 @@ Something 'special' with quotes
 # Unescaped variable references:
 Something "special" with quotes
 Something 'special' with quotes
+Something "special" with quotes
+Something 'special' with quotes

--- a/tests/acceptance/10_files/templating/mustache_render_quote.cf.mustache
+++ b/tests/acceptance/10_files/templating/mustache_render_quote.cf.mustache
@@ -4,3 +4,5 @@
 # Unescaped variable references:
 {{&vars.init.variable_containing_double_quote}}
 {{&vars.init.variable_containing_single_quote}}
+{{{vars.init.variable_containing_double_quote}}}
+{{{vars.init.variable_containing_single_quote}}}


### PR DESCRIPTION
The mustache spec allows variables to be inside of `{{{`. This extends the
test to cover that style in addition to including the characters to not
escape.
