### PR TITLE
Rephrased message when abandoning collect call attempt.

### DIFF
--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -699,7 +699,7 @@ static void CollectCallIfDue(EvalContext *ctx)
         if (waiting_queue > COLLECT_WINDOW)
         {
             Log(LOG_LEVEL_INFO,
-                "Closing collect call with queue longer than the allocated window [%d > %d]",
+                "Abandoning collect call attempt with queue longer than collect_window [%d > %d]",
                 waiting_queue, COLLECT_WINDOW);
             cf_closesocket(new_client);
         }


### PR DESCRIPTION
Mentioning the parameter, collect_window, that controls whether to do
this gives the admin some chance of tweaking it, if that might help.
From the user's perspective, we're abandoning the call; the fact that
we're closing the socket is an implementation detail; so change
wording to say "abandon" instead of "close".