### PR TITLE
redmine #2912: readfile and textxform functions do not rely on 4k limit anymore

### DIFF
--- a/tests/acceptance/01_vars/02_functions/readfile.cf
+++ b/tests/acceptance/01_vars/02_functions/readfile.cf
@@ -24,13 +24,13 @@ bundle agent check
 {
   vars:
       "sizes" ilist => { @(test.sizes) };
-      "expected[0]" int => "4095";
+      "expected[0]" int => "10240";
       "expected[1]" int => "1";
       "expected[4094]" int => "4094";
       "expected[4095]" int => "4095";
-      "expected[4096]" int => "4095";
-      "expected[4097]" int => "4095";
-      "expected[99999999]" int => "4095";
+      "expected[4096]" int => "4096";
+      "expected[4097]" int => "4097";
+      "expected[99999999]" int => "10240";
 
   classes:
       "ok_$(sizes)" expression => strcmp("$(test.length_$(sizes))",


### PR DESCRIPTION
Do not merge this. This is a PoC for discussion on the dev-cfengine list.
- Change allocation in `FnCallTextXform` to be dynamic instead of hammering the stack
- Change limit in `FnCallTextXform` and `FnCallReadFile` to CF_INFINITY
