### PR TITLE
On a badly configured host, hostname might return "(none)", and ...

### DIFF
--- a/examples/peerleader.cf
+++ b/examples/peerleader.cf
@@ -25,7 +25,7 @@
 #@ echo beta >> /tmp/cfe_hostlist
 #@ echo gamma >> /tmp/cfe_hostlist
 #@ echo "Set HOSTNAME appropriately beforehand"
-#@ echo $HOSTNAME >> /tmp/cfe_hostlist
+#@ echo "$HOSTNAME" >> /tmp/cfe_hostlist
 #@ echo "Delta Delta Delta may I help ya help ya help ya"
 #@ echo delta1 >> /tmp/cfe_hostlist
 #@ echo delta2 >> /tmp/cfe_hostlist

--- a/examples/peerleaders.cf
+++ b/examples/peerleaders.cf
@@ -25,7 +25,7 @@
 #@ echo beta >> /tmp/cfe_hostlist
 #@ echo gamma >> /tmp/cfe_hostlist
 #@ echo "Set HOSTNAME appropriately beforehand"
-#@ echo $HOSTNAME >> /tmp/cfe_hostlist
+#@ echo "$HOSTNAME" >> /tmp/cfe_hostlist
 #@ echo "Delta Delta Delta may I help ya help ya help ya"
 #@ echo delta1 >> /tmp/cfe_hostlist
 #@ echo delta2 >> /tmp/cfe_hostlist

--- a/examples/peers.cf
+++ b/examples/peers.cf
@@ -25,7 +25,7 @@
 #@ echo beta >> /tmp/cfe_hostlist
 #@ echo gamma >> /tmp/cfe_hostlist
 #@ echo "Set HOSTNAME appropriately beforehand"
-#@ echo $HOSTNAME >> /tmp/cfe_hostlist
+#@ echo "$HOSTNAME" >> /tmp/cfe_hostlist
 #@ echo "Delta Delta Delta may I help ya help ya help ya"
 #@ echo delta1 >> /tmp/cfe_hostlist
 #@ echo delta2 >> /tmp/cfe_hostlist


### PR DESCRIPTION
...thos parenthesis are erring the shell, so they need to be quoted.