### PR TITLE
Add: Test that isvariable works with array keys that have spaces

### DIFF
--- a/tests/acceptance/02_classes/01_basic/array_key_with_space_isvariable.cf
+++ b/tests/acceptance/02_classes/01_basic/array_key_with_space_isvariable.cf
@@ -1,0 +1,44 @@
+# isvariable should be able to check array indexes that have spaces
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  vars:
+    "array[one]" string => "1";
+    "array[twenty one]" string => "21";
+
+  classes:
+    "have_one"
+      expression => isvariable("array[one]"),
+      scope => "namespace";
+
+    "have_twenty_one"
+      expression => isvariable("array[twenty one]"),
+      scope => "namespace";
+
+  reports:
+    have_one.DEBUG::
+      "Have array key 'one' as expected containing value '$(array[one])'";
+    have_twenty_one.DEBUG::
+      "Have array key 'twenty one' as expected containing value '$(array[twenty one])'";
+}
+
+bundle agent check
+{
+  meta:
+    "test_soft_fail"
+      string => "any",
+      meta => { "redmine#7088" };
+
+  methods:
+    have_one.have_twenty_one::
+      "result" usebundle => dcs_pass("$(this.promise_filename)");
+
+    !(have_one.have_twenty_one)::
+      "result" usebundle => dcs_fail("$(this.promise_filename)");
+}


### PR DESCRIPTION
Arrays and data having spaces in a key is valid, so isvariable should be able
to test for them like any other variable.

Ref: https://dev.cfengine.com/issues/7088