### PR TITLE
Support changing call-collect's schedule while running

### DIFF
--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -624,7 +624,7 @@ static void PrepareServer(int sd)
  *
  * @return Number of live threads remaining after waiting.
  */
-static int WaitOnThreads(Policy *server_policy)
+static int WaitOnThreads()
 {
     int result = 1;
     for (int i = 2; i > 0; i--)
@@ -659,7 +659,6 @@ static int WaitOnThreads(Policy *server_policy)
         Log(LOG_LEVEL_VERBOSE,
             "All threads are done, cleaning up allocations");
         ClearAuthAndACLs();
-        PolicyDestroy(server_policy);
         ServerTLSDeInitialize();
     }
 
@@ -861,8 +860,9 @@ int StartServer(EvalContext *ctx, Policy **policy, GenericAgentConfig *config)
     }
 
     /* This is a graceful exit, give 2 seconds chance to threads. */
-    int threads_left = WaitOnThreads(server_cfengine_policy);
+    int threads_left = WaitOnThreads();
     YieldCurrentLock(thislock);
+    PolicyDestroy(server_cfengine_policy);
 
     return threads_left;
 }


### PR DESCRIPTION
Now that enterprise has the needed changes to not raise a programming error if we try this, it's time for the core half of the change, to actually exploit the back-end's ability to notice a change in report collection interval.
At the same time, tidy up StartServer(), as it was getting rather hairy().
Best reviewed one commit at a time !
