### PR TITLE
Add testcase for Redmine #6577

### DIFF
--- a/tests/acceptance/01_vars/02_functions/function_with_skipped_promise.cf
+++ b/tests/acceptance/01_vars/02_functions/function_with_skipped_promise.cf
@@ -1,0 +1,43 @@
+# Make sure function is (not) evaluated in a promise (not) skipped via ifvarclass
+# Redmine 6577
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  files:
+      "$(G.testdir)/." create => "true";
+}
+
+bundle agent test 
+{
+  vars:
+      "files" slist => { "want_file", "dont_want_file" };
+
+  classes:
+      "want_file" expression => "any";
+
+      "test" expression => returnszero("$(G.touch) $(G.testdir)/$(files)", "noshell"),
+      ifvarclass => "$(files)";
+}
+
+bundle agent check
+{
+  classes:
+      "$(test.files)_exists" expression => fileexists("$(G.testdir)/$(test.files)"); 
+
+      "ok" expression => "want_file_exists.!dont_want_file_exists";
+
+  reports:
+    DEBUG.!ok::
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
This verifies that functions are not evaluated if they are used
in a promise that is skipped via ifvarclass.

This is not a bug in master, and this test passes with 3.6.2 as well,
but there is a bug in 3.6.x due to code that explicitly tries to
skip function evaluations in disabled proimses (the redmine ticket).
Fixing the bug by removing that code, and including this test to
ensure that we don't regress wrt function evaluations.
