### PR TITLE
Define a hard class with just the OS major version on FreeBSD

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1151,6 +1151,26 @@ static void OSClasses(EvalContext *ctx)
     snprintf(context, CF_BUFSIZE, "%s_%s", VSYSNAME.sysname, vbuff);
     SetFlavour(ctx, context);
 
+#ifdef __FreeBSD__
+    /*
+     * Define a hard class with just the version major number on FreeBSD
+     *
+     * For example, when being run on either FreeBSD 10.0 or 10.1 a class
+     * called freebsd_10 will be defined
+     */
+    for (char *sp = vbuff; *sp != '\0'; sp++)
+    {
+        if (*sp == '.')
+        {
+            *sp = '\0';
+            break;
+        }
+    }
+
+    snprintf(context, CF_BUFSIZE, "%s_%s", VSYSNAME.sysname, vbuff);
+    EvalContextClassPutHard(ctx, context, "source=agent,derived-from=sys.flavour");
+#endif
+
 #endif
 
     GetCPUInfo(ctx);


### PR DESCRIPTION
On FreeBSD, VSYSNAME.release will look some like ’11.0-CURRENT’ 

When defining the $(sys.flavour) you read up to the ‘-‘ character so it will become freebsd-11.0
and that will also gets converted into the hard class ‘freebsd_11_0’

It would be helpful to also define a hard class that is just the major version such as freebsd_10 or
freebsd_11 so you wouldn’t have to do any additional work in an agent by calling regcmp() or
the like 