### PR TITLE
Don't freeaddrinfo(3) response2 as it may not be initialized

### DIFF
--- a/libcfnet/net.c
+++ b/libcfnet/net.c
@@ -247,7 +247,6 @@ int SocketConnect(const char *host, const char *port,
                         "Unable to lookup interface '%s' to bind. (getaddrinfo: %s)",
                         BINDINTERFACE, gai_strerror(ret2));
 
-                    freeaddrinfo(response2);
                     freeaddrinfo(response);
                     cf_closesocket(sd);
                     return -1;


### PR DESCRIPTION
In the case where the second getaddrinfo(3) fails, the error condition
should _not_ call freeaddrinfo(3), as response2 has not been initialized
yet.

It looks like we came across this case in 3.6.1:

```
#0  __libc_free (mem=0x40) at malloc.c:3714
3714      if (chunk_is_mmapped(p))                       /* release mmapped
memory. */
Missing separate debuginfos, use: debuginfo-install
cfengine-community-3.6.1-1.x86_64
(gdb) bt
#0  __libc_free (mem=0x40) at malloc.c:3714
#1  0x00000036206cf8e0 in freeaddrinfo (ai=0x2b4110) at
../sysdeps/posix/getaddrinfo.c:2608
#2  0x00007f76b865b168 in SocketConnect (host=0xdf5590
"<redacted>", port=0x7f76b87c14c0 "5308",
connect_timeout=30,
    force_ipv4=false, txtaddr=0x7fffba237850 "172.17.210.24",
txtaddr_size=<value optimized out>) at net.c:250
#3  0x00007f76b865c894 in ServerConnection (server=0xdf5590
"<redacted>", port=0x7f76b87c14c0 "5308",
connect_timeout=30,
    flags=..., err=0x7fffba23823c) at client_code.c:258
#4  0x000000000041a8f4 in ScheduleCopyOperation ()
#5  0x0000000000414557 in VerifyFilePromise ()
#6  0x000000000041484a in FindAndVerifyFilesPromises ()
#7  0x000000000040fbc1 in KeepAgentPromise ()
#8  0x00007f76b8629125 in ExpandPromiseAndDo (ctx=0xcb4960, pp=<value
optimized out>, ActOnPromise=0x40f7a0 <KeepAgentPromise>, param=0x0) at
expand.c:207
#9  ExpandPromise (ctx=0xcb4960, pp=<value optimized out>,
ActOnPromise=0x40f7a0 <KeepAgentPromise>, param=0x0) at expand.c:161
#10 0x000000000040ff4a in ScheduleAgentOperations ()
#11 0x000000000041ec2e in VerifyMethod ()
#12 0x000000000041f151 in VerifyMethodsPromise ()
#13 0x000000000040fbb1 in KeepAgentPromise ()
#14 0x00007f76b8629125 in ExpandPromiseAndDo (ctx=0xcb4960, pp=<value
optimized out>, ActOnPromise=0x40f7a0 <KeepAgentPromise>, param=0x0) at
expand.c:207
#15 ExpandPromise (ctx=0xcb4960, pp=<value optimized out>,
ActOnPromise=0x40f7a0 <KeepAgentPromise>, param=0x0) at expand.c:161
#16 0x000000000040ff4a in ScheduleAgentOperations ()
#17 0x00000000004106d5 in KeepPromises ()
#18 0x0000000000411888 in main ()
(gdb) frame 1
#1  0x00000036206cf8e0 in freeaddrinfo (ai=0x2b4110) at
../sysdeps/posix/getaddrinfo.c:2608
2608          free (p->ai_canonname);
(gdb) print p->ai_canonname
$1 = 0x40 <Address 0x40 out of bounds>
```
