### PR TITLE
Add support for adding/removing fifos in CFEngine

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -173,6 +173,13 @@ static int FileSanityChecks(char *path, Attributes a, const Promise *pp)
         return false;
     }
 
+    if ((a.haveedit) && (a.file_type) && (!strncmp(a.file_type, "fifo", 5)))
+    {
+        Log(LOG_LEVEL_ERR, "Editing is not allowed on fifos");
+        PromiseRef(LOG_LEVEL_ERR, pp);
+        return false;
+    }
+
     return true;
 }
 

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -73,6 +73,7 @@ Attributes GetFilesAttributes(const EvalContext *ctx, const Promise *pp)
     attr.transformer = PromiseGetConstraintAsRval(pp, "transformer", RVAL_TYPE_SCALAR);
     attr.move_obstructions = PromiseGetConstraintAsBoolean(ctx, "move_obstructions", pp);
     attr.pathtype = PromiseGetConstraintAsRval(pp, "pathtype", RVAL_TYPE_SCALAR);
+    attr.file_type = PromiseGetConstraintAsRval(pp, "file_type", RVAL_TYPE_SCALAR);
 
     attr.acl = GetAclConstraints(ctx, pp);
     attr.perms = GetPermissionConstraints(ctx, pp);

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1507,6 +1507,7 @@ typedef struct
     Environments env;
     char *transformer;
     char *pathtype;
+    char *file_type;
     char *repository;
     char *edit_template;
     char *template_method;

--- a/libpromises/mod_files.c
+++ b/libpromises/mod_files.c
@@ -343,6 +343,7 @@ static const ConstraintSyntax CF_FILES_BODIES[] =
     ConstraintSyntaxNewString("edit_template", CF_ABSPATHRANGE, "The name of a special CFEngine template file to expand", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBundle("edit_xml", "XML editing model for file", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBody("file_select", &file_select_body, "Choose which files select in a search", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewOption("file_type", "regular,fifo", "Type of file to create. Default value: regular", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBody("link_from", &link_from_body, "Criteria for linking file from a source", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBool("move_obstructions", "true/false whether to move obstructions to file-object creation. Default value: false", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewOption("pathtype", "literal,regex,guess", "Menu option for interpreting promiser file object", SYNTAX_STATUS_NORMAL),

--- a/tests/acceptance/10_files/01_create/011.cf
+++ b/tests/acceptance/10_files/01_create/011.cf
@@ -1,0 +1,63 @@
+#######################################################
+#
+# Create a fifo, check defaults
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  files:
+      "$(G.testfile)"
+      delete => init_delete;
+}
+
+body delete init_delete
+{
+      dirlinks => "delete";
+      rmdirs   => "true";
+}
+
+bundle agent test
+{
+  vars:
+      "mode" int => "0644";
+
+  files:
+      "$(G.testfile)"
+      create => "true",
+      file_type => "fifo";
+}
+
+bundle agent check
+{
+  vars:
+    !windows::
+      "expect[permoct]" string => "600";
+    any::
+      "expect[nlink]" string => "1";
+      "expect[uid]" string => "\d+";
+      "expect[gid]" string => "\d+";
+      "expect[size]" string => "0";
+
+      "fields" slist => getindices("expect");
+      "result[$(fields)]" string => filestat("$(G.testfile)", "$(fields)");
+
+  classes:
+      "not_ok" not => regcmp("$(expect[$(fields)])", "$(result[$(fields)])");
+
+  reports:
+    DEBUG::
+      "expected: $(fields) = '$(expect[$(fields)])'";
+      "got:      $(fields) = '$(result[$(fields)])'";
+    !not_ok::
+      "$(this.promise_filename) Pass";
+    not_ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/01_create/012.cf
+++ b/tests/acceptance/10_files/01_create/012.cf
@@ -1,0 +1,71 @@
+#######################################################
+#
+# Create a file, change perms
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  files:
+      "$(G.testfile)"
+      delete => init_delete;
+}
+
+body delete init_delete
+{
+      dirlinks => "delete";
+      rmdirs   => "true";
+}
+
+bundle agent test
+{
+  vars:
+      "mode" int => "0644";
+
+  files:
+      "$(G.testfile)"
+      create => "true",
+      file_type => "fifo",
+      perms => test_perms;
+}
+
+body perms test_perms
+{
+      mode => "$(test.mode)";
+      owners => { "3" };
+      groups => { "3" };
+}
+
+bundle agent check
+{
+  vars:
+    !windows::
+      "expect[permoct]" string => "$(test.mode)";
+    any::
+      "expect[nlink]" string => "1";
+      "expect[uid]" string => "\d+";
+      "expect[gid]" string => "\d+";
+      "expect[size]" string => "0";
+
+      "fields" slist => getindices("expect");
+      "result[$(fields)]" string => filestat("$(G.testfile)", "$(fields)");
+
+  classes:
+      "not_ok" not => regcmp("$(expect[$(fields)])", "$(result[$(fields)])");
+
+  reports:
+    DEBUG::
+      "expected: $(fields) = '$(expect[$(fields)])'";
+      "got:      $(fields) = '$(result[$(fields)])'";
+    !not_ok::
+      "$(this.promise_filename) Pass";
+    not_ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/07_delete_lines/700.cf
+++ b/tests/acceptance/10_files/07_delete_lines/700.cf
@@ -1,0 +1,38 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testfile)"
+      create => "true",
+      file_type => "fifo",
+      edit_line => init_delete("foo");
+}
+
+bundle edit_line init_delete(str)
+{
+  delete_lines:
+      "$(str)";
+}
+
+bundle agent check
+{
+  classes:
+    "exists" expression => fileexists("$(G.testfile)");
+    "ok" not => "exists";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/09_insert_lines/400.cf
+++ b/tests/acceptance/10_files/09_insert_lines/400.cf
@@ -1,0 +1,43 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testfile)"
+      file_type => "fifo",
+      edit_line => init_insert("foo"),
+      edit_defaults => init_empty;
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+body edit_defaults init_empty
+{
+      empty_file_before_editing => "true";
+}
+
+bundle agent check
+{
+  classes:
+    "exists" expression => fileexists("$(G.testfile)");
+    "ok" not => "exists";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
It would be nice if CFEngine could create and manage FIFOs. This functionality could be extended to include doors as well on Solaris, as well as other special files.