### PR TITLE
Invalid write of newline in MakeTemporaryBundleFromTemplate

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -264,7 +264,8 @@ Bundle *MakeTemporaryBundleFromTemplate(EvalContext *ctx, Policy *policy, Attrib
                     sp += len;
                 }
 
-                *(sp-1) = '\0'; // StripTrailingNewline(promiser) and terminate
+                int nl = StripTrailingNewline(promiser, size);
+				assert(nl != -1);
 
                 np = PromiseTypeAppendPromise(tp, promiser, (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, context);
                 np->offset.line = lineno;


### PR DESCRIPTION
In some cases, this would cause an oob write if the string was empty. This patch uses StripTrailingNewline to remove the newline, which includes checks for empty strings.
