### PR TITLE
A key must now be loaded at the beginning of the agent run.

### DIFF
--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -68,7 +68,8 @@ static void ThisAgentInit(void);
 static GenericAgentConfig *CheckOpts(int argc, char **argv);
 
 static void KeepControlPromises(EvalContext *ctx, const Policy *policy);
-static int HailServer(EvalContext *ctx, char *host);
+static int HailServer(const EvalContext *ctx, const GenericAgentConfig *config,
+                      char *host);
 static void SendClassData(AgentConnection *conn);
 static void HailExec(AgentConnection *conn, char *peer, char *recvbuffer, char *sendbuffer);
 static FILE *NewStream(char *name);
@@ -195,7 +196,7 @@ int main(int argc, char *argv[])
                 {
                     if (fork() == 0)    /* child process */
                     {
-                        HailServer(ctx, RlistScalarValue(rp));
+                        HailServer(ctx, config, RlistScalarValue(rp));
                         exit(EXIT_SUCCESS);
                     }
                     else        /* parent process */
@@ -214,7 +215,7 @@ int main(int argc, char *argv[])
             else                /* serial */
 #endif /* __MINGW32__ */
             {
-                HailServer(ctx, RlistScalarValue(rp));
+                HailServer(ctx, config, RlistScalarValue(rp));
                 rp = rp->next;
             }
         }                       /* end while */
@@ -404,7 +405,8 @@ static void ThisAgentInit(void)
 
 /********************************************************************/
 
-static int HailServer(EvalContext *ctx, char *host)
+static int HailServer(const EvalContext *ctx, const GenericAgentConfig *config,
+                      char *host)
 {
     assert(host != NULL);
 
@@ -498,11 +500,8 @@ static int HailServer(EvalContext *ctx, char *host)
         Log(LOG_LEVEL_INFO, "...........................................................................");
     }
 
-    const char *s =
-        EvalContextVariableControlCommonGet(ctx, COMMON_CONTROL_PROTOCOL_VERSION);
-
     ConnectionFlags connflags = {
-        .protocol_version = ProtocolVersionParse(s),
+        .protocol_version = config->protocol_version,
         .trust_server = trustkey
     };
     int err = 0;

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -400,10 +400,22 @@ static void CheckFileChanges(EvalContext *ctx, Policy **policy, GenericAgentConf
              * calling the same steps as in cf-serverd.c:main()? Those are:
              *   GenericAgentConfigApply();     // not here!
              *   GenericAgentDiscoverContext(); // not here!
+             *   EvalContextClassPutHard("server");             // only here!
              *   if (GenericAgentCheckPolicy()) // not here!
-             *     policy=GenericAgentLoadPolicy();
+             *     policy = LoadPolicy();
+             *   ThisAgentInit();               // not here, only calls umask()
+             *   ReloadHAConfig();                              // only here!
              *   KeepPromises();
              *   Summarize();
+             * Plus the following from within StartServer() which is only
+             * called during startup:
+             *   InitSignals();                  // not here
+             *   ServerTLSInitialize();          // not here
+             *   SetServerListenState();         // not here
+             *   InitServer()                    // not here
+             *   PolicyNew()+AcquireServerLock() // not here
+             *   PrepareServer(sd);              // not here
+             *   CollectCallStart();  // both
              */
 
             char *existing_policy_server = ReadPolicyServerFile(GetWorkDir());
@@ -415,6 +427,7 @@ static void CheckFileChanges(EvalContext *ctx, Policy **policy, GenericAgentConf
             DetectEnvironment(ctx);
             KeepHardClasses(ctx);
 
+            /* During startup this is done in GenericAgentDiscoverContext(). */
             EvalContextClassPutHard(ctx, CF_AGENTTYPES[AGENT_TYPE_SERVER], "cfe_internal,source=agent");
 
             time_t t = SetReferenceTime();

--- a/cf-serverd/server_classic.c
+++ b/cf-serverd/server_classic.c
@@ -620,10 +620,10 @@ static int AuthenticationDialogue(ServerConnectionState *conn, char *recvbuffer,
 {
     unsigned char digest[EVP_MAX_MD_SIZE + 1] = { 0 };
 
-    if ((PRIVKEY == NULL) || (PUBKEY == NULL))
+    if (PRIVKEY == NULL || PUBKEY == NULL)
     {
-        Log(LOG_LEVEL_ERR,
-            "No public/private key pair exists, create one with cf-key");
+        Log(LOG_LEVEL_ERR, "No public/private key pair is loaded,"
+            " please create one using cf-key");
         return false;
     }
 

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -95,8 +95,8 @@ bool ServerTLSInitialize()
 
     if (PRIVKEY == NULL || PUBKEY == NULL)
     {
-        Log(LOG_LEVEL_ERR,
-            "No public/private key pair is loaded, create one with cf-key");
+        Log(LOG_LEVEL_ERR, "No public/private key pair is loaded,"
+            " please create one using cf-key");
         goto err2;
     }
 

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -90,6 +90,7 @@ bool ServerTLSInitialize()
         Log(LOG_LEVEL_ERR,
             "No valid ciphers in cipher list: %s",
             cipher_list);
+        goto err2;
     }
 
     if (PRIVKEY == NULL || PUBKEY == NULL)

--- a/libcfnet/client_protocol.c
+++ b/libcfnet/client_protocol.c
@@ -209,17 +209,11 @@ int AuthenticateAgent(AgentConnection *conn, bool trust_key)
     bool need_to_implicitly_trust_server;
     char enterprise_field = 'c';
 
-    if (PUBKEY == NULL || PRIVKEY == NULL)
+    if (PRIVKEY == NULL || PUBKEY == NULL)
     {
-        /* Try once more to load the keys, maybe the system is converging. */
-        LoadSecretKeys();
-        if (PUBKEY == NULL || PRIVKEY == NULL)
-        {
-            char *pubkeyfile = PublicKeyFile(GetWorkDir());
-            Log(LOG_LEVEL_ERR, "No public/private key pair found at: %s", pubkeyfile);
-            free(pubkeyfile);
-            return false;
-        }
+        Log(LOG_LEVEL_ERR, "No public/private key pair is loaded,"
+            " please create one using cf-key");
+        return false;
     }
 
     enterprise_field = CfEnterpriseOptions();

--- a/libcfnet/tls_client.c
+++ b/libcfnet/tls_client.c
@@ -61,6 +61,12 @@ bool TLSClientInitialize()
         return true;
     }
 
+    if (PRIVKEY == NULL || PUBKEY == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "No public/private key pair is loaded,"
+            " please create one using cf-key");
+        return false;
+    }
     if (!TLSGenericInitialize())
     {
         return false;
@@ -265,13 +271,13 @@ int TLSClientIdentificationDialog(ConnectionInfo *conn_info,
  */
 int TLSTry(ConnectionInfo *conn_info)
 {
-    /* SSL Context might not be initialised up to now due to lack of keys, as
-     * they might be generated as part of the policy (e.g. failsafe.cf). */
-    if (!TLSClientInitialize())
+    if (PRIVKEY == NULL || PUBKEY == NULL)
     {
+        Log(LOG_LEVEL_ERR, "No public/private key pair is loaded,"
+            " please create one using cf-key");
         return -1;
     }
-    assert(SSLCLIENTCONTEXT != NULL && PRIVKEY != NULL && PUBKEY != NULL);
+    assert(SSLCLIENTCONTEXT != NULL);
 
     conn_info->ssl = SSL_new(SSLCLIENTCONTEXT);
     if (conn_info->ssl == NULL)

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1562,7 +1562,7 @@ void GenericAgentConfigApply(EvalContext *ctx, const GenericAgentConfig *config)
         if (config->agent_specific.agent.bootstrap_trust_server)
         {
             EvalContextClassPutHard(ctx, "trust_server", "source=agent");
-            Log(LOG_LEVEL_NOTICE, "Bootstrap mode: implicitly trust server, "
+            Log(LOG_LEVEL_NOTICE, "Bootstrap mode: implicitly trusting server, "
                 "use --trust-server=no if server trust is already established");
         }
     }

--- a/tests/unit/tls_generic_test.c
+++ b/tests/unit/tls_generic_test.c
@@ -134,8 +134,8 @@ static bool init_test_server()
 
     if (PRIVKEY == NULL || PUBKEY == NULL)
     {
-        Log(LOG_LEVEL_ERR,
-            "No public/private key pair is loaded, create one with cf-key");
+        Log(LOG_LEVEL_ERR, "No public/private key pair is loaded,"
+            " please create one using cf-key");
         goto err2;
     }
     assert_true(SSLSERVERCERT == NULL);


### PR DESCRIPTION
For example, if we try to initialise a TLS connection but a key is not
loaded, we will fail. Previously, it was possible to create a key
*while* the system was converging, so the first iteration it would fail,
the second iteration it would succeed.

The reason for changing this is that proper TLS initialisation involves
much more than just reading the keys (for example we need to set ciphers
and TLS version to be used), thus it can only happen during program
initialisation where that information (usually configured in body common
control) is easily accessible.

Most obvious side-effect in practice: "cf-agent --bootstrap".

If you have no key generated while bootstrapping, the bootstrap
procedure can't generate one for you, but it should inform you to
generate on by running cf-key, and then retry to bootstrap.
