### PR TITLE
Add: Acceptance test for abortbundleclasses

### DIFF
--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -1010,20 +1010,10 @@ int StatFile(ServerConnectionState *conn, char *sendbuffer, char *ofilename)
 
         cfst.cf_readlink = linkbuf;
     }
-#endif /* !__MINGW32__ */
-
-    if ((!islink) && (stat(filename, &statbuf) == -1))
-    {
-        Log(LOG_LEVEL_VERBOSE, "BAD: unable to stat file '%s'. (stat: %s)",
-            filename, GetErrorStr());
-        SendTransaction(conn->conn_info, sendbuffer, 0, CF_DONE);
-        return -1;
-    }
-
-    Log(LOG_LEVEL_DEBUG, "Getting size of link deref '%s'", linkbuf);
 
     if (islink && (stat(filename, &statlinkbuf) != -1))       /* linktype=copy used by agent */
     {
+        Log(LOG_LEVEL_DEBUG, "Getting size of link deref '%s'", linkbuf);
         statbuf.st_size = statlinkbuf.st_size;
         statbuf.st_mode = statlinkbuf.st_mode;
         statbuf.st_uid = statlinkbuf.st_uid;
@@ -1031,6 +1021,8 @@ int StatFile(ServerConnectionState *conn, char *sendbuffer, char *ofilename)
         statbuf.st_mtime = statlinkbuf.st_mtime;
         statbuf.st_ctime = statlinkbuf.st_ctime;
     }
+
+#endif /* !__MINGW32__ */
 
     if (S_ISDIR(statbuf.st_mode))
     {

--- a/tests/acceptance/15_control/02_agent/abortbundle_classes.cf
+++ b/tests/acceptance/15_control/02_agent/abortbundle_classes.cf
@@ -1,0 +1,28 @@
+##########################################################################
+#
+# Test that bundles will abort when an abortbundleclass is found to match
+# exactly. Only the one bundle should be aborted, not the entire agent
+# execution.
+#
+##########################################################################
+
+body common control
+{
+      inputs => {
+                  "../../default.cf.sub",
+      };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_agent) -Kf $(this.promise_filename).sub -DAUTO";
+
+  methods:
+    "check"
+      usebundle => dcs_passif_output(".*aborted on defined class 'abort_bundle'.*PASS.*", ".*Should Never Reach.*", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/15_control/02_agent/abortbundle_classes.cf.sub
+++ b/tests/acceptance/15_control/02_agent/abortbundle_classes.cf.sub
@@ -1,0 +1,42 @@
+##########################################################################
+#
+# Test that bundles will abort when an abortbundleclass is found to match
+# exactly. Only the one bundle should be aborted, not the entire agent
+# execution.
+#
+##########################################################################
+
+body agent control
+{
+  abortbundleclasses => { "abort_bundle" };
+}
+
+body common control
+{
+      inputs => {
+                  "../../default.cf.sub",
+      };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  classes:
+      "abort_bundle" expression => "any";
+
+  reports:
+    "Should Never Reach"
+      comment => "This report should not happen since the bundle should abort
+                  first";
+}
+
+bundle agent check
+{
+  reports:
+    "PASS"
+      comment => "This should be reported, as only the previous bundle was
+                  aborted not the whole agent execution";
+}

--- a/tests/acceptance/15_control/02_agent/abortbundle_classexpression.cf
+++ b/tests/acceptance/15_control/02_agent/abortbundle_classexpression.cf
@@ -1,0 +1,29 @@
+##########################################################################
+#
+# Test that bundles will abort when a class expression is used with
+# abortbundleclass and found to match . Only the one bundle should be aborted,
+# not the entire agent execution.
+#
+##########################################################################
+
+
+body common control
+{
+      inputs => {
+                  "../../default.cf.sub",
+      };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_agent) -Kf $(this.promise_filename).sub -DAUTO";
+
+  methods:
+    "check"
+      usebundle => dcs_passif_output(".*Setting abort for 'abort_bundle.something_else' when setting class 'something_else'.*PASS.*", ".*Should Never Reach.*", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/15_control/02_agent/abortbundle_classexpression.cf.sub
+++ b/tests/acceptance/15_control/02_agent/abortbundle_classexpression.cf.sub
@@ -1,0 +1,42 @@
+##########################################################################
+#
+# Test that bundles will abort when a class expression is used with
+# abortbundleclass and found to match . Only the one bundle should be aborted,
+# not the entire agent execution.
+#
+##########################################################################
+body agent control
+{
+  abortbundleclasses => { "abort_bundle.something_else" };
+}
+
+body common control
+{
+      inputs => {
+                  "../../default.cf.sub",
+      };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  classes:
+      "abort_bundle" expression => "any";
+      "something_else" expression => "abort_bundle";
+
+  reports:
+    "Should Never Reach"
+      comment => "This report should not happen since the bundle should abort
+                  first";
+}
+
+bundle agent check
+{
+  reports:
+    "PASS"
+      comment => "This should be reported, as only the previous bundle was
+                  aborted not the whole agent execution";
+}

--- a/tests/acceptance/15_control/02_agent/abortbundle_nomatchclassexpression.cf
+++ b/tests/acceptance/15_control/02_agent/abortbundle_nomatchclassexpression.cf
@@ -1,0 +1,27 @@
+##########################################################################
+#
+# Test that bundles will not abort when a class expression used in
+# abortbundleclass does not match.
+##########################################################################
+
+
+body common control
+{
+      inputs => {
+                  "../../default.cf.sub",
+      };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_agent) -Kf $(this.promise_filename).sub -DAUTO";
+
+  methods:
+    "check"
+      usebundle => dcs_passif_output(".*PASS.*", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/15_control/02_agent/abortbundle_nomatchclassexpression.cf.sub
+++ b/tests/acceptance/15_control/02_agent/abortbundle_nomatchclassexpression.cf.sub
@@ -1,0 +1,34 @@
+##########################################################################
+#
+# Test that bundles will not abort when a class expression used in
+# abortbundleclass does not match.
+##########################################################################
+
+
+body agent control
+{
+  abortbundleclasses => { "abort_bundle.something_else" };
+}
+
+body common control
+{
+      inputs => {
+                  "../../default.cf.sub",
+      };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  classes:
+      "abort_bundle" expression => "!any";
+      "something_else" expression => "any";
+
+  reports:
+    "PASS"
+      comment => "This report should happen as abort_bundle.something_else is
+                  not valid and the bundle should not abort.";
+}

--- a/tests/acceptance/15_control/02_agent/abortbundle_regex.cf
+++ b/tests/acceptance/15_control/02_agent/abortbundle_regex.cf
@@ -1,0 +1,29 @@
+##########################################################################
+#
+# Test that bundles will abort when an abortbundleclass is found to match
+# a regular expression. Only the one bundle should be aborted, not the entire
+# agent execution.
+#
+##########################################################################
+
+
+body common control
+{
+      inputs => {
+                  "../../default.cf.sub",
+      };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_agent) -Kf $(this.promise_filename).sub -DAUTO";
+
+  methods:
+    "check"
+      usebundle => dcs_passif_output(".*aborted on defined class 'abort_bundle_please'.*PASS.*", ".*Should Never Reach.*", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/15_control/02_agent/abortbundle_regex.cf.sub
+++ b/tests/acceptance/15_control/02_agent/abortbundle_regex.cf.sub
@@ -1,0 +1,43 @@
+##########################################################################
+#
+# Test that bundles will abort when an abortbundleclass is found to match
+# a regular expression. Only the one bundle should be aborted, not the entire
+# agent execution.
+#
+##########################################################################
+
+
+body agent control
+{
+  abortbundleclasses => { "abort_bundle.*" };
+}
+
+body common control
+{
+      inputs => {
+                  "../../default.cf.sub",
+      };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  classes:
+      "abort_bundle_please" expression => "any";
+
+  reports:
+    "Should Never Reach"
+      comment => "This report should not happen since the bundle should abort
+                  first";
+}
+
+bundle agent check
+{
+  reports:
+    "PASS"
+      comment => "This should be reported, as only the previous bundle was
+                  aborted not the whole agent execution";
+}


### PR DESCRIPTION
Test that the agent aborts the current bundle when an exact abortclass is
matched and that the agent continues on to the next bundle.

Test that the agent aborts the current bundle when a regular expression is
matched and that the agent continues on to the next bundle.