### PR TITLE
Redmine #6926 Fix cf-monitord open ports report

### DIFF
--- a/cf-monitord/mon_network.c
+++ b/cf-monitord/mon_network.c
@@ -200,6 +200,12 @@ void MonNetworkGatherData(double *cf_this)
 
     DeleteItemList(ALL_INCOMING);
     ALL_INCOMING = NULL;
+    
+    DeleteItemList(MON_TCP4);
+    DeleteItemList(MON_TCP6);
+    DeleteItemList(MON_UDP4);
+    DeleteItemList(MON_UDP6);
+    MON_UDP4 = MON_UDP6 = MON_TCP4 = MON_TCP6 = NULL;
 
     sscanf(VNETSTAT[VSYSTEMHARDCLASS], "%s", comm);
 


### PR DESCRIPTION
Cf-monitord is not removing entries from the list containing open ports.
Once port was open and is closed later on it is reported as open.
This makes sure list is empty before open ports are collected.