### PR TITLE
Fix uninitialized path variable

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -2232,7 +2232,7 @@ int DepthSearch(EvalContext *ctx, char *name, struct stat *sb, int rlevel, Attri
             Log(LOG_LEVEL_ERR, "Failed to chdir into '%s'. (chdir: '%s')", basedir, GetErrorStr());
             return false;
         }
-        if (!attr.haveselect || SelectLeaf(ctx, path, sb, attr.select))
+        if (!attr.haveselect || SelectLeaf(ctx, name, sb, attr.select))
         {
             VerifyFileLeaf(ctx, name, sb, attr, pp, result);
             return true;
@@ -2248,8 +2248,6 @@ int DepthSearch(EvalContext *ctx, char *name, struct stat *sb, int rlevel, Attri
         Log(LOG_LEVEL_WARNING, "Very deep nesting of directories (>%d deep) for '%s' (Aborting files)", rlevel, name);
         return false;
     }
-
-    memset(path, 0, CF_BUFSIZE);
 
     if (!PushDirState(ctx, name, sb))
     {
@@ -2281,7 +2279,11 @@ int DepthSearch(EvalContext *ctx, char *name, struct stat *sb, int rlevel, Attri
             continue;
         }
 
-        strcpy(path, name);
+        memset(path, 0, sizeof(path));
+        if (strlcpy(path, name, sizeof(path)-2) >= sizeof(path)-2)
+        {
+            Log(LOG_LEVEL_ERR, "Truncated filename %s while performing depth-first search", path);
+        }
         AddSlash(path);
 
         if (!JoinPath(path, dirp->d_name))


### PR DESCRIPTION
This function needs to be revisited to solve the 4k problem, however
there is a much more critical bug here, where path is uninitialized
before use.

imo this ought to be merged soon, and then we can worry about 4k-sanitizing this function, since that will presumably take a lot longer.

My test case for the valgrind output below was running valgrind on cf-agent running through the entirety of LinkedIn's policy set.

Valgrind output before (also includes a different bug that I fixed):

```
==29838== Memcheck, a memory error detector
==29838== Copyright (C) 2002-2012, and GNU GPL'd, by Julian Seward et al.
==29838== Using Valgrind-3.8.1 and LibVEX; rerun with -h for copyright info
==29838== Command: /var/cfengine/bin/cf-agent -KI
==29838== Parent PID: 29836
==29838== 
==29838== Conditional jump or move depends on uninitialised value(s)
==29838==    at 0x3E6D2480AC: vfprintf (in /lib64/libc-2.12.so)
==29838==    by 0x3E6D26F659: vasprintf (in /lib64/libc-2.12.so)
==29838==    by 0x4C93205: xvasprintf (alloc.c:83)
==29838==    by 0x4C953C6: StringVFormat (string_lib.c:40)
==29838==    by 0x4C99164: VLog (logging.c:239)
==29838==    by 0x4C992C7: Log (logging.c:305)
==29838==    by 0x4376CE: SelectLeaf (files_select.c:189)
==29838==    by 0x414891: DepthSearch (verify_files_utils.c:2235)
==29838==    by 0x40FB78: VerifyFilePromise (verify_files.c:413)
==29838==    by 0x444790: LocateFilePromiserGroup (promiser_regex_resolver.c:61)
==29838==    by 0x410508: FindAndVerifyFilesPromises (verify_files.c:793)
==29838==    by 0x40B923: KeepAgentPromise (cf-agent.c:1735)
==29838== 
==29838== Invalid write of size 1
==29838==    at 0x429D20: MakeTemporaryBundleFromTemplate (files_editline.c:267)
==29838==    by 0x40E9EE: ScheduleEditOperation (verify_files.c:512)
==29838==    by 0x40FC6F: VerifyFilePromise (verify_files.c:461)
==29838==    by 0x444790: LocateFilePromiserGroup (promiser_regex_resolver.c:61)
==29838==    by 0x410508: FindAndVerifyFilesPromises (verify_files.c:793)
==29838==    by 0x40B923: KeepAgentPromise (cf-agent.c:1735)
==29838==    by 0x4C6EE64: ExpandPromise (expand.c:202)
==29838==    by 0x40B0EF: ScheduleAgentOperations (cf-agent.c:1243)
==29838==    by 0x40D4E7: main (cf-agent.c:1158)
==29838==  Address 0x74ed0bf is 1 bytes before a block of size 1 alloc'd
==29838==    at 0x4A0577B: calloc (vg_replace_malloc.c:593)
==29838==    by 0x4C933A8: xcalloc (alloc.c:47)
==29838==    by 0x429CB9: MakeTemporaryBundleFromTemplate (files_editline.c:258)
==29838==    by 0x40E9EE: ScheduleEditOperation (verify_files.c:512)
==29838==    by 0x40FC6F: VerifyFilePromise (verify_files.c:461)
==29838==    by 0x444790: LocateFilePromiserGroup (promiser_regex_resolver.c:61)
==29838==    by 0x410508: FindAndVerifyFilesPromises (verify_files.c:793)
==29838==    by 0x40B923: KeepAgentPromise (cf-agent.c:1735)
==29838==    by 0x4C6EE64: ExpandPromise (expand.c:202)
==29838==    by 0x40B0EF: ScheduleAgentOperations (cf-agent.c:1243)
==29838==    by 0x40D4E7: main (cf-agent.c:1158)
==29838== 
==29838== Conditional jump or move depends on uninitialised value(s)
==29838==    at 0x4A07F59: strlen (mc_replace_strmem.c:403)
==29838==    by 0x4C715C8: LastFileSeparator (files_names.c:385)
==29838==    by 0x4C71608: ReadLastNode (files_names.c:535)
==29838==    by 0x437154: SelectLeaf (files_select.c:399)
==29838==    by 0x414891: DepthSearch (verify_files_utils.c:2235)
==29838==    by 0x40FB78: VerifyFilePromise (verify_files.c:413)
==29838==    by 0x444790: LocateFilePromiserGroup (promiser_regex_resolver.c:61)
==29838==    by 0x410508: FindAndVerifyFilesPromises (verify_files.c:793)
==29838==    by 0x40B923: KeepAgentPromise (cf-agent.c:1735)
==29838==    by 0x4C6EE64: ExpandPromise (expand.c:202)
==29838==    by 0x40B0EF: ScheduleAgentOperations (cf-agent.c:1243)
==29838==    by 0x40D4E7: main (cf-agent.c:1158)
==29838== 
==29838== Conditional jump or move depends on uninitialised value(s)
==29838==    at 0x4A0849C: strcmp (mc_replace_strmem.c:729)
==29838==    by 0x40E6A6: FullTextMatch (match_scope.c:91)
==29838==    by 0x437164: SelectLeaf (files_select.c:399)
==29838==    by 0x414891: DepthSearch (verify_files_utils.c:2235)
==29838==    by 0x40FB78: VerifyFilePromise (verify_files.c:413)
==29838==    by 0x444790: LocateFilePromiserGroup (promiser_regex_resolver.c:61)
==29838==    by 0x410508: FindAndVerifyFilesPromises (verify_files.c:793)
==29838==    by 0x40B923: KeepAgentPromise (cf-agent.c:1735)
==29838==    by 0x4C6EE64: ExpandPromise (expand.c:202)
==29838==    by 0x40B0EF: ScheduleAgentOperations (cf-agent.c:1243)
==29838==    by 0x40D4E7: main (cf-agent.c:1158)
==29838== 
==29838== Conditional jump or move depends on uninitialised value(s)
==29838==    at 0x4A084C7: strcmp (mc_replace_strmem.c:729)
==29838==    by 0x40E6A6: FullTextMatch (match_scope.c:91)
==29838==    by 0x437164: SelectLeaf (files_select.c:399)
==29838==    by 0x414891: DepthSearch (verify_files_utils.c:2235)
==29838==    by 0x40FB78: VerifyFilePromise (verify_files.c:413)
==29838==    by 0x444790: LocateFilePromiserGroup (promiser_regex_resolver.c:61)
==29838==    by 0x410508: FindAndVerifyFilesPromises (verify_files.c:793)
==29838==    by 0x40B923: KeepAgentPromise (cf-agent.c:1735)
==29838==    by 0x4C6EE64: ExpandPromise (expand.c:202)
==29838==    by 0x40B0EF: ScheduleAgentOperations (cf-agent.c:1243)
==29838==    by 0x40D4E7: main (cf-agent.c:1158)
==29838== 
==29838== Conditional jump or move depends on uninitialised value(s)
==29838==    at 0x40E6B0: FullTextMatch (match_scope.c:91)
==29838==    by 0x437164: SelectLeaf (files_select.c:399)
==29838==    by 0x414891: DepthSearch (verify_files_utils.c:2235)
==29838==    by 0x40FB78: VerifyFilePromise (verify_files.c:413)
==29838==    by 0x444790: LocateFilePromiserGroup (promiser_regex_resolver.c:61)
==29838==    by 0x410508: FindAndVerifyFilesPromises (verify_files.c:793)
==29838==    by 0x40B923: KeepAgentPromise (cf-agent.c:1735)
==29838==    by 0x4C6EE64: ExpandPromise (expand.c:202)
==29838==    by 0x40B0EF: ScheduleAgentOperations (cf-agent.c:1243)
==29838==    by 0x40D4E7: main (cf-agent.c:1158)
==29838== 
==29838== Conditional jump or move depends on uninitialised value(s)
==29838==    at 0x4A07F59: strlen (mc_replace_strmem.c:403)
==29838==    by 0x40E4D9: RegExMatchSubString (match_scope.c:39)
==29838==    by 0x40E6F4: FullTextMatch (match_scope.c:77)
==29838==    by 0x437164: SelectLeaf (files_select.c:399)
==29838==    by 0x414891: DepthSearch (verify_files_utils.c:2235)
==29838==    by 0x40FB78: VerifyFilePromise (verify_files.c:413)
==29838==    by 0x444790: LocateFilePromiserGroup (promiser_regex_resolver.c:61)
==29838==    by 0x410508: FindAndVerifyFilesPromises (verify_files.c:793)
==29838==    by 0x40B923: KeepAgentPromise (cf-agent.c:1735)
==29838==    by 0x4C6EE64: ExpandPromise (expand.c:202)
==29838==    by 0x40B0EF: ScheduleAgentOperations (cf-agent.c:1243)
==29838==    by 0x40D4E7: main (cf-agent.c:1158)
==29838== 
==29838== 
==29838== HEAP SUMMARY:
==29838==     in use at exit: 861,201 bytes in 6,882 blocks
==29838==   total heap usage: 148,127,673 allocs, 148,120,791 frees, 10,776,399,795 bytes allocated
==29838== 
==29838== LEAK SUMMARY:
==29838==    definitely lost: 192,576 bytes in 2,230 blocks
==29838==    indirectly lost: 509,454 bytes in 2,197 blocks
==29838==      possibly lost: 0 bytes in 0 blocks
==29838==    still reachable: 159,171 bytes in 2,455 blocks
==29838==         suppressed: 0 bytes in 0 blocks
==29838== Rerun with --leak-check=full to see details of leaked memory
==29838== 
==29838== For counts of detected and suppressed errors, rerun with: -v
==29838== Use --track-origins=yes to see where uninitialised values come from
==29838== ERROR SUMMARY: 29 errors from 7 contexts (suppressed: 6 from 6)
```

and after:

```
==20417== Memcheck, a memory error detector
==20417== Copyright (C) 2002-2012, and GNU GPL'd, by Julian Seward et al.
==20417== Using Valgrind-3.8.1 and LibVEX; rerun with -h for copyright info
==20417== Command: /var/cfengine/bin/cf-agent -KI
==20417== Parent PID: 20415
==20417== 
==20417== 
==20417== HEAP SUMMARY:
==20417==     in use at exit: 861,360 bytes in 6,888 blocks
==20417==   total heap usage: 148,192,330 allocs, 148,185,442 frees, 10,786,793,854 bytes allocated
==20417== 
==20417== LEAK SUMMARY:
==20417==    definitely lost: 192,576 bytes in 2,230 blocks
==20417==    indirectly lost: 508,697 bytes in 2,196 blocks
==20417==      possibly lost: 907 bytes in 5 blocks
==20417==    still reachable: 159,180 bytes in 2,457 blocks
==20417==         suppressed: 0 bytes in 0 blocks
==20417== Rerun with --leak-check=full to see details of leaked memory
==20417== 
==20417== For counts of detected and suppressed errors, rerun with: -v
==20417== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 6 from 6)
```
