### PR TITLE
redmine#7113: agent_expireafter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 Cfengine Propulsion Lab
         Changes:
+	- cf-execd: agent_expireafter default was changed to 120 minutes
+	  (Redmine #7113)
         - all embedded databases are now rooted in the state/ directory.
 
         New features:

--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -257,14 +257,17 @@ void LocalExec(const ExecConfig *config)
 
     while (!IsPendingTermination())
     {
-        if (!IsReadReady(fileno(pp), (config->agent_expireafter * SECONDS_PER_MINUTE)))
+        if (!IsReadReady(fileno(pp),
+                         config->agent_expireafter * SECONDS_PER_MINUTE))
         {
-            char errmsg[CF_MAXVARSIZE];
-            snprintf(errmsg, sizeof(errmsg), "cf-execd: !! Timeout waiting for output from agent (agent_expireafter=%d) - terminating it",
-                     config->agent_expireafter);
+            char errmsg[] =
+                "cf-execd: timeout waiting for output from agent"
+                " (agent_expireafter=%d) - terminating it\n";
 
-            Log(LOG_LEVEL_ERR, "%s", errmsg);
-            fprintf(fp, "%s\n", errmsg);
+            fprintf(fp, errmsg, config->agent_expireafter);
+            /* Trim '\n' before Log()ing. */
+            errmsg[strlen(errmsg) - 1] = '\0';
+            Log(LOG_LEVEL_NOTICE, errmsg, config->agent_expireafter);
             count++;
 
             pid_t pid_agent;

--- a/cf-execd/exec-config.c
+++ b/cf-execd/exec-config.c
@@ -34,7 +34,6 @@
 #include <generic_agent.h> // TODO: fix
 #include <item_lib.h>
 
-static const int THREE_HOURS = 3 * 60 * 60;
 
 static char *GetIpAddresses(const EvalContext *ctx)
 {
@@ -58,7 +57,7 @@ ExecConfig *ExecConfigNew(bool scheduled_run, const EvalContext *ctx, const Poli
 
     exec_config->scheduled_run = scheduled_run;
     exec_config->exec_command = xstrdup("");
-    exec_config->agent_expireafter = THREE_HOURS;
+    exec_config->agent_expireafter = 2 * 60;                   /* two hours */
 
     exec_config->mail_server = xstrdup("");
     exec_config->mail_from_address = xstrdup("");

--- a/cf-execd/exec-config.h
+++ b/cf-execd/exec-config.h
@@ -33,7 +33,7 @@ typedef struct
 {
     bool scheduled_run;
     char *exec_command;
-    int agent_expireafter;
+    int agent_expireafter;                                    /* in minutes */
 
     char *mail_server;
     char *mail_from_address;

--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -380,7 +380,7 @@ const ConstraintSyntax CFEX_CONTROLBODY[] = /* enum cfexcontrol */
     ConstraintSyntaxNewStringList("schedule", "", "The class schedule used by cf-execd for activating cf-agent", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewOption("executorfacility", CF_FACILITY, "Menu option for syslog facility level. Default value: LOG_USER", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("exec_command", CF_ABSPATHRANGE,"The full path and command to the executable run by default (overriding builtin)", SYNTAX_STATUS_NORMAL),
-    ConstraintSyntaxNewInt("agent_expireafter", "0,10080", "Maximum agent runtime (in minutes). Default value: 10080", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewInt("agent_expireafter", "0,10080", "Maximum agent runtime (in minutes). Default value: 120", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewNull()
 };
 

--- a/tests/unit/exec-config-test.c
+++ b/tests/unit/exec-config-test.c
@@ -87,7 +87,6 @@ static void test_execd_config_full(void)
     run_test_in_policy("body_executor_control_full.cf", &execd_config_full_cb);
 }
 
-#define THREE_HOURS (3*60*60)
 
 static void exec_config_empty_cb(const EvalContext *ctx, const Policy *policy)
 {
@@ -96,7 +95,6 @@ static void exec_config_empty_cb(const EvalContext *ctx, const Policy *policy)
     assert_int_equal(false, config->scheduled_run);
     /* FIXME: exec-config should provide default exec_command */
     assert_string_equal("", config->exec_command);
-    assert_int_equal(THREE_HOURS, config->agent_expireafter);
     assert_string_equal("", config->mail_server);
     /* FIXME: exec-config should provide default from address */
     assert_string_equal("", config->mail_from_address);


### PR DESCRIPTION
Change from one week, down to two hours, see redmine#7113 for more
details.

Also changed LOG_LEVEL_ERR to LOG_LEVEL_NOTICE since this isn't some
kind of failure.