### PR TITLE
Redmine#7098: let filestat() support xattr

### DIFF
--- a/libpromises/files_copy.c
+++ b/libpromises/files_copy.c
@@ -198,15 +198,6 @@ bool CopyFilePermissionsDisk(const char *source, const char *destination)
     return true;
 }
 
-#ifdef WITH_XATTR_EXTRA_ARGS
-#define listxattr(__arg1, __arg2, __arg3) \
-    listxattr((__arg1), (__arg2), (__arg3), 0)
-#define getxattr(__arg1, __arg2, __arg3, __arg4) \
-    getxattr((__arg1), (__arg2), (__arg3), (__arg4), 0, 0)
-#define setxattr(__arg1, __arg2, __arg3, __arg4, __arg5) \
-    setxattr((__arg1), (__arg2), (__arg3), (__arg4), 0, (__arg5))
-#endif
-
 bool CopyFileExtendedAttributesDisk(const char *source, const char *destination)
 {
 #if defined(WITH_XATTR)

--- a/libpromises/files_copy.h
+++ b/libpromises/files_copy.h
@@ -27,6 +27,15 @@
 
 #include <cf3.defs.h>
 
+#ifdef WITH_XATTR_EXTRA_ARGS
+#define listxattr(__arg1, __arg2, __arg3) \
+    listxattr((__arg1), (__arg2), (__arg3), 0)
+#define getxattr(__arg1, __arg2, __arg3, __arg4) \
+    getxattr((__arg1), (__arg2), (__arg3), (__arg4), 0, 0)
+#define setxattr(__arg1, __arg2, __arg3, __arg4, __arg5) \
+    setxattr((__arg1), (__arg2), (__arg3), (__arg4), 0, (__arg5))
+#endif
+
 bool CopyRegularFileDisk(const char *source, const char *destination);
 bool CopyFilePermissionsDisk(const char *source, const char *destination);
 bool CopyFileExtendedAttributesDisk(const char *source, const char *destination);

--- a/tests/acceptance/01_vars/02_functions/filestat_xattr.cf
+++ b/tests/acceptance/01_vars/02_functions/filestat_xattr.cf
@@ -1,0 +1,58 @@
+#######################################################
+#
+# Redmine#4079: Test filestat() with xattr
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "xattr" string => "/usr/bin/xattr";
+
+  classes:
+      "has_xattr" and => { fileexists($(xattr)) },
+      scope => "namespace";
+
+  methods:
+      "" usebundle => file_make($(G.testfile), "");
+}
+
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "test_suppress_fail" string => "windows",
+        meta => { "redmine4079" };
+
+  commands:
+    has_xattr::
+      "$(init.xattr) -w foo bar $(G.testfile)";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    has_xattr::
+      "attributes" string => filestat($(G.testfile), "xattr");
+    !has_xattr::
+      "attributes" string => "foo=bar";
+
+  methods:
+      "" usebundle => dcs_check_strcmp($(attributes), "foo=bar",
+                                      $(this.promise_filename),
+                                      "no");
+}


### PR DESCRIPTION
https://dev.cfengine.com/issues/7098

Adds a `xattr` parameter to `filestat()` which also will return SELinux attributes in addition to extended attributes.

```
bundle agent main
{
  vars:
      "files" slist => { "/etc/passwd", "/etc/shadow", "/tmp/t" };
      "info[$(files)]" string => filestat($(files), "xattr");
  reports:
      "$(this.bundle): $(files): xattr=$(info[$(files)])";
}
```

Note that `/etc/shadow` doesn't exist.

```console
% mkdir /tmp/t
% xattr -w foo bar /tmp/t
R: main: /etc/passwd: xattr=
R: main: /etc/shadow: xattr=$(info[/etc/shadow])
R: main: /tmp/t: xattr=foo=bar
```

I think it's fairly minimal.  I'd really like feedback, especially whether this is acceptable.

If accepted, it would also require modifying the `fileinfo` bundle in the masterfiles.