### PR TITLE
cfengine.el: Fix compilation error.

### DIFF
--- a/contrib/cfengine.el
+++ b/contrib/cfengine.el
@@ -1299,7 +1299,7 @@ see.  Use it by executing `turn-on-eldoc-mode'."
          ;; In the main syntax-table, \ is marked as a punctuation, because
          ;; of its use in DOS-style directory separators.  Here we try to
          ;; recognize the cases where \ is used as an escape inside strings.
-         (syntax-propertize-rules '("\\(\\(?:\\\\\\)+\\)\"" (1 "\\"))))
+         (syntax-propertize-rules ("\\(\\(?:\\\\\\)+\\)\"" (1 "\\"))))
 
     ;; Backwards compatibility without `syntax-propertize-function'.
     (setq font-lock-defaults


### PR DESCRIPTION
Fixes error "Eager macro-expansion failure: (void-variable quote)"
and a similar one happening while byte-compiling the file
on Emacs 24.3.1 (but possibly other versions too).