### PR TITLE
Redmine#6008: provide Mustache % and $ escape sequence for serialization

### DIFF
--- a/tests/acceptance/10_files/templating/mustache_container_serialization.cf
+++ b/tests/acceptance/10_files/templating/mustache_container_serialization.cf
@@ -1,0 +1,81 @@
+#######################################################
+#
+# Demo of Mustache templates with no external JSON data
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "a" string => "[]";
+      "b" string => "{}";
+      "c" string => '{"a":100,"b":200}';
+      "d" string => '[{"a":100,"b":200},null,true,false,"abcde"]';
+
+      "test" slist => { "a", "b", "c", "d" };
+
+  methods:
+      "" usebundle => file_mustache_jsonstring("$(this.promise_filename).mustache",
+                                              '{ "name": "$(test)", "data": $($(test)) }',
+                                              "$(G.testdir)/$(test)");
+
+      "" usebundle => test2;
+}
+
+bundle agent test2
+{
+  files:
+      "$(G.testfile).expected" create => "true", edit_line => insertthem;
+      "$(G.testfile).actual" create => "true", edit_line => readthem;
+}
+
+bundle edit_line insertthem
+{
+  vars:
+      "test" slist => { @(test.test) };
+      "parsed_$(test)" data => parsejson("$(test.$(test))");
+      "fulldump_$(test)" string => storejson("parsed_$(test)");
+
+  insert_lines:
+      "$(test)$(test.$(test))$(test)
+$(test)$(fulldump_$(test))$(test)" insert_type => "preserve_block";
+
+  reports:
+    EXTRA::
+      "Full dump of $(test) is $(fulldump_$(test))";
+}
+
+bundle edit_line readthem
+{
+  vars:
+      "test" slist => { @(test.test) };
+      "read_$(test)" string => readfile("$(G.testdir)/$(test)", 1k);
+  insert_lines:
+      "$(read_$(test))";
+
+  reports:
+    EXTRA::
+      "For $(test) we got '$(read_$(test))'";
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "test" slist => { @(test.test) };
+
+  methods:
+      "" usebundle => dcs_check_diff("$(G.testfile).expected",
+                                    "$(G.testfile).actual",
+                                    $(this.promise_filename));
+}

--- a/tests/acceptance/10_files/templating/mustache_container_serialization.cf.mustache
+++ b/tests/acceptance/10_files/templating/mustache_container_serialization.cf.mustache
@@ -1,0 +1,2 @@
+{{name}}{{$data}}{{name}}
+{{name}}{{%data}}{{name}}


### PR DESCRIPTION
Summary:

Test Mustache template:

```
all variables serialized, multi-line format: {{%vars}}

all classes serialized, compact format: {{$classes}}

a single variable serialized: %focus = {{%vars.main.focus}}

a single variable serialized: $focus = {{$vars.main.focus}}
```

The output is the serialized version of any passed-in data container, just like `storejson()` or `format("%S", container)` puts it in a string.

Test policy (note that the `datastate()` function's output is the passed data):

```
bundle agent main
{
  vars:
      "focus" string => "attention";

  files:
      "/tmp/out.json"
      create => "true",
      edit_template => "$(this.promise_filename).mustache",
      template_method => "mustache";
}
```

Unlike writing the output of `storejson()` or `format("%S")` to a file, this doesn't go through the evaluator strings.  The acceptance test will show it, and you can also see a demo at https://gist.github.com/tzz/ba215a1e49df140eec1d
