### PR TITLE
Fix typos found by codespell

### DIFF
--- a/3rdparty/peg-0.1.13/src/peg.1
+++ b/3rdparty/peg-0.1.13/src/peg.1
@@ -868,7 +868,7 @@ structure and the storage to deallocate.  The default definition is:
 The name of the function that releases all resources held by a
 yycontext structure.  The default value is 'yyrelease'.
 .PP
-The following variables can be reffered to within actions.
+The following variables can be referred to within actions.
 .TP
 .B char *yybuf
 This variable points to the parser's input buffer used to store input

--- a/AUTHORS
+++ b/AUTHORS
@@ -69,7 +69,7 @@ Copyright
 The cfengine 3 design and code is by Cfengine AS and all rights are
 reserved.
 
-In order to offer commericial support of cfengine to customers it is
+In order to offer commercial support of cfengine to customers it is
 important for Cfengine AS to have an uncomplicated ownership of rights
 to cfengine 3 code in future products. For that reason we will require
 that substantial code contrbutions (contributions of sufficient size
@@ -78,9 +78,9 @@ form to cfengine AS.
 
 Such a transfer will not take away any of your freedoms under the GNU
 public licence, but will guarantee that community contributions can be
-included in cfengine's commerical future, without the need to split
+included in cfengine's commercial future, without the need to split
 cfengine into multiple versions i.e. this allows cfengine AS to make
-money on commerical versions of cfengine thus supporting future
+money on commercial versions of cfengine thus supporting future
 in-house development.
 
 ========================================================================

--- a/ChangeLog
+++ b/ChangeLog
@@ -30,7 +30,7 @@ Next patch release:
         - fix mustache template method to run in dryrun mode (Redmine #6739)
         - set mailto and mailfrom settings for execd in def.cf (Redmine #6702)
         - fix conflation of multi-index entries in arrays (Redmine #6674)
-        - fix promise locking when transfering using update.cf (Redmine #6623)
+        - fix promise locking when transferring using update.cf (Redmine #6623)
         - update JSON parser to return an error on truncation (Redmine #6608)
         - fix sys.hardware_addresses not expanded (Redmine #6603)
         - fix opening database txn /var/cfengine/cf_lastseen.lmdb:
@@ -105,7 +105,7 @@ Next patch release:
           bug fixes.
 
 	Changes:
-        - Short-circut evaluation of classes promises if class is already set (Redmine #5241)
+        - Short-circuit evaluation of classes promises if class is already set (Redmine #5241)
         - fix to assume all non-specified return codes are failed in commands promises (Redmine #5986)
         - cf-serverd logs reconfiguration message to NOTICE (was INFO) so that it's always logged in syslog
 
@@ -222,7 +222,7 @@ Next patch release:
               (e.g. "cfengine.com") or subdomains (starting with dot,
               e.g. ".cfengine.com") for "admit/deny"_hostnames. Same rules
               apply to 'deny_*' attributes.
-            - These new constaints and the paths in access_rules, can contain
+            - These new constraints and the paths in access_rules, can contain
               special variables "$(connection.ip)", "$(connection.hostname)",
               "$(connection.key)", which are expanded dynamically for every
               received connection.
@@ -667,7 +667,7 @@ Next patch release:
 	  ** WARNING: When upgrading, make sure that any existing use
 		      of depends_on does not make some promises being
 		      unintentionally ignored. This can happen if you are
-		      currently refering to non-existant or never-run handles
+		      currently referring to non-existent or never-run handles
 		      in depends_on attributes.
 
 	- methods return values, initial implementation
@@ -800,7 +800,7 @@ Next patch release:
 
 	- Do not lose hard classes in cf-serverd during policy reload
 	  (Mantis #1218).
-	- Implement recieve network timeout in cf-serverd. Prevents
+	- Implement receive network timeout in cf-serverd. Prevents
 	  overloading cf-serverd with stale connections.
 
 3.3.8   (Bugfix and Stability release)
@@ -1078,7 +1078,7 @@ Next patch release:
 	Added detection of network interfaces which belong to BSD jails.
 
 	Improve robustness of multi-threaded code, in particular fix
-	problems with spurious acces denials in server and losing of
+	problems with spurious access denials in server and losing of
 	authentication rules after policy reload.
 
 	cf-promises accepts option -b matching cf-agent, which causes it
@@ -1141,7 +1141,7 @@ Next patch release:
 3.1.2   (Scalability/efficiency release)
 
 	Big efficiency improvements by caching output from
-	cf-promises. Can also be used for much more efficent policy
+	cf-promises. Can also be used for much more efficient policy
 	deployment (only pull if changed).
 
 	Caching state of ps command for greater efficiency. Reloaded for each bundle.
@@ -1475,7 +1475,7 @@ Next patch release:
 	Reporting rationalized in cf-promises with -r only to avoid
 	leaving output files everywhere.
 
-	Hooks added for upcoming commerical additions to cfengine.
+	Hooks added for upcoming commercial additions to cfengine.
 
 	Added classify() and hostinnetgroup() functions
 	Added additional change management options for change detection

--- a/INSTALL
+++ b/INSTALL
@@ -88,7 +88,7 @@ INSTALLATION INSTRUCTIONS
 CFEngine might be installed in two configurations:
 
  * (default) Native CFEngine file layout. Everything is installed in
-   /var/cfengine, layed out as a "secondary FHS root". This layout is designed to
+   /var/cfengine, laid out as a "secondary FHS root". This layout is designed to
    keep CFEngine running even if most of the system is broken (e.g. /usr is not
    mounted due to NFS breakage).
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 This file contains a copy of:
 
 1) The GNU General Public License version 3
-1) The Commericial Open Source License (COSL)
+1) The Commercial Open Source License (COSL)
 
 ----------------------------------------------------------------------------
 

--- a/cf-agent/routing_services.c
+++ b/cf-agent/routing_services.c
@@ -17,7 +17,7 @@
   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
 
   To the extent this program is licensed as part of the Enterprise
-  versions of CFEngine, the applicable Commerical Open Source License
+  versions of CFEngine, the applicable Commercial Open Source License
   (COSL) may apply to this file if you as a licensee so wish it. See
   included file COSL.txt.
 */

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -838,7 +838,7 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
         if ((attr.recursion.travlinks) || (attr.copy.link_type == FILE_LINK_TYPE_NONE))
         {
             /* No point in checking if there are untrusted symlinks here,
-               since this is from a trusted source, by defintion */
+               since this is from a trusted source, by definition */
 
             if (cf_stat(newfrom, &sb, attr.copy, conn) == -1)
             {

--- a/cf-agent/verify_interfaces.c
+++ b/cf-agent/verify_interfaces.c
@@ -17,7 +17,7 @@
   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
 
   To the extent this program is licensed as part of the Enterprise
-  versions of CFEngine, the applicable Commerical Open Source License
+  versions of CFEngine, the applicable Commercial Open Source License
   (COSL) may apply to this file if you as a licensee so wish it. See
   included file COSL.txt.
 */
@@ -1042,7 +1042,7 @@ static void AssessBridge(char *promiser, PromiseResult *result, ARG_UNUSED EvalC
 
         if ((ExecCommand(comm, result, pp) != 0))
         {
-            Log(LOG_LEVEL_VERBOSE, "Memeber for bridge %s could not be added", promiser);
+            Log(LOG_LEVEL_VERBOSE, "Member for bridge %s could not be added", promiser);
             *result = PROMISE_RESULT_FAIL;
             return;
         }

--- a/cf-agent/verify_interfaces.h
+++ b/cf-agent/verify_interfaces.h
@@ -17,7 +17,7 @@
   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
 
   To the extent this program is licensed as part of the Enterprise
-  versions of CFEngine, the applicable Commerical Open Source License
+  versions of CFEngine, the applicable Commercial Open Source License
   (COSL) may apply to this file if you as a licensee so wish it. See
   included file COSL.txt.
 */

--- a/cf-agent/verify_networks.c
+++ b/cf-agent/verify_networks.c
@@ -17,7 +17,7 @@
   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
 
   To the extent this program is licensed as part of the Enterprise
-  versions of CFEngine, the applicable Commerical Open Source License
+  versions of CFEngine, the applicable Commercial Open Source License
   (COSL) may apply to this file if you as a licensee so wish it. See
   included file COSL.txt.
 */

--- a/cf-agent/verify_networks.h
+++ b/cf-agent/verify_networks.h
@@ -17,7 +17,7 @@
   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
 
   To the extent this program is licensed as part of the Enterprise
-  versions of CFEngine, the applicable Commerical Open Source License
+  versions of CFEngine, the applicable Commercial Open Source License
   (COSL) may apply to this file if you as a licensee so wish it. See
   included file COSL.txt.
 */

--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -52,7 +52,7 @@
 /*****************************************************************************/
 
 #define CF_ENVNEW_FILE   "env_data.new"
-#define cf_noise_threshold 6    /* number that does not warrent large anomaly status */
+#define cf_noise_threshold 6    /* number that does not warrant large anomaly status */
 #define MON_THRESHOLD_HIGH 1000000      // samples should stay below this threshold
 #define LDT_BUFSIZE 10
 

--- a/cf-monitord/mon_entropy.c
+++ b/cf-monitord/mon_entropy.c
@@ -61,7 +61,7 @@ void MonEntropyClassesReset(void)
  *   E = -------------------------
  *                 ln(N)
  *
- *   Divisor is a uncertainity per digit, to normalize it to [0..1] we divide it
+ *   Divisor is a uncertainty per digit, to normalize it to [0..1] we divide it
  *   by ln(N).
  */
 

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -236,7 +236,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 exit(EXIT_FAILURE);
             }
             cf_popen("/etc/init.d/avahi-daemon restart", "r", true);
-            Log(LOG_LEVEL_NOTICE, "Avahi configuration file generated successfuly.");
+            Log(LOG_LEVEL_NOTICE, "Avahi configuration file generated successfully.");
 #else
             Log(LOG_LEVEL_ERR, "Generating avahi configuration can only be done when avahi-daemon and libavahi are installed on the machine.");
 #endif

--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -1336,7 +1336,7 @@ int CfSecOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *dirn
 
 
 /**
- * Replace all occurences of #find with #replace.
+ * Replace all occurrences of #find with #replace.
  *
  * @return the length of #buf or (size_t) -1 in case of overflow, or 0
  *         if no replace took place.
@@ -1396,7 +1396,7 @@ static size_t StringReplace(char *buf, size_t buf_size,
 }
 
 /**
- * Search and replace occurences of #find1, #find2, #find3, with
+ * Search and replace occurrences of #find1, #find2, #find3, with
  * #repl1, #repl2, #repl3 respectively.
  *
  *   "$(connection.ip)" from "191.168.0.1"

--- a/cf-upgrade/tests/cf-upgrade-test.sh
+++ b/cf-upgrade/tests/cf-upgrade-test.sh
@@ -113,7 +113,7 @@ then
 else
     if [ ! -f $TEST_FOLDER/cf-upgrade-done ];
     then
-        echo "$TEST_NAME: Verfication Failure";
+        echo "$TEST_NAME: Verification Failure";
         echo "*** Debug info below ***";
         echo "command line: $CL";
         echo "output:";

--- a/examples/edit_column_files.cf
+++ b/examples/edit_column_files.cf
@@ -26,7 +26,7 @@
 #
 # Normal ordering:
 # - delete
-# - replace | colum_edit
+# - replace | column_edit
 # - insert
 # 
 ######################################################################

--- a/examples/edit_comment_lines.cf
+++ b/examples/edit_comment_lines.cf
@@ -26,7 +26,7 @@
 #
 # Normal ordering:
 # - delete
-# - replace | colum_edit
+# - replace | column_edit
 # - insert
 # 
 ######################################################################

--- a/examples/edit_replace_string.cf
+++ b/examples/edit_replace_string.cf
@@ -26,7 +26,7 @@
 #
 # Normal ordering:
 # - delete
-# - replace | colum_edit
+# - replace | column_edit
 # - insert
 # 
 ######################################################################

--- a/examples/fix_names.cf
+++ b/examples/fix_names.cf
@@ -26,7 +26,7 @@
 #
 # Normal ordering:
 # - delete
-# - replace | colum_edit
+# - replace | column_edit
 # - insert
 # 
 ######################################################################

--- a/examples/linking.cf
+++ b/examples/linking.cf
@@ -26,7 +26,7 @@
 #
 # Normal ordering:
 # - delete
-# - replace | colum_edit
+# - replace | column_edit
 # - insert
 # 
 ######################################################################

--- a/examples/package_apt.cf
+++ b/examples/package_apt.cf
@@ -23,7 +23,7 @@
 # to see list of packages type "apt-cache pkgnames"
 # to see list of installed packages type "dpkg --get-selections"
 #
-# Package managment
+# Package management
 #
 
 body common control

--- a/examples/package_freebsd.cf
+++ b/examples/package_freebsd.cf
@@ -22,7 +22,7 @@
 
 
 #
-# Package managment
+# Package management
 #
 
 body common control

--- a/examples/package_msi_file.cf
+++ b/examples/package_msi_file.cf
@@ -19,7 +19,7 @@
 # included file COSL.txt.
 
 #
-# MSI package managment using file name
+# MSI package management using file name
 #
 
 body common control

--- a/examples/package_msi_version.cf
+++ b/examples/package_msi_version.cf
@@ -19,7 +19,7 @@
 # included file COSL.txt.
 
 #
-# MSI package managment using version criteria
+# MSI package management using version criteria
 #
 
 body common control

--- a/examples/package_rpm.cf
+++ b/examples/package_rpm.cf
@@ -21,7 +21,7 @@
 # included file COSL.txt.
 
 #
-# Package managment
+# Package management
 #
 
 body common control

--- a/examples/package_solaris.cf
+++ b/examples/package_solaris.cf
@@ -22,7 +22,7 @@
 
 
 #
-# Package managment
+# Package management
 #
 
 body common control

--- a/examples/package_yum.cf
+++ b/examples/package_yum.cf
@@ -22,7 +22,7 @@
 
 
 #
-# Package managment
+# Package management
 #
 
 body common control

--- a/examples/package_zypper.cf
+++ b/examples/package_zypper.cf
@@ -22,7 +22,7 @@
 
 
 #
-# Package managment
+# Package management
 #
 
 body common control

--- a/ext/rpmvercmp.c
+++ b/ext/rpmvercmp.c
@@ -74,7 +74,7 @@ static int rpmvercmp(const char * a, const char * b)
 	while (*one && !risalnum(*one) && *one != '~') one++;
 	while (*two && !risalnum(*two) && *two != '~') two++;
 
-	/* handle the tilde separator, it sorts before everthing else */
+	/* handle the tilde separator, it sorts before everything else */
 	if (*one == '~' || *two == '~') {
 	    if (*one != '~') return 1;
 	    if (*two != '~') return -1;

--- a/libcfnet/classic.c
+++ b/libcfnet/classic.c
@@ -56,7 +56,7 @@ static bool LastRecvTimedOut(void)
 
  * @return -1 on error; or number of bytes received. It should return less
  *         than #toget bytes only if the peer closed the connection or timeout
- *         or other unrecoverable error occured.
+ *         or other unrecoverable error occurred.
  */
 int RecvSocketStream(int sd, char buffer[CF_BUFSIZE], int toget)
 {

--- a/libcfnet/client_code.h
+++ b/libcfnet/client_code.h
@@ -36,7 +36,7 @@ bool cfnet_init(void);
 void cfnet_shut(void);
 void DetermineCfenginePort(void);
 /**
-  @param err Set to 0 on success, -1 no server responce, -2 authentication failure.
+  @param err Set to 0 on success, -1 no server response, -2 authentication failure.
   */
 AgentConnection *ServerConnection(const char *server, const char *port,
                                   unsigned int connect_timeout,

--- a/libcfnet/net.c
+++ b/libcfnet/net.c
@@ -477,7 +477,7 @@ bool TryConnect(int sd, unsigned long timeout_ms,
         }
     }
 
-    /* Connection suceeded, return to blocking mode. */
+    /* Connection succeeded, return to blocking mode. */
     ret = fcntl(sd, F_SETFL, arg);
     if (ret == -1)
     {

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -275,7 +275,7 @@ int TLSVerifyCallback(X509_STORE_CTX *store_ctx,
  * @retval 0 if stored key for the host is missing or differs from the one
  *         received.
  * @retval -1 in case of other error (error will be Log()ed).
- * @note When return value is != -1 (so no error occured) the #conn_info struct
+ * @note When return value is != -1 (so no error occurred) the #conn_info struct
  *       should have been populated, with key received and its hash.
  */
 int TLSVerifyPeer(ConnectionInfo *conn_info, const char *remoteip, const char *username)
@@ -612,7 +612,7 @@ static void assert_SSLIsBlocking(const SSL *ssl)
  * @note Use only for *blocking* sockets. Set
  *       SSL_CTX_set_mode(SSL_MODE_AUTO_RETRY) and make sure you haven't
  *       turned on SSL_MODE_ENABLE_PARTIAL_WRITE so that either the
- *       operation is completed (retval==length) or an error occured.
+ *       operation is completed (retval==length) or an error occurred.
  *
  * @TODO ERR_get_error is only meaningful for some error codes, so check and
  *       return empty string otherwise.
@@ -663,7 +663,7 @@ int TLSSend(SSL *ssl, const char *buffer, int length)
  *         closed.
  * @note Use only for *blocking* sockets. Set
  *       SSL_CTX_set_mode(SSL_MODE_AUTO_RETRY) to make sure that either
- *       operation completed or an error occured.
+ *       operation completed or an error occurred.
  */
 int TLSRecv(SSL *ssl, char *buffer, int length)
 {

--- a/libcompat/strrstr.c
+++ b/libcompat/strrstr.c
@@ -27,7 +27,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /*
- * strrstr.c -- find last occurence of string in another string
+ * strrstr.c -- find last occurrence of string in another string
  *
  * Part of publib.  See man page for more information.
  * "@(#)publib-strutil:$Id: strrstr.c,v 1.1.1.1 1994/02/03 17:25:29 liw Exp $"

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1574,7 +1574,7 @@ static int Linux_Redhat_Version(EvalContext *ctx)
 
 /* Now, grok the release.  For AS, we neglect the AS at the end of the
  * numerical release because we already figured out that it *is* AS
- * from the infomation above.  We assume that all the strings will
+ * from the information above.  We assume that all the strings will
  * have the word 'release' before the numerical release.
  */
 

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -647,7 +647,7 @@ static void FindV6InterfacesInfo(EvalContext *ctx)
             }
         }
 
-        if (isalnum(buffer[0])) // This line is the interface indentifier
+        if (isalnum(buffer[0])) // This line is the interface identifier
         {
             char one[CF_SMALLBUF], two[CF_SMALLBUF];
             one[0] = '\0';

--- a/libpromises/bootstrap.h
+++ b/libpromises/bootstrap.h
@@ -70,7 +70,7 @@ bool WriteAmPolicyHubFile(const char *workdir, bool am_policy_hub);
 
 /**
  * @brief Write the builtin failsafe policy to the default location
- * @return True if succesful
+ * @return True if successful
  */
 bool WriteBuiltinFailsafePolicy(const char *workdir);
 
@@ -82,7 +82,7 @@ bool WriteBuiltinFailsafePolicyToPath(const char *filename);
 /**
  * @brief Removes all files in $(sys.inputdir)
  * @param inputdir
- * @return True if succesful
+ * @return True if successful
  */
 bool RemoveAllExistingPolicyInInputs(const char *inputdir);
 

--- a/libpromises/cf3globals.c
+++ b/libpromises/cf3globals.c
@@ -53,7 +53,7 @@ int LASTSEENEXPIREAFTER = SECONDS_PER_WEEK; /* GLOBAL_P */
 char POLICY_SERVER[CF_MAX_IP_LEN] = ""; /* GLOBAL_X */
 
 /*****************************************************************************/
-/* Compatability infrastructure                                              */
+/* Compatibility infrastructure                                              */
 /*****************************************************************************/
 
 bool DONTDO = false; /* GLOBAL_A */

--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -324,7 +324,7 @@ bool DBPrivHasKey(DBPriv *db, const void *key, int key_size)
     MDB_val mkey, data;
     MDB_txn *txn;
     int rc;
-    // FIXME: distinguish between "entry not found" and "error occured"
+    // FIXME: distinguish between "entry not found" and "error occurred"
 
     rc = GetReadTransaction(db, &txn);
     if (rc == MDB_SUCCESS)

--- a/libpromises/dbm_tokyocab.c
+++ b/libpromises/dbm_tokyocab.c
@@ -223,7 +223,7 @@ void DBPrivCommit(ARG_UNUSED DBPriv *db)
 
 bool DBPrivHasKey(DBPriv *db, const void *key, int key_size)
 {
-    // FIXME: distinguish between "entry not found" and "error occured"
+    // FIXME: distinguish between "entry not found" and "error occurred"
 
     return tchdbvsiz(db->hdb, key, key_size) != -1;
 }

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -117,7 +117,7 @@ int FnNumArgs(const FnCallType *call_type)
   */
 
 /*
- * Return succesful FnCallResult with copy of str retained.
+ * Return successful FnCallResult with copy of str retained.
  */
 static FnCallResult FnReturn(const char *str)
 {
@@ -125,7 +125,7 @@ static FnCallResult FnReturn(const char *str)
 }
 
 /*
- * Return succesful FnCallResult with str as is.
+ * Return successful FnCallResult with str as is.
  */
 static FnCallResult FnReturnNoCopy(char *str)
 {
@@ -6493,7 +6493,7 @@ void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print
             break;
         }
 
-        // TODO: the variable name is limited to 256 to accomodate the
+        // TODO: the variable name is limited to 256 to accommodate the
         // context name once it's in the vartable.  Maybe this can be relaxed.
         sscanf(line + 1, "%256[^=]=%4095[^\n]", name, content);
 
@@ -6511,7 +6511,7 @@ void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print
         break;
 
     case '%':
-        // TODO: the variable name is limited to 256 to accomodate the
+        // TODO: the variable name is limited to 256 to accommodate the
         // context name once it's in the vartable.  Maybe this can be relaxed.
         sscanf(line + 1, "%256[^=]=", name);
 

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -74,7 +74,7 @@ substituted directly for a LIST is not iterated, but dropped into
 place, i.e. in list-lvals and the promisee (since this would be
 equivalent to a re-concatenation of the expanded separate promises)
 
-Any list variable occuring within a scalar or in place of a scalar
+Any list variable occurring within a scalar or in place of a scalar
 is assumed to be iterated i.e. $(name).
 
 To expand a promise, we build temporary hash tables. There are two

--- a/libpromises/expand.h
+++ b/libpromises/expand.h
@@ -58,14 +58,14 @@ bool IsNakedVar(const char *str, char vtype);
   @brief Takes a variable and removes decorations.
 
   This function performs no validations, it is necessary to call the validation functions before calling this function.
-  @remarks This function does not check for NULL pointers, that is the caller's responsability.
+  @remarks This function does not check for NULL pointers, that is the caller's responsibility.
   @param s1 Buffer to store the undecorated variable.
   @param s2 Decorated variable
   */
 void GetNaked(char *s1, const char *s2);
 /**
   @brief Checks if a given variable is a list or not.
-  @remarks This function does not check for NULL pointers, it is responsability of the caller.
+  @remarks This function does not check for NULL pointers, it is responsibility of the caller.
   @param variable Variable to be checked
   @return True if the variable is a list, False otherwise.
   */

--- a/libpromises/extensions.c
+++ b/libpromises/extensions.c
@@ -139,7 +139,7 @@ void *extension_library_open(const char *name)
     const char * (*GetExtensionLibraryVersion)() = shlib_load(handle, "GetExtensionLibraryVersion");
     if (!GetExtensionLibraryVersion)
     {
-        Log(LOG_LEVEL_ERR, "Could not retreive version from extension plugin (%s). Not loading the plugin.", name);
+        Log(LOG_LEVEL_ERR, "Could not retrieve version from extension plugin (%s). Not loading the plugin.", name);
         goto close_and_fail;
     }
 

--- a/libpromises/logic_expressions.h
+++ b/libpromises/logic_expressions.h
@@ -92,7 +92,7 @@ struct Expression_
  * if succeeded, then result is the result of parsing and position is last
  * character consumed.
  *
- * if not succeded, then result is NULL and position is last character consumed
+ * if not succeeded, then result is NULL and position is last character consumed
  * before the error.
  */
 typedef struct

--- a/libpromises/mod_interfaces.c
+++ b/libpromises/mod_interfaces.c
@@ -17,7 +17,7 @@
   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
 
   To the extent this program is licensed as part of the Enterprise
-  versions of CFEngine, the applicable Commerical Open Source License
+  versions of CFEngine, the applicable Commercial Open Source License
   (COSL) may apply to this file if you as a licensee so wish it. See
   included file COSL.txt.
 */
@@ -91,7 +91,7 @@ static const ConstraintSyntax interface_constraints[] =
     ConstraintSyntaxNewBool("delete", "Delete an interface or bridge altogether", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewStringList("bridge_interfaces", "", "List of interfaces to bridge with IP forwarding", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewStringList("bond_interfaces", "", "List of interfaces to bond with LACP", SYNTAX_STATUS_NORMAL),
-    ConstraintSyntaxNewStringList("tagged_vlans", "", "List of labelled (trunk) vlan identifers for this interface", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewStringList("tagged_vlans", "", "List of labelled (trunk) vlan identifiers for this interface", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("untagged_vlan", CF_IDRANGE, "Unlabelled (access) vlan", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewStringList("ipv4_addresses", CF_IPRANGE, "A static IPV4 address", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewStringList("ipv6_addresses", CF_IPRANGE, "A static IPV6 address", SYNTAX_STATUS_NORMAL),

--- a/libpromises/mod_interfaces.h
+++ b/libpromises/mod_interfaces.h
@@ -17,7 +17,7 @@
   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
 
   To the extent this program is licensed as part of the Enterprise
-  versions of CFEngine, the applicable Commerical Open Source License
+  versions of CFEngine, the applicable Commercial Open Source License
   (COSL) may apply to this file if you as a licensee so wish it. See
   included file COSL.txt.
 */

--- a/libpromises/ornaments.c
+++ b/libpromises/ornaments.c
@@ -155,7 +155,7 @@ void Legend()
 
     Log(LOG_LEVEL_VERBOSE, "------------------------------------------------------------------------");
     Log(LOG_LEVEL_VERBOSE, "PREFIX LEGEND:");
-    Log(LOG_LEVEL_VERBOSE, " V: variable or paramter new definition in scope");
+    Log(LOG_LEVEL_VERBOSE, " V: variable or parameter new definition in scope");
     Log(LOG_LEVEL_VERBOSE, " C: class/context new definition ");
     Log(LOG_LEVEL_VERBOSE, " B: bundle start/end execution marker");
     Log(LOG_LEVEL_VERBOSE, " P: promise execution output ");

--- a/libpromises/patches.c
+++ b/libpromises/patches.c
@@ -27,7 +27,7 @@
   given platform These are conditionally compiled, pending extensions or
   developments in the OS concerned.
 
-  FIXME: move to the libcompat/ directory or to the apropriate source file.
+  FIXME: move to the libcompat/ directory or to the appropriate source file.
 */
 
 #include <cf3.defs.h>

--- a/libpromises/policy.h
+++ b/libpromises/policy.h
@@ -148,7 +148,7 @@ unsigned PolicyHash(const Policy *policy);
 StringSet *PolicySourceFiles(const Policy *policy);
 
 /**
- * @brief Merge two partial policy objects. The memory for the child objects of the original policies are transfered to the new parent.
+ * @brief Merge two partial policy objects. The memory for the child objects of the original policies are transferred to the new parent.
  * @param a
  * @param b
  * @return Merged policy

--- a/libpromises/process_unix.c
+++ b/libpromises/process_unix.c
@@ -189,7 +189,7 @@ static int SafeKill(pid_t pid, time_t expected_start_time, int signal)
     int saved_errno = errno;
 
     /*
-     * We don't check return value of SIGCONT, as the proces may have been
+     * We don't check return value of SIGCONT, as the process may have been
      * terminated already by previous kill. Moreover, what would we do with the
      * return code?
      */

--- a/libpromises/string_expressions.h
+++ b/libpromises/string_expressions.h
@@ -92,7 +92,7 @@ struct StringExpression_
  * if succeeded, then result is the result of parsing and position is last
  * character consumed.
  *
- * if not succeded, then result is NULL and position is last character consumed
+ * if not succeeded, then result is NULL and position is last character consumed
  * before the error.
  */
 typedef struct

--- a/libutils/ip_address.c
+++ b/libutils/ip_address.c
@@ -368,7 +368,7 @@ static int IPV6_parser(const char *source, struct IPV6Address *address)
     /*
      * IPV6 parsing is more complex than IPV4 parsing. There are a few ground rules:
      * - Leading zeros can be omitted.
-     * - Fields that are just zeros can be abreviated to one zero or completely omitted.
+     * - Fields that are just zeros can be abbreviated to one zero or completely omitted.
      * In the later case the following notation is used: '::'.
      * - Port number is specified in a special way:
      * [hhhh:hhhh:hhhh:hhhh:hhhh:hhhh:hhhh:hhhh]:ppppp

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -245,7 +245,7 @@ void JsonObjectAppendElement(JsonElement *object, const char *key, JsonElement *
   @brief Get the value of a field in an object, as a string.
   @param object [in] The JSON object parent.
   @param key [in] the key of the field.
-  @returns A pointer to the string value, or NULL if non-existant.
+  @returns A pointer to the string value, or NULL if non-existent.
   */
 const char *JsonObjectGetAsString(const JsonElement *object, const char *key);
 
@@ -253,7 +253,7 @@ const char *JsonObjectGetAsString(const JsonElement *object, const char *key);
   @brief Get the value of a field in an object, as an object.
   @param object [in] The JSON object parent.
   @param key [in] the key of the field.
-  @returns A pointer to the object value, or NULL if non-existant.
+  @returns A pointer to the object value, or NULL if non-existent.
   */
 JsonElement *JsonObjectGetAsObject(JsonElement *object, const char *key);
 
@@ -261,7 +261,7 @@ JsonElement *JsonObjectGetAsObject(JsonElement *object, const char *key);
   @brief Get the value of a field in an object, as an array.
   @param object [in] The JSON object parent.
   @param key [in] the key of the field.
-  @returns A pointer to the array value, or NULL if non-existant.
+  @returns A pointer to the array value, or NULL if non-existent.
   */
 JsonElement *JsonObjectGetAsArray(JsonElement *object, const char *key);
 
@@ -332,7 +332,7 @@ void JsonContainerReverse(JsonElement *array);
   @brief Get a string value from an array
   @param array [in] The JSON array parent
   @param index [in] Position of the value to get
-  @returns A pointer to the string value, or NULL if non-existant.
+  @returns A pointer to the string value, or NULL if non-existent.
   */
 const char *JsonArrayGetAsString(JsonElement *array, size_t index);
 
@@ -340,7 +340,7 @@ const char *JsonArrayGetAsString(JsonElement *array, size_t index);
   @brief Get an object value from an array
   @param array [in] The JSON array parent
   @param index [in] Position of the value to get
-  @returns A pointer to the object value, or NULL if non-existant.
+  @returns A pointer to the object value, or NULL if non-existent.
   */
 JsonElement *JsonArrayGetAsObject(JsonElement *array, size_t index);
 

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -28,7 +28,7 @@
 /*
  * Platform-specific definitions and declarations.
  *
- * INCLUDE THIS HEADER ALWAYS FIRST in order to define apropriate macros for
+ * INCLUDE THIS HEADER ALWAYS FIRST in order to define appropriate macros for
  * including system headers (such as _FILE_OFFSET_BITS).
  */
 

--- a/libutils/sequence.h
+++ b/libutils/sequence.h
@@ -138,7 +138,7 @@ ssize_t SeqIndexOf(Seq *seq, const void *key, SeqItemComparator Compare);
 ssize_t SeqBinaryIndexOf(Seq *seq, const void *key, SeqItemComparator Compare);
 
 /**
-  @brief Remove an inclusive range of items in the Sequence. A single item may be removed by specifiying start = end.
+  @brief Remove an inclusive range of items in the Sequence. A single item may be removed by specifying start = end.
   @param seq [in] The Sequence to remove from.
   @param start [in] Index of the first element to remove
   @param end [in] Index of the last element to remove.
@@ -165,7 +165,7 @@ void SeqSort(Seq *seq, SeqItemComparator compare, void *user_data);
 Seq *SeqSoftSort(const Seq *seq, SeqItemComparator compare, void *user_data);
 
 /**
-  @brief Remove an inclusive range of item handles in the Sequence. A single item may be removed by specifiying start = end.
+  @brief Remove an inclusive range of item handles in the Sequence. A single item may be removed by specifying start = end.
   @param seq [in] The Sequence to remove from.
   @param start [in] Index of the first element to remove
   @param end [in] Index of the last element to remove.

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -478,7 +478,7 @@ int CountChar(const char *string, char sep)
 }
 
 void ReplaceChar(char *in, char *out, int outSz, char from, char to)
-/* Replaces all occurences of 'from' to 'to' in preallocated
+/* Replaces all occurrences of 'from' to 'to' in preallocated
  * string 'out'. */
 {
     int len;
@@ -503,7 +503,7 @@ void ReplaceChar(char *in, char *out, int outSz, char from, char to)
 /* TODO replace with StringReplace. This one is pretty slow, calls strncmp
  * O(n) times even if string matches nowhere. */
 bool ReplaceStr(const char *in, char *out, int outSz, const char *from, const char *to)
-/* Replaces all occurences of strings 'from' to 'to' in preallocated
+/* Replaces all occurrences of strings 'from' to 'to' in preallocated
  * string 'out'. Returns true on success, false otherwise. */
 {
     int inSz;

--- a/m4/snprintf.m4
+++ b/m4/snprintf.m4
@@ -90,7 +90,7 @@ AC_DEFUN([HW_FUNC_VSNPRINTF],
 [
   AC_REQUIRE([HW_HEADER_STDARG_H])dnl Our check evaluates HAVE_STDARG_H.
 
-  dnl The folowing checks are not *required* to HAVE_VSNPRINTF, but they
+  dnl The following checks are not *required* to HAVE_VSNPRINTF, but they
   dnl should be checked (and pass!) for the test in snprintf.c to pass.
   AC_CHECK_HEADERS([inttypes.h locale.h stddef.h stdint.h])
   AC_CHECK_MEMBERS([struct lconv.decimal_point, struct lconv.thousands_sep],

--- a/tests/acceptance/01_vars/01_basic/long_string_from_embedded.cf
+++ b/tests/acceptance/01_vars/01_basic/long_string_from_embedded.cf
@@ -35,7 +35,7 @@ bundle agent check
 {
   classes:
       "ok" expression => "any",
-        comment => "If we made it to here, we didnt crash";
+        comment => "If we made it to here, we didn't crash";
 
   reports:
     DEBUG::

--- a/tests/acceptance/01_vars/02_functions/long_string_from_module.cf
+++ b/tests/acceptance/01_vars/02_functions/long_string_from_module.cf
@@ -39,7 +39,7 @@ bundle agent check
 {
   classes:
       "ok" expression => "any",
-        comment => "If we made it to here, we didnt crash";
+        comment => "If we made it to here, we didn't crash";
 
   reports:
     ok::

--- a/tests/acceptance/01_vars/02_functions/long_string_from_text_file.cf
+++ b/tests/acceptance/01_vars/02_functions/long_string_from_text_file.cf
@@ -38,7 +38,7 @@ bundle agent check
 {
   classes:
       "ok" expression => "any",
-        comment => "If we made it to here, we didnt crash";
+        comment => "If we made it to here, we didn't crash";
 
   reports:
     ok::

--- a/tests/acceptance/01_vars/02_functions/read_empty_file.cf
+++ b/tests/acceptance/01_vars/02_functions/read_empty_file.cf
@@ -1,4 +1,4 @@
-# Test that empty file is succesfully read by readfile() function
+# Test that empty file is successfully read by readfile() function
 
 body common control
 {

--- a/tests/acceptance/01_vars/02_functions/read_long_file.cf
+++ b/tests/acceptance/01_vars/02_functions/read_long_file.cf
@@ -1,4 +1,4 @@
-# Test that long file is succesfully read by readstringlist() function
+# Test that long file is successfully read by readstringlist() function
 
 body common control
 {

--- a/tests/acceptance/01_vars/02_functions/read_sys_file.cf
+++ b/tests/acceptance/01_vars/02_functions/read_sys_file.cf
@@ -1,4 +1,4 @@
-# Redmine#1032: Test that /sys and /proc files with 0 length are succesfully read by readfile() function
+# Redmine#1032: Test that /sys and /proc files with 0 length are successfully read by readfile() function
 
 body common control
 {

--- a/tests/acceptance/07_packages/001.cf
+++ b/tests/acceptance/07_packages/001.cf
@@ -93,7 +93,7 @@ bundle agent check
       "$(this.promise_filename) FAIL";
 }
 
-body classes succesfully_executed(class)
+body classes successfully_executed(class)
 {
       kept_returncodes => { "0" };
       promise_kept => { "$(class)" };

--- a/tests/acceptance/07_packages/002.cf
+++ b/tests/acceptance/07_packages/002.cf
@@ -95,7 +95,7 @@ bundle agent check
       "$(this.promise_filename) FAIL";
 }
 
-body classes succesfully_executed(class)
+body classes successfully_executed(class)
 {
       kept_returncodes => { "0" };
       promise_kept => { "$(class)" };

--- a/tests/acceptance/07_packages/003.cf
+++ b/tests/acceptance/07_packages/003.cf
@@ -95,7 +95,7 @@ bundle agent check
       "$(this.promise_filename) FAIL";
 }
 
-body classes succesfully_executed(class)
+body classes successfully_executed(class)
 {
       kept_returncodes => { "0" };
       promise_kept => { "$(class)" };

--- a/tests/acceptance/07_packages/004.cf
+++ b/tests/acceptance/07_packages/004.cf
@@ -98,7 +98,7 @@ bundle agent check
       "$(this.promise_filename) FAIL";
 }
 
-body classes succesfully_executed(class)
+body classes successfully_executed(class)
 {
       kept_returncodes => { "0" };
       promise_kept => { "$(class)" };

--- a/tests/acceptance/07_packages/005.cf
+++ b/tests/acceptance/07_packages/005.cf
@@ -99,7 +99,7 @@ bundle agent check
       "$(this.promise_filename) FAIL";
 }
 
-body classes succesfully_executed(class)
+body classes successfully_executed(class)
 {
       kept_returncodes => { "0" };
       promise_kept => { "$(class)" };

--- a/tests/acceptance/07_packages/006.cf
+++ b/tests/acceptance/07_packages/006.cf
@@ -99,7 +99,7 @@ bundle agent check
       "$(this.promise_filename) FAIL";
 }
 
-body classes succesfully_executed(class)
+body classes successfully_executed(class)
 {
       kept_returncodes => { "0" };
       promise_kept => { "$(class)" };

--- a/tests/acceptance/10_files/09_insert_lines/004.cf
+++ b/tests/acceptance/10_files/09_insert_lines/004.cf
@@ -24,7 +24,7 @@ bundle agent init
 BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END
         small potatoes";
@@ -35,7 +35,7 @@ BEGIN
     Three potatoe
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END
         small potatoes";

--- a/tests/acceptance/10_files/09_insert_lines/005.cf
+++ b/tests/acceptance/10_files/09_insert_lines/005.cf
@@ -24,7 +24,7 @@ bundle agent init
 BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END
         small potatoes";
@@ -34,7 +34,7 @@ END
 BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Three potatoe
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/006.cf
+++ b/tests/acceptance/10_files/09_insert_lines/006.cf
@@ -24,7 +24,7 @@ bundle agent init
 BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END
         small potatoes";
@@ -35,7 +35,7 @@ BEGIN
     One potato
     Three potatoe
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END
         small potatoes";

--- a/tests/acceptance/10_files/09_insert_lines/007.cf
+++ b/tests/acceptance/10_files/09_insert_lines/007.cf
@@ -24,7 +24,7 @@ bundle agent init
 BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END
         small potatoes";
@@ -35,7 +35,7 @@ BEGIN
     One potato
     Two potato
     Three potatoe
-    Two potatos
+    Two potatoes
     Four
 END
         small potatoes";

--- a/tests/acceptance/10_files/09_insert_lines/008.cf
+++ b/tests/acceptance/10_files/09_insert_lines/008.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 
@@ -31,7 +31,7 @@ END";
     Three potatoe
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 

--- a/tests/acceptance/10_files/09_insert_lines/009.cf
+++ b/tests/acceptance/10_files/09_insert_lines/009.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 
@@ -30,7 +30,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Three potatoe
     Four
 END";

--- a/tests/acceptance/10_files/09_insert_lines/010.cf
+++ b/tests/acceptance/10_files/09_insert_lines/010.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 
@@ -31,7 +31,7 @@ END";
     One potato
     Three potatoe
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 

--- a/tests/acceptance/10_files/09_insert_lines/011.cf
+++ b/tests/acceptance/10_files/09_insert_lines/011.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 
@@ -31,7 +31,7 @@ END";
     One potato
     Two potato
     Three potatoe
-    Two potatos
+    Two potatoes
     Four
 END";
 

--- a/tests/acceptance/10_files/09_insert_lines/012.cf
+++ b/tests/acceptance/10_files/09_insert_lines/012.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 
@@ -39,7 +39,7 @@ END";
     Two potato
     Three potatoe
             Spuds spuds spuds
-    Two potatos
+    Two potatoes
     Four
 END";
 

--- a/tests/acceptance/10_files/09_insert_lines/013.cf
+++ b/tests/acceptance/10_files/09_insert_lines/013.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 
@@ -37,7 +37,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END
     Three potatoe

--- a/tests/acceptance/10_files/09_insert_lines/014.cf
+++ b/tests/acceptance/10_files/09_insert_lines/014.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 
@@ -37,7 +37,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END
     Three potatoe

--- a/tests/acceptance/10_files/09_insert_lines/015.cf
+++ b/tests/acceptance/10_files/09_insert_lines/015.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 
@@ -37,7 +37,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END
     Three potatoe

--- a/tests/acceptance/10_files/09_insert_lines/016.cf
+++ b/tests/acceptance/10_files/09_insert_lines/016.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 
@@ -37,7 +37,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END
             Spuds spuds spuds";

--- a/tests/acceptance/10_files/09_insert_lines/101.cf
+++ b/tests/acceptance/10_files/09_insert_lines/101.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/102.cf
+++ b/tests/acceptance/10_files/09_insert_lines/102.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/103.cf
+++ b/tests/acceptance/10_files/09_insert_lines/103.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/104.cf
+++ b/tests/acceptance/10_files/09_insert_lines/104.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/105.cf
+++ b/tests/acceptance/10_files/09_insert_lines/105.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -38,7 +38,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/106.cf
+++ b/tests/acceptance/10_files/09_insert_lines/106.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -38,7 +38,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/107.cf
+++ b/tests/acceptance/10_files/09_insert_lines/107.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -38,7 +38,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/108.cf
+++ b/tests/acceptance/10_files/09_insert_lines/108.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -38,7 +38,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/112.cf
+++ b/tests/acceptance/10_files/09_insert_lines/112.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/113.cf
+++ b/tests/acceptance/10_files/09_insert_lines/113.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/114.cf
+++ b/tests/acceptance/10_files/09_insert_lines/114.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/115.cf
+++ b/tests/acceptance/10_files/09_insert_lines/115.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/116.cf
+++ b/tests/acceptance/10_files/09_insert_lines/116.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/117.cf
+++ b/tests/acceptance/10_files/09_insert_lines/117.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/118.cf
+++ b/tests/acceptance/10_files/09_insert_lines/118.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/119.cf
+++ b/tests/acceptance/10_files/09_insert_lines/119.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/121.cf
+++ b/tests/acceptance/10_files/09_insert_lines/121.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/122.cf
+++ b/tests/acceptance/10_files/09_insert_lines/122.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/201.cf
+++ b/tests/acceptance/10_files/09_insert_lines/201.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/202.cf
+++ b/tests/acceptance/10_files/09_insert_lines/202.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/203.cf
+++ b/tests/acceptance/10_files/09_insert_lines/203.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/204.cf
+++ b/tests/acceptance/10_files/09_insert_lines/204.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/205.cf
+++ b/tests/acceptance/10_files/09_insert_lines/205.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -38,7 +38,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/206.cf
+++ b/tests/acceptance/10_files/09_insert_lines/206.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -38,7 +38,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/207.cf
+++ b/tests/acceptance/10_files/09_insert_lines/207.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -38,7 +38,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/208.cf
+++ b/tests/acceptance/10_files/09_insert_lines/208.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -38,7 +38,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/212.cf
+++ b/tests/acceptance/10_files/09_insert_lines/212.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/213.cf
+++ b/tests/acceptance/10_files/09_insert_lines/213.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/214.cf
+++ b/tests/acceptance/10_files/09_insert_lines/214.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/215.cf
+++ b/tests/acceptance/10_files/09_insert_lines/215.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/216.cf
+++ b/tests/acceptance/10_files/09_insert_lines/216.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/217.cf
+++ b/tests/acceptance/10_files/09_insert_lines/217.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ Leading embedded and trailing spaces
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/218.cf
+++ b/tests/acceptance/10_files/09_insert_lines/218.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/219.cf
+++ b/tests/acceptance/10_files/09_insert_lines/219.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/221.cf
+++ b/tests/acceptance/10_files/09_insert_lines/221.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/222.cf
+++ b/tests/acceptance/10_files/09_insert_lines/222.cf
@@ -23,7 +23,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -39,7 +39,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/insertion-order-reversal.cf
+++ b/tests/acceptance/10_files/09_insert_lines/insertion-order-reversal.cf
@@ -22,7 +22,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Three potatos
+    Three potatoes
     Four
 END";
 

--- a/tests/acceptance/10_files/09_insert_lines/selectlinematching.cf.sub_1
+++ b/tests/acceptance/10_files/09_insert_lines/selectlinematching.cf.sub_1
@@ -28,7 +28,7 @@ vars:
 "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Four
 END";
 
@@ -36,7 +36,7 @@ END";
 "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Three potatoe
     Four
 END";

--- a/tests/acceptance/10_files/09_insert_lines/staging/120.x.cf
+++ b/tests/acceptance/10_files/09_insert_lines/staging/120.x.cf
@@ -21,7 +21,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -37,7 +37,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/09_insert_lines/staging/220.x.cf
+++ b/tests/acceptance/10_files/09_insert_lines/staging/220.x.cf
@@ -21,7 +21,7 @@ bundle agent init
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END";
@@ -37,7 +37,7 @@ END";
       "BEGIN
     One potato
     Two potato
-    Two potatos
+    Two potatoes
     Leading   embedded   and trailing spaces   
     Four
 END

--- a/tests/acceptance/10_files/templating/mustache_invalid_template.cf
+++ b/tests/acceptance/10_files/templating/mustache_invalid_template.cf
@@ -61,7 +61,7 @@ bundle agent check
 {
   classes:
       "ok" expression => "any",
-        comment => "If we made it to here we didnt segfault";
+        comment => "If we made it to here we didn't segfault";
 
   reports:
     ok::

--- a/tests/acceptance/15_control/01_common/004.cf
+++ b/tests/acceptance/15_control/01_common/004.cf
@@ -1,6 +1,6 @@
 #######################################################
 #
-# Test ignore_missing_bundles, expect to pass, order independant
+# Test ignore_missing_bundles, expect to pass, order independent
 #
 #######################################################
 

--- a/tests/acceptance/15_control/01_common/014.cf
+++ b/tests/acceptance/15_control/01_common/014.cf
@@ -1,6 +1,6 @@
 #######################################################
 #
-# Test ignore_missing_inputs, expect to pass, order independant
+# Test ignore_missing_inputs, expect to pass, order independent
 #
 #######################################################
 

--- a/tests/acceptance/mock_package_manager.c
+++ b/tests/acceptance/mock_package_manager.c
@@ -331,7 +331,7 @@ static void AddPackage(PackagePattern *pattern)
         Package *p = SeqAt(matching_available, i);
 
         SeqAppend(installed_packages, p);
-        fprintf(stderr, "Succesfully installed package %s\n", SerializePackage(p));
+        fprintf(stderr, "Successfully installed package %s\n", SerializePackage(p));
     }
 
     SavePackages(INSTALLED_PACKAGES_FILE_NAME, installed_packages);

--- a/tests/acceptance/plucked.cf.sub
+++ b/tests/acceptance/plucked.cf.sub
@@ -786,7 +786,7 @@ bundle edit_line set_config_values(v)
            classes => always("replace_attempted_$(cindex[$(index)])");
 
   insert_lines:
-      # If the line doesn't exist, or there is more than one occurance
+      # If the line doesn't exist, or there is more than one occurrence
       # of the LHS commented out, insert a new line and try to place it
       # after the commented LHS (keep new line with old comments)
       "$(index) $($(v)[$(index)])"
@@ -794,7 +794,7 @@ bundle edit_line set_config_values(v)
         location => after("^\s*#\s*($(index)\s+.*|$(index))$"),
       ifvarclass => "replace_attempted_$(cindex[$(index)]).multiple_comments_$(cindex[$(index)])";
 
-      # If the line doesn't exist and there are no occurances
+      # If the line doesn't exist and there are no occurrences
       # of the LHS commented out, insert a new line at the eof
       "$(index) $($(v)[$(index)])"
          comment => "Insert the value, marker doesn't exist $(index)",

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -197,7 +197,7 @@ usage() {
   echo "testall [-h|--help] [-q|--quiet] [--gainroot=<command>] [--agent=<agent>] [--cfpromises=<cf-promises>] [--cfserverd=<cf-serverd>] [--cfkey=<cf-key>] [--bindir=<bindir>] [--staging] [--unsafe] [--no-network] [--gdb] [--printlog] [<test> <test>...]"
   echo
   echo "If no test is given, all standard tests are run:"
-  echo "  Tests with names of form <file>.cf are expected to run succesfully"
+  echo "  Tests with names of form <file>.cf are expected to run successfully"
   echo "  Tests with names of form <file>.x.cf are expected to crash"
   echo "Set ${COLOR_SUCCESS}CFENGINE_COLOR=1${COLOR_NORMAL} to get ANSI color markers where appropriate."
   echo

--- a/tests/unit/cmockery.h
+++ b/tests/unit/cmockery.h
@@ -222,7 +222,7 @@
         cast_to_largest_integral_type(minimum), \
         cast_to_largest_integral_type(maximum), __FILE__, __LINE__)
 
-// Assert that the specified value is < minumum or > maximum
+// Assert that the specified value is < minimum or > maximum
 # define assert_not_in_range(value, minimum, maximum) \
     _assert_not_in_range( \
         cast_to_largest_integral_type(value), \
@@ -421,7 +421,7 @@ void _expect_any(const char *const function, const char *const parameter,
 void _check_expected(const char *const function_name, const char *const parameter_name,
                      const char *file, const int line, const LargestIntegralType value);
 
-// Can be used to replace assert in tested code so that in conjuction with
+// Can be used to replace assert in tested code so that in conjunction with
 // check_assert() it's possible to determine whether an assert condition has
 // failed without stopping a test.
 void mock_assert(const int result, const char *const expression, const char *const file, const int line);

--- a/tests/unit/findhub_test.c
+++ b/tests/unit/findhub_test.c
@@ -155,7 +155,7 @@ int avahi_client_errno(AvahiClient *c)
 
 const char *avahi_strerror(int error)
 {
-    return "Avahi error occured";
+    return "Avahi error occurred";
 }
 
 AvahiServiceResolver *avahi_service_resolver_new(AvahiClient *c, AvahiIfIndex index, AvahiProtocol protocol, const char * s1, const char *s2, const char *s3, 


### PR DESCRIPTION
Most typos are obvious and in comments or documentation, but some are in log messages or code, so please review carefully.
