### PR TITLE
Canonify promiser name before testing if class is set

### DIFF
--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -367,12 +367,11 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
     // if this is a class promise, check if it is already set, if so, skip
     if (strcmp("classes", pp->parent_promise_type->name) == 0)
     {
-        if (IsDefinedClass(ctx, pcopy->promiser))
+        if (IsDefinedClass(ctx, CanonifyName(pcopy->promiser)))
         {
-            if (excluded)
-            {
-                *excluded = true;
-            }
+            Log(LOG_LEVEL_VERBOSE, "Skipping evaluation of classes promise as class '%s' is already set",
+                CanonifyName(pcopy->promiser));
+            *excluded = true;
 
             return pcopy;
         }
@@ -390,10 +389,7 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
         if (ifvarclass && !IsVarClassDefined(ctx, ifvarclass, pcopy))
         {
             Log(LOG_LEVEL_VERBOSE, "Skipping promise '%s', for if/ifvarclass is not in scope", pp->promiser);
-            if (excluded)
-            {
-                *excluded = true;
-            }
+            *excluded = true;
 
             return pcopy;
         }
@@ -406,10 +402,7 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
         if (unless && IsVarClassDefined(ctx, unless, pcopy))
         {
             Log(LOG_LEVEL_VERBOSE, "Skipping promise '%s', for unless is in scope", pp->promiser);
-            if (excluded)
-            {
-                *excluded = true;
-            }
+            *excluded = true;
 
             return pcopy;
         }
@@ -428,10 +421,7 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
 
                 if (MissingDependencies(ctx, pcopy))
                 {
-                    if (excluded)
-                    {
-                        *excluded = true;
-                    }
+                    *excluded = true;
 
                     return pcopy;
                 }

--- a/tests/acceptance/02_classes/01_basic/avoid_reevaluation.cf
+++ b/tests/acceptance/02_classes/01_basic/avoid_reevaluation.cf
@@ -17,7 +17,7 @@ bundle agent check
 {
   methods:
       "" usebundle => dcs_passif_output(".*",
-                                        ".*loquacious quaalude.*",
-                                        "$(sys.cf_agent) -KI -f $(this.promise_filename).sub -Dloquacious | $(G.grep) qua",
+                                        ".*loquacious quaalude.*|.*/etc/debian_version.*",
+                                        "$(sys.cf_agent) -KI -f $(this.promise_filename).sub -Dloquacious",
                                         $(this.promise_filename));
 }

--- a/tests/acceptance/02_classes/01_basic/avoid_reevaluation.cf.sub
+++ b/tests/acceptance/02_classes/01_basic/avoid_reevaluation.cf.sub
@@ -6,6 +6,10 @@ body common control
 
 bundle agent run
 {
+  vars:
+      "path" string => "/etc/debian_version";
+
   classes:
       "loquacious" expression => returnszero("$(G.echo) loquacious quaalude", "noshell");
+      "$(path)" expression => returnszero("$(G.echo) redmine6561", "noshell");
 }


### PR DESCRIPTION
Also clean up some code; the function now asserts that
excluded is valid, and there is only one caller.

Add uncanonifed promiser to existing test case.

Fixes Redmine #6561
