### PR TITLE
Do not fallback on unsafe seed data for the PRNG

### DIFF
--- a/cf-key/cf-key-functions.c
+++ b/cf-key/cf-key-functions.c
@@ -314,7 +314,13 @@ void KeepKeyPromises(const char *public_key_file, const char *private_key_file)
     fclose(fp);
 
     snprintf(vbuff, CF_BUFSIZE, "%s/randseed", CFWORKDIR);
-    RAND_write_file(vbuff);
+    if (RAND_write_file(vbuff) != 1024)
+    {
+        Log(LOG_LEVEL_ERR, "Unable to write randseed");
+        unlink(vbuff); /* randseed isn't safe to use */
+        return;
+    }
+
     chmod(vbuff, 0644);
 }
 


### PR DESCRIPTION
Seeding OpenSSL's PRNG with the output of rand() isn't safe. It's better to
abort early than to continue with unsafe entropy.

Also write out a new randseed file on a deinitialization, and free our error
strings.