### PR TITLE
Fix context update when iterating on individual package actions

### DIFF
--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -2569,7 +2569,7 @@ static bool ExecuteSchedule(EvalContext *ctx, const PackageManager *schedule, Pa
                     }
 
                     PromiseResult result = PROMISE_RESULT_NOOP;
-                    EvalContextStackPushPromiseFrame(ctx, pp, false);
+                    EvalContextStackPushPromiseFrame(ctx, ppi, false);
                     if (EvalContextStackPushPromiseIterationFrame(ctx, 0, NULL))
                     {
                         if (ExecPackageCommand(ctx, command_string, verify, true, a, ppi, &result))

--- a/tests/acceptance/07_packages/800.cf
+++ b/tests/acceptance/07_packages/800.cf
@@ -21,11 +21,13 @@ bundle agent test
       "a:b:c"
       package_policy => "add",
       package_method => mock,
+      ifvarclass => "!a",
       classes => ok("a");
 
       "d:e:f"
       package_policy => "add",
       package_method => mock,
+      ifvarclass => "!d",
       classes => ok("d");
 }
 


### PR DESCRIPTION
Ticket: https://dev.cfengine.com/issues/7181

`EvalContextStackPushPromiseFrame` is always called with the first promise, whereas it should be called with the current promise.