### PR TITLE
YAML: Make sure that key is reset when adding non-string elements.

### DIFF
--- a/libutils/json-yaml.c
+++ b/libutils/json-yaml.c
@@ -171,6 +171,8 @@ static void JsonParseYamlData(yaml_parser_t *parser, JsonElement *element, const
                 else if (JsonGetContainerType(element) == JSON_CONTAINER_TYPE_ARRAY)
                 {
                     JsonArrayAppendElement(element, JsonParseYamlScalarValue(&event));
+                    // clear key
+                    key = NULL;
                 }
                 else
                 {
@@ -195,6 +197,8 @@ static void JsonParseYamlData(yaml_parser_t *parser, JsonElement *element, const
                     {
                         JsonObjectAppendElement(element, key, arr);
                         JsonParseYamlData(parser, arr, depth+1);
+                        // clear key
+                        key = NULL;
                     }
                     else
                     {
@@ -205,6 +209,8 @@ static void JsonParseYamlData(yaml_parser_t *parser, JsonElement *element, const
                 {
                     JsonArrayAppendArray(element, arr);
                     JsonParseYamlData(parser, arr, depth+1);
+                    // clear key
+                    key = NULL;
                 }
                 else
                 {
@@ -245,6 +251,8 @@ static void JsonParseYamlData(yaml_parser_t *parser, JsonElement *element, const
                     {
                         JsonObjectAppendElement(element, key, obj);
                         JsonParseYamlData(parser, obj, depth+1);
+                        // clear key
+                        key = NULL;
                     }
                     else
                     {
@@ -255,6 +263,8 @@ static void JsonParseYamlData(yaml_parser_t *parser, JsonElement *element, const
                 {
                     JsonArrayAppendObject(element, obj);
                     JsonParseYamlData(parser, obj, depth+1);
+                    // clear key
+                    key = NULL;
                 }
                 else
                 {

--- a/tests/acceptance/01_vars/04_containers/parseyaml.cf
+++ b/tests/acceptance/01_vars/04_containers/parseyaml.cf
@@ -50,6 +50,30 @@ bundle edit_line init_insert_lines
       "string_spears": "yes",
       "bows": "maybe"
     }
+  ],
+  "f": [
+    {
+      "hostname": "prd-web",
+      "packages": [
+        "apache",
+        "memcache"
+      ],
+      "users": [
+        "root",
+        "mike"
+      ]
+    },
+    {
+      "hostname": "prd-db",
+      "packages": [
+        "postgresql"
+      ],
+      "users": [
+        "root",
+        "john",
+        "debbie"
+      ]
+    }
   ]
 }';
 }
@@ -68,6 +92,21 @@ e:
     boolean_spears: yes
     string_spears: "yes"
     bows: maybe
+f:
+  - hostname: prd-web
+    packages:
+      - apache
+      - memcache
+    users:
+      - root
+      - mike
+  - hostname: prd-db
+    packages:
+      - postgresql
+    users:
+      - root
+      - john
+      - debbie
 ');
 
       "load_s" string => storejson(load);


### PR DESCRIPTION
Otherwise CFEngine will assert when you try to mix key/values and
arrays inside another key/value and array.

Originally discovered and fixed approx. five min before presenting it at CfgMgmtCamp. :-)