### PR TITLE
Fix stale processes lingering after test and reenable it.

### DIFF
--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/defaults.cf
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/defaults.cf
@@ -25,14 +25,21 @@ body common control
     bundlesequence => { default($(this.promiser_filename)) };
 }
 
+bundle common fakeroot_check
+{
+  classes:
+      "using_fakeroot"
+        expression => regcmp(".+", getenv("FAKEROOTKEY", "10")),
+        scope => "namespace";
+}
+
 bundle agent init
 {
   meta:
       # Backgrounding doesn't work properly on Windows.
-      #"test_skip_needs_work" string => "windows";
-      # Somehow the backgrounding leaves stale processes behind which messes
-      # with later executions. Needs to be fixed later.
-      "test_skip_needs_work" string => "any";
+      # Also, fakeroot somehow interferes with background processes, and causes
+      # stale processes to linger, so disable test when using that.
+      "test_skip_needs_work" string => "windows|using_fakeroot";
 
   methods:
     test_pass_4::
@@ -43,6 +50,10 @@ one promise execution");
 one promise execution");
       "any" usebundle => file_make("$(G.testfile).long_ifelapsed.expected", "one promise execution");
 
+  commands:
+    test_pass_4::
+      "kill `$(G.cat) $(G.testfile)*.pid`"
+        contain => in_shell;
 }
 
 bundle agent test

--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/defaults.cf.sub
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/defaults.cf.sub
@@ -11,11 +11,19 @@ bundle agent test
     # sleep making the promise last for two minutes. Default ifelapsed time is
     # 1 minute.
     !has_run.expireafter::
-      "$(G.echo) one promise execution >> $(G.testfile).expireafter ; $(G.sleep) 120"
+      "$(G.echo) $$ $PPID >> $(G.testfile).expireafter.pid
+$(G.echo) one promise execution >> $(G.testfile).expireafter
+$(G.sleep) 120 &
+$(G.echo) $! >> $(G.testfile).expireafter.pid
+wait"
         contain => in_shell,
         classes => always("has_run");
     !has_run.short_expireafter::
-      "$(G.echo) one promise execution >> $(G.testfile).short_expireafter ; $(G.sleep) 120"
+      "$(G.echo) $$ $PPID >> $(G.testfile).short_expireafter.pid
+$(G.echo) one promise execution >> $(G.testfile).short_expireafter
+$(G.sleep) 120 &
+$(G.echo) $! >> $(G.testfile).short_expireafter.pid
+wait"
         contain => in_shell,
         action => set_expireafter(1),
         classes => always("has_run");


### PR DESCRIPTION
It still doesn't work under fakeroot, but the test is skipped if you
use it.