### PR TITLE
Use F4 as RSA exponent - it's common practice.

### DIFF
--- a/cf-key/cf-key-functions.c
+++ b/cf-key/cf-key-functions.c
@@ -243,11 +243,11 @@ void KeepKeyPromises(const char *public_key_file, const char *private_key_file)
     printf("Making a key pair for cfengine, please wait, this could take a minute...\n");
 
 #ifdef OPENSSL_NO_DEPRECATED
-    BN_set_word(rsa_bignum, 35);
+    BN_set_word(rsa_bignum, RSA_F4);
 
     if (!RSA_generate_key_ex(pair, 2048, rsa_bignum, NULL))
 #else
-    pair = RSA_generate_key(2048, 35, NULL, NULL);
+    pair = RSA_generate_key(2048, 65537, NULL, NULL);
 
     if (pair == NULL)
 #endif

--- a/tests/unit/hash_test.c
+++ b/tests/unit/hash_test.c
@@ -52,7 +52,7 @@ void tests_setup()
             initialized = 0;
             return;
         }
-        BN_set_word(bn, 3);
+        BN_set_word(bn, RSA_F4);
         RSA_generate_key_ex(rsa, 1024, bn, NULL);
         BN_free(bn);
     }

--- a/tests/unit/key_test.c
+++ b/tests/unit/key_test.c
@@ -25,7 +25,7 @@ void test_setup()
             initialized = 0;
             return;
         }
-        BN_set_word(bn, 3);
+        BN_set_word(bn, RSA_F4);
         RSA_generate_key_ex(rsa, 1024, bn, NULL);
         BN_free(bn);
     }

--- a/tests/unit/tls_generic_test.c
+++ b/tests/unit/tls_generic_test.c
@@ -54,7 +54,7 @@ static bool init_test_server()
     int ret;
     RSA *key = RSA_new();
     BIGNUM *bignum = BN_new();
-    BN_set_word(bignum, 17);
+    BN_set_word(bignum, RSA_F4);
     ret = RSA_generate_key_ex(key, 1024, bignum, NULL);
     if (!ret)
     {
@@ -451,7 +451,7 @@ static bool init_test_client()
     int ret;
     RSA *key = RSA_new();
     BIGNUM *bignum = BN_new();
-    BN_set_word(bignum, 17);
+    BN_set_word(bignum, RSA_F4);
     ret = RSA_generate_key_ex(key, 1024, bignum, NULL);
     if (!ret)
     {


### PR DESCRIPTION
Redmine 7053. Thanks to Tomáš Chvátal for submitting the patch.