### PR TITLE
[3.6.x] server_common: remove double stat() of file, on non-link paths

### DIFF
--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -1003,20 +1003,10 @@ int StatFile(ServerConnectionState *conn, char *sendbuffer, char *ofilename)
 
         cfst.cf_readlink = linkbuf;
     }
-#endif /* !__MINGW32__ */
-
-    if ((!islink) && (stat(filename, &statbuf) == -1))
-    {
-        Log(LOG_LEVEL_VERBOSE, "BAD: unable to stat file '%s'. (stat: %s)",
-            filename, GetErrorStr());
-        SendTransaction(conn->conn_info, sendbuffer, 0, CF_DONE);
-        return -1;
-    }
-
-    Log(LOG_LEVEL_DEBUG, "Getting size of link deref '%s'", linkbuf);
 
     if (islink && (stat(filename, &statlinkbuf) != -1))       /* linktype=copy used by agent */
     {
+        Log(LOG_LEVEL_DEBUG, "Getting size of link deref '%s'", linkbuf);
         statbuf.st_size = statlinkbuf.st_size;
         statbuf.st_mode = statlinkbuf.st_mode;
         statbuf.st_uid = statlinkbuf.st_uid;
@@ -1024,6 +1014,8 @@ int StatFile(ServerConnectionState *conn, char *sendbuffer, char *ofilename)
         statbuf.st_mtime = statlinkbuf.st_mtime;
         statbuf.st_ctime = statlinkbuf.st_ctime;
     }
+
+#endif /* !__MINGW32__ */
 
     if (S_ISDIR(statbuf.st_mode))
     {


### PR DESCRIPTION
In an audit to way server "stat" method is implemented, discovered that `sendbuffer` would be uninitialized in the /extremely rare/ case that 2nd `stat()` call would fail for the same regular file.

In fact, the 2nd call to `stat()` is redundant, at least on POSIX systems (according to documentation of `lstat()` ) . We can ommit the buggy lines altogether.
