### PR TITLE
[3.6.x] redmine4094: Infer start-time from elapsed when needed.

### DIFF
--- a/libpromises/systype.c
+++ b/libpromises/systype.c
@@ -91,7 +91,7 @@ const char *const VPSOPTS[] =
     [PLATFORM_CONTEXT_OPENVZ] = "-E 0 -o user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* virt_host_vz_vzps (with vzps, the -E 0 replace the -e) */
     [PLATFORM_CONTEXT_HP] = "-ef",                    /* hpux */
     [PLATFORM_CONTEXT_AIX] =  "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args",       /* aix */
-    [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss:9,nlwp,stime,time,args",        /* linux */
+    [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss:9,nlwp,stime,etime,time,args",/* linux */
     [PLATFORM_CONTEXT_SOLARIS] = "auxww",     /* solaris >= 11 */
     [PLATFORM_CONTEXT_SUN_SOLARIS] = "auxww", /* solaris < 11 */
     [PLATFORM_CONTEXT_FREEBSD] = "auxw",  /* freebsd */

--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -37,6 +37,7 @@ bundle common G
                         "od",
                         "perl",
                         "printf",
+                        "ps",
                         "psexec",
                         "pwd",
                         "rm",


### PR DESCRIPTION
Some variants of ps report start-time as a date if before today (no
matter how recently today started) or even report a year for dates
before this year (even if new year's day started mere seconds ago).
These, naturally, give very imprecise information.  When that happens
but we have an elapsed time column (containing a value we can parse),
use this to infer a better start-time.  At the same time, improve
parsing of relevant time strings generally.  Based on a patch from
Tony Lill - many thanks.

This is the fix, cherry-picked from master, but with the brittle acceptance test omitted, at least until I can fix it to work properly.  For the attention of @vohi.
