### PR TITLE
Add: Acceptance test for variable expansion

### DIFF
--- a/tests/acceptance/01_vars/03_lists/double_expand_remote_list.cf
+++ b/tests/acceptance/01_vars/03_lists/double_expand_remote_list.cf
@@ -1,0 +1,37 @@
+# Redmine#6866
+# Test that varibles are fully expanded
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent check
+{
+  meta:
+    "test_soft_fail"
+      meta => { "redmine#6866" },
+      string => "any";
+
+  vars:
+    "command" string => "$(sys.cf_agent) -Kf $(this.promise_filename).sub";
+    "expected" string => "R: Direct: 1
+R: Direct: 2
+R: Direct: 3
+R: Indirect: 1
+R: Indirect: 2
+R: Indirect: 3";
+
+  methods:
+    "check"
+      usebundle => dcs_passif_output(".*$(expected).*", "", $(command), $(this.promise_filename));
+
+  reports:
+    DEBUG::
+      "=== Expected ===
+'$(expected)'
+================";
+
+}

--- a/tests/acceptance/01_vars/03_lists/double_expand_remote_list.cf.sub
+++ b/tests/acceptance/01_vars/03_lists/double_expand_remote_list.cf.sub
@@ -1,0 +1,32 @@
+# Redmine#6866
+# Test that nested expansion of arrays works
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { "init", "test", "report" };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  vars:
+    "list" slist => { "1", "2", "3" };
+}
+
+bundle agent test
+{
+  vars:
+    "other_list" string => "init.list";
+}
+
+bundle agent report
+{
+  reports:
+    # This should print
+    #R: List : 1
+    #R: List : 2
+    #R: List : 3
+    "Direct: $(init.list)";
+    "Indirect: $($(test.other_list))";
+}


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/6866

This tests that a variable can contain the name of a list and it will
expand properly if that variable is double dereferenced.

"list" slist => { "1", "2", "3" };
"list_ref" string => "bundle.list";

reports:
  # These should be equivalent, that is both should expand identically
  "Indirect: $($(list_ref))";
  "Direct: $(bundle.list)"
