### PR TITLE
Redmine#7111: @if macro

### DIFF
--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -69,6 +69,8 @@ P.offsets.current += yyleng;
 
 %}
 
+%x if_ignore_state
+
 space      [ \t]+
 
 newline    ([\n]|[\xd][\xa])
@@ -76,6 +78,9 @@ newline    ([\n]|[\xd][\xa])
 line       ^.*$
 
 comment    #[^\n]*
+
+macro_if    ^@if\ version_after\([0-9]{1,10}\.[0-9]{1,10}\)
+macro_endif ^@endif
 
 promises   bundle
 
@@ -132,6 +137,80 @@ promise_type   [a-zA-Z_]+:
                           P.line_no++;
                           P.line_pos = 0;
                       }
+
+{macro_if}            {
+                        const char* version_text = yytext+18;
+                        ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, version_text);
+                        {
+                          int request_major = 0;
+                          int request_minor = 0;
+                          int major = 0;
+                          int minor = 0;
+                          int patch = 0;
+
+                          if (P.if_depth > 0)
+                          {
+                            yyerror("fatal: nested @if macros are not allowed");
+                            return 0;
+                          }
+
+                          P.if_depth++;
+
+                          if (3 == sscanf(Version(), "%d.%d.%d", &major, &minor, &patch))
+                          {
+                            if (2 == sscanf(version_text, "%d.%d", &request_major, &request_minor))
+                            {
+                            if ((request_major > major) ||
+                                (request_major == major && request_minor > minor))
+                              {
+                                /* ignore to the next @endif */
+                                ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
+                                BEGIN(if_ignore_state);
+                              }
+                              else /* we're OK with the version */
+                              {
+                                ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
+                              }
+                            }
+                            else
+                            {
+                              yyerror("fatal: macro @if requested an unparseable version");
+                              return 0;
+                            }
+                          }
+                          else
+                          {
+                            yyerror("fatal: Version() was unparseable");
+                            return 0;
+                          }
+                        }
+                      }
+
+{macro_endif}         {
+                        ParserDebug("\tL:macro @endif %d\n", P.line_pos);
+                        BEGIN(INITIAL);
+                        if (P.if_depth <= 0)
+                        {
+                          yyerror("fatal: @endif macros without a matching @if are not allowed");
+                          return 0;
+                        }
+                        P.if_depth--;
+                      }
+
+<if_ignore_state>{macro_endif} {
+                                 ParserDebug("\tL:macro @endif %d\n", P.line_pos);
+                                 BEGIN(INITIAL);
+                                 if (P.if_depth <= 0)
+                                 {
+                                   yyerror("fatal: @endif macros without a matching @if are not allowed");
+                                   return 0;
+                                 }
+                                 P.if_depth--;
+                               }
+
+<if_ignore_state>.*          {
+                               ParserDebug("\tL:inside macro @if, ignoring text:%s\n", yytext);
+                             }
 
 {promises}            {
                           /* Note this has to come before "id" since it is a subset of id */
@@ -298,6 +377,21 @@ promise_type   [a-zA-Z_]+:
                           return yytext[0];
                       }
 
+<if_ignore_state><<EOF>>     {
+                               if (P.if_depth > 0)
+                               {
+                                 yyerror("EOF seen while @if was waiting for @endif");
+                                 return 0;
+                               }
+                             }
+
+<<EOF>>     {
+              if (P.if_depth > 0)
+              {
+                yyerror("EOF seen while @if was waiting for @endif");
+              }
+              return 0; // loops forever without this
+            }
 
 %%
 

--- a/libpromises/parser_state.h
+++ b/libpromises/parser_state.h
@@ -49,6 +49,8 @@ typedef struct
     int warnings; // bitfield of warnings not considered to be an error
     int warnings_error; // bitfield of warnings considered to be an error
 
+    int if_depth;
+
     int arg_nesting;
     int list_nesting;
 

--- a/tests/acceptance/00_basics/macros/if.cf
+++ b/tests/acceptance/00_basics/macros/if.cf
@@ -1,0 +1,48 @@
+######################################################
+#
+#  Test that @if works
+#
+#####################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle common test
+{
+@if version_after(3.7)
+  classes:
+      "expected" expression => "any";
+@endif
+
+@if version_after(3.6)
+  classes:
+      "expected2" expression => "any";
+@endif
+
+@if version_after(2.100)
+  classes:
+      "expected_2_100" expression => "any";
+@endif
+
+@if version_after(300.700)
+  classes:
+      "not_expected" expression => "any";
+@endif
+}
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_passif_expected("expected,expected2,expected_2_100",
+                                         "not_expected",
+                                         $(this.promise_filename));
+}
+
+@if version_after(300.600)
+
+This text should never be seen, it's completely ignored
+@endif

--- a/tests/acceptance/00_basics/macros/if_eof_without_endif.x.cf
+++ b/tests/acceptance/00_basics/macros/if_eof_without_endif.x.cf
@@ -1,0 +1,24 @@
+######################################################
+#
+#  Test that @if works
+#
+#####################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_passif_expected("any",
+                                         "",
+                                         $(this.promise_filename));
+}
+
+@if version_after(300.100)
+
+This text should never be seen, it's completely ignored

--- a/tests/acceptance/00_basics/macros/if_eof_without_endif2.x.cf
+++ b/tests/acceptance/00_basics/macros/if_eof_without_endif2.x.cf
@@ -1,0 +1,24 @@
+######################################################
+#
+#  Test that @if works
+#
+#####################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_passif_expected("any",
+                                         "",
+                                         $(this.promise_filename));
+}
+
+@if version_after(1.1)
+
+# just testing for EOF

--- a/tests/acceptance/00_basics/macros/if_mismatched.x.cf
+++ b/tests/acceptance/00_basics/macros/if_mismatched.x.cf
@@ -1,0 +1,50 @@
+######################################################
+#
+#  Test that @if works
+#
+#####################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle common test
+{
+@if version_after(3.7)
+@if version_after(3.6)
+  classes:
+      "expected" expression => "any";
+@endif
+@endif
+@endif
+@endif
+@endif
+
+@if version_after(3.6)
+  classes:
+      "expected2" expression => "any";
+@endif
+
+@if version_after(300.700)
+@if version_after(3.6)
+  classes:
+      "not_expected" expression => "any";
+@endif
+@endif
+}
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_passif_expected("expected,expected2",
+                                         "not_expected",
+                                         $(this.promise_filename));
+}
+
+@if version_after(300.600)
+
+This text should never be seen, it's completely ignored
+@endif

--- a/tests/acceptance/00_basics/macros/if_multiple_endif.x.cf
+++ b/tests/acceptance/00_basics/macros/if_multiple_endif.x.cf
@@ -1,0 +1,44 @@
+######################################################
+#
+#  Test that @if works
+#
+#####################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle common test
+{
+@if version_after(3.7)
+  classes:
+      "expected" expression => "any";
+@endif
+@endif
+
+@if version_after(3.6)
+  classes:
+      "expected2" expression => "any";
+@endif
+
+@if version_after(300.700)
+  classes:
+      "not_expected" expression => "any";
+@endif
+}
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_passif_expected("expected,expected2",
+                                         "not_expected",
+                                         $(this.promise_filename));
+}
+
+@if version_after(300.600)
+
+This text should never be seen, it's completely ignored
+@endif

--- a/tests/acceptance/00_basics/macros/if_nested.x.cf
+++ b/tests/acceptance/00_basics/macros/if_nested.x.cf
@@ -1,0 +1,45 @@
+######################################################
+#
+#  Test that nested @if fails
+#
+#####################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle common test
+{
+@if version_after(3.7)
+@if version_after(3.6)
+  classes:
+      "expected" expression => "any";
+@endif
+@endif
+
+@if version_after(3.6)
+  classes:
+      "expected2" expression => "any";
+@endif
+
+@if version_after(300.700)
+  classes:
+      "not_expected" expression => "any";
+@endif
+}
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_passif_expected("expected,expected2",
+                                         "not_expected",
+                                         $(this.promise_filename));
+}
+
+@if version_after(300.600)
+
+This text should never be seen, it's completely ignored
+@endif


### PR DESCRIPTION
See https://dev.cfengine.com/issues/7111

* `@if after_version(a.b)` is hard-coded to exactly that format
* you can give multiple `@if` statements and they "stack up"
* `@endif` ends **any** `@if` state, and it's safe to give multiples

The acceptance tests should make it clear.  I'm not sure if the stacking behavior is best but I'd be OK with it as a user, since typically you'd only give one `@if` at a time.