### PR TITLE
foo!bar should not be interpretted as a valid class statement

### DIFF
--- a/libpromises/string_expressions.c
+++ b/libpromises/string_expressions.c
@@ -169,7 +169,18 @@ static StringParseResult ParseToken(const char *expr, int start, int end)
         endlit++;
     }
 
-    if (endlit > start)
+    if (endlit > start &&
+        (expr[endlit] == ':' ||
+        expr[endlit] == '.' ||
+        expr[endlit] == '|' ||
+        expr[endlit] == ')' ||
+        expr[endlit] == '(' ||
+        expr[endlit] == '$' ||
+        expr[endlit] == '@' ||
+        expr[endlit] == '{' ||
+        expr[endlit] == '}' ||
+        expr[endlit] == '&' ||
+        expr[endlit] == '\0'))
     {
         StringExpression *ret = xcalloc(1, sizeof(StringExpression));
 

--- a/tests/acceptance/00_basics/04_bundles/bad-namespace-placement.x.cf
+++ b/tests/acceptance/00_basics/04_bundles/bad-namespace-placement.x.cf
@@ -1,0 +1,27 @@
+body common control
+{
+      inputs => { "../../default.cf.sub", "namespaced.cf.subx" };
+      bundlesequence => { test,
+                          default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+}
+
+bundle agent test
+{
+  classes:
+    default:!any::
+      "ok" not => "any";
+}
+
+bundle agent check
+{
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Adds stricter token parsing. Only certain symbols should legally follow
valid tokens. ParseToken now checks the following character to ensure
that we aren't writing invalid class statements.

Before, `foo!bar` or `default:!foo` would be interpreted as valid class statements. It's unlikely that a user would encounter the former, but we had a case at LinkedIn where we encountered the latter. The old behavior was to just resolve that class as false *all* the time. Now, it triggers a parse error.

@nickanderson: this was the bug that I was talking to you about at the bar