### PR TITLE
Add: Test dry-run mode does not assert it changes perms

### DIFF
--- a/tests/acceptance/00_basics/02_switches/dry_run_perms_doesnt_lie.cf
+++ b/tests/acceptance/00_basics/02_switches/dry_run_perms_doesnt_lie.cf
@@ -1,0 +1,38 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  files:
+    "$(G.testdir)/."
+      create => "true";
+
+    "$(G.testdir)/redmine_7082"
+      create => "true",
+      perms => m("777"),
+      comment => "We first ensure a file exists with specific permissions so
+                  that we can test if we get unexpected output when later
+                  running with dry-run.";
+}
+
+bundle agent check
+{
+  meta:
+      "test_soft_fail"
+        meta => { "redmine#7082" },
+        string => "any";
+
+  vars:
+    "command" string => "$(sys.cf_agent) -Knf $(this.promise_filename).sub -I -b test";
+
+  methods:
+    # Since the agent is run with dry-run (-n) there should be no statement of permissions changing.
+    # In fact, permissions are not changed, the agent only says they are, so it is only the false statement that needs to be checked.
+    "test_agent_output"
+      usebundle => dcs_passif_output(".*has permission 0777, should change it to 0700.*", ".*had permission 0777, changed it to 0700.*", $(command), $(this.promise_filename));
+
+}

--- a/tests/acceptance/00_basics/02_switches/dry_run_perms_doesnt_lie.cf.sub
+++ b/tests/acceptance/00_basics/02_switches/dry_run_perms_doesnt_lie.cf.sub
@@ -1,0 +1,14 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/redmine_7082"
+    create => "true",
+    perms => m("go-rwx");
+}


### PR DESCRIPTION
When run in dry run mode, the agent should not say that it changes any 
permissions, because in fact it does not.

Ref: https://dev.cfengine.com/issues/7082