### PR TITLE
Redmine #6582: Fix deletion of dangling symlinks

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -264,6 +264,7 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
     struct stat osb, oslb, dsb;
     CfLock thislock;
     int exists;
+    bool link = false;
 
     Attributes attr = GetFilesAttributes(ctx, pp);
 
@@ -307,6 +308,7 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
             cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a, "File '%s' exists as promised", path);
         }
         exists = true;
+        link = true;
     }
 
     if ((a.havedelete) && (!exists))
@@ -406,7 +408,8 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
 
 /* Phase 1 - */
 
-    if (exists && ((a.havedelete) || (a.haverename) || (a.haveperms) || (a.havechange) || (a.transformer)))
+    if ((exists && ((a.haverename) || (a.haveperms) || (a.havechange) || (a.transformer))) ||
+        ((exists || link) && a.havedelete))
     {
         lstat(path, &oslb);     /* if doesn't exist have to stat again anyway */
 

--- a/tests/acceptance/10_files/10_links/003.cf
+++ b/tests/acceptance/10_files/10_links/003.cf
@@ -1,0 +1,54 @@
+#######################################################
+#
+# Delete dangling symlinks
+# https://dev.cfengine.com/issues/6582
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+}
+
+#######################################################
+
+bundle agent test
+{
+  files:
+      "$(G.testdir)/mylink"
+      link_from => ln_s("$(G.testdir)/sourcefile");
+
+      "$(G.testdir)/mylink"
+      delete => tidy;
+}
+
+body link_from ln_s(x)
+{
+      link_type => "symlink";
+      source => "$(x)";
+      when_no_source => "force";
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "link_present" expression => fileexists("$(G.testdir)/mylink");
+
+  reports:
+    !link_present::
+      "$(this.promise_filename) Pass";
+
+    link_present::
+      "$(this.promise_filename) Fail";
+}

--- a/tests/acceptance/10_files/10_links/003.cf
+++ b/tests/acceptance/10_files/10_links/003.cf
@@ -16,7 +16,9 @@ body common control
 
 bundle agent init
 {
-  vars:
+  files:
+      "$(G.testfile)/sourcefile"
+        delete => init_delete;
 }
 
 #######################################################
@@ -25,10 +27,10 @@ bundle agent test
 {
   files:
       "$(G.testdir)/mylink"
-      link_from => ln_s("$(G.testdir)/sourcefile");
+        link_from => ln_s("$(G.testdir)/sourcefile");
 
       "$(G.testdir)/mylink"
-      delete => tidy;
+        delete => tidy;
 }
 
 body link_from ln_s(x)


### PR DESCRIPTION
`DepthSearch` isn't entered when there's a dangling symlink. This is usually a good thing, however if a user wants to delete a dangling symlink with CFEngine, this poses a problem.

Also includes acceptance test.