### PR TITLE
redmine7219: clarify error message and condition on caring.

### DIFF
--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -945,9 +945,20 @@ static void GetProcessColumnNames(const char *proc, char **names, int *start, in
             {
                 Log(LOG_LEVEL_DEBUG, "End of '%s' is %d", title, offset - 1);
                 end[col++] = offset - 1;
-                if (col > CF_PROCCOLS - 1)
+                if (col >= CF_PROCCOLS) /* No space for more columns. */
                 {
-                    Log(LOG_LEVEL_ERR, "Column overflow in process table");
+                    size_t blank = strspn(sp, " \t\r\n\f\v");
+                    if (sp[blank]) /* i.e. that wasn't everything. */
+                    {
+                        /* If this happens, we have more columns in
+                         * our ps output than space to store them.
+                         * Update the #define CF_PROCCOLS (last seen
+                         * in libpromises/cf3.defs.h) to a bigger
+                         * number ! */
+                        Log(LOG_LEVEL_ERR,
+                            "Process table lacks space for last columns: %s",
+                            sp + blank);
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
No column has overflowed anything.  We *are* on the point of
overflowing the table, if there's more columns to come - except that
we side-step and don't make that mistake.  In any case, filling the
last column of the table isn't an error; the only problem would come
if there were another column to come, for which we lack space in the
table.  So stop to see if there actually *is* another column to come,
before Log()ging any error.  Also, testing > limit - 1 is just an ugly
way to test >= limit !