### PR TITLE
Redmine#3660: inlined JSON

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -600,11 +600,9 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
                                                Buffer *copy = BufferNewFrom(P.rval.item, strlen(P.rval.item));
 
                                                const char* fname = NULL;
-                                               int offset = 0;
                                                if (strlen(P.rval.item) > 3 && strncmp("---", P.rval.item, 3) == 0)
                                                {
                                                    fname = "parseyaml";
-                                                   offset = 0;
 
                                                    // look for unexpanded variables
                                                    if (NULL == strstr(P.rval.item, "$(") && NULL == strstr(P.rval.item, "${"))
@@ -617,7 +615,6 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
                                                else
                                                {
                                                    fname = "parsejson";
-                                                   offset = 0;
                                                    // look for unexpanded variables
                                                    if (NULL == strstr(P.rval.item, "$(") && NULL == strstr(P.rval.item, "${"))
                                                    {
@@ -631,11 +628,11 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
 
                                                if (json_parse_attempted && res != JSON_PARSE_OK)
                                                {
-                                                   // no error, we'll try with the fname fncall
+                                                   // Parsing failed, insert fncall so it can be retried during evaluation
                                                }
                                                else if (NULL != json && JsonGetElementType(json) == JSON_ELEMENT_TYPE_PRIMITIVE)
                                                {
-                                                   // no error, we'll try with the fname fncall
+                                                   // Parsing failed, insert fncall so it can be retried during evaluation
                                                    JsonDestroy(json);
                                                    json = NULL;
                                                }
@@ -645,7 +642,7 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
                                                    if (NULL == json)
                                                    {
                                                        Rlist *synthetic_args = NULL;
-                                                       RlistAppendScalar(&synthetic_args, xstrdup(P.rval.item+offset));
+                                                       RlistAppendScalar(&synthetic_args, xstrdup(P.rval.item));
                                                        RvalDestroy(P.rval);
 
                                                        P.rval = (Rval) { FnCallNew(xstrdup(fname), synthetic_args), RVAL_TYPE_FNCALL };

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -36,6 +36,7 @@
 #include "mod_files.h"
 #include "string_lib.h"
 #include "logic_expressions.h"
+#include <json-yaml.h>
 
 // FIX: remove
 #include "syntax.h"
@@ -575,6 +576,72 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
                                        // Intentional fall
                                    case SYNTAX_STATUS_NORMAL:
                                        {
+                                           if (P.rval.type == RVAL_TYPE_SCALAR && strcmp(P.lval, "data") == 0)
+                                           {
+                                               JsonElement *json = NULL;
+                                               JsonParseError res;
+                                               bool json_parse_attempted = false;
+                                               Buffer *copy = BufferNewFrom(P.rval.item, strlen(P.rval.item));
+
+                                               const char* fname = NULL;
+                                               int offset = 0;
+                                               if (strlen(P.rval.item) > 3 && strncmp("---", P.rval.item, 3) == 0)
+                                               {
+                                                   fname = "parseyaml";
+                                                   offset = 0;
+
+                                                   // look for unexpanded variables
+                                                   if (NULL == strstr(P.rval.item, "$(") && NULL == strstr(P.rval.item, "${"))
+                                                   {
+                                                       const char *copy_data = BufferData(copy);
+                                                       res = JsonParseYamlString(&copy_data, &json);
+                                                       json_parse_attempted = true;
+                                                   }
+                                               }
+                                               else
+                                               {
+                                                   fname = "parsejson";
+                                                   offset = 0;
+                                                   // look for unexpanded variables
+                                                   if (NULL == strstr(P.rval.item, "$(") && NULL == strstr(P.rval.item, "${"))
+                                                   {
+                                                       const char *copy_data = BufferData(copy);
+                                                       res = JsonParse(&copy_data, &json);
+                                                       json_parse_attempted = true;
+                                                   }
+                                               }
+
+                                               BufferDestroy(copy);
+
+                                               if (json_parse_attempted && res != JSON_PARSE_OK)
+                                               {
+                                                   // no error, we'll try with the fname fncall
+                                               }
+                                               else if (NULL != json && JsonGetElementType(json) == JSON_ELEMENT_TYPE_PRIMITIVE)
+                                               {
+                                                   // no error, we'll try with the fname fncall
+                                                   JsonDestroy(json);
+                                                   json = NULL;
+                                               }
+
+                                               if (NULL != fname)
+                                               {
+                                                   if (NULL == json)
+                                                   {
+                                                       Rlist *synthetic_args = NULL;
+                                                       RlistAppendScalar(&synthetic_args, xstrdup(P.rval.item+offset));
+                                                       RvalDestroy(P.rval);
+
+                                                       P.rval = (Rval) { FnCallNew(xstrdup(fname), synthetic_args), RVAL_TYPE_FNCALL };
+                                                   }
+                                                   else
+                                                   {
+                                                       RvalDestroy(P.rval);
+                                                       P.rval = (Rval) { json, RVAL_TYPE_CONTAINER };
+                                                   }
+                                               }
+                                           }
+
                                            {
                                                SyntaxTypeMatch err = CheckConstraint(P.currenttype, P.lval, P.rval, promise_type_syntax);
                                                if (err != SYNTAX_TYPE_MATCH_OK && err != SYNTAX_TYPE_MATCH_ERROR_UNEXPANDED)

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -1529,15 +1529,20 @@ static char *EscapeQuotes(const char *s, char *out, int outSz)
 
 static JsonElement *AttributeValueToJson(Rval rval, bool symbolic_reference)
 {
-    JsonElement *json_attribute = JsonObjectCreate(10);
-
     switch (rval.type)
     {
+    case RVAL_TYPE_CONTAINER:
+    {
+        return JsonCopy(RvalContainerValue(rval));
+    }
+
     case RVAL_TYPE_SCALAR:
     {
         char buffer[CF_BUFSIZE];
 
         EscapeQuotes((const char *) rval.item, buffer, sizeof(buffer));
+
+        JsonElement *json_attribute = JsonObjectCreate(10);
 
         if (symbolic_reference)
         {
@@ -1558,6 +1563,7 @@ static JsonElement *AttributeValueToJson(Rval rval, bool symbolic_reference)
         Rlist *rp = NULL;
         JsonElement *list = JsonArrayCreate(10);
 
+        JsonElement *json_attribute = JsonObjectCreate(10);
         JsonObjectAppendString(json_attribute, "type", "list");
 
         for (rp = (Rlist *) rval.item; rp != NULL; rp = rp->next)
@@ -1574,6 +1580,7 @@ static JsonElement *AttributeValueToJson(Rval rval, bool symbolic_reference)
         Rlist *argp = NULL;
         FnCall *call = (FnCall *) rval.item;
 
+        JsonElement *json_attribute = JsonObjectCreate(10);
         JsonObjectAppendString(json_attribute, "type", "functionCall");
         JsonObjectAppendString(json_attribute, "name", call->name);
 
@@ -1591,7 +1598,6 @@ static JsonElement *AttributeValueToJson(Rval rval, bool symbolic_reference)
         return json_attribute;
     }
 
-    case RVAL_TYPE_CONTAINER:
     case RVAL_TYPE_NOPROMISEE:
         ProgrammingError("Attempted to export attribute of type: %c", rval.type);
         return NULL;

--- a/tests/acceptance/01_vars/04_containers/inline_json.cf
+++ b/tests/acceptance/01_vars/04_containers/inline_json.cf
@@ -1,0 +1,59 @@
+#######################################################
+#
+# Test inline JSON and YAML data
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "included" string => "( included text )";
+      "options1" data => '
+{
+  "max_content": 512,
+  "verbose": 0,
+  "headers": [ "Foo: bar" ]
+}';
+
+      "options2" data => '---
+a: b
+c: d
+e:
+  - 1
+  - 2
+';
+
+      "options3" data => '
+{
+  "max_content": 512,
+  "verbose": "$(included)",
+  "headers": [ "Foo: bar" ]
+}';
+
+      "options4" data => '---
+a: $(included)
+c: d
+e:
+  - 1
+  - 2
+';
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
+}

--- a/tests/acceptance/01_vars/04_containers/inline_json.cf.expected.json
+++ b/tests/acceptance/01_vars/04_containers/inline_json.cf.expected.json
@@ -1,0 +1,33 @@
+{
+  "included": "( included text )",
+  "options1": {
+    "headers": [
+      "Foo: bar"
+    ],
+    "max_content": 512,
+    "verbose": 0
+  },
+  "options2": {
+    "a": "b",
+    "c": "d",
+    "e": [
+      1,
+      2
+    ]
+  },
+  "options3": {
+    "headers": [
+      "Foo: bar"
+    ],
+    "max_content": 512,
+    "verbose": "( included text )"
+  },
+  "options4": {
+    "a": "( included text )",
+    "c": "d",
+    "e": [
+      1,
+      2
+    ]
+  }
+}

--- a/tests/acceptance/01_vars/04_containers/inline_json_parse.cf
+++ b/tests/acceptance/01_vars/04_containers/inline_json_parse.cf
@@ -1,0 +1,23 @@
+#######################################################
+#
+# Test inline JSON and YAML data
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_passif_output(".*e8hoeAM1UJC5xmqwCx9iJARKZ9qGk8GU.*",
+                                             "",
+                                             "cf-promises -p json $(this.promise_filename).sub",
+                                             $(this.promise_filename));
+}

--- a/tests/acceptance/01_vars/04_containers/inline_json_parse.cf.sub
+++ b/tests/acceptance/01_vars/04_containers/inline_json_parse.cf.sub
@@ -1,0 +1,5 @@
+bundle agent mytest
+{
+  vars:
+      "inline" data => '{ "key": "special value e8hoeAM1UJC5xmqwCx9iJARKZ9qGk8GU" }';
+}


### PR DESCRIPTION
This PR implements inlined JSON/YAML as a literal string that gets either directly parsed or synthetically replaced with the equivalent `parsejson()` or `parseyaml()` call.  The trigger for this behavior is that:

* a `SCALAR` is passed to a `data` attribute
* the string **begins** with either `---` for YAML or else it's JSON
* if the string begins with the YAML marker and contains no unexpanded variables (found by just looking for `$(` or `${`) we try to parse the YAML directly
    * if the YAML parse fails or unexpanded variables were found, we insert a synthetic fncall to `parseyaml()`
* else, we try JSON: if the string contains no unexpanded variables (found by just looking for `$(` or `${`) we try to parse the JSON directly
    * if the JSON parse fails or unexpanded variables were found, we insert a synthetic fncall to `parsejson()`

The example below will demonstrate:

```
bundle agent main
{
  vars:
      "options1" data => '
{
  "cfengine.max_content": 512,
  "curl.verbose": 0,
  "curl.headers": [ "Foo: bar" ]
}';

      "options2" data => '---
a: b
c: d
e:
  - 1
  - 2
';

      "options3" data => '
{
  "cfengine.max_content": 512,
  "curl.verbose": "$(sys.os)",
  "curl.headers": [ "Foo: bar" ]
}';

      "options4" data => '---
a: $(sys.os)
c: d
e:
  - 1
  - 2
';

      "out1" string => format("%S", options1);
      "out2" string => format("%S", options2);
      "out3" string => format("%S", options3);
      "out4" string => format("%S", options4);

  reports:
      "$(this.bundle): we got $(out1)";
      "$(this.bundle): we got $(out2)";
      "$(this.bundle): we got $(out3)";
      "$(this.bundle): we got $(out4)";
}
```

Output:
```console
R: main: we got {"cfengine.max_content":512,"curl.verbose":0,"curl.headers":["Foo: bar"]}
R: main: we got {"a":"b","c":"d","e":[1,2]}
R: main: we got {"cfengine.max_content":512,"curl.verbose":"linux","curl.headers":["Foo: bar"]}
R: main: we got {"a":"linux","c":"d","e":[1,2]}
```

There are some minor problems with this approach:

* if the JSON or YAML are malformed, the error points to a nonexistent position on the trigger line
* inserting synthetic function calls is kind of weird
* the `cf-promises` JSON output needs to be adapted to deal with containers in the policy itself, as shown here with our earlier example.  That should be an easy fix.

```console
% cf-promises -p json .//test_inline_json.cf
policy.c:1579: Programming Error: Attempted to export attribute of type: c
```