### PR TITLE
For vailidating input files we must use GetInputDIr()

### DIFF
--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -625,7 +625,7 @@ FilePathType FilePathGetType(const char *file_path)
 
 bool IsFileOutsideDefaultRepository(const char *f)
 {
-    return !StringStartsWith(f, GetWorkDir());
+    return !StringStartsWith(f, GetInputDir());
 }
 
 /*******************************************************************/


### PR DESCRIPTION
because we can override its setting via configure options:
- see https://dev.cfengine.com/issues/6551
