### PR TITLE
Add: Discovery of Redhat Enterprise ComputeNodes

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1446,6 +1446,7 @@ static int Linux_Redhat_Version(EvalContext *ctx)
 #define REDHAT_C_ID "Red Hat Enterprise Linux Client"
 #define REDHAT_S_ID "Red Hat Enterprise Linux Server"
 #define REDHAT_W_ID "Red Hat Enterprise Linux Workstation"
+#define REDHAT_CN_ID "Red Hat Enterprise Linux ComputerNode"
 #define MANDRAKE_ID "Linux Mandrake"
 #define MANDRAKE_10_1_ID "Mandrakelinux"
 #define WHITEBOX_ID "White Box Enterprise Linux"
@@ -1519,6 +1520,11 @@ static int Linux_Redhat_Version(EvalContext *ctx)
     {
         vendor = "redhat";
         edition = "c";
+    }
+    else if (!strncmp(relstring, REDHAT_CN_ID, strlen(REDHAT_CN_ID)))
+    {
+        vendor = "redhat";
+        edition = "cn";
     }
     else if (!strncmp(relstring, REDHAT_ID, strlen(REDHAT_ID)))
     {


### PR DESCRIPTION
This allows successful identification of redhat compute nodes.

Ref: https://dev.cfengine.com/issues/3148
