### PR TITLE
bundlestate: new function

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -595,7 +595,7 @@ static PromiseResult RenderTemplateMustache(EvalContext *ctx, const Promise *pp,
     JsonElement *default_template_data = NULL;
     if (!a.template_data)
     {
-        a.template_data = default_template_data = DefaultTemplateData(ctx);
+        a.template_data = default_template_data = DefaultTemplateData(ctx, NULL);
     }
 
     Buffer *output_buffer = BufferNew();

--- a/examples/bundlestate.cf
+++ b/examples/bundlestate.cf
@@ -1,0 +1,57 @@
+#  Copyright (C) Cfengine AS
+
+#  This file is part of Cfengine 3 - written and maintained by Cfengine AS.
+
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License as published by the
+#  Free Software Foundation; version 3.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+# To the extent this program is licensed as part of the Enterprise
+# versions of Cfengine, the applicable Commercial Open Source License
+# (COSL) may apply to this file if you as a licensee so wish it. See
+# included file COSL.txt.
+
+#+begin_src cfengine3
+body common control
+{
+      bundlesequence => { holder, test };
+}
+
+bundle common holder
+{
+  classes:
+      "holderclass" expression => "any"; # will be global
+
+  vars:
+      "s" string => "Hello!";
+      "d" data => parsejson('[4,5,6]');
+      "list" slist => { "element1", "element2" };
+}
+
+bundle agent test
+{
+  vars:
+      "bundle_state" data => bundlestate("holder");
+
+      # all the variables in bundle "holder" defined as of the execution of bundlestate() will be here
+      "holderstate" string => format("%S", "bundle_state");
+
+  reports:
+      "holder vars = $(holderstate)";
+}
+#+end_src
+###############################################################################
+#+begin_src example_output
+#@ ```
+#@ R: holder vars = {"list":["element1","element2"],"s":"Hello!","d":[4,5,6]}
+#@ ```
+#+end_src

--- a/libpromises/evalfunction.h
+++ b/libpromises/evalfunction.h
@@ -40,6 +40,6 @@ void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print
 FnCallResult FnCallGroupExists(EvalContext *ctx, const Policy *policy, const FnCall *fp, const Rlist *finalargs);
 FnCallResult FnCallUserExists(EvalContext *ctx, const Policy *policy, const FnCall *fp, const Rlist *finalargs);
 
-JsonElement *DefaultTemplateData(const EvalContext *ctx);
+JsonElement *DefaultTemplateData(const EvalContext *ctx, const char *wantbundle);
 
 #endif

--- a/tests/acceptance/01_vars/02_functions/bundlestate.cf
+++ b/tests/acceptance/01_vars/02_functions/bundlestate.cf
@@ -1,0 +1,65 @@
+# Test that the bundlestate() function gives good data
+
+body common control
+{
+      inputs => { "../../default.cf.sub", "bundlestate.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  vars:
+      "s" string => "Hello!";
+      "d" data => parsejson('[4,5,6]');
+      "list" slist => { "element1", "element2" };
+      "h" data => parsejson('{ "a": "x", "b": "y"}');
+
+  methods:
+      "" usebundle => external:init;
+      "" usebundle => external:dump;
+}
+
+bundle agent test
+{
+  vars:
+      "holder" data => bundlestate("init");
+      "holder2" data => bundlestate("$(this.namespace):init");
+      "holder3" data => bundlestate("nosuchnamespace:init");
+      "holder4" data => bundlestate("external:init");
+
+      "holder_s" string => format("%S", holder);
+      "holder2_defined" string => ifelse(isvariable(holder2), "we have holder 2 and we shouldn't", "");
+      "holder3_defined" string => ifelse(isvariable("holder3"), "we have holder 3 and we shouldn't", "");
+      "holder4_s" string => format("%S", holder4);
+
+      "s_s" string => format("%S", "holder[s]");
+      "s_d" string => format("%S", "holder[d]");
+      "s_list" string => format("%S", "holder[list]");
+      "s_h" string => format("%S", "holder[h]");
+}
+
+bundle agent check
+{
+  methods:
+      "check" usebundle => dcs_check_strcmp("$(test.s_s)
+$(test.s_d)
+$(test.s_list)
+$(test.s_h)
+$(test.holder4_s)
+$(external:dump.external_holder_s)
+$(external:dump.external_holder2_s)
+$(test.holder2_defined)
+$(test.holder3_defined)",
+                                           '"Hello!"
+[4,5,6]
+["element1","element2"]
+{"a":"x","b":"y"}
+{"external_s":"External Hello!"}
+$(test.holder_s)
+{"external_s":"External Hello!"}
+
+',
+                                           $(this.promise_filename),
+                                           "no");
+}

--- a/tests/acceptance/01_vars/02_functions/bundlestate.cf.sub
+++ b/tests/acceptance/01_vars/02_functions/bundlestate.cf.sub
@@ -1,0 +1,20 @@
+body file control
+{
+      namespace => "external";
+}
+
+bundle agent init
+{
+  vars:
+      "external_s" string => "External Hello!";
+}
+
+bundle agent dump
+{
+  vars:
+      "external_holder" data => bundlestate("init");
+      "external_holder2" data => bundlestate("external:init");
+
+      "external_holder_s" string => format("%S", external_holder);
+      "external_holder2_s" string => format("%S", external_holder2);
+}


### PR DESCRIPTION
This is not finished because I'm unable to test on Mac OS X (error: 

```
duplicate symbol _DEFAULT_CONTAINER_CAPACITY in:
    ../libutils/.libs/libutils.a(json.o)
    ../libutils/.libs/libutils.a(json-yaml.o)
ld: 1 duplicate symbol for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
)

Thus the acceptance test is not finished and the code may be slightly broken, but I hope the general idea is acceptable: this function allows all the variables of a bundle to be returned in a single data container, formatted correctly (especially nested data structures).