### PR TITLE
data_regextract: new function like regextract, returns data container with named captures

### DIFF
--- a/examples/data_regextract.cf
+++ b/examples/data_regextract.cf
@@ -1,0 +1,52 @@
+#  Copyright (C) Cfengine AS
+
+#  This file is part of Cfengine 3 - written and maintained by Cfengine AS.
+
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License as published by the
+#  Free Software Foundation; version 3.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+# To the extent this program is licensed as part of the Enterprise
+# versions of Cfengine, the applicable Commercial Open Source License
+# (COSL) may apply to this file if you as a licensee so wish it. See
+# included file COSL.txt.
+
+###############################################################################
+#+begin_src cfengine3
+bundle agent main
+{
+  vars:
+      # the returned data container is a key-value map:
+
+      # the whole matched string is put in key "0"
+      # the first three characters are put in key "name1"
+      # the next three characters go into key "2" (the capture has no name)
+      # the next two characters go into key "3" (the capture has no name)
+      # then the dash is ignored
+      # then three characters are put in key "name2"
+      # then another dash is ignored
+      # the next three characters go into key "5" (the capture has no name)
+      # anything else is ignored
+
+      "parsed" data => data_regextract("^(?<name1>...)(...)(..)-(?<name2>...)-(..).*", "abcdef12-345-67andsoon");
+      "parsed_str" string => format("%S", parsed);
+
+  reports:
+      "$(this.bundle): '$(parsed[0])' parses into: $(parsed_str)";
+}
+#+end_src
+###############################################################################
+#+begin_src example_output
+#@ ```
+#@ R: main: 'abcdef12-345-67andsoon' parses into: {"0":"abcdef12-345-67andsoon","name1":"abc","2":"def","3":"12","name2":"345","5":"67"}
+#@ ```
+#+end_src

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -2632,24 +2632,24 @@ static FnCallResult FnCallMergeData(EvalContext *ctx, ARG_UNUSED const Policy *p
 
         if (name_len > 2 && name_str[0] == '[')
         {
-            Seq *s = StringMatchCaptures("^\\[ *([^ ]+) *\\]$", name_str);
+            Seq *s = StringMatchCaptures("^\\[ *([^ ]+) *\\]$", name_str, false);
 
             if (s && SeqLength(s) == 2)
             {
                 wrap_array_mode = true;
-                name = BufferNewFrom(SeqAt(s, 1), strlen(SeqAt(s, 1)));
+                name = BufferCopy((const Buffer*) SeqAt(s, 1));
             }
 
             SeqDestroy(s);
         }
         else if (name_len > 0 && name_str[0] == '{' && name_str[name_len-1] == '}')
         {
-            Seq *s = StringMatchCaptures("^\\{ *\"([^\"]+)\" *: *([^ ]+) *\\}$", name_str);
+            Seq *s = StringMatchCaptures("^\\{ *\"([^\"]+)\" *: *([^ ]+) *\\}$", name_str, false);
 
             if (s && SeqLength(s) == 3)
             {
-                wrap_map_key = BufferNewFrom(SeqAt(s, 1), strlen(SeqAt(s, 1)));
-                name = BufferNewFrom(SeqAt(s, 2), strlen(SeqAt(s, 2)));
+                wrap_map_key = BufferCopy((const Buffer*) SeqAt(s, 1));
+                name = BufferCopy((const Buffer*) SeqAt(s, 2));
             }
 
             SeqDestroy(s);
@@ -4128,12 +4128,12 @@ static FnCallResult FnCallFormat(EvalContext *ctx, ARG_UNUSED const Policy *poli
         Seq *s;
 
         while (check &&
-               (s = StringMatchCaptures("^(%%|%[^diouxXeEfFgGaAcsCSpnm%]*?[diouxXeEfFgGaAcsCSpnm])([^%]*)(.*)$", check)))
+               (s = StringMatchCaptures("^(%%|%[^diouxXeEfFgGaAcsCSpnm%]*?[diouxXeEfFgGaAcsCSpnm])([^%]*)(.*)$", check, false)))
         {
             {
                 if (SeqLength(s) >= 2)
                 {
-                    const char *format_piece = SeqAt(s, 1);
+                    const char *format_piece = BufferData(SeqAt(s, 1));
                     bool percent = (0 == strncmp(format_piece, "%%", 2));
                     char *data = NULL;
 
@@ -4288,9 +4288,7 @@ static FnCallResult FnCallFormat(EvalContext *ctx, ARG_UNUSED const Policy *poli
             {
                 if (SeqLength(s) >= 3)
                 {
-                    const char* static_piece = SeqAt(s, 2);
-                    BufferAppend(buf, static_piece, strlen(static_piece));
-                    // CfOut(OUTPUT_LEVEL_INFORM, "", "format: appending static piece = '%s'", static_piece);
+                    BufferAppend(buf, BufferData(SeqAt(s, 2)), BufferSize(SeqAt(s, 2)));
                 }
                 else
                 {
@@ -4301,7 +4299,7 @@ static FnCallResult FnCallFormat(EvalContext *ctx, ARG_UNUSED const Policy *poli
             {
                 if (SeqLength(s) >= 4)
                 {
-                    strlcpy(check_buffer, SeqAt(s, 3), CF_BUFSIZE);
+                    strlcpy(check_buffer, BufferData(SeqAt(s, 3)), CF_BUFSIZE);
                     check = check_buffer;
                 }
                 else
@@ -4793,49 +4791,85 @@ static FnCallResult FnCallRegCmp(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const P
 
 static FnCallResult FnCallRegExtract(EvalContext *ctx, ARG_UNUSED const Policy *policy, ARG_UNUSED const FnCall *fp, const Rlist *finalargs)
 {
+    const bool container_mode = strcmp(fp->name, "data_regextract") == 0;
+
     const char *regex = RlistScalarValue(finalargs);
     const char *data = RlistScalarValue(finalargs->next);
-    char *arrayname = xstrdup(RlistScalarValue(finalargs->next->next));
-    if (!IsQualifiedVariable(arrayname))
+    char *arrayname = NULL;
+
+    if (!container_mode)
     {
-        if (fp->caller)
+        arrayname = xstrdup(RlistScalarValue(finalargs->next->next));
+
+        if (!IsQualifiedVariable(arrayname))
         {
-            VarRef *ref = VarRefParseFromBundle(arrayname, PromiseGetBundle(fp->caller));
-            free(arrayname);
-            arrayname = VarRefToString(ref, true);
-            VarRefDestroy(ref);
-        }
-        else
-        {
-            Log(LOG_LEVEL_ERR, "Function '%s' called with an unqualifed array reference '%s', "
-                "and the reference could not be automatically qualified as the function was not called from a promise.",
-                fp->name, arrayname);
-            free(arrayname);
-            return FnFailure();
+            if (fp->caller)
+            {
+                VarRef *ref = VarRefParseFromBundle(arrayname, PromiseGetBundle(fp->caller));
+                free(arrayname);
+                arrayname = VarRefToString(ref, true);
+                VarRefDestroy(ref);
+            }
+            else
+            {
+                Log(LOG_LEVEL_ERR, "Function '%s' called with an unqualifed array reference '%s', "
+                    "and the reference could not be automatically qualified as the function was not called from a promise.",
+                    fp->name, arrayname);
+                free(arrayname);
+                return FnFailure();
+            }
         }
     }
 
-    Seq *s = StringMatchCaptures(regex, data);
+    Seq *s = StringMatchCaptures(regex, data, true);
 
     if (!s || SeqLength(s) == 0)
     {
         SeqDestroy(s);
         free(arrayname);
-        return FnReturnContext(false);
+        return container_mode ? FnFailure() : FnReturnContext(false);
     }
 
-    for (int i = 0; i < SeqLength(s); ++i)
+    JsonElement *json = NULL;
+
+    if (container_mode)
     {
-        char var[CF_MAXVARSIZE] = "";
-        snprintf(var, CF_MAXVARSIZE - 1, "%s[%d]", arrayname, i);
-        VarRef *new_ref = VarRefParse(var);
-        EvalContextVariablePut(ctx, new_ref, SeqAt(s, i), CF_DATA_TYPE_STRING, "source=function,function=regextract");
-        VarRefDestroy(new_ref);
+        json = JsonObjectCreate(SeqLength(s)/2);
+    }
+
+    for (int i = 0; i < SeqLength(s); i+=2)
+    {
+        Buffer *key = SeqAt(s, i);
+        Buffer *value = SeqAt(s, i+1);
+
+
+        if (container_mode)
+        {
+            JsonObjectAppendString(json, BufferData(key), BufferData(value));
+        }
+        else
+        {
+            char var[CF_MAXVARSIZE] = "";
+            snprintf(var, CF_MAXVARSIZE - 1, "%s[%s]", arrayname, BufferData(key));
+            VarRef *new_ref = VarRefParse(var);
+            EvalContextVariablePut(ctx, new_ref, BufferData(value),
+                                   CF_DATA_TYPE_STRING,
+                                   "source=function,function=regextract");
+            VarRefDestroy(new_ref);
+        }
     }
 
     free(arrayname);
     SeqDestroy(s);
-    return FnReturnContext(true);
+
+    if (container_mode)
+    {
+        return (FnCallResult) { FNCALL_SUCCESS, (Rval) { json, RVAL_TYPE_CONTAINER } };
+    }
+    else
+    {
+        return FnReturnContext(true);
+    }
 }
 
 /*********************************************************************/
@@ -7324,6 +7358,13 @@ static const FnCallArg REGEXTRACT_ARGS[] =
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
+static const FnCallArg DATA_REGEXTRACT_ARGS[] =
+{
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Regular expression"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Match string"},
+    {NULL, CF_DATA_TYPE_NONE, NULL}
+};
+
 static const FnCallArg REGISTRYVALUE_ARGS[] =
 {
     {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Windows registry key"},
@@ -7893,6 +7934,10 @@ const FnCallType CF_FNCALL_TYPES[] =
     FnCallTypeNew("min", CF_DATA_TYPE_STRING, SORT_ARGS, &FnCallFold, "Return the minimum of a list",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("variance", CF_DATA_TYPE_REAL, STAT_FOLD_ARGS, &FnCallFold, "Return the variance of a list",
+                  FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
+
+    // Data container functions
+    FnCallTypeNew("data_regextract", CF_DATA_TYPE_CONTAINER, DATA_REGEXTRACT_ARGS, &FnCallRegExtract, "Matches the regular expression in arg 1 against the string in arg2 and returns a data container holding the backreferences by name",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
 
     // File parsing functions that output a data container

--- a/libutils/regex.h
+++ b/libutils/regex.h
@@ -41,7 +41,7 @@ bool StringMatchWithPrecompiledRegex(pcre *regex, const char *str,
                                      int *start, int *end);
 bool StringMatchFull(const char *regex, const char *str);
 bool StringMatchFullWithPrecompiledRegex(pcre *regex, const char *str);
-Seq *StringMatchCaptures(const char *regex, const char *str);
+Seq *StringMatchCaptures(const char *regex, const char *str, const bool return_names);
 bool CompareStringOrRegex(const char *value, const char *compareTo, bool regex);
 
 

--- a/tests/acceptance/01_vars/02_functions/data_regextract.cf
+++ b/tests/acceptance/01_vars/02_functions/data_regextract.cf
@@ -1,0 +1,73 @@
+# data_regextract() test
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+}
+
+bundle agent test
+{
+  vars:
+      "patterns" data => parsejson('["^(?<name1>...)(...)(..)-(?<name2>...)-(..).*", "", ".*", "(?<myword>...)"]');
+      "plength" int => length(patterns);
+      "pi" slist => expandrange("[0-$(plength)]", 1); # this is one more than the valid indices
+
+      "strings" data => parsejson('[ "abcdef12-345-67andsoon", "", "!!!", "one two three"]');
+      "slength" int => length(strings);
+      "si" slist => expandrange("[0-$(slength)]", 1); # this is one more than the valid indices
+
+      "parsed_$(pi)_$(si)" data => data_regextract(nth(patterns, $(pi)),
+                                                  nth(strings, $(si)));
+      "parsed_$(pi)_$(si)_str" string => format("%S", "parsed_$(pi)_$(si)");
+
+  reports:
+    EXTRA::
+      "$(this.bundle): $(pi) $(si) '$(patterns[$(pi)])' matching '$(strings[$(si)])' => $(parsed_$(pi)_$(si)_str)";
+}
+
+bundle agent check
+{
+  vars:
+      "actual" string => "
+0 0 $(test.parsed_0_0_str)
+
+1 0 $(test.parsed_1_0_str)
+1 1 $(test.parsed_1_1_str)
+1 2 $(test.parsed_1_2_str)
+1 3 $(test.parsed_1_3_str)
+
+2 0 $(test.parsed_2_0_str)
+2 1 $(test.parsed_2_1_str)
+2 2 $(test.parsed_2_2_str)
+2 3 $(test.parsed_2_3_str)
+
+3 0 $(test.parsed_3_0_str)
+3 2 $(test.parsed_3_2_str)
+3 3 $(test.parsed_3_3_str)
+";
+
+      "expected" string => '
+0 0 {"0":"abcdef12-345-67andsoon","name1":"abc","2":"def","3":"12","name2":"345","5":"67"}
+
+1 0 {"0":""}
+1 1 {"0":""}
+1 2 {"0":""}
+1 3 {"0":""}
+
+2 0 {"0":"abcdef12-345-67andsoon"}
+2 1 {"0":""}
+2 2 {"0":"!!!"}
+2 3 {"0":"one two three"}
+
+3 0 {"0":"abc","myword":"abc"}
+3 2 {"0":"!!!","myword":"!!!"}
+3 3 {"0":"one","myword":"one"}
+';
+
+  methods:
+      "" usebundle => dcs_check_strcmp($(actual), $(expected),
+                                      $(this.promise_filename),
+                                      "no");
+
+}

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -61,9 +61,15 @@ libtest_la_SOURCES = cmockery.c cmockery.h schema.h test.c test.h \
 libtest_la_LIBADD = ../../libcompat/libcompat.la
 
 check_LTLIBRARIES += libstr.la
-libstr_la_SOURCES = ../../libutils/string_lib.c ../../libutils/regex.c \
-	../../libutils/encode.c ../../libutils/writer.c \
-	../../libutils/sequence.c
+libstr_la_SOURCES = \
+	../../libutils/buffer.c \
+	../../libutils/encode.c \
+	../../libutils/logging.c \
+	../../libutils/misc_lib.c \
+	../../libutils/regex.c \
+	../../libutils/sequence.c \
+	../../libutils/string_lib.c \
+	../../libutils/writer.c
 libstr_la_LIBADD = libtest.la
 
 
@@ -230,6 +236,9 @@ list_test_SOURCES = list_test.c
 refcount_test_SOURCES = refcount_test.c ../../libutils/refcount.c
 
 buffer_test_SOURCES = buffer_test.c ../../libutils/buffer.c
+# Workaround for object file basename conflicts, search the web for
+# "automake created with both libtool and without"
+buffer_test_CPPFLAGS = $(AM_CPPFLAGS)
 
 csv_parser_test_SOURCES = csv_parser_test.c ../../libutils/csv_parser.c
 csv_parser_test_LDADD = libtest.la ../../libutils/libutils.la
@@ -321,8 +330,11 @@ connection_management_test_SOURCES = connection_management_test.c ../../cf-serve
 connection_management_test_LDADD = ../../libpromises/libpromises.la libtest.la ../../cf-serverd/libcf-serverd.la
 
 rlist_test_SOURCES = rlist_test.c \
-       ../../libpromises/rlist.c ../../libutils/logging.c
-rlist_test_LDADD = libtest.la libstr.la ../../libpromises/libpromises.la
+	../../libpromises/rlist.c \
+rlist_test_LDADD = libtest.la ../../libpromises/libpromises.la
+# Workaround for object file basename conflicts, search the web for
+# "automake created with both libtool and without"
+rlist_test_CPPFLAGS = $(AM_CPPFLAGS)
 
 process_test_LDADD = libtest.la ../../libpromises/libpromises.la
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -330,7 +330,7 @@ connection_management_test_SOURCES = connection_management_test.c ../../cf-serve
 connection_management_test_LDADD = ../../libpromises/libpromises.la libtest.la ../../cf-serverd/libcf-serverd.la
 
 rlist_test_SOURCES = rlist_test.c \
-	../../libpromises/rlist.c \
+	../../libpromises/rlist.c
 rlist_test_LDADD = libtest.la ../../libpromises/libpromises.la
 # Workaround for object file basename conflicts, search the web for
 # "automake created with both libtool and without"

--- a/tests/unit/str_test.c
+++ b/tests/unit/str_test.c
@@ -598,28 +598,3 @@ int main()
 
     return run_tests(tests);
 }
-
-/* LCOV_EXCL_START */
-
-/* Stub out functions we do not use in test */
-
-void __ProgrammingError(ARG_UNUSED const char *file,
-                        ARG_UNUSED int lineno,
-                        ARG_UNUSED const char *format, ...)
-{
-    fail();
-    exit(42);
-}
-
-void FatalError(ARG_UNUSED char *s, ...)
-{
-    fail();
-    exit(42);
-}
-
-void Log(ARG_UNUSED LogLevel level, ARG_UNUSED const char *fmt, ...)
-{
-    fail();
-}
-
-/* LCOV_EXCL_STOP */


### PR DESCRIPTION
This proposed function does two things:

* adds a new `regextract` variant that creates a data container rather than "classic" array variables
* the data container is a key-value map where the keys are either the position of the match or, if the capture group was named, the name of the capture group (see the example policy below).  This is extremely nice in combination with Mustache templates, because the resulting data container can be fed directly to them.

In addition:

* the function `regex.c:StringMatchCaptures()` now returns a `Seq` of `Buffer` elements, which is nicer and removes the 4K limitation there
* the code is cleaner
* no extra variables are created

Sample policy:

```
bundle agent main
{
  vars:
      "parsed" data => data_regextract("^(?<name1>...)(...)(..)-(?<name2>...)-(..).*", "abcdef12-345-67andsoon");
      "parsed_str" string => format("%S", parsed);

  reports:
      "$(this.bundle): '$(parsed[0])' parses into: $(parsed_str)";
}
```

Output:

```console
% cf-agent -KI -f ~/Dropbox/cf/test/test_data_regextract.cf
R: main: 'abcdef12-345-67andsoon' parses into: {"0":"abcdef12-345-67andsoon","name1":"abc","2":"def","3":"12","name2":"345","5":"67"}
```

I'll finish this with docs and tests if it's acceptable.  I think it's very useful.