### PR TITLE
Solaris build fixes

### DIFF
--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -503,6 +503,9 @@ int lstat(const char *file_name, struct stat *buf);
 #if !HAVE_DECL_SLEEP
 unsigned int sleep(unsigned int seconds);
 #endif
+#if !HAVE_DECL_ROUND
+double round(double x);
+#endif
 #if !HAVE_DECL_NANOSLEEP
 int nanosleep(const struct timespec *req, struct timespec *rem);
 #endif

--- a/tests/acceptance/06_storage/01_local/001.cf
+++ b/tests/acceptance/06_storage/01_local/001.cf
@@ -24,7 +24,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "sunos_5_10|sunos_5_11",
+      "test_suppress_fail" string => "sunos_5_11",
         meta => { "redmine5234" };
 
   vars:

--- a/tests/acceptance/10_files/09_insert_lines/017.cf
+++ b/tests/acceptance/10_files/09_insert_lines/017.cf
@@ -16,7 +16,7 @@ body common control
 
 bundle agent test {
   meta:
-      "test_suppress_fail" string => "aix|hpux",
+      "test_suppress_fail" string => "aix|hpux|sunos_5_9|sunos_5_10",
         meta => { "redmine6336" };
 
   files:

--- a/tests/acceptance/17_users/unsafe/10_modify_user_with_same_password.cf
+++ b/tests/acceptance/17_users/unsafe/10_modify_user_with_same_password.cf
@@ -28,14 +28,16 @@ bundle agent init
   meta:
       "test_skip_unsupported" string => "hpux_trusted_mode_test.!hpux";
 
-      # Something in the Solaris 10/11 chroot test environment makes it impossible
+      # Something in the Solaris chroot test environment makes it impossible
       # to test matching passwords, the pam module always returns error.
       # This should not happen in a production system though.
       # Since the error is not on our part, and likely unsolvable, we set
       # Redmine to zero. However, it would be nice to know if the problem ever
       # goes away, so using soft_fail.
-      "test_soft_fail" string => "!hpux_trusted_mode_test.(sunos_5_10|sunos_5_11)",
+      "test_soft_fail" string => "!hpux_trusted_mode_test.(solaris.!sunos_5_9)",
         meta => { "redmine0" };
+      # On Solaris 9 PAM just crashes inside chroot.
+      "test_skip_needs_work" string => "!hpux_trusted_mode_test.sunos_5_9";
   vars:
     # This is the same password as the plaintext one further down.
     "hash" string => "dTloMVpjYt1w2";

--- a/tests/acceptance/17_users/unsafe/10_modify_user_with_same_password.cf
+++ b/tests/acceptance/17_users/unsafe/10_modify_user_with_same_password.cf
@@ -34,7 +34,7 @@ bundle agent init
       # Since the error is not on our part, and likely unsolvable, we set
       # Redmine to zero. However, it would be nice to know if the problem ever
       # goes away, so using soft_fail.
-      "test_soft_fail" string => "sunos_5_10|sunos_5_11",
+      "test_soft_fail" string => "!hpux_trusted_mode_test.(sunos_5_10|sunos_5_11)",
         meta => { "redmine0" };
   vars:
     # This is the same password as the plaintext one further down.

--- a/tests/acceptance/17_users/unsafe/10_promise_outcomes.cf
+++ b/tests/acceptance/17_users/unsafe/10_promise_outcomes.cf
@@ -24,14 +24,16 @@ bundle agent init
   meta:
       "test_skip_unsupported" string => "hpux_trusted_mode_test.!hpux";
 
-      # Something in the Solaris 10/11 chroot test environment makes it impossible
+      # Something in the Solaris chroot test environment makes it impossible
       # to test matching passwords, the pam module always returns error.
       # This should not happen in a production system though.
       # Since the error is not on our part, and likely unsolvable, we set
       # Redmine to zero. However, it would be nice to know if the problem ever
       # goes away, so using soft_fail.
-      "test_soft_fail" string => "!hpux_trusted_mode_test.(sunos_5_10|sunos_5_11)",
+      "test_soft_fail" string => "!hpux_trusted_mode_test.(solaris.!sunos_5_9)",
         meta => { "redmine0" };
+      # On Solaris 9 PAM just crashes inside chroot.
+      "test_skip_needs_work" string => "!hpux_trusted_mode_test.sunos_5_9";
 
   # AIX doesn't like long names (> 8 chars), so keep them short.
   # a = absent

--- a/tests/acceptance/17_users/unsafe/10_promise_outcomes.cf
+++ b/tests/acceptance/17_users/unsafe/10_promise_outcomes.cf
@@ -30,7 +30,7 @@ bundle agent init
       # Since the error is not on our part, and likely unsolvable, we set
       # Redmine to zero. However, it would be nice to know if the problem ever
       # goes away, so using soft_fail.
-      "test_soft_fail" string => "sunos_5_10|sunos_5_11",
+      "test_soft_fail" string => "!hpux_trusted_mode_test.(sunos_5_10|sunos_5_11)",
         meta => { "redmine0" };
 
   # AIX doesn't like long names (> 8 chars), so keep them short.

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -192,6 +192,10 @@ if HPUX
 XFAIL_TESTS = mon_load_test # Redmine #3569
 endif
 
+if SOLARIS
+XFAIL_TESTS = process_test # Redmine #6946
+endif
+
 #
 # OS X uses real system calls instead of our stubs unless this option is used
 #

--- a/tests/unit/dynamic_dependency_test.sh
+++ b/tests/unit/dynamic_dependency_test.sh
@@ -51,7 +51,8 @@ fi
 cd ../..
 
 # Sanity check that nm works.
-if ! nm --help >/dev/null; then
+if ! which nm | grep '^/' >/dev/null; then
+    echo "Could not find nm"
     exit 2
 fi
 

--- a/tests/unit/dynamic_dependency_test.sh
+++ b/tests/unit/dynamic_dependency_test.sh
@@ -49,6 +49,12 @@ fi
 
 
 cd ../..
+
+# Sanity check that nm works.
+if ! nm --help >/dev/null; then
+    exit 2
+fi
+
 #                libutils.a         libenv.a         libcfnet.a
 #                    v                 v                 v
 for symbol in LogSetGlobalLevel GetInterfacesInfo ConnectionInfoNew; do


### PR DESCRIPTION
Various fixes for Solaris. This was used to build the 3.6.4 package so the commit IDs should not be altered. If fixes are needed they should be put on top.