### PR TITLE
Remove dependency that is not needed for community and enterprise.

### DIFF
--- a/misc/systemd/cfengine3.service
+++ b/misc/systemd/cfengine3.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=CFEngine 3 deamons
 After=syslog.target
-Wants=cfengine3-web.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
IMPORTANT: this will break rhel7 hub package so needs to be fixed
when hub package support will be added.
(cherry picked from commit f7258ca52ba6eea95547eb0d57ff6f16f6f6d551)