### PR TITLE
Add missing call to CollectCallMarkProcessed();

### DIFF
--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -720,6 +720,7 @@ static void CollectCallIfDue(EvalContext *ctx)
                 "Abandoning collect call attempt with queue longer than collect_window [%d > %d]",
                 waiting_queue, COLLECT_WINDOW);
             cf_closesocket(new_client);
+            CollectCallMarkProcessed();
         }
         else
         {


### PR DESCRIPTION
When CollectCallHasPending()/CollectCallGetPending() have been used to
take over ownership of the pending CC socket, their caller has a duty
to CollectCallMarkProcessed() when done with it.  That was all handled
suitably when actually using the socket; but was neglected when
discarding it due to an over-long queue.  This would leave a client
permanently failing to attempt collect calls.  Added the missing call.