### PR TITLE
join: Don't add delimiter if only null-values are left

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -2182,17 +2182,32 @@ static FnCallResult JoinRlist(const Rlist *input_list, const char *delimiter)
         return FnReturn("");
     }
 
+    bool more = false;
     Buffer *result = BufferNew();
     for (const Rlist *rp = input_list; rp; rp = rp->next)
     {
-        if (strcmp(RlistScalarValue(rp), CF_NULL_VALUE) == 0)
+        if (!more && strcmp(RlistScalarValue(rp), CF_NULL_VALUE) == 0)
         {
             continue;
         }
 
         BufferAppendString(result, RlistScalarValue(rp));
 
-        if (rp->next)
+        more = false;
+        // skip all following cf_null values
+        while (rp->next)
+        {
+            if (strcmp(RlistScalarValue(rp->next), CF_NULL_VALUE) == 0)
+            {
+                rp = rp->next;
+            }
+            else
+            {
+                more = true;
+                break;
+            }
+        }
+        if (more)
         {
             BufferAppendString(result, delimiter);
         }

--- a/tests/acceptance/01_vars/02_functions/join.cf
+++ b/tests/acceptance/01_vars/02_functions/join.cf
@@ -28,8 +28,15 @@ bundle agent init
       "j" data => parsejson('[ 1, 2, [ 3, 4, 5 ], null, true, false ]');
       "k" data => parsejson('{}');
       "l" data => parsejson('{ "a": 100, "b": 200, "c": null}');
+      "m" slist => { "cf_null" };
+      "n" slist => { "a", "b", "c", "cf_null" };
+      "o" slist => { @(a), @(c) };
+      "p" slist => { @(c), @(m) };
+      "q" slist => { ":", ":" };
+      "r" slist => { ":", @(c) };
+      "s" slist => { ":", @(c), @(m) };
 
-      "lists" slist => { "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l" };
+      "lists" slist => { "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s" };
 }
 
 #######################################################
@@ -61,6 +68,13 @@ bundle agent check
       "expected_j" string => "1:2:true:false";
       "expected_k" string => "";
       "expected_l" string => "100:200";
+      "expected_m" string => "";
+      "expected_n" string => "a:b:c";
+      "expected_o" string => "b:c:a";
+      "expected_p" string => "";
+      "expected_q" string => ":::";
+      "expected_r" string => ":";
+      "expected_s" string => ":";
 
   classes:
       "ok_$(lists)" expression => strcmp("$(expected_$(lists))",
@@ -69,7 +83,8 @@ bundle agent check
                                       "$(test.join_$(lists))");
 
       "ok" and => { "ok_a", "ok_b", "ok_c", "ok_d", "ok_e", "ok_f",
-                    "ok_g", "ok_h", "ok_i", "ok_j", "ok_k", "ok_l" };
+                    "ok_g", "ok_h", "ok_i", "ok_j", "ok_k", "ok_l",
+                    "ok_m", "ok_n", "ok_o", "ok_p", "ok_q", "ok_r", "ok_s" };
 
   reports:
     DEBUG::


### PR DESCRIPTION
Looks like a nested loop that introduces polinomial complexity,
but the inner loop advances the outer loop as well.

Fixes Redmine #6552
