### PR TITLE
Advance ap if socket(2) fails

### DIFF
--- a/libcfnet/net.c
+++ b/libcfnet/net.c
@@ -231,6 +231,7 @@ int SocketConnect(const char *host, const char *port,
         {
             Log(LOG_LEVEL_ERR, "Couldn't open a socket. (socket: %s)",
                 GetErrorStr());
+            ap = ap->ai_next;
         }
         else
         {


### PR DESCRIPTION
In the case where socket(2) fails in SocketConnect, ap will advance,
causing an infinite loop.

https://dev.cfengine.com/issues/6560

Found by one of our engineers.
