### PR TITLE
Fix improper use of #!/bin/bash

### DIFF
--- a/tests/unit/dynamic_dependency_test.sh
+++ b/tests/unit/dynamic_dependency_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Tests that the symbols in our static libraries do not occur twice in the
 # output binaries. Most platforms don't warn about this, but it has potential


### PR DESCRIPTION
This fixes unit test failures on *BSD environments where bash is at `/usr/local/bin/bash` or similar. (Also certain AIX and HP-UX configurations.)