### PR TITLE
Fix array-size inconsistency in mon_network.c

### DIFF
--- a/cf-monitord/mon_network.c
+++ b/cf-monitord/mon_network.c
@@ -35,8 +35,6 @@
 
 /* Globals */
 
-#define ATTR        22
-
 Item *ALL_INCOMING = NULL;
 Item *MON_UDP4 = NULL, *MON_UDP6 = NULL, *MON_TCP4 = NULL, *MON_TCP6 = NULL;
 
@@ -52,7 +50,7 @@ typedef struct
     enum observables out;
 } Sock;
 
-static const Sock ECGSOCKS[ATTR] =     /* extended to map old to new using enum */
+static const Sock ECGSOCKS[] =     /* extended to map old to new using enum */
 {
     {"137", "netbiosns", ob_netbiosns_in, ob_netbiosns_out},
     {"138", "netbiosdgm", ob_netbiosdgm_in, ob_netbiosdgm_out},
@@ -75,6 +73,7 @@ static const Sock ECGSOCKS[ATTR] =     /* extended to map old to new using enum 
     {"5432", "postgresql", ob_postgresql_in, ob_postgresql_out},
     {"631", "ipp", ob_ipp_in, ob_ipp_out},
 };
+#define ATTR (sizeof(ECGSOCKS) / sizeof(ECGSOCKS[0]))
 
 static const char *const VNETSTAT[] =
 {


### PR DESCRIPTION
The ECGSOCKS[] array size was given by a macro that had to be updated
to stay in sync with the actual contents of the array.  Growing the
array without updating the macro would have produced a compile-time
error.  Just for once, we recently shrank it; this lead to the array
containing NULL-filled entries.  Since code accessing it used the
size, rather than a check for NULL-filled entries, cf-monitord crashed
on a strcmp(, NULL).

Change the array to unspecified size, so the compiler gets it right
reliably; and redefine the size to be derived from the actual array.
This'll avoid needing to change the size define every time we add an
entry to the array.