### PR TITLE
server_common: remove double stat() of file, on non-link paths

### DIFF
--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -1010,20 +1010,10 @@ int StatFile(ServerConnectionState *conn, char *sendbuffer, char *ofilename)
 
         cfst.cf_readlink = linkbuf;
     }
-#endif /* !__MINGW32__ */
-
-    if ((!islink) && (stat(filename, &statbuf) == -1))
-    {
-        Log(LOG_LEVEL_VERBOSE, "BAD: unable to stat file '%s'. (stat: %s)",
-            filename, GetErrorStr());
-        SendTransaction(conn->conn_info, sendbuffer, 0, CF_DONE);
-        return -1;
-    }
-
-    Log(LOG_LEVEL_DEBUG, "Getting size of link deref '%s'", linkbuf);
 
     if (islink && (stat(filename, &statlinkbuf) != -1))       /* linktype=copy used by agent */
     {
+        Log(LOG_LEVEL_DEBUG, "Getting size of link deref '%s'", linkbuf);
         statbuf.st_size = statlinkbuf.st_size;
         statbuf.st_mode = statlinkbuf.st_mode;
         statbuf.st_uid = statlinkbuf.st_uid;
@@ -1031,6 +1021,8 @@ int StatFile(ServerConnectionState *conn, char *sendbuffer, char *ofilename)
         statbuf.st_mtime = statlinkbuf.st_mtime;
         statbuf.st_ctime = statlinkbuf.st_ctime;
     }
+
+#endif /* !__MINGW32__ */
 
     if (S_ISDIR(statbuf.st_mode))
     {


### PR DESCRIPTION
The algorithm first calls `lstat()`, which should bring all required
fields in the plain-file case.
Only on posix systems, and when `lstat()` indicates we have a symlink,
we need to call `stat()` again to read destination fields.

Note that the removed lines contain a bug: in the extremely rare case
that a regular file vanishes between first and second `stat()` calls,
we would be sending an uninitialized sendbuffer!