### PR TITLE
Ignore HAVE_STRUCT_SOCKADDR_SA_LEN on NetBSD.

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -54,7 +54,7 @@
 
 #ifndef __MINGW32__
 
-# ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+# if defined(HAVE_STRUCT_SOCKADDR_SA_LEN) && !defined(__NetBSD__)
 #  ifdef _SIZEOF_ADDR_IFREQ
 #   define SIZEOF_IFREQ(x) _SIZEOF_ADDR_IFREQ(x)
 #  else


### PR DESCRIPTION
This has been used on NetBSD for quite some time.
See https://github.com/jsonn/pkgsrc/blob/trunk/sysutils/cfengine3/patches/patch-src_unix.c

Merging this will reduce the number of patches that need to be maintained for NetBSD in pkgsrc.