### PR TITLE
Test metadata for users

### DIFF
--- a/tests/acceptance/17_users/unsafe/add_user.cf
+++ b/tests/acceptance/17_users/unsafe/add_user.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_locked.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_locked.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a which is locked.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added locked";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_locked_with_password.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_locked_with_password.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a locked a user and setting a password.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added locked with password";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_warn.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_warn.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test warning about adding a user
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added (dry run only)";
+  "story_id" string => "5525";
+  "covers" string => "dryrun_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_description.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_description.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with a description.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with description";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_hashed_password.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_hashed_password.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with a password.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with password";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_many_attributes.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_many_attributes.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with many attributes.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with several attributes";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_many_attributes_warn.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_many_attributes_warn.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test warning about adding a user with many attributes.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with multiple attributes (dry run only)";
+  "story_id" string => "5525";
+  "covers" string => "dryrun_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_many_empty_attributes.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_many_empty_attributes.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with many empty attributes.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with several empty attributes";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_password.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_password.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with a password.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with password";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_primary_gid.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_primary_gid.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with a primary gid.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with primary group id";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_primary_group.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_primary_group.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with a primary group.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with primary group";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_secondary_gid.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_secondary_gid.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with a secondary gid.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with secondary group id";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_secondary_group.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_secondary_group.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with a secondary group.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with secondary group";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_several_secondary_groups.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_several_secondary_groups.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with several secondary groups.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with several seconday groups";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_shell.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_shell.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with a specific shell.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with a shell";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/add_user_with_uid.cf
+++ b/tests/acceptance/17_users/unsafe/add_user_with_uid.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test adding a user with a specific uid.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added with uid";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/home_bundle_when_removing_user.cf
+++ b/tests/acceptance/17_users/unsafe/home_bundle_when_removing_user.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test home_bundle when removing a user.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets the home bundle run";
+  "story_id" string => "5526";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/home_bundle_with_existing_user.cf
+++ b/tests/acceptance/17_users/unsafe/home_bundle_with_existing_user.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test home_bundle when modifying an existing user.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets the home bundle run";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/home_bundle_with_new_user_and_default_inherit.cf
+++ b/tests/acceptance/17_users/unsafe/home_bundle_with_new_user_and_default_inherit.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test home_bundle when adding a new user.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user added gets the home bundle run";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/home_bundle_with_new_user_and_inherit.cf
+++ b/tests/acceptance/17_users/unsafe/home_bundle_with_new_user_and_inherit.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test home_bundle when adding a new user.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets the home bundle run (2)";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/home_bundle_with_new_user_and_no_inherit.cf
+++ b/tests/acceptance/17_users/unsafe/home_bundle_with_new_user_and_no_inherit.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test home_bundle when adding a new user.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets the home bundle run (3)";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/missing_policy.cf
+++ b/tests/acceptance/17_users/unsafe/missing_policy.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test a user promise without a policy attribute.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user not present gets added when there is no policy attribute";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_lock.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_lock.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test locking a user.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets set to locked";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_lock_warn.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_lock_warn.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test warning about locking a user.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets locked (dry run)";
+  "story_id" string => "5525";
+  "covers" string => "dryrun_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_lock_with_password.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_lock_with_password.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test locking a user and setting a password.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets locked and the password changed";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_unlock.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_unlock.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test unlocking a user.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets enabled";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_unlock_warn.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_unlock_warn.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test warning about unlocking a user.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets enabled and the password changed (dry run)";
+  "story_id" string => "5525";
+  "covers" string => "dryrun_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_unlock_with_password.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_unlock_with_password.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test unlocking a user and setting a password.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets enabled and the password changed";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_with_hashed_password.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_with_hashed_password.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test modifying a user with a password.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets the hashed password changed";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_with_many_attributes.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_with_many_attributes.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test modifying a user with many attributes.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets several attributes changed";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_with_many_attributes_warn.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_with_many_attributes_warn.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test warning about modifying a user with many attributes.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets many attributes changed (dry run)";
+  "story_id" string => "5525";
+  "covers" string => "dryrun_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_with_many_empty_attributes.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_with_many_empty_attributes.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test modifying a user with many empty attributes.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets multiple attributes changed";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_with_password.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_with_password.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test modifying a user with a password.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets the password changed";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/modify_user_with_same_password.cf
+++ b/tests/acceptance/17_users/unsafe/modify_user_with_same_password.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test modifying a user with a password.
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets the password set to the same as before";
+  "story_id" string => "5525";
+  "covers" string => "operational_kept";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/newly_created_account_should_not_count_as_locked.cf
+++ b/tests/acceptance/17_users/unsafe/newly_created_account_should_not_count_as_locked.cf
@@ -1,3 +1,11 @@
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets locked";
+  "story_id" string => "5525";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 #
 # Test that a newly created account does not confuse

--- a/tests/acceptance/17_users/unsafe/password_with_no_data.cf
+++ b/tests/acceptance/17_users/unsafe/password_with_no_data.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test missing password data
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets the password unchanged when it is unspecified";
+  "story_id" string => "5525";
+  "covers" string => "operational_kept";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/password_with_no_format.cf
+++ b/tests/acceptance/17_users/unsafe/password_with_no_format.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test missing password format
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present has the password unchanged when password format is unspecified";
+  "story_id" string => "5525";
+  "covers" string => "operational_kept";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/remove_user.cf
+++ b/tests/acceptance/17_users/unsafe/remove_user.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test removing a user
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets removed";
+  "story_id" string => "5526";
+  "covers" string => "operational_repaired";
+}
+
 #######################################################
 
 body common control

--- a/tests/acceptance/17_users/unsafe/remove_user_warn.cf
+++ b/tests/acceptance/17_users/unsafe/remove_user_warn.cf
@@ -1,7 +1,11 @@
-#######################################################
-#
-# Test warning about removing a user
-#
+bundle common test_meta
+{
+vars:
+  "description" string => "A user present gets removed (dry run)";
+  "story_id" string => "5526";
+  "covers" string => "dryrun_repaired";
+}
+
 #######################################################
 
 body common control


### PR DESCRIPTION
metadata for story id 5525 and 5526 (user present and absent)

Note that it also includes cases for operational_kept, operational_repaired and dryrun_repaired as "covers" so it is a good test case for the scanner.
