### PR TITLE
mustache: allow iterating over a key-value hash with {{@}} for the key and {{.}} for the value

### DIFF
--- a/libutils/json.c
+++ b/libutils/json.c
@@ -94,6 +94,13 @@ static void JsonElementSetPropertyName(JsonElement *element, const char *propert
     }
 }
 
+const char* JsonElementGetPropertyName(const JsonElement *element)
+{
+    assert(element);
+
+    return element->propertyName;
+}
+
 static JsonElement *JsonElementCreateContainer(JsonContainerType containerType, const char *propertyName,
                                                size_t initialCapacity)
 {

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -154,6 +154,7 @@ void JsonDestroy(JsonElement *element);
 size_t JsonLength(const JsonElement *element);
 
 JsonElementType JsonGetElementType(const JsonElement *element);
+const char* JsonElementGetPropertyName(const JsonElement *element);
 
 JsonContainerType JsonGetContainerType(const JsonElement *container);
 

--- a/tests/acceptance/10_files/templating/demo.datastate.mustache
+++ b/tests/acceptance/10_files/templating/demo.datastate.mustache
@@ -7,3 +7,11 @@
 {{#classes.empty}}
   <p>The list is empty.</p>
 {{/classes.empty}}
+
+{{#vars.test.d}}
+ {{.}}
+{{/vars.test.d}}
+
+{{#vars.test.h}}
+ key "{{@}}" value "{{.}}"
+{{/vars.test.h}}

--- a/tests/acceptance/10_files/templating/mustache_datastate_demo.cf
+++ b/tests/acceptance/10_files/templating/mustache_datastate_demo.cf
@@ -41,6 +41,8 @@ bundle agent test
       "template_file" string => "$(init.origtestdir)/demo.datastate.mustache";
       "header" string => "Colors";
       "items" slist => { "red", "green", "blue" };
+      "d" data => parsejson('[4,5,6]');
+      "h" data => parsejson('{ "a": "x", "b": "y"}');
 
   files:
       "$(G.testfile)"
@@ -65,6 +67,13 @@ bundle agent check
  blue
 
   <p>The list is empty.</p>
+
+ 4
+ 5
+ 6
+
+ key "a" value "x"
+ key "b" value "y"
 ';
 
       "actual" string => readfile("$(G.testfile)", 10000);


### PR DESCRIPTION
Mustache template improvement:
- allows iterating over a hash, not just a list
- the value is `{{.}}` just like with lists
- the key is `{{@}}` but could be some other special string, e.g. `@key`...
- when iterating over lists, the key behavior is undefined but currently is same as the value
- acceptance test included
