### PR TITLE
Redmine #7030: Don't hang when operating on fifos

### DIFF
--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -1271,6 +1271,8 @@ static bool DoModifyUser (const char *puser, User u, const struct passwd *passwd
         StringAppend(cmd, "\"", sizeof(cmd));
     }
 
+#ifndef __hpux
+    // HP-UX does not support -G with empty argument
     if (CFUSR_CHECKBIT (changemap, i_groups) != 0)
     {
         /* Work around bug on SUSE. If secondary groups contain a group that is
@@ -1281,6 +1283,7 @@ static bool DoModifyUser (const char *puser, User u, const struct passwd *passwd
         */
         StringAppend(cmd, " -G \"\"", sizeof(cmd));
     }
+#endif
 
     if (CFUSR_CHECKBIT (changemap, i_home) != 0)
     {
@@ -1357,9 +1360,19 @@ static bool DoModifyUser (const char *puser, User u, const struct passwd *passwd
     }
     else if (changemap != 0)
     {
-        if (!ExecuteUserCommand(puser, cmd, sizeof(cmd), "modifying", "Modifying"))
+#ifdef __hpux
+        // This is to overcome the Suse hack above which does not work on HP-UX and thus we
+        // risk getting an empty command if change of secondary groups is the only change
+        // Only run for other changes than i_groups, otherwise the command will be empty
+        uint32_t changemap_without_groups = changemap;
+        CFUSR_CLEARBIT(changemap_without_groups, i_groups);
+        if(changemap_without_groups != 0)
+#endif
         {
-            return false;
+            if (!ExecuteUserCommand(puser, cmd, sizeof(cmd), "modifying", "Modifying"))
+            {
+                return false;
+            }
         }
         if (CFUSR_CHECKBIT (changemap, i_groups) != 0)
         {

--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -1149,12 +1149,20 @@ static bool DoCreateUser(const char *puser, User u, enum cfopaction action,
         StringAppend(cmd, u.shell, sizeof(cmd));
         StringAppend(cmd, "\"", sizeof(cmd));
     }
+
+#ifndef __hpux
+    // HP-UX has two variants of useradd, the normal one which does
+    // not support -M and one variant to modify default values which
+    // does take -M and yes or no
+    // Since both are output with -h SupportOption incorrectly reports
+    // -M as supported
     if (SupportsOption(USERADD, "-M"))
     {
         // Prevents creation of home_dir.
         // We want home_bundle to do that.
         StringAppend(cmd, " -M", sizeof(cmd));
     }
+#endif
     StringAppend(cmd, " ", sizeof(cmd));
     StringAppend(cmd, puser, sizeof(cmd));
 

--- a/configure.ac
+++ b/configure.ac
@@ -1011,7 +1011,8 @@ AC_REPLACE_FUNCS(pthread_sigmask)
 AC_CHECK_DECLS([openat], [], [], [[#include <fcntl.h>]])
 AC_CHECK_DECLS([fstatat], [], [], [[#include <sys/stat.h>]])
 AC_CHECK_DECLS([fchownat], [], [], [[#include <unistd.h>]])
-AC_REPLACE_FUNCS(openat fstatat fchownat)
+AC_CHECK_DECLS([fchmodat], [], [], [[#include <sys/stat.h>]])
+AC_REPLACE_FUNCS(openat fstatat fchownat fchmodat)
 
 AC_CHECK_DECLS([log2], [], [], [[#include <math.h>]])
 AC_REPLACE_FUNCS(log2)
@@ -1159,6 +1160,10 @@ case "$target_os" in
         ;;
    aix*)
         CPPFLAGS="$CPPFLAGS -w"
+        ;;
+   linux*)
+        AC_LIBSOURCE([fchmodat.c])
+        AC_LIBOBJ([fchmodat])
         ;;
    linux*|*bsd*gnu)
         AC_CHECK_LIB(nss_nis, yp_get_default_domain)

--- a/libcompat/fchmodat.c
+++ b/libcompat/fchmodat.c
@@ -1,0 +1,106 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <platform.h>
+#include <misc_lib.h>
+#include <logging.h>
+#include <generic_at.h>
+
+#include <fcntl.h>
+#include <grp.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef __MINGW32__
+
+typedef struct
+{
+    const char *pathname;
+    mode_t mode;
+    int dirfd;
+    int flags;
+} fchmodat_data;
+
+static int fchmodat_inner(void *generic_data)
+{
+    struct stat buf;
+	struct group *gr;
+    int ret = 0;
+	gid_t gid = 0, oldgid = 0;
+	uid_t olduid = 0;
+
+    fchmodat_data *data = generic_data;
+    if ((ret = fstatat(data->dirfd, data->pathname, &buf, data->flags)))
+        return ret;
+
+	/* save old euid and egid */
+	olduid = geteuid();
+	oldgid = getegid();
+
+	fputs("getgrnam\n", stderr);
+	if (! (gr = getgrnam("nobody")) && ! (gr = getgrnam("nogroup")))
+		return -1;
+	gid = gr->gr_gid;
+
+	fprintf(stderr, "%d\n", gid);
+	fputs("setegid\n", stderr);
+	if ((ret = setegid(gid))) {
+		perror("setegid");
+		return ret;
+	}
+
+	fputs("seteuid\n", stderr);
+    if ((ret = seteuid(buf.st_uid)))
+        return ret;
+
+	fputs("chmod\n", stderr);
+	ret = chmod(data->pathname, data->mode);
+
+	if (seteuid(olduid))
+		return -1;
+
+	if (setegid(oldgid))
+		return -1;
+
+	return ret;
+}
+
+static void cleanup(ARG_UNUSED void *generic_data)
+{
+}
+
+int fchmodat(int dirfd, const char *pathname, mode_t mode, int flags)
+{
+    fchmodat_data data = {
+		.pathname = pathname,
+		.mode = mode,
+		.flags = flags,
+		.dirfd = dirfd,
+	};
+
+    return generic_at_function(dirfd, &fchmodat_inner, &cleanup, &data);
+}
+
+#endif // !__MINGW32__

--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -97,6 +97,9 @@ bool FileWriteOver(char *filename, char *contents)
  * Like MakeParentDirectory, but honours warn-only and dry-run mode.
  * We should eventually migrate to this function to avoid making changes
  * in these scenarios.
+ *
+ * @WARNING like MakeParentDirectory, this function will not behave right on
+ *          Windows if the path contains double (back)slashes!
  **/
 
 int MakeParentDirectory2(char *parentandchild, int force, bool enforce_promise)
@@ -122,6 +125,9 @@ int MakeParentDirectory2(char *parentandchild, int force, bool enforce_promise)
 
 /**
  * Please consider using MakeParentDirectory2() instead.
+ *
+ * @WARNING this function will not behave right on Windows if the path
+ *          contains double (back)slashes!
  **/
 
 bool MakeParentDirectory(const char *parentandchild, bool force)
@@ -277,6 +283,7 @@ bool MakeParentDirectory(const char *parentandchild, bool force)
         {
             /* We are at dir "/" of an absolute path, no need to create. */
         }
+        /* WARNING: on Windows stat() fails if path has a trailing slash! */
         else if (stat(currentpath, &statbuf) == -1)
         {
             if (!DONTDO)

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -363,7 +363,8 @@ static bool WritePolicyValidatedFile(ARG_UNUSED const GenericAgentConfig *config
 {
     if (!MakeParentDirectory(filename, true))
     {
-        Log(LOG_LEVEL_ERR, "While writing policy validated marker file '%s', could not create directory (MakeParentDirectory: %s)", filename, GetErrorStr());
+        Log(LOG_LEVEL_ERR,
+            "Could not write policy validated marker file: %s", filename);
         return false;
     }
 
@@ -915,7 +916,9 @@ static bool GeneratePolicyReleaseID(char *release_id_out, size_t out_size,
  */
 static void GetPromisesValidatedFile(char *filename, size_t max_size, const GenericAgentConfig *config, const char *maybe_dirname)
 {
-    char dirname[PATH_MAX + 1];
+    char dirname[max_size];
+
+    /* TODO overflow error checking! */
     GetAutotagDir(dirname, max_size, maybe_dirname);
 
     if (NULL == maybe_dirname && MINUSF)
@@ -941,7 +944,7 @@ static void GetAutotagDir(char *dirname, size_t max_size, const char *maybe_dirn
     }
     else if (MINUSF)
     {
-        snprintf(dirname, max_size, "%s%c", GetStateDir(), FILE_SEPARATOR);
+        strlcpy(dirname, GetStateDir(), max_size);
     }
     else
     {

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -1446,6 +1446,7 @@ Constraint *PromiseAppendConstraint(Promise *pp, const char *lval, Rval rval, bo
                     Log(LOG_LEVEL_DEBUG, "PromiseAppendConstraint: MERGED %s rval %s", old_cp->lval, RvalToString(replacement));
 
                     // overwrite the old Constraint rval with its replacement
+                    RvalDestroy(cp->rval);
                     cp->rval = replacement;
                 }
                 break;

--- a/m4/snprintf.m4
+++ b/m4/snprintf.m4
@@ -203,8 +203,13 @@ AC_DEFUN([HW_FUNC_SNPRINTF],
 AC_DEFUN([HW_FUNC_VASPRINTF],
 [
   AC_REQUIRE([HW_FUNC_VSNPRINTF])dnl Our vasprintf(3) calls vsnprintf(3).
-  AC_CHECK_FUNCS([vasprintf],
-    [hw_cv_func_vasprintf=yes],
+  # Don't even bother checking for vasprintf if snprintf was standards
+  # incompliant, this one is going to be too.
+  AS_IF([test "$hw_cv_func_snprintf_c99" = yes],
+    [AC_CHECK_FUNCS([vasprintf],
+      [hw_cv_func_vasprintf=yes],
+      [hw_cv_func_vasprintf=no])
+    ],
     [hw_cv_func_vasprintf=no])
   AS_IF([test "$hw_cv_func_vasprintf" = no],
     [AC_DEFINE([vasprintf], [rpl_vasprintf],
@@ -224,8 +229,13 @@ AC_DEFUN([HW_FUNC_VASPRINTF],
 AC_DEFUN([HW_FUNC_ASPRINTF],
 [
   AC_REQUIRE([HW_FUNC_VASPRINTF])dnl Our asprintf(3) calls vasprintf(3).
-  AC_CHECK_FUNCS([asprintf],
-    [hw_cv_func_asprintf=yes],
+  # Don't even bother checking for asprintf if snprintf was standards
+  # incompliant, this one is going to be too.
+  AS_IF([test "$hw_cv_func_snprintf_c99" = yes],
+    [AC_CHECK_FUNCS([asprintf],
+      [hw_cv_func_asprintf=yes],
+      [hw_cv_func_asprintf=no])
+    ],
     [hw_cv_func_asprintf=no])
   AS_IF([test "$hw_cv_func_asprintf" = no],
     [AC_DEFINE([asprintf], [rpl_asprintf],

--- a/tests/acceptance/00_basics/01_compiler/string_contexts.cf
+++ b/tests/acceptance/00_basics/01_compiler/string_contexts.cf
@@ -1,3 +1,6 @@
+# fixes https://dev.cfengine.com/issues/2504
+# using variables in string contexts
+
 body common control
 {
       inputs => { "../../default.cf.sub" };

--- a/tests/acceptance/00_basics/01_compiler/string_contexts_rval.cf
+++ b/tests/acceptance/00_basics/01_compiler/string_contexts_rval.cf
@@ -1,0 +1,21 @@
+# fixes https://dev.cfengine.com/issues/2504 using variables in string
+# contexts when a promise has a previous ifvarclass *with a FnCall*
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+}
+
+bundle agent check
+{
+  reports:
+    "any"::
+      "$(this.promise_filename) Pass"
+      ifvarclass => and("any");
+}

--- a/tests/acceptance/10_files/02_maintain/fifos.cf
+++ b/tests/acceptance/10_files/02_maintain/fifos.cf
@@ -1,0 +1,41 @@
+# https://dev.cfengine.com/issues/7030
+#
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+bundle agent init
+{
+  vars:
+    "test_fifo" string => "$(G.testfile).fifo";
+
+  commands:
+    "/usr/bin/mkfifo $(test_fifo)";
+}
+
+bundle agent test
+{
+  files:
+    "$(init.test_fifo)"
+      create => "false",
+      perms => m("0700");
+}
+
+bundle agent check
+{
+  classes:
+    "ok" expression => isexecutable("$(init.test_fifo)");
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+
+}
+
+


### PR DESCRIPTION
The bug is caused by basic fifo semantics. CFEngine uses `openat(2)` to get an fd to `fchown(2)`. However, `open(2)`ing a fifo `RDONLY` blocks until at least one other process has opened it `WRONLY`.

The fix will involve using `chown(2)` rather than `fchown(2)`, since we cannot act on an fd reliably in this case. Fix attached.