### PR TITLE
Use poll(2) instead of select(2) in TryConnect

### DIFF
--- a/libcfnet/net.c
+++ b/libcfnet/net.c
@@ -342,13 +342,6 @@ bool TryConnect(int sd, unsigned long timeout_ms,
 {
     assert(sa != NULL);
 
-    if (sd >= FD_SETSIZE)
-    {
-        Log(LOG_LEVEL_ERR, "Open connections exceed FD_SETSIZE limit of %d",
-            FD_SETSIZE);
-        return false;
-    }
-
     /* set non-blocking socket */
     int arg = fcntl(sd, F_GETFL, NULL);
     int ret = fcntl(sd, F_SETFL, arg | O_NONBLOCK);
@@ -371,25 +364,25 @@ bool TryConnect(int sd, unsigned long timeout_ms,
 
         int errcode;
         socklen_t opt_len = sizeof(errcode);
-        fd_set myset;
-        FD_ZERO(&myset);
-        FD_SET(sd, &myset);
+
+        struct pollfd pfd[] = {
+            {
+                .fd = sd,
+                .events = POLLOUT
+            }
+        };
 
         Log(LOG_LEVEL_VERBOSE, "Waiting to connect...");
 
-        struct timeval tv, *tvp;
-        if (timeout_ms > 0)
+        if (timeout_ms > INT_MAX)
         {
-            tv.tv_sec = timeout_ms / 1000;
-            tv.tv_usec = (timeout_ms % 1000) * 1000;
-            tvp = &tv;
+            // Overflow
+            Log(LOG_LEVEL_ERR, "Timeout %lu too large", timeout_ms);
+            return false;
         }
-        else
-        {
-            tvp = NULL;                                /* wait indefinitely */
-        }
+        int timeout = (unsigned long)timeout_ms;
 
-        ret = select(sd + 1, NULL, &myset, NULL, tvp);
+        ret = poll(pfd, 1, timeout);
         if (ret == 0)
         {
             Log(LOG_LEVEL_INFO, "Timeout connecting to server");

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -899,6 +899,8 @@ struct timespec
 # include <direct.h>
 #endif
 
+#include <poll.h>
+
 /* Must be always the last one! */
 #include <deprecated.h>
 #include <config.post.h>


### PR DESCRIPTION
Use poll(2) instead of select(2) as select is limited by FD_SETSIZE, which is possible to exceed.

Found by one of our engineers.

Tested on Linux on x86-64. Network acceptance tests passed.

https://dev.cfengine.com/issues/6557
