### PR TITLE
Redmine#7031: string_mustache() function

### DIFF
--- a/examples/string_mustache.cf
+++ b/examples/string_mustache.cf
@@ -1,0 +1,70 @@
+#  Copyright (C) Cfengine AS
+
+#  This file is part of Cfengine 3 - written and maintained by Cfengine AS.
+
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License as published by the
+#  Free Software Foundation; version 3.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+# To the extent this program is licensed as part of the Enterprise
+# versions of Cfengine, the applicable Commercial Open Source License
+# (COSL) may apply to this file if you as a licensee so wish it. See
+# included file COSL.txt.
+
+#+begin_src cfengine3
+body common control
+{
+      bundlesequence => { "config", "example" };
+}
+
+bundle agent config
+{
+  vars:
+      "deserts" data => parsejson('{ "deserts": {
+  "Africa": "Sahara",
+  "Asia": "Gobi"
+} }');
+}
+
+
+bundle agent example
+{
+  vars:
+      # {{@}} is the current key during an iteration in 3.7 with Mustache
+      "with_data_container" string => string_mustache("from container: deserts = {{%deserts}}
+from container: {{#deserts}}The desert {{.}} is in {{@}}. {{/deserts}}", "config.deserts");
+
+      # you can dump an entire data structure with {{%myvar}} in 3.7 with Mustache
+      "with_system_state" string => string_mustache("from datastate(): deserts = {{%vars.config.deserts.deserts}}
+from datastate(): {{#vars.config.deserts.deserts}}The desert {{.}} is in {{@}}. {{/vars.config.deserts.deserts}}"); # will use datastate()
+
+  reports:
+      "With an explicit data container: $(with_data_container)";
+
+      "With the system datastate(): $(with_system_state)";
+}
+#+end_src
+###############################################################################
+#+begin_src example_output
+#@ ```
+#@ R: With an explicit data container: from container: deserts = {
+#@   "Africa": "Sahara",
+#@   "Asia": "Gobi"
+#@ }
+#@ from container: The desert Sahara is in Africa. The desert Gobi is in Asia. 
+#@ R: With the system datastate(): from datastate(): deserts = {
+#@   "Africa": "Sahara",
+#@   "Asia": "Gobi"
+#@ }
+#@ from datastate(): The desert Sahara is in Africa. The desert Gobi is in Asia. 
+#@ ```
+#+end_src

--- a/tests/acceptance/01_vars/02_functions/string_mustache.cf
+++ b/tests/acceptance/01_vars/02_functions/string_mustache.cf
@@ -1,0 +1,48 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  vars:
+      "desert" string => "Sahara";
+}
+
+bundle agent test
+{
+  vars:
+      "state1" data => datastate();
+      "out11" string => string_mustache("desert = {{vars.init.desert}}", state1);
+      "out12" string => string_mustache("desert = {{vars.init.desert}}");
+
+      "state2" data => parsejson('{"x": 1, "y": [{"item": 2}, {"item": 3}, {"item": 4}]}');
+      "out21" string => string_mustache("desert = {{vars.init.desert}}", state2);
+      "out22" string => string_mustache("x = {{x}}", state2);
+      "out23" string => string_mustache("{{#y}}{{item}} {{/y}}", state2);
+}
+
+bundle agent check
+{
+  vars:
+      "actual" string => "
+out11 = $(test.out11)
+out12 = $(test.out12)
+out21 = $(test.out21)
+out22 = $(test.out22)
+out23 = $(test.out23)
+";
+      "expected" string => "
+out11 = desert = Sahara
+out12 = desert = Sahara
+out21 = desert = 
+out22 = x = 1
+out23 = 2 3 4 
+";
+
+  methods:
+      "" usebundle => dcs_check_strcmp($(actual), $(expected), $(this.promise_filename), "no");
+
+}


### PR DESCRIPTION
See https://dev.cfengine.com/issues/7031

This is a very simple function that is useful when you don't want to create an external `.mustache` file.

Test policy:

```
bundle agent main
{
  vars:
      "state" data => datastate();
      "out" string => string_mustache(state, "sys.os = {{vars.sys.os}}");
      "out2" string => string_mustache(state, "sys.os = {{vars.sys.os");
      "out3" string => string_mustache(nosuchstate, "sys.os = {{vars.sys.os}}");

  reports:
      "mustache out: $(out)";
      "mustache out: $(out2)"; # no expansion
      "mustache out: $(out3)"; # no expansion
}
```

Output:

```console
% cf-agent -KI -f test_string_mustache.cf
R: mustache out: sys.os = linux
R: mustache out: $(out2)
R: mustache out: $(out3)
warning: Broken Mustache template, could not find end delimiter after reading start delimiter at 'sys.os = {{vars.sys.os'...
```