### PR TITLE
4k/execresult

### DIFF
--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -60,6 +60,7 @@
 /* Various defines                                                 */
 /*******************************************************************/
 
+#define CF_MAXSIZE 102400000
 #define CF_BILLION 1000000000L
 #define CF_EXPANDSIZE (2*CF_BUFSIZE)
 #define CF_BUFFERMARGIN 128

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1600,9 +1600,10 @@ static FnCallResult FnCallExecResult(ARG_UNUSED EvalContext *ctx, ARG_UNUSED con
         return FnFailure();
     }
 
-    char buffer[CF_EXPANDSIZE];
+    size_t buffer_size = CF_EXPANDSIZE;
+    char *buffer = xcalloc(1, buffer_size);
 
-    if (GetExecOutput(RlistScalarValue(finalargs), buffer, shelltype))
+    if (GetExecOutput(RlistScalarValue(finalargs), &buffer, &buffer_size, shelltype))
     {
         Log(LOG_LEVEL_VERBOSE, "%s ran '%s' successfully", fp->name, RlistScalarValue(finalargs));
         return FnReturn(buffer);

--- a/libpromises/exec_tools.h
+++ b/libpromises/exec_tools.h
@@ -30,7 +30,7 @@
 
 int IsExecutable(const char *file);
 bool ShellCommandReturnsZero(const char *command, ShellType shell);
-bool GetExecOutput(const char *command, char *buffer, ShellType shell);
+bool GetExecOutput(const char *command, char **buffer, size_t *buffer_size, ShellType shell);
 void ActAsDaemon();
 char **ArgSplitCommand(const char *comm);
 void ArgFree(char **args);

--- a/tests/acceptance/01_vars/02_functions/execresult_4k.cf
+++ b/tests/acceptance/01_vars/02_functions/execresult_4k.cf
@@ -1,0 +1,38 @@
+#######################################################
+#
+# Test returnszero()
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+}
+
+bundle agent test
+{
+  vars:
+    any::
+      "cwd" string => dirname("$(this.promise_filename)");
+      "cat_4k" string => "$(G.cat) $(cwd)$(const.dirsep)text_xform.cf.txt";
+      "result" string => execresult("$(cat_4k)", "useshell");
+
+  classes:
+    any::
+      "ok" expression => regcmp(".*3456789abcdefghij$", "$(result)");
+
+  reports:
+    DEBUG::
+      "$(result)";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+
+}


### PR DESCRIPTION
This is a bit of a hack to remove the 4k limit from `execresult`. Unfortunately, this does change the prototype of `GetExecOutput`. It now requires that the caller dynamically allocate `buffer`. No other functions rely on it, so it doesn't seem to be that big of a problem.