### PR TITLE
Correct a pair of comments about call-collect's completion.

### DIFF
--- a/cf-serverd/server_classic.c
+++ b/cf-serverd/server_classic.c
@@ -1629,8 +1629,8 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
 
         ReceiveCollectCall(conn);
         /* On success that returned true; otherwise, it did all
-         * relevant Log()ging.  Either way, it closed the connection,
-         * so we're no longer busy with it: */
+         * relevant Log()ging.  Either way, we're no longer busy with
+         * it and our caller can close the connection: */
         return false;
 
     case PROTOCOL_COMMAND_AUTH_PLAIN:

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -1040,8 +1040,8 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
 
         ReceiveCollectCall(conn);
         /* On success that returned true; otherwise, it did all
-         * relevant Log()ging.  Either way, it closed the connection,
-         * so we're no longer busy with it: */
+         * relevant Log()ging.  Either way, we're no longer busy with
+         * it and our caller can close the connection: */
         return false;
 
     case PROTOCOL_COMMAND_BAD:


### PR DESCRIPTION
In BusyWith... functions for both TLS and classic, the comment after
ReceiveCollectCall() claimed that it had closed the connection, which
is actually done by the BusyWith...'s caller.  So correct those two
comments to tell the truth.