### PR TITLE
Make backgrounding in tests easier by introducing no_fds command.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -766,6 +766,13 @@ AC_C_BIGENDIAN
 AC_CHECK_HEADERS([endian.h])
 AC_CHECK_DECLS(le32toh, [], [], [[#include <endian.h>]])
 
+AC_CHECK_DECLS(closefrom, [], [], [[#include <unistd.h>
+                                    #include <stdlib.h>]])
+AC_REPLACE_FUNCS(closefrom)
+
+AC_CHECK_HEADERS([sys/pstat.h])
+AC_CHECK_FUNCS(pstat_getfile2)
+
 CF3_PATH_ROOT_PROG([CHPASSWD], [chpasswd], [], [/sbin:/usr/sbin:/bin:/usr/bin:$PATH])
 AS_IF([test "x$CHPASSWD" != "x"],
       [AC_DEFINE(HAVE_CHPASSWD, 1, [Define if chpasswd tool is present])]

--- a/libcompat/closefrom.c
+++ b/libcompat/closefrom.c
@@ -1,0 +1,120 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <platform.h>
+#include <dir.h>
+#include <misc_lib.h>
+
+#ifdef HAVE_SYS_PSTAT_H
+# include <sys/pstat.h>
+#endif
+
+/*
+ * Does the same as FreeBSD's closefrom: Close all file descriptors higher than
+ * the given one.
+ */
+int closefrom(int fd)
+{
+#ifdef F_CLOSEM
+    return (fcntl(fd, F_CLOSEM, 0) == -1) ? -1 : 0;
+
+#elif defined(HAVE_PSTAT_GETFILE2)
+    const int block_size = 100;
+    struct pst_fileinfo2 info[block_size];
+    pid_t our_pid = getpid();
+
+    while (true)
+    {
+        int count = pstat_getfile2(info, sizeof(info[0]), block_size, 0, our_pid);
+        if (count < 0)
+        {
+            return -1;
+        }
+        else if (count == 0)
+        {
+            break;
+        }
+
+        for (int info_index = 0; info_index < count; info_index++)
+        {
+            close(info[info_index].psf_fd);
+        }
+    }
+
+#else
+# ifndef _WIN32
+    char proc_dir[50];
+
+    xsnprintf(proc_dir, sizeof(proc_dir), "/proc/%i/fd", getpid());
+
+    DIR *iter = opendir(proc_dir);
+    int iter_fd = dirfd(iter);
+    if (iter)
+    {
+        const struct dirent *entry;
+
+        while ((entry = readdir(iter)))
+        {
+            int curr_fd;
+
+            if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            {
+                continue;
+            }
+
+            if (sscanf(entry->d_name, "%i", &curr_fd) != 1)
+            {
+                closedir(iter);
+                errno = EBADF;
+                return -1;
+            }
+
+            if (curr_fd != iter_fd && curr_fd >= fd)
+            {
+                close(curr_fd);
+            }
+        }
+
+        closedir(iter);
+
+        return 0;
+    }
+# endif // !_WIN32
+
+    // Fall back to closing every file descriptor. Very inefficient, but will
+    // work.
+# ifdef _SC_OPEN_MAX
+    long max_fds = sysconf(_SC_OPEN_MAX);
+# else
+    long max_fds = 1024;
+# endif
+
+    for (long curr_fd = fd; curr_fd < max_fds; curr_fd++)
+    {
+        close(curr_fd);
+    }
+#endif
+
+    return 0;
+}

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -430,6 +430,10 @@ static inline uint32_t ByteSwap32(uint32_t le32uint)
 # endif
 #endif // !HAVE_DECL_LE32TOH
 
+#if !HAVE_DECL_CLOSEFROM
+int closefrom(int fd);
+#endif
+
 #if !HAVE_DECL_PTHREAD_ATTR_SETSTACKSIZE
 int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize);
 #endif

--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/defaults.cf
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/defaults.cf
@@ -28,11 +28,8 @@ body common control
 bundle agent init
 {
   meta:
-      # Backgrounding doesn't work properly on Windows.
-      #"test_skip_needs_work" string => "windows";
-      # Somehow the backgrounding leaves stale processes behind which messes
-      # with later executions. Needs to be fixed later.
-      "test_skip_needs_work" string => "any";
+      # Backgrounding doesn't work properly on Windows or with fakeroot.
+      "test_skip_needs_work" string => "windows|using_fakeroot";
 
   methods:
     test_pass_4::
@@ -56,7 +53,7 @@ bundle agent test
 
   commands:
     test_pass_1|test_pass_2|test_pass_3::
-      "$(sys.cf_agent) -D $(cases) -f $(this.promise_filename).sub 1>$(G.testfile).$(cases).output.log 2>&1 &"
+      "$(G.no_fds) $(sys.cf_agent) -D $(cases) -f $(this.promise_filename).sub 1>>$(G.testfile).$(cases).output.log 2>&1 &"
         contain => in_shell;
 }
 

--- a/tests/acceptance/Makefile.am
+++ b/tests/acceptance/Makefile.am
@@ -41,6 +41,9 @@ noinst_PROGRAMS += mock_package_manager
 
 mock_package_manager_SOURCES =
 mock_package_manager_LDADD = libmock_package_manager.la
+
+noinst_PROGRAMS += no_fds
+no_fds_LDADD = ../../libutils/libutils.la
 endif # !BUILTIN_EXTENSIONS
 
 if HAVE_LIBXML2

--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -38,6 +38,7 @@ bundle common G
                         "mkdir",
                         "mock_package_manager",
                         "mv",
+                        "no_fds",
                         "od",
                         "perl",
                         "printf",
@@ -133,6 +134,9 @@ bundle common G
       "testdir" string => "$(const.dirsep)tmp$(const.dirsep)TEST.cfengine";
       "testfile" string => "$(const.dirsep)tmp$(const.dirsep)TEST.cfengine";
 
+  classes:
+      "using_fakeroot"
+        expression => regcmp(".+", getenv("FAKEROOTKEY", "10"));
 }
 
 bundle common dcs_strings

--- a/tests/acceptance/no_fds.c
+++ b/tests/acceptance/no_fds.c
@@ -1,0 +1,101 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <logging.h>
+#include <platform.h>
+
+static void usage(void)
+{
+    printf("Runs the given command without inheriting any file descriptors.\n"
+           "Usage: no_fds [options]\n"
+           "Options:\n"
+           "      --no-std\n"
+           "        Even stdin/stdout/stderr will not be inherited.\n"
+           "  -h, --help\n"
+           "        This help screen.\n");
+}
+
+static void close_on_exec(int fd)
+{
+#ifdef _WIN32
+    SetHandleInformation((HANDLE)_get_osfhandle(fd), HANDLE_FLAG_INHERIT, 0);
+#else
+    long flags = fcntl(fd, F_GETFD);
+    flags |= FD_CLOEXEC;
+    fcntl(fd, F_SETFD, flags);
+#endif
+}
+
+int main(int argc, char **argv)
+{
+    bool std = true;
+    int startarg = 1;
+
+    for (int arg = 1; arg < argc; arg++)
+    {
+        if (strcmp(argv[arg], "--no-std") == 0)
+        {
+            std = false;
+            startarg++;
+        }
+        else if (strcmp(argv[arg], "-h") == 0 || strcmp(argv[arg], "--help") == 0)
+        {
+            usage();
+            return 0;
+        }
+        else if (argv[arg][0] == '-')
+        {
+            fprintf(stderr, "Unknown option: %s\n", argv[arg]);
+            usage();
+            return 1;
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    closefrom(3);
+
+    if (!std)
+    {
+        for (int fd = 0; fd < 3; fd++)
+        {
+            close_on_exec(fd);
+        }
+    }
+
+    char *new_args[argc - startarg + 1];
+    for (int i = startarg; i < argc; i++)
+    {
+        new_args[i - startarg] = argv[i];
+    }
+    new_args[argc - startarg] = NULL;
+
+    execvp(new_args[0], new_args);
+
+    fprintf(stderr, "Could not execute command '%s': %s\n", new_args[0], GetErrorStr());
+
+    return 1;
+}


### PR DESCRIPTION
The problem is that we don't know which file descriptors have been
opened behind our back, and most will be inherited by the new process.
The original process or its parent may then hang because some file
descriptor is still open, even though we didn't intend that. The
FD_CLOEXEC mechanism is not very helpful for descriptors we don't own,
so use the closefrom call to close all the descriptors we don't need
in the new process instead.