### PR TITLE
Remove: Inventory tag on ipv4 addresses

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -579,7 +579,7 @@ void GetInterfacesInfo(EvalContext *ctx)
     if (ips)
     {
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "ip_addresses", ips, CF_DATA_TYPE_STRING_LIST,
-                                      "inventory,source=agent,attribute_name=IPv4 addresses");
+                                      "source=agent");
     }
 
     RlistDestroy(interfaces);


### PR DESCRIPTION
This has moved to policy so that undesired addresses like the local loopback
can be easily filtered out using a regular expression that is user accessible.

Ref: https://dev.cfengine.com/issues/7097

This should be merged with a change to masterfiles: https://github.com/cfengine/masterfiles/pull/444