### PR TITLE
Change script interpreter to /bin/sh

### DIFF
--- a/tests/unit/dynamic_dependency_test.sh
+++ b/tests/unit/dynamic_dependency_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Tests that the symbols in our static libraries do not occur twice in the
 # output binaries. Most platforms don't warn about this, but it has potential


### PR DESCRIPTION
Some operating systems don't have bash installed by default, and if they do its not installed in /bin. This script isn't making use of any bash specific features so changing the interpreter to /bin/sh will allow it to run on several different platforms without modification
