### PR TITLE
Redmine #6994: Fix HPUX LMDB corruption due to non-unified file cache.

### DIFF
--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -216,15 +216,27 @@ DBPriv *DBPrivOpenDB(const char *dbpath, dbid id)
             goto err;
         }
     }
+
+    unsigned int open_flags = MDB_NOSUBDIR;
     if (id == dbid_locks
         || (GetAmPolicyHub() && id == dbid_lastseen))
     {
-        rc = mdb_env_open(db->env, dbpath, MDB_NOSUBDIR|MDB_NOSYNC, 0644);
+        open_flags |= MDB_NOSYNC;
     }
-    else
-    {
-        rc = mdb_env_open(db->env, dbpath, MDB_NOSUBDIR, 0644);
-    }
+
+#ifdef __hpux
+    /*
+     * On HP-UX, a unified file cache was not introduced until version 11.31.
+     * This means that on 11.23 there are separate file caches for mmap()'ed
+     * files and open()'ed files. When these two are mixed, changes made using
+     * one mode won't be immediately seen by the other mode, which is an
+     * assumption LMDB is relying on. The MDB_WRITEMAP flag causes LMDB to use
+     * mmap() only, so that we stay within one file cache.
+     */
+    open_flags |= MDB_WRITEMAP;
+#endif
+
+    rc = mdb_env_open(db->env, dbpath, open_flags, 0644);
     if (rc)
     {
         Log(LOG_LEVEL_ERR, "Could not open database %s: %s",

--- a/tests/load/Makefile.am
+++ b/tests/load/Makefile.am
@@ -46,10 +46,6 @@ TESTS = \
 	run_db_load.sh \
 	run_lastseen_threaded_load.sh
 
-if HPUX
-XFAIL_TESTS = run_lastseen_threaded_load.sh
-endif
-
 check_PROGRAMS = db_load lastseen_load lastseen_threaded_load
 
 

--- a/tests/load/run_lastseen_threaded_load.sh
+++ b/tests/load/run_lastseen_threaded_load.sh
@@ -1,8 +1,3 @@
 #!/bin/sh
 
-if [ "`uname`" = "HP-UX" ]; then
-  echo "$0: Known to hang on HPUX, see Redmine #6907. We will simply fail without attempting."
-  exit 1
-fi
-
 ./lastseen_threaded_load -c 1   4 1 1

--- a/tests/unit/lastseen_test.c
+++ b/tests/unit/lastseen_test.c
@@ -325,20 +325,10 @@ static void test_consistent_1a()
     LastSaw1(IP1, KEY1, ACC);
     LastSaw1(IP2, KEY2, ACC);
 
-#ifdef __hpux
-    // Redmine #6994: NULL is not the desired result, it's just so that we don't
-    // have to xfail the whole test just because of one failure. The #else
-    // portion has the right results.
-    assert_string_equal(DBGetStr(DBH, "a"IP1), NULL);
-    assert_string_equal(DBGetStr(DBH, "a"IP2), NULL);
-    assert_string_equal(DBGetStr(DBH, "k"KEY1), NULL);
-    assert_string_equal(DBGetStr(DBH, "k"KEY2), NULL);
-#else
     assert_string_equal(DBGetStr(DBH, "a"IP1), KEY1);
     assert_string_equal(DBGetStr(DBH, "a"IP2), KEY2);
     assert_string_equal(DBGetStr(DBH, "k"KEY1), IP1);
     assert_string_equal(DBGetStr(DBH, "k"KEY2), IP2);
-#endif
 
     assert_int_equal(IsLastSeenCoherent(), true);
 }


### PR DESCRIPTION
On HP-UX, a unified file cache was not introduced until version 11.31.
This means that on 11.23 there are separate file caches for mmap()'ed
files and open()'ed files. When these two are mixed, changes made using
one mode won't be immediately seen by the other mode, which is an
assumption LMDB is relying on. The MDB_WRITEMAP flag causes LMDB to use
mmap() only, so that we stay within one file cache.