### PR TITLE
libpromises/evalfunction.c: let mergedata() wrap containers

### DIFF
--- a/examples/mergedata.cf
+++ b/examples/mergedata.cf
@@ -43,7 +43,12 @@ bundle agent test
       "merged_d1_array1" data => mergedata("d1", "array1");
       "merged_d2_array2" data => mergedata("d2", "array2");
 
+      "merged_d1_wrap_array_d2" data => mergedata("d1", "[ d2 ]");
+      "merged_d1_wrap_map_d2" data => mergedata("d1", '{ "newkey": d2 }');
+
       "merged_d1_d2_str" string => format("merging %S with %S produced %S", d1, d2, merged_d1_d2);
+      "merged_d1_wrap_array_d2_str" string => format("merging %S with wrapped [ %S ] produced %S", d1, d2, merged_d1_wrap_array_d2);
+      "merged_d1_wrap_map_d2_str" string => format('merging %S with wrapped { "newkey": %S produced %S', d1, d2, merged_d1_wrap_map_d2);
       "merged_d1_d3_str" string => format("merging %S with %S produced %S", d1, d3, merged_d1_d3);
       "merged_d3_list1_str" string => format("merging %S with %S produced %S", d3, list1, merged_d3_list1);
 
@@ -51,6 +56,8 @@ bundle agent test
       "merged_d2_array2_str" string => format("merging %S with %s produced %S", d2, array2, merged_d2_array2);
   reports:
       "$(merged_d1_d2_str)";
+      "$(merged_d1_wrap_array_d2_str)";
+      "$(merged_d1_wrap_map_d2_str)";
       "$(merged_d1_d3_str)";
       "$(merged_d3_list1_str)";
       "$(merged_d1_array1_str)";
@@ -87,6 +94,8 @@ bundle agent cmerge(varlist)
 #+begin_src example_output
 #@ ```
 #@ R: merging {"a":[1,2,3],"b":[]} with {"b":[4,5,6]} produced {"a":[1,2,3],"b":[4,5,6]}
+#@ R: merging {"a":[1,2,3],"b":[]} with wrapped [ {"b":[4,5,6]} ] produced {"a":[1,2,3],"b":[],"0":{"b":[4,5,6]}}
+#@ R: merging {"a":[1,2,3],"b":[]} with wrapped { "newkey": {"b":[4,5,6]} produced {"a":[1,2,3],"b":[],"newkey":{"b":[4,5,6]}}
 #@ R: merging {"a":[1,2,3],"b":[]} with [4,5,6] produced {"a":[1,2,3],"b":[],"0":4,"1":5,"2":6}
 #@ R: merging [4,5,6] with { "element1", "element2" } produced [4,5,6,"element1","element2"]
 #@ R: merging {"a":[1,2,3],"b":[]} with array1 produced {"a":[1,2,3],"b":[],"mykey":["array_element1","array_element2"]}

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -2619,23 +2619,91 @@ static FnCallResult FnCallMergeData(EvalContext *ctx, ARG_UNUSED const Policy *p
 
     for (const Rlist *arg = args; arg; arg = arg->next)
     {
-        VarRef *ref = ResolveAndQualifyVarName(fp, RlistScalarValue(arg));
+        const char *name_str = RlistScalarValue(arg);
+        int name_len = strlen(name_str);
+        bool wrap_array_mode = false;
+        Buffer *wrap_map_key = NULL;
+        Buffer *name = NULL;
+
+        if (name_len > 2 && name_str[0] == '[')
+        {
+            Seq *s = StringMatchCaptures("^\\[ *([^ ]+) *\\]$", name_str);
+
+            if (s && SeqLength(s) == 2)
+            {
+                wrap_array_mode = true;
+                name = BufferNewFrom(SeqAt(s, 1), strlen(SeqAt(s, 1)));
+            }
+
+            SeqDestroy(s);
+        }
+        else if (name_len > 0 && name_str[0] == '{' && name_str[name_len-1] == '}')
+        {
+            Seq *s = StringMatchCaptures("^\\{ *\"([^\"]+)\" *: *([^ ]+) *\\}$", name_str);
+
+            if (s && SeqLength(s) == 3)
+            {
+                wrap_map_key = BufferNewFrom(SeqAt(s, 1), strlen(SeqAt(s, 1)));
+                name = BufferNewFrom(SeqAt(s, 2), strlen(SeqAt(s, 2)));
+            }
+
+            SeqDestroy(s);
+        }
+        else
+        {
+            name = BufferNewFrom(name_str, name_len);
+        }
+
+        VarRef *ref = NULL;
+
+        if (NULL != name)
+        {
+            ref = ResolveAndQualifyVarName(fp, BufferData(name));
+            BufferDestroy(name);
+        }
+
         if (!ref)
         {
             SeqDestroy(containers);
+
+            if (NULL != wrap_map_key) BufferDestroy(wrap_map_key);
+
             return FnFailure();
         }
 
         JsonElement *json = VarRefValueToJson(ctx, fp, ref, NULL, 0);
+
         VarRefDestroy(ref);
 
         if (!json)
         {
             SeqDestroy(containers);
+
+            if (NULL != wrap_map_key) BufferDestroy(wrap_map_key);
+
             return FnFailure();
         }
 
+        if (wrap_array_mode)
+        {
+            JsonElement *parent = JsonArrayCreate(1);
+            JsonArrayAppendElement(parent, json);
+            json = parent;
+        }
+        else if (NULL != wrap_map_key)
+        {
+            JsonElement *parent = JsonObjectCreate(1);
+            JsonObjectAppendElement(parent, BufferData(wrap_map_key), json);
+            json = parent;
+        }
+        else
+        {
+            // do nothing, no wrapping
+        }
+
         SeqAppend(containers, json);
+
+        if (NULL != wrap_map_key) BufferDestroy(wrap_map_key);
 
     } // end of args loop
 

--- a/tests/acceptance/01_vars/02_functions/mergedata.cf
+++ b/tests/acceptance/01_vars/02_functions/mergedata.cf
@@ -36,6 +36,8 @@ bundle agent test
 
       "load_$(X)" data => mergedata("load$(X)");
       "load_$(X)_$(Y)" data => mergedata("load$(X)", "load$(Y)");
+      "wrap_key_$(X)" data => mergedata('{ "wrapkey": load$(X) }');
+      "wrap_array_$(X)" data => mergedata('[ load$(X) ]');
 
       "bad1" data => mergedata(missingvar);
       "bad2" data => mergedata(load1, missingvar);
@@ -84,8 +86,22 @@ bundle agent check
       "expected_5_4" string => '{"mykey":["myvalue"],"lastkey!":[],"anotherkey":"anothervalue"}';
       "expected_5_5" string => '{"mykey":["myvalue"],"lastkey!":[],"anotherkey":"anothervalue"}';
 
+      "expected_wrapped_key_1" string => '{"wrapkey":[1,2,3]}';
+      "expected_wrapped_key_2" string => '{"wrapkey":["element1","element2","element3"]}';
+      "expected_wrapped_key_3" string => '{"wrapkey":{"x":"y"}}';
+      "expected_wrapped_key_4" string => '{"wrapkey":[]}';
+      "expected_wrapped_key_5" string => '{"wrapkey":{"mykey":["myvalue"],"lastkey!":[],"anotherkey":"anothervalue"}}';
+
+      "expected_wrapped_array_1" string => '[[1,2,3]]';
+      "expected_wrapped_array_2" string => '[["element1","element2","element3"]]';
+      "expected_wrapped_array_3" string => '[{"x":"y"}]';
+      "expected_wrapped_array_4" string => '[[]]';
+      "expected_wrapped_array_5" string => '[{"mykey":["myvalue"],"lastkey!":[],"anotherkey":"anothervalue"}]';
+
       "actual_$(X)_$(Y)" string => format("%S", "test.load_$(X)_$(Y)");
       "actual_$(X)" string => format("%S", "test.load_$(X)");
+      "actual_wrapped_key_$(X)" string => format("%S", "test.wrap_key_$(X)");
+      "actual_wrapped_array_$(X)" string => format("%S", "test.wrap_array_$(X)");
 
   classes:
       "not_ok_$(X)_$(Y)" not => strcmp("$(actual_$(X)_$(Y))",
@@ -94,12 +110,24 @@ bundle agent check
       "not_ok_$(X)" not => strcmp("$(actual_$(X))",
                                   "$(expected_$(X))");
 
+      "not_ok_wrapped_key_$(X)" not => strcmp("$(actual_wrapped_key_$(X))",
+                                             "$(expected_wrapped_key_$(X))");
+
+      "not_ok_wrapped_array_$(X)" not => strcmp("$(actual_wrapped_array_$(X))",
+                                               "$(expected_wrapped_array_$(X))");
+
       "ok" not => classmatch("not_ok_.*");
 
   reports:
     DEBUG::
       "$(X): actual $(actual_$(X)) != $(X) expected $(expected_$(X))"
        ifvarclass => "not_ok_$(X)";
+
+      "$(X): actual wrap key $(actual_wrapped_key_$(X)) != $(X) expected wrapped key $(expected_wrapped_key_$(X))"
+       ifvarclass => "not_ok_wrapped_key_$(X)";
+
+      "$(X): actual wrap array $(actual_wrapped_array_$(X)) != $(X) expected wrapped array $(expected_wrapped_array_$(X))"
+       ifvarclass => "not_ok_wrapped_array_$(X)";
 
       "$(X)+$(Y): actual $(actual_$(X)_$(Y)) != $(X)+$(Y) expected $(expected_$(X)_$(Y))"
        ifvarclass => "not_ok_$(X)_$(Y)";


### PR DESCRIPTION
This is a proposal for functionality I need often: wrapping a data container.  Here's an example of the new usage:

```
bundle agent main
{
  vars:

      "ub" slist => { "b", "b2" };
      "uc" slist => { };
      "ud" slist => { };
      "ue" slist => { "foo", "bar" };

      "merge" data => mergedata('[ub]', '{ "mykey" : uc }', '{"otherkey":ue}');
      "merge_s" string => format("%S", merge);

  reports:
      "${merge_s}";
}
```

Output:

```console
% cf-agent -KI -f ./test_mergedata_wraps.cf
R: {"mykey":[],"0":["b","b2"],"otherkey":["foo","bar"]}
```

What does this mean?

* naming a container works like usual, this is 100% backwards compatible
* the format `[ container1 ]` means "wrap `container1` in an array"
* the format `{ "mykey": container2 }` means "wrap `container2` in a map under key `mykey`"
* spaces are allowed inside, but the string must have `{` or `[` at the beginning and the corresponding `}` or `]` at the end

This functionality is not available today.

Let me know if this is acceptable and I will write tests, examples, and docs.