### PR TITLE
On the first run of cf-monitord histogram data is not present, but it's not an error.

### DIFF
--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -210,7 +210,9 @@ static void LoadHistogram(void)
 
     if ((fp = fopen(filename, "r")) == NULL)
     {
-        Log(LOG_LEVEL_ERR, "Unable to load histogram data from '%s' (fopen: %s)", filename, GetErrorStr());
+        Log(LOG_LEVEL_VERBOSE,
+            "Unable to load histogram data from '%s' (fopen: %s)",
+            filename, GetErrorStr());
         return;
     }
 


### PR DESCRIPTION
Partially reverts 756492778fb022629b19b6e370c1f9b655295ce8.