### PR TITLE
Fix crash when package_add_command is missing.

### DIFF
--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -502,6 +502,13 @@ static bool PackageListInstalledFromCommand(EvalContext *ctx,
 {
     if (a.packages.package_list_update_command != NULL)
     {
+        if (!a.packages.package_add_command)
+        {
+            Log(LOG_LEVEL_ERR, "package_add_command missing while trying to "
+                               "generate list of installed packages");
+            return false;
+        }
+
         time_t horizon = 24 * 60, now = time(NULL);
         bool call_update = true;
         struct stat sb;

--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -716,6 +716,8 @@ const char *GetSoftwarePatchesFilename(char *buffer)
 
 const char *RealPackageManager(const char *manager)
 {
+    assert(manager);
+
     const char *pos = strchr(manager, ' ');
     if (strncmp(manager, "env ", 4) != 0
         && (!pos || pos - manager < 4 || strncmp(pos - 4, "/env", 4) != 0))


### PR DESCRIPTION
When using packages promise and not defining 'package_add_command'
agent crashes. This fixes crash.
(cherry picked from commit 163086eda00ef930553050aed2afa875f2bdb564)

Conflicts:

```
cf-agent/verify_packages.c
```
