### PR TITLE
Reload HA configuration when policy is changed.

### DIFF
--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -405,6 +405,10 @@ static void CheckFileChanges(EvalContext *ctx, Policy **policy, GenericAgentConf
             time_t t = SetReferenceTime();
             UpdateTimeClasses(ctx, t);
             *policy = LoadPolicy(ctx, config);
+
+            /* Reload HA related configuration */
+            ReloadHAConfig();
+
             KeepPromises(ctx, *policy, config);
             Summarize();
         }

--- a/libpromises/enterprise_stubs.c
+++ b/libpromises/enterprise_stubs.c
@@ -234,6 +234,10 @@ ENTERPRISE_VOID_FUNC_1ARG_DEFINE_STUB(void, SetMeasurementPromises, ARG_UNUSED I
 {
 }
 
-ENTERPRISE_VOID_FUNC_2ARG_DEFINE_STUB(void, CheckAndSetHAState, const char *, workdir, EvalContext *, ctx)
+ENTERPRISE_VOID_FUNC_2ARG_DEFINE_STUB(void, CheckAndSetHAState, ARG_UNUSED const char *, workdir, ARG_UNUSED EvalContext *, ctx)
+{
+}
+
+ENTERPRISE_VOID_FUNC_0ARG_DEFINE_STUB(void, ReloadHAConfig)
 {
 }

--- a/libpromises/prototypes3.h
+++ b/libpromises/prototypes3.h
@@ -86,6 +86,7 @@ ENTERPRISE_VOID_FUNC_3ARG_DECLARE(void, GetObservable, int, i, char *, name, cha
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, SetMeasurementPromises, Item **, classlist);
 
 ENTERPRISE_VOID_FUNC_2ARG_DECLARE(void, CheckAndSetHAState, const char *, workdir, EvalContext *, ctx);
+ENTERPRISE_VOID_FUNC_0ARG_DECLARE(void, ReloadHAConfig);
 
 /* manual.c */
 


### PR DESCRIPTION
After policy is changed make sure that HA configuration is reloaded.
This is needed by the cf-serverd as we don't want to restart it all
the time HA configuration is changed.
