### PR TITLE
Conform to revised coding style for do { ... } while (...);

### DIFF
--- a/cf-agent/verify_files_hashes.c
+++ b/cf-agent/verify_files_hashes.c
@@ -96,8 +96,7 @@ int CompareBinaryFiles(const char *file1, const char *file2, struct stat *sstat,
                 close(fd1);
                 return true;
             }
-        }
-        while (bytes1 > 0);
+        } while (bytes1 > 0);
 
         close(fd2);
         close(fd1);

--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -1372,8 +1372,7 @@ static size_t StringReplace(char *buf, size_t buf_size,
 
         buf_idx = buf_newidx + find_len;
         p = strstr(&buf[buf_idx], find);
-    }
-    while (p != NULL);
+    } while (p != NULL);
 
     /* Copy leftover plus terminating '\0'. */
     size_t leftover_len = buf_len - buf_idx;

--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -869,12 +869,10 @@ static void NewHostToOldACL(Auth *old, const char *host)
             do
             {
                 dot++; /* Step over prior dot. */
-            }
-            while (dot[0] == '.'); /* Treat many dots as one. */
+            } while (dot[0] == '.'); /* Treat many dots as one. */
             extra++; /* For a backslash before the dot */
             dot = strchr(dot, '.');
-        }
-        while (dot);
+        } while (dot);
 
         char regex[strlen(host) + extra], *dst = regex;
         dst++[0] = '.';
@@ -891,8 +889,7 @@ static void NewHostToOldACL(Auth *old, const char *host)
             do /* Step over prior dot(s), as before. */
             {
                 dot++;
-            }
-            while (dot[0] == '.');
+            } while (dot[0] == '.');
 
             /* Identify next fragment: */
             const char *d = strchr(dot, '.');
@@ -904,8 +901,7 @@ static void NewHostToOldACL(Auth *old, const char *host)
 
             /* Advance: */
             dot = d;
-        }
-        while (dot);
+        } while (dot);
 
         /* Terminate: */
         assert(dst < regex + sizeof(regex));

--- a/cf-upgrade/update.c
+++ b/cf-upgrade/update.c
@@ -62,7 +62,8 @@ int private_copy_to_temporary_location(const char *source, const char *destinati
     }
     char buffer[1024];
     int so_far = 0;
-    do {
+    do
+    {
         int this_read = 0;
         int this_write = 0;
         this_read = read(source_fd, buffer, sizeof(buffer));
@@ -87,6 +88,7 @@ int private_copy_to_temporary_location(const char *source, const char *destinati
         }
         so_far += this_read;
     } while (so_far < source_stat.st_size);
+
     fsync(destination_fd);
     close(source_fd);
     close(destination_fd);
@@ -152,8 +154,7 @@ int private_copy_to_temporary_location(const char *source, const char *destinati
                 goto bad_twofd;
             }
         }
-    }
-    while (this_read > 0);
+    } while (this_read > 0);
 
     assert(this_read == 0);
     if (so_far != source_stat.st_size)

--- a/libcfnet/classic.c
+++ b/libcfnet/classic.c
@@ -127,8 +127,7 @@ int SendSocketStream(int sd, const char buffer[CF_BUFSIZE], int tosend)
         }
 
         already += sent;
-    }
-    while (already < tosend);
+    } while (already < tosend);
 
     return already;
 }

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -701,8 +701,7 @@ int TLSRecvLines(SSL *ssl, char *buf, size_t buf_size)
             return -1;
         }
         got += ret;
-    }
-    while ((buf[got-1] != '\n') && (got < buf_size));
+    } while ((buf[got-1] != '\n') && (got < buf_size));
     assert(got <= buf_size);
 
     /* Append '\0', there is room because buf_size has been decremented. */

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -354,9 +354,10 @@ void DetectDomainName(EvalContext *ctx, const char *orig_nodename)
 
         ptr = strchr(ptr, '.');
         if (ptr != NULL)
+        {
             ptr++;
-    }
-    while (ptr != NULL);
+        }
+    } while (ptr != NULL);
 
     EvalContextClassPutHard(ctx, VUQNAME, "source=agent,derived-from=sys.uqhost");
     EvalContextClassPutHard(ctx, VDOMAIN, "source=agent,derived-from=sys.domain");

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1790,7 +1790,8 @@ static FnCallResult FnCallReadTcp(ARG_UNUSED EvalContext *ctx,
         int sent = 0;
         int result = 0;
         size_t length = strlen(sendstring);
-        do {
+        do
+        {
             result = send(sd, sendstring, length, 0);
             if (result < 0)
             {

--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -563,8 +563,7 @@ static int SplitProcLine(const char *proc,
                 do
                 {
                     np++;
-                }
-                while (isdigit((unsigned char) np[0]));
+                } while (isdigit((unsigned char) np[0]));
                 ep = np;
             }
         }

--- a/libutils/hash.c
+++ b/libutils/hash.c
@@ -175,7 +175,8 @@ Hash *HashNewFromDescriptor(const int descriptor, HashMethod method)
     Hash *hash = HashBasicInit(method);
     context = EVP_MD_CTX_create();
     EVP_DigestInit_ex(context, md, NULL);
-    do {
+    do
+    {
         read_count = read(descriptor, buffer, 1024);
         EVP_DigestUpdate(context, buffer, (size_t) read_count);
     } while (read_count > 0);

--- a/tests/unit/parsemode_test.c
+++ b/tests/unit/parsemode_test.c
@@ -22,7 +22,8 @@ void test_mode(void)
     mode_t minus = 0;
 
     int mode = 0;
-    do {
+    do
+    {
 	ret = ParseModeString(modes[mode].string, &plus, &minus);
 	assert_true(ret);
 	assert_int_equal(modes[mode].plus, plus);
@@ -50,7 +51,8 @@ void test_validation(void)
     mode_t plus = 0;
 
     int mode = 0;
-    do {
+    do
+    {
        ret = ParseModeString( validation_modes[mode].string, &plus, &minus);
        assert_int_equal(validation_modes[mode].valid, ret);
     } while (validation_modes[mode++].string);

--- a/tests/unit/tls_generic_test.c
+++ b/tests/unit/tls_generic_test.c
@@ -328,7 +328,8 @@ static void child_mainloop(int channel)
         int received = 0;
         int sent = 0;
         char buffer[4096];
-        do {
+        do
+        {
             received = SSL_read(ssl, buffer, 4096);
             if (received < 0)
             {
@@ -1223,7 +1224,8 @@ static void test_TLSVerifyPeer(void)
     /*
      * Shutting down is not as easy as it seems.
      */
-    do {
+    do
+    {
         result = SSL_shutdown(ssl);
         assert_int_not_equal(-1, result);
     } while (result != 1);


### PR DESCRIPTION
Spacing change only: put the opening { on a line of its own, not after
the do, so that it lines up with the closing }; and put the while on
the same line as the closing, so as to make clear that we're not
looking at a while (...) { /\* empty */ } written as while (...);

Did also include one blank line for clarity of reading.
... and braces, required by our coding standard, round the one-line body of an if inside the do-while's block.
