### PR TITLE
Bounds checks for read_file, string_head and string_tail

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -5260,6 +5260,12 @@ static FnCallResult FnCallReadFile(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const
         maxsize = CF_BUFSIZE;
     }
 
+    if (maxsize < 0)
+    {
+        Log(LOG_LEVEL_ERR, "%s: requested max size %s is less than 0", fp->name, requested_max);
+        return FnFailure();
+    }
+
     // Read once to validate structure of file in itemlist
     char *contents = CfReadFile(filename, maxsize);
     if (contents)


### PR DESCRIPTION
These functions don't have bounds checks for negative values, and can fail hard when they encounter such values. This PR ensures that they can't be called with negative values for the respective size fields.
