### PR TITLE
cf-upgrade: Fix out of tree builds

### DIFF
--- a/cf-upgrade/Makefile.am
+++ b/cf-upgrade/Makefile.am
@@ -25,7 +25,7 @@ sbin_PROGRAMS = cf-upgrade
 
 LIBS=				 # This tool should not link to anything
 AM_LDFLAGS=
-AM_CPPFLAGS=
+AM_CPPFLAGS=-I$(top_srcdir)/libutils # platform.h
 
 LDADD=../libcompat/libcompat.la
 


### PR DESCRIPTION
Building cfengine core out of the source tree fails with this error:

Making all in cf-upgrade
  CC       process.o
../../../../cf-upgrade/process.c:25:22: fatal error:
 platform.h: No such file or directory
 #include <platform.h>
                      ^
compilation terminated.
Makefile:513: recipe for target 'process.o' failed

After adding the missing include path to CPPFLAGS, the build
finishes successfully.

Signed-off-by: Stefan Weil <sw@weilnetz.de>