### PR TITLE
Add: Acceptance test for getvalues

### DIFF
--- a/tests/acceptance/01_vars/02_functions/getvalues_array_and_data_return_similar.cf
+++ b/tests/acceptance/01_vars/02_functions/getvalues_array_and_data_return_similar.cf
@@ -1,0 +1,118 @@
+# Test that running getvalues on data and on a classic array returns similar results
+# https://dev.cfengine.com/issues/7116
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+    "test_soft_fail"
+      string => "any",
+      meta => { "redmine7116"};
+
+  vars:
+    any::
+      "keys" slist => { "foo", "bar" };
+
+      "data" data => parsejson('{
+                                  "foo": [
+                                           "alpha",
+                                           "bravo",
+                                         ],
+                                  "bar": "zulu"
+                              }');
+
+
+      "array[foo]" slist => { "alpha", "bravo" };
+      "array[bar]" string => "zulu";
+
+
+      "data_values_$(keys)" slist => getvalues("data[$(keys)]");
+      "array_values_$(keys)" slist => getvalues("array[$(keys)]");
+}
+
+bundle agent check
+{
+  vars:
+    "expected_values_foo" slist => { "alpha", "bravo" };
+    "expected_values_bar" slist => { "zulu" };
+
+    # The result is a list of values that we did not expect to find.
+    "unexpected_extra_data_values_$(test.keys)"
+      slist => difference( "test.data_values_$(test.keys)", "expected_values_$(test.keys)" );
+
+    # Get the list of values for each key that we expected to find, but did not
+    "unexpected_missing_data_values_$(test.keys)"
+      slist => difference( "expected_values_$(test.keys)", "test.data_values_$(test.keys)" );
+
+    # The result is a list of values that we did not expect to find.
+    "unexpected_extra_array_values_$(test.keys)"
+      slist => difference( "test.array_values_$(test.keys)", "expected_values_$(test.keys)" );
+
+    # Get the list of values for each key that we expected to find, but did not
+    "unexpected_missing_array_values_$(test.keys)"
+      slist => difference( "expected_values_$(test.keys)", "test.array_values_$(test.keys)" );
+
+
+  classes:
+    # Did we find any unexpected extra values?
+    "found_extra_data_values_$(test.keys)"
+      expression => isgreaterthan( length("unexpected_extra_data_values_$(test.keys)"), 0 );
+
+    # Did we find any unexpecred missing values?
+    "found_missing_data_values_$(test.keys)"
+      expression => isgreaterthan( length("unexpected_missing_data_values_$(test.keys)"), 0);
+
+    # Did we find any unexpected extra values?
+    "found_extra_array_values_$(test.keys)"
+      expression => isgreaterthan( length("unexpected_extra_array_values_$(test.keys)"), 0 );
+
+    # Did we find any unexpecred missing values?
+    "found_missing_array_values_$(test.keys)"
+      expression => isgreaterthan( length("unexpected_missing_array_values_$(test.keys)"), 0);
+
+    # Fail the test if any of these unexpected things happen
+    "fail" or => {
+                   "found_extra_data_values_foo", "found_extra_data_values_bar",
+                   "found_missing_data_values_foo", "found_missing_data_values_bar",
+                   "found_extra_array_values_foo", "found_extra_array_values_bar",
+                   "found_missing_array_values_foo", "found_missing_array_values_bar",
+                 };
+
+    # Pass the test if it doesn't fail
+    "ok" expression => "!fail";
+
+  reports:
+    DEBUG::
+      "Found extra data values for key: '$(test.keys)'"
+        ifvarclass => "found_extra_data_values_$(test.keys)";
+      "Extra data value for '$(test.keys)': '$(unexpected_extra_data_values_$(test.keys))'"
+        ifvarclass => "found_extra_data_values_$(test.keys)";
+
+      "Found missing data values for key: '$(test.keys)'"
+        ifvarclass => "found_missing_data_values_$(test.keys)";
+      "Missing data value for '$(test.keys)': '$(unexpected_missing_data_values_$(test.keys))'"
+        ifvarclass => "found_missing_data_values_$(test.keys)";
+
+      "Found extra array values for key: '$(test.keys)'"
+        ifvarclass => "found_extra_array_values_$(test.keys)";
+      "Extra array value for '$(test.keys)': '$(unexpected_extra_array_values_$(test.keys))'"
+        ifvarclass => "found_extra_array_values_$(test.keys)";
+
+      "Found missing array values for key: '$(test.keys)'"
+        ifvarclass => "found_missing_array_values_$(test.keys)";
+      "Missing array value for '$(test.keys)': '$(unexpected_missing_array_values_$(test.keys))'"
+        ifvarclass => "found_missing_array_values_$(test.keys)";
+
+
+    ok::
+      "$(this.promise_filename) Pass";
+
+    fail::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Getvalues should return similar results when used on a datacontainer and 
similar classic array.

Ref: https://dev.cfengine.com/issues/7116