### PR TITLE
redmine7138: pass open file descriptors portably

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1527,7 +1527,20 @@ AC_MSG_RESULT([-> Statedir: $STATEDIR])
 
 AC_MSG_RESULT( )
 
+dnl ######################################################################
+dnl Check how file descriptor transfers are supported between proceses.
+dnl ######################################################################
+AC_CHECK_MEMBER([struct msghdr.msg_control],
+                [AC_DEFINE([HAVE_MSGHDR_MSG_CONTROL], [1], [Define to 1 if SCM_RIGHTS supported])],
+                [AC_DEFINE([HAVE_NO_MSGHDR_MSG_CONTROL], [1], [Define to 1 if SCM_RIGHTS support])],
+                [[#include <sys/types.h>
+                  #include <sys/socket.h>]])
 
+AC_CHECK_MEMBER([struct msghdr.msg_accrights],
+                [AC_DEFINE([HAVE_MSGHDR_ACCRIGHTS], [1], [Define to 1 if BSD .msg_accrights supported])],
+                [AC_DEFINE([HAVE_NO_MSGHDR_ACCRIGHTS], [1], [Define to 1 if no BSD .msg_accrights support])],
+                [[#include <sys/types.h>
+                  #include <sys/socket.h>]])
 
 dnl ######################################################################
 dnl Now make the Makefiles

--- a/libpromises/signals.c
+++ b/libpromises/signals.c
@@ -79,6 +79,8 @@ void MakeSignalPipe(void)
         exit(EXIT_FAILURE);
     }
 
+    atexit(&CloseSignalPipe);
+
     for (int c = 0; c < 2; c++)
     {
 #ifndef __MINGW32__
@@ -98,8 +100,6 @@ void MakeSignalPipe(void)
         }
 #endif // __MINGW32__
     }
-
-    atexit(&CloseSignalPipe);
 }
 
 /**

--- a/libpromises/signals.c
+++ b/libpromises/signals.c
@@ -83,22 +83,24 @@ void MakeSignalPipe(void)
 
     for (int c = 0; c < 2; c++)
     {
-#ifndef __MINGW32__
-        if (fcntl(SIGNAL_PIPE[c], F_SETFL, O_NONBLOCK) != 0)
-        {
-            Log(LOG_LEVEL_CRIT, "Could not create internal communication pipe. Cannot continue. (fcntl: '%s')",
-                GetErrorStr());
-            exit(EXIT_FAILURE);
-        }
-#else // __MINGW32__
+#ifdef __MINGW32__
         u_long enable = 1;
-        if (ioctlsocket(SIGNAL_PIPE[c], FIONBIO, &enable) != 0)
+        int ret = ioctlsocket(SIGNAL_PIPE[c], FIONBIO, &enable);
+#define CNTLNAME "ioctlsocket"
+#else /* Unix: */
+        int ret = fcntl(SIGNAL_PIPE[c], F_SETFL, O_NONBLOCK);
+#define CNTLNAME "fcntl"
+#endif /* __MINGW32__ */
+
+        if (ret != 0)
         {
-            Log(LOG_LEVEL_CRIT, "Could not create internal communication pipe. Cannot continue. (ioctlsocket: '%s')",
+            Log(LOG_LEVEL_CRIT,
+                "Could not unblock internal communication pipe. "
+                "Cannot continue. (" CNTLNAME ": '%s')",
                 GetErrorStr());
             exit(EXIT_FAILURE);
         }
-#endif // __MINGW32__
+#undef CNTLNAME
     }
 }
 

--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -66,6 +66,7 @@ libutils_la_SOURCES = \
 	rb-tree.c rb-tree.h \
 	mustache.c mustache.h \
 	cfversion.c cfversion.h \
+	passopenfile.c passopenfile.h \
 	unicode.c unicode.h \
 	hash.c hash.h \
 	queue.c queue.h \

--- a/libutils/passopenfile.c
+++ b/libutils/passopenfile.c
@@ -1,0 +1,34 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+#include <passopenfile.h> /* Starts with <platform.h> */
+
+bool PassOpenFile_Put(int uds, int descriptor, const char *text)
+{
+    return false;
+}
+
+int PassOpenFile_Get(int uds, char **text)
+{
+    return -1;
+}

--- a/libutils/passopenfile.c
+++ b/libutils/passopenfile.c
@@ -338,6 +338,9 @@ int PassOpenFile_Get(int uds, char **text)
 #error "No support for connection sharing on this platform :-("
 #endif
 
+#ifndef MSG_WAITALL /* Linux >= 2.2 */
+#define MSG_WAITALL 0
+#endif
 static const char NULL_MSG[] = "\0NULL";
 
 bool PassOpenFile_Put(int uds, int descriptor, const char *text)
@@ -451,7 +454,7 @@ int PassOpenFile_Get(int uds, char **text)
 #endif
 
     /* Receive message: */
-    if (recvmsg(uds, &message, 0) < 0)
+    if (recvmsg(uds, &message, MSG_WAITALL) < 0)
     {
         Log(LOG_LEVEL_ERR,
             "Can't receive descriptor (recvmsg: %s)",

--- a/libutils/passopenfile.c
+++ b/libutils/passopenfile.c
@@ -23,12 +23,499 @@
 */
 #include <passopenfile.h> /* Starts with <platform.h> */
 
+#include <logging.h>
+#include <alloc.h>
+
+/* Local tuning parameter: should anything else know about it ? */
+#define MAX_MESSAGE_SIZE  1024 /* strlen()+1 limit on text transmitted */
+
+#ifdef __MINGW32__
+#include <printsize.h>
+static const char PID_FMT[] = "PID: %lu\n";
+#define PID_MSG_SIZE (PRINTSIZE(unsigned long) + 8)
+static const char ACK_MSG[] = "ACK\n";
+typedef uint32_t MSG_LEN_T;
+
+/* TODO: replace explicit waiting with use of blocking UDS. */
+/* Package a call to select(), to avoid duplicating boilerplate code. */
+static bool wait_for(const int uds, bool write, bool *ready)
+{
+    struct timeval tv;
+    fd_set fds;
+
+    FD_ZERO(&fds);
+    FD_SET(uds, &fds);
+    tv.tv_sec = 1; /* Wait for up to a second */
+    tv.tv_usec = 0;
+
+    int ret;
+    if (write)
+    {
+        ret = select(uds + 1, NULL, &fds, NULL, &tv);
+    }
+    else
+    {
+        ret = select(uds + 1, &fds, NULL, NULL, &tv);
+    }
+
+    if (ret < 0)
+    {
+        return false;
+    }
+    *ready = FD_ISSET(uds, &fds);
+    return true;
+}
+
 bool PassOpenFile_Put(int uds, int descriptor, const char *text)
 {
+    /* From the WSADuplicateSocket() doc [0]: "A process can call
+     * closesocket on a duplicated socket and the descriptor will
+     * become deallocated. The underlying socket, however, will remain
+     * open until closesocket is called by the last remaining
+     * descriptor."  So our caller can cf_closesocket(descriptor), as
+     * long as they do it after the recipient calls WSASocket(); we
+     * include an ACK at the end of this protocol to ensure that.
+     *
+     * [0] https://msdn.microsoft.com/en-us/library/windows/desktop/ms741565(v=vs.85).aspx
+     */
+    WSAPROTOCOL_INFO blob;
+    /* Receive pid from peer */
+    char buffer[PID_MSG_SIZE + 1];
+    ssize_t got = recv(uds, buffer, PID_MSG_SIZE, 0);
+    if (got < 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to read PID to which to pass descriptor");
+        return false;
+    }
+    buffer[got] = '\0';
+    unsigned long pid;
+    if (sscanf(buffer, PID_FMT, &pid) != 1)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to parse peer PID from: %s", buffer);
+        return false;
+    }
+    else if (0 != WSADuplicateSocket(descriptor, pid, &blob))
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to generate socket transmission data blob");
+        return false;
+    }
+
+    bool ready;
+    if (!wait_for(uds, true, &ready))
+    {
+        Log(LOG_LEVEL_ERR,
+            "Can't pass socket to peer (select: %s)",
+            GetErrorStr());
+        return false;
+    }
+    else if (!ready)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Can't pass socket (peer not ready)");
+        return false;
+    }
+    else
+    {
+        /* Transmit blob and text over UDS: */
+        ssize_t had = send(uds, (const void*)&blob, sizeof(blob), 0);
+        /* Casts needed because MinGW thinks send(,const char*,,) :-( */
+        if (had == sizeof(blob))
+        {
+            MSG_LEN_T size = text ? strlen(text) + 1 : 0;
+            had = send(uds, (const void*)&size, sizeof(size), 0);
+            if (had == sizeof(size))
+            {
+                if (text)
+                {
+                    had = send(uds, text, size, 0);
+                }
+            }
+            else
+            {
+                had = -1;
+            }
+        }
+        else
+        {
+            had = -1;
+        }
+        if (had < 0)
+        {
+            Log(LOG_LEVEL_ERR,
+                "Failed to send socket-blob and accompanying text to peer");
+            return false;
+        }
+    }
+
+    /* Wait for ACK so we don't closesocket() before recipient has opened it */
+    if (!wait_for(uds, false, &ready))
+    {
+        Log(LOG_LEVEL_ERR,
+            "Can't get ACK from descriptor recipient (select: %s)",
+            GetErrorStr());
+    }
+    else if (!ready)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Can't get ACK from descriptor recipient (peer not ready)");
+    }
+    else
+    {
+        char answer[sizeof(ACK_MSG) + 1]; /* +1 for the '\0' below */
+        ssize_t got = recv(uds, answer, sizeof(ACK_MSG), 0);
+        if (got > 0)
+        {
+            answer[got] = '\0'; /* In case unexpected message isn't terminated */
+            if (0 != strcmp(answer, ACK_MSG))
+            {
+                Log(LOG_LEVEL_WARNING,
+                    "ACK message wasn't as expected: '%s' != '%s' (ignoring)",
+                    ACK_MSG, answer);
+            }
+            return true;
+        }
+    }
     return false;
 }
 
 int PassOpenFile_Get(int uds, char **text)
 {
+    SOCKET descriptor = SOCKET_ERROR;
+
+    /* Deliver pid to peer over uds */
+    char msg[PID_MSG_SIZE];
+    assert(sizeof(PID_FMT) - 3 + PRINTSIZE(unsigned long) <= PID_MSG_SIZE);
+    unsigned long pid = GetCurrentProcessId();
+    int len = snprintf(msg, sizeof(msg), PID_FMT, pid);
+    assert(len > 0 && len < PID_MSG_SIZE);
+    send(uds, msg, len + 1, 0);
+
+    bool ready;
+    if (!wait_for(uds, false, &ready))
+    {
+        Log(LOG_LEVEL_ERR,
+            "Can't receive descriptor (select: %s)",
+            GetErrorStr());
+        return -1;
+    }
+    else if (!ready)
+    {
+        Log(LOG_LEVEL_VERBOSE, "No descriptor received.");
+        return -1;
+    }
+    else
+    {
+        WSAPROTOCOL_INFO blob;
+
+        /* Receive blob and text over UDS: */
+        ssize_t got = recv(uds, (const void*)&blob, sizeof(blob), 0);
+        /* Casts needed because MinGW thinks recv(,const char*,,) :-( */
+        if (got == sizeof(blob))
+        {
+            descriptor = WSASocket(FROM_PROTOCOL_INFO,
+                                   FROM_PROTOCOL_INFO,
+                                   FROM_PROTOCOL_INFO,
+                                   /* Args after the blob are ignored. */
+                                   &blob, 0, WSA_FLAG_OVERLAPPED);
+            if (descriptor == SOCKET_ERROR)
+            {
+                return -1;
+            }
+            /* else we *must* either use or closesocket() this descriptor. */
+
+            if (text)
+            {
+                *text = NULL;
+            }
+            MSG_LEN_T size; /* Including space for final '\0' byte: */
+            got = recv(uds, (const void*)&size, sizeof(size), 0);
+            if (got == sizeof(size))
+            {
+                if (size)
+                {
+                    char *buffer = malloc(size);
+                    if (*text)
+                    {
+                        got = recv(uds, buffer, size, 0);
+                        if (got != size)
+                        {
+                            Log(LOG_LEVEL_ERR,
+                                "Failed to receive whole text accompanying descriptor");
+                        }
+                    }
+                    else
+                    {
+                        got = 0; /* != size */
+                        Log(LOG_LEVEL_ERR,
+                            "Failed to allocate buffer for text accompanying descriptor");
+                    }
+
+                    if (text && got == size)
+                    {
+                        *text = buffer;
+                    }
+                    else
+                    {
+                        free(buffer);
+                    }
+                }
+            }
+            else
+            {
+                Log(LOG_LEVEL_ERR,
+                    "Failed to read size of text accompanying descriptor");
+                size = 0;
+            }
+
+            if (text && size && !*text)
+            {
+                closesocket(descriptor);
+                return -1;
+            }
+        }
+        else
+        {
+            Log(LOG_LEVEL_ERR,
+                "Failed to receive whole descriptor blob");
+            return -1;
+        }
+    }
+
+    /* Send ACK now that we've opened our end of the socket. */
+    if (!wait_for(uds, true, &ready))
+    {
+        Log(LOG_LEVEL_ERR,
+            "Can't ACK received descriptor (select: %s)",
+            GetErrorStr());
+    }
+    else if (!ready)
+    {
+        Log(LOG_LEVEL_VERBOSE,
+            "No descriptor supplier to ACK to, aborting receipt.");
+    }
+    else
+    {
+        send(uds, ACK_MSG, sizeof(ACK_MSG), 0);
+
+        return descriptor;
+    }
+
+    closesocket(descriptor);
     return -1;
 }
+
+#else /* Unix: */
+
+#ifdef HAVE_MSGHDR_MSG_CONTROL
+/* This is the modern interface.  It should be present in most modern
+ * Unix systems (conforming to the Single UNIX Specification).
+ *
+ * Transferred file descriptors "behave as though they have been
+ * created with dup(2)" according to Linux's unix(7); which means the
+ * sender can close() its end without prejudice to the recipient's use
+ * of its copy. */
+#define INTERFACE_STYLE "SUS"
+
+# ifndef CMSG_SPACE
+/* Solaris 9 contains support for .msg_control but lacks these macros
+ * (here copied from Linux's <socket.h> - thankfully they're platform
+ * agnostic) that we use to manipulate its header: */
+#define CMSG_ALIGN(len) (((len) + sizeof (size_t) - 1) \
+			 & (size_t) ~(sizeof (size_t) - 1))
+#define CMSG_SPACE(len) (CMSG_ALIGN (len) \
+			 + CMSG_ALIGN (sizeof (struct cmsghdr)))
+#define CMSG_LEN(len)   (CMSG_ALIGN (sizeof (struct cmsghdr)) + (len))
+# endif
+
+#elif defined(HAVE_MSGHDR_ACCRIGHTS)
+/* This is the old (BSD) interface.  No Linux should use this, it's
+ * only known to be present in older BSD-based Unixes. */
+#define INTERFACE_STYLE "BSD"
+#else
+#error "No support for connection sharing on this platform :-("
+#endif
+
+static const char NULL_MSG[] = "\0NULL";
+
+bool PassOpenFile_Put(int uds, int descriptor, const char *text)
+{
+    struct msghdr message;
+    struct iovec vector;
+    size_t msglen = text ? strlen(text) + 1 : sizeof(NULL_MSG);
+    assert(MAX_MESSAGE_SIZE >= msglen);
+    Log(LOG_LEVEL_VERBOSE,
+        "Connected to peer, passing descriptor %d with %s %s",
+        descriptor,
+        text ? "text:" : "no",
+        text ? text : "text");
+
+    /* Prepare the message
+     *
+     * We need to send at least one byte of content, in an iovec, so
+     * that a message actually gets received at the other end.  This
+     * means that we want to send *at least something* even when our
+     * text is NULL.  Fortunately, what we send isn't constrained by
+     * C-string '\0'-termination, so we can send a message that
+     * follows a '\0' byte with non-'\0' content (the NULL_MSG above)
+     * which is definitely distinct from what we send for any non-NULL
+     * text - non-empty has non-'\0' first byte; empty has size 1;
+     * NULL also has '\0' as first byte but has size 6.  The recipient
+     * isn't actually told the size sent, though; so has to pre-fill
+     * the receiving buffer with something that can't be mistaken for
+     * our NULL_MSG, so as to safely compare.
+     *
+     * We are confident that the .iov_base on the sending end is only
+     * ever read, so casting away its constness here is not a problem.
+     *
+     * The manual page of sendmsg(2) says .msg_name is used to specify
+     * the target address of a datagram; its documentation of failure
+     * modes says you can get EISCONN if:
+     * "The connection-mode socket was connected already but a
+     *  recipient was specified.  (Now either this error is returned,
+     *  or the recipient specification is ignored.)"
+     * So, in order to keep world peace we need to set the name to NULL.
+     * While we're at it, we clear all fields (using memset, so we don't
+     * trip over variation between platforms in what fields exist).
+     */
+    memset(&message, 0, sizeof(message));
+    memset(&vector, 0, sizeof(vector));
+    vector.iov_base = (void*) (text ? text : NULL_MSG); /* const_cast */
+    vector.iov_len = msglen;
+    message.msg_iov = &vector;
+    message.msg_iovlen = 1;
+
+#ifdef HAVE_MSGHDR_MSG_CONTROL
+    char control_message_data[CMSG_SPACE(sizeof(descriptor))];
+    struct cmsghdr *control_message = NULL;
+    message.msg_control = control_message_data;
+    message.msg_controllen = sizeof(control_message_data);
+    /* Conjecture: setting .msg_controllen influences CMSG_FIRSTHDR in
+     * ways we need; but notice that we over-write it below. */
+    control_message = CMSG_FIRSTHDR(&message);
+    control_message->cmsg_level = SOL_SOCKET;
+    control_message->cmsg_type = SCM_RIGHTS;
+    control_message->cmsg_len = CMSG_LEN(sizeof(descriptor));
+    *(int*)CMSG_DATA(control_message) = descriptor;
+    message.msg_controllen = control_message->cmsg_len;
+#elif HAVE_MSGHDR_ACCRIGHTS
+    message.msg_accrights  = (char *)&descriptor;
+    message.msg_accrightslen = sizeof(descriptor);
+#endif
+
+    /* Send message: */
+    if (sendmsg(uds, &message, 0) < 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Can't pass descriptor to peer (sendmsg: %s)",
+            GetErrorStr());
+    }
+    else
+    {
+        Log(LOG_LEVEL_VERBOSE, "Descriptor %d sent", descriptor);
+        return true;
+    }
+
+    return false;
+}
+
+int PassOpenFile_Get(int uds, char **text)
+{
+    struct msghdr message;
+    struct iovec vector;
+    char buffer[MAX_MESSAGE_SIZE] = "PassOpenFile: failed to transmit any message";
+    assert(strcmp(buffer + 1, NULL_MSG + 1) != 0);
+    int received_descriptor = -1;
+
+    Log(LOG_LEVEL_DEBUG, "Receiving descriptor via " INTERFACE_STYLE
+        " interface (UDS descriptor %d)", uds);
+
+    memset(&message, 0, sizeof(message));
+    memset(&vector, 0, sizeof(vector));
+    memset(buffer, 0, sizeof(buffer));
+    vector.iov_base = buffer;
+    vector.iov_len = sizeof(buffer); /* This is *not* updated by recvmsg ! */
+    /* Prepare the message.  See Put()'s comment on the topic. */
+    message.msg_iov = &vector;
+    message.msg_iovlen = 1;
+
+#ifdef HAVE_MSGHDR_MSG_CONTROL
+    char control_message_data[CMSG_SPACE(sizeof(received_descriptor))];
+    message.msg_control = control_message_data;
+    message.msg_controllen = sizeof(control_message_data);
+#elif HAVE_MSGHDR_ACCRIGHTS
+    message.msg_accrights    = (char *)&received_descriptor;
+    message.msg_accrightslen = sizeof(received_descriptor);
+#endif
+
+    /* Receive message: */
+    if (recvmsg(uds, &message, 0) < 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Can't receive descriptor (recvmsg: %s)",
+            GetErrorStr());
+        return -1;
+    }
+
+    /* Recover the file descriptor */
+#ifdef HAVE_MSGHDR_MSG_CONTROL
+    struct cmsghdr *control_message = CMSG_FIRSTHDR(&message);
+    if (control_message == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Received no message.");
+        return -1;
+    }
+    else if (control_message->cmsg_type != SCM_RIGHTS)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Received message does not deliver a descriptor.");
+        return -1;
+    }
+    assert((char *)control_message + control_message->cmsg_len ==
+           /* i.e. we only have *one* descriptor here; otherwise, we
+            * need to close() all but the first. */
+           (char *)CMSG_DATA(control_message) + sizeof(int));
+    received_descriptor = *(int*)CMSG_DATA(control_message);
+#elif HAVE_MSGHDR_ACCRIGHTS
+    if (message.msg_accrightslen <= 0)
+    {
+        Log(LOG_LEVEL_ERR, "Received no data for descriptor.");
+        return -1;
+    }
+#endif
+
+    if (received_descriptor < 0)
+    {
+        Log(LOG_LEVEL_ERR, "Received invalid descriptor.");
+        return -1;
+    }
+    /* Else, have a duty to close received_descriptor, one way or another. */
+
+    /* Recover the message and report success: */
+    if (buffer[0] || strcmp(buffer + 1, NULL_MSG + 1))
+    {
+        if (text)
+        {
+            *text = xstrndup(buffer, sizeof(buffer));
+        }
+        Log(LOG_LEVEL_VERBOSE,
+            "Received descriptor %d with text '%s'",
+            received_descriptor, buffer);
+    }
+    else
+    {
+        if (text)
+        {
+            *text = NULL;
+        }
+        Log(LOG_LEVEL_VERBOSE,
+            "Received descriptor %d with no text",
+            received_descriptor);
+    }
+
+    return received_descriptor;
+}
+
+#endif /* __MINGW32__ */

--- a/libutils/passopenfile.h
+++ b/libutils/passopenfile.h
@@ -1,0 +1,91 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+#ifndef CFENGINE_PASSOPENFILE_H
+#define CFENGINE_PASSOPENFILE_H
+
+/* Sharing file descriptors between processes.
+ *
+ * This presumes a local communication socket (archetypically a Unix
+ * Domain Socket, opened with domain AF_UNIX - also known as AF_LOCAL)
+ * between two processes on a single machine.  One process has an open
+ * file descriptor (and possibly some accompanying data), to be passed
+ * to the other process.  The former Put()s, the latter Get()s to
+ * implement this.  See ../tests/unit/passopenfile_test.c for a test
+ * that illustrates usage.
+ *
+ * The accompanying text is optional: if NULL is passed to Put(),
+ * Get() shall receive NULL; in contrast, any non-NULL pointer (even
+ * to an empty string) shall result in Get() allocating memory in
+ * which to receive a copy (even if it's just allocating one byte in
+ * which to store a '\0').
+ *
+ * Details of how the local socket is established are left to the
+ * callers; one end shall need to bind() a listen()ing socket so that
+ * the other can connect() one end and the first can accept() the
+ * other end.  Callers are responsible for ensuring the local sockets
+ * are ready for use, e.g. by calling select().
+ *
+ * This allows a process that has accept()ed a connection to hand off
+ * its socket (and the information accept() gave it about the other
+ * end) to another process for handling; or allows one process to
+ * initiate a connection and then hand it off to another to work with
+ * it.  We use this where there is one process that naturally should
+ * do certain jobs but some other process to which initiating the
+ * connection, or accept()ing it, is more practical.
+ *
+ * This can also be used for privilege separation, with a privileged
+ * process sending open descriptors to a worker process that lacks
+ * privileges to open the files but handles untrusted data so can't be
+ * trusted to perform access control reliably.
+ *
+ * The essential activity here is the same as GNUlib's passfd, albeit
+ * with a slightly different API (most notably, providing for
+ * transmission of a text message accompanying the descriptor).
+ */
+
+#include <platform.h>
+/* Send a file descriptor to another process.
+ *
+ * @param uds The local communications socket.
+ * @param descriptor Descriptor for the open file to transfer.
+ * @param text NULL or a '\0'-terminated string to transmit.
+ * @return True on successful transmission.
+ */
+extern bool PassOpenFile_Put(int uds, int descriptor, const char *text);
+
+/* Receive a file descriptor from another process.
+ *
+ * On success, the caller is responsible for close()ing the descriptor
+ * and free()ing the text (if any).  If text == NULL is passed, any
+ * text transmitted with the descriptor is (read, if necessary, and)
+ * discarded; otherwise, on failure, *text should be treated as
+ * uninitialised (even if it was initialised before).
+ *
+ * @param uds The local communications socket.
+ * @param text Pointer to where to record the returned string.
+ * @return The received descriptor or, on failure, -1.
+ */
+extern int PassOpenFile_Get(int uds, char **text);
+
+#endif /* CFENGINE_PASSOPENFILE_H */

--- a/libutils/passopenfile.h
+++ b/libutils/passopenfile.h
@@ -38,7 +38,7 @@
  * Get() shall receive NULL; in contrast, any non-NULL pointer (even
  * to an empty string) shall result in Get() allocating memory in
  * which to receive a copy (even if it's just allocating one byte in
- * which to store a '\0').
+ * which to store a '\0').  Texts over 1023 bytes shall be truncated.
  *
  * Details of how the local socket is established are left to the
  * callers; one end shall need to bind() a listen()ing socket so that
@@ -54,10 +54,16 @@
  * do certain jobs but some other process to which initiating the
  * connection, or accept()ing it, is more practical.
  *
- * This can also be used for privilege separation, with a privileged
- * process sending open descriptors to a worker process that lacks
- * privileges to open the files but handles untrusted data so can't be
- * trusted to perform access control reliably.
+ * Passing local file descriptors can also be used for privilege
+ * separation, with a privileged process sending open descriptors to a
+ * worker process that lacks privileges to open the files but handles
+ * untrusted data so can't be trusted to perform access control
+ * reliably.  However (see following) this only works on Unix.
+ *
+ * On MinGW (i.e. MS-Win), the present implementation can only pass
+ * sockets, not local file descriptors.  It also may block, calling
+ * select(), in its improvised protocol for exchanging needed
+ * information over the local sockets.
  *
  * The essential activity here is the same as GNUlib's passfd, albeit
  * with a slightly different API (most notably, providing for

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -129,6 +129,7 @@ check_PROGRAMS = \
 	map_test \
 	parsemode_test \
 	parser_test \
+	passopenfile_test \
 	policy_test \
 	sort_test \
 	file_name_test \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -233,7 +233,7 @@ str_test_LDADD = libstr.la
 xml_writer_test_SOURCES = xml_writer_test.c ../../libutils/xml_writer.c
 xml_writer_test_LDADD = libtest.la libstr.la
 
-list_test_SOURCES = list_test.c 
+list_test_SOURCES = list_test.c
 
 refcount_test_SOURCES = refcount_test.c ../../libutils/refcount.c
 
@@ -249,7 +249,7 @@ regex_test_SOURCES = regex_test.c ../../cf-agent/match_scope.c
 
 cf_key_functions_test_SOURCES = cf_key_functions_test.c ../../cf-key/cf-key-functions.c
 
-ipaddress_test_SOURCES = ipaddress_test.c 
+ipaddress_test_SOURCES = ipaddress_test.c
 
 protocol_test_SOURCES = protocol_test.c \
 	../../cf-serverd/server_common.c \

--- a/tests/unit/passopenfile_test.c
+++ b/tests/unit/passopenfile_test.c
@@ -1,0 +1,1339 @@
+#include <test.h>
+#include <passopenfile.h>
+
+#include <file_lib.h>
+#include <prototypes3.h>
+
+#ifndef __MINGW32__
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <sys/un.h>
+#endif /* !__MINGW32__ */
+#include <unistd.h>
+
+/* Whether to re-use Unix Domain Sockets
+ *
+ * Strictly, the API is only advertised to be fit for sending *one*
+ * descriptor over each UDS; but there's no reason it shouldn't work
+ * for more - and stressing it is good.  Enabling REUSE_UDS thus
+ * semi-abuses the API to stress it a bit more.
+#define REUSE_UDS
+ */
+
+/* Globals used by the tests. */
+
+static int SPAWNED_PID = -1; /* child used as other process in each test */
+static char DIALUP[PATH_MAX] = ""; /* synchronisation file for listen()/connect() */
+static bool DIALEDUP = false;
+
+/* TODO - not really testing this API, but testing we can use it
+ * securely: test that the listener can secure its socket to only be
+ * connect()ed to by the same user; likewise by one in its group.
+ * Probably put that test in some other file ! */
+
+static void wait_for_child(bool impatient)
+{
+    /* Ensure no stray child is running: */
+    while (SPAWNED_PID >= 0)
+    {
+        errno = 0;
+        if ((impatient && kill(SPAWNED_PID, SIGKILL) == -1 && errno == ESRCH) ||
+            waitpid(SPAWNED_PID, NULL, 0) > 0)
+        {
+            SPAWNED_PID = -1;
+        }
+    }
+}
+
+static bool wait_for_io(int whom, bool write)
+{
+    struct timeval tv;
+    fd_set fds;
+
+    FD_ZERO(&fds);
+    FD_SET(whom, &fds);
+    tv.tv_sec = 10; /* 10s timeout for select() */
+    tv.tv_usec = 0;
+
+    int ret;
+    if (write)
+    {
+        ret = select(whom + 1, NULL, &fds, NULL, &tv);
+    }
+    else
+    {
+        ret = select(whom + 1, &fds, NULL, NULL, &tv);
+    }
+
+    if (ret < 0)
+    {
+        Log(LOG_LEVEL_ERR, "Failed select: %s", GetErrorStr());
+    }
+    else if (!FD_ISSET(whom, &fds))
+    {
+        Log(LOG_LEVEL_ERR, "Timed out select() for descriptor %d", whom);
+    }
+
+    return ret > 0 && FD_ISSET(whom, &fds);
+}
+
+/* Whoever connect()s needs to wait for the other to bind() and listen(): */
+
+static bool wait_for_dialup(bool write)
+{
+    if (DIALUP[0])
+    {
+        for (int i = 5; i-- > 0;)
+        {
+            if (access(DIALUP, write ? W_OK : R_OK) == 0) /* bind() has happened */
+            {
+                sleep(1); /* To let listen() happen, too. */
+                return true;
+            }
+            sleep(1);
+        }
+        Log(LOG_LEVEL_ERR,
+            "Failed to access %s as synchronisation file: %s",
+            DIALUP, GetErrorStr());
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "No synchronisation file");
+    }
+    return false;
+}
+
+/* Used, via atexit(), to ensure we delete the file if we create it. */
+
+static void clear_dialup(void)
+{
+    if (DIALUP[0] && DIALEDUP)
+    {
+        unlink(DIALUP);
+        DIALUP[0] = '\0';
+    }
+}
+
+/* Chose a file by which to connect() to the bind()er. */
+
+static bool setup_dialup(void)
+{
+    if (!DIALUP[0])
+    {
+        /* Using insecure tempnam().
+         *
+         * There really isn't any sensible alternative.  What we need
+         * is a file *name* for use in the address we bind() and
+         * connect() to.  A file descriptor (from mkstemp) or FILE*
+         * (from tmpfile) does us no good.  The former would at least
+         * give us a unique filename, but we'd be unlink()ing the file
+         * it creates in order to actually bind() to it, and we'd have
+         * the exact same race condition as tempnam between when we
+         * bind() and when we connect().  This is a deficiency of the
+         * UDS APIs that we just have to live with.  In production, we
+         * need to make sure we use a UDS based on a file somewhere we
+         * secure suitably (e.g. in a directory owned by root and
+         * inaccessible to anyone else).  The "cfpof" stands for
+         * CF(Engine) Pass Open File, in case you wondered.
+         */
+        char *using = tempnam("/tmp", "cfpof");
+        if (using == NULL)
+        {
+            Log(LOG_LEVEL_ERR, "Failed tempnam: %s", GetErrorStr());
+        }
+        else
+        {
+            assert(using[0]); /* non-empty */
+            strlcpy(DIALUP, using, sizeof(DIALUP));
+            free(using);
+            Log(LOG_LEVEL_VERBOSE, "Synchronising UDS via %s", DIALUP);
+
+            /* Need to call atexit() only once, so do here (called
+             * once, commits us to attempting all tests) instead of
+             * when each test bind()s; that can then set DIALEDUP to
+             * make clear_dialup() actually do something. */
+            atexit(clear_dialup);
+        }
+    }
+    return DIALUP[0] != '\0';
+}
+
+/* Set up listen()ing socket; used by one process in each test. */
+
+static int setup_listener(void)
+{
+    /* Create "server" socket, bind() it, listen() on it, return it. */
+    assert(DIALUP[0]);
+    unlink(DIALUP);
+    int server = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (server >= 0)
+    {
+        Log(LOG_LEVEL_VERBOSE, "Opened %d to bind to and listen on.", server);
+        if (server < FD_SETSIZE) /* else problem for FD_SET when select()ing */
+        {
+            struct sockaddr_un address = { 0 };
+            assert(strlen(DIALUP) < sizeof(address.sun_path));
+            address.sun_family = AF_UNIX;
+            strlcpy(address.sun_path, DIALUP, sizeof(address.sun_path));
+
+            Log(LOG_LEVEL_VERBOSE, "Attempting to bind(%d, ...)", server);
+            if (bind(server, (struct sockaddr *)&address, sizeof(address)) == 0)
+            {
+                /* That's created the file DIALUP, that we now have a
+                 * duty to tidy away. */
+                DIALEDUP = true;
+
+                Log(LOG_LEVEL_VERBOSE, "Calling listen(%d, 1)", server);
+                if (listen(server, 2) == 0)
+                {
+                    /* Success */
+                    return server;
+                }
+                else
+                {
+                    Log(LOG_LEVEL_ERR, "Failed listen: %s", GetErrorStr());
+                }
+            }
+            else
+            {
+                Log(LOG_LEVEL_ERR, "Failed bind: %s", GetErrorStr());
+            }
+        }
+        cf_closesocket(server);
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed socket: %s", GetErrorStr());
+    }
+    return -1;
+}
+
+/* Set up Unix Domain Sockets.
+ *
+ * One of parent and child uses setup_accept(); the other uses
+ * setup_connect().  Each gets a UDS back.  One wants to write to the
+ * result, the other wants to read from it.  These two two-way choices
+ * give us four tests. */
+
+static int setup_accept(int server, bool write)
+{
+    /* When listening socket is ready, accept(); wait for the result
+     * to be ready to read/write. */
+    assert(server >= 0);
+    Log(LOG_LEVEL_VERBOSE, "Calling accept(%d, NULL, NULL)", server);
+    if (wait_for_io(server, false))
+    {
+        int uds = accept(server, NULL, NULL);
+        if (uds == -1)
+        {
+            Log(LOG_LEVEL_ERR, "Failed accept: %s", GetErrorStr());
+        }
+        else if (uds < FD_SETSIZE && /* else problem for FD_SET when select()ing */
+                 wait_for_io(uds, write))
+        {
+            Log(LOG_LEVEL_VERBOSE, "Ready to use accept()ed UDS %d", uds);
+
+            return uds; /* Success */
+        }
+        else
+        {
+            Log(LOG_LEVEL_ERR,
+                "Unable to %s on accept()ed Unix Domain Socket",
+                write ? "write" : "read");
+            cf_closesocket(uds);
+        }
+    }
+    return -1;
+}
+
+static int setup_connect(bool write)
+{
+    /* Create socket, connect() to the listening socket, wait until
+     * ready to read/write */
+    int uds = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (uds >= 0)
+    {
+        if (uds < FD_SETSIZE && /* else problem for FD_SET when select()ing */
+            wait_for_dialup(write))
+        {
+            struct sockaddr_un address;
+            assert(strlen(DIALUP) < sizeof(address.sun_path));
+            address.sun_family = AF_UNIX;
+            strlcpy(address.sun_path, DIALUP, sizeof(address.sun_path));
+
+            if (connect(uds, (struct sockaddr *)&address, sizeof(address)) == 0 &&
+                wait_for_io(uds, write))
+            {
+                Log(LOG_LEVEL_VERBOSE,
+                    "Ready to use connect()ed UDS %d", uds);
+
+                return uds; /* Success */
+            }
+            else
+            {
+                Log(LOG_LEVEL_ERR,
+                    "Failed connect (or select): %s", GetErrorStr());
+            }
+        }
+        cf_closesocket(uds);
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed socket: %s", GetErrorStr());
+    }
+    return -1;
+}
+
+/* Wrapper to set up a Unix Domain Socket.
+ *
+ * Variants on the child/parent processes are given a listening socket
+ * on which to accept() or -1 to tell them to connect().  This
+ * function mediates that choice for them.  It probably gets inlined. */
+static int setup_uds(int server, bool write)
+{
+    return server < 0 ? setup_connect(write) : setup_accept(server, write);
+}
+
+/* Reverse of setup_pipe: */
+
+static void close_pipe(int pair[2])
+{
+    int idx = 2;
+    while (idx-- > 0)
+    {
+        if (pair[idx] >= 0)
+        {
+            cf_closesocket(pair[idx]);
+            pair[idx] = -1;
+        }
+    }
+}
+
+/* Socket pair used by the conversation between processes over the
+ * exchanged descriptors. */
+
+static bool setup_pipe(int pipe[2])
+{
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, pipe) == 0)
+    {
+        /* No need to make them non-blocking ! */
+        return true;
+    }
+    Log(LOG_LEVEL_ERR, "Failed socketpair: %s", GetErrorStr());
+    return false;
+}
+
+/* Check we can use transferred sockets.
+ *
+ * For the parent-child dialogs, we only try one direction.  Each end
+ * actually has both ends of the pipe, but trying to communicate both
+ * ways gets mixed up with the communication we're doing with the
+ * given ends. */
+const char FALLBACK[] = "\0Fallback Message";
+
+/* Parent's half: checks everything. */
+static bool check_hail(int sock, const char *message)
+{
+    const char *msg = message ? message : (FALLBACK + 1);
+    const size_t msglen = message ? strlen(message) : sizeof(FALLBACK);
+    const char noise[] = "The quick brown fox jumps over the lazy dog";
+    char buffer[80];
+    assert(msglen && msglen < sizeof(buffer));
+    strlcpy(buffer, noise, sizeof(buffer));
+
+    errno = 0;
+    ssize_t sent;
+    if (!wait_for_io(sock, true))
+    {
+        /* wait_for_io already Log()ged. */
+
+    }
+    else if (0 > (sent = send(sock, "hello", 6, 0)))
+    {
+        Log(LOG_LEVEL_ERR,
+            "Parent failed to send 'hello': %s",
+            GetErrorStr());
+    }
+    else if (sent != 6)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Parent sent wrong length (%zd != 5) for 'hello'",
+            sent);
+    }
+    else if (!wait_for_io(sock, false))
+    {
+        /* wait_for_io already Log()ged. */
+
+    }
+    else if (0 > (sent = recv(sock, buffer, sizeof(buffer), 0)))
+    {
+        Log(LOG_LEVEL_ERR,
+            "Parent failed to receive '%s': %s",
+            msg, GetErrorStr());
+    }
+    else if (sent != msglen)
+    {
+        buffer[MIN(sent, sizeof(buffer) - 1)] = '\0';
+        Log(LOG_LEVEL_ERR,
+            "Parent received wrong length (%zd != %zd) for '%s' != %s",
+            sent, msglen,
+            (message || buffer[0]) ? buffer : (buffer + 1),
+            msg);
+    }
+    else if (strcmp(buffer + msglen, noise + msglen) != 0)
+    {
+        buffer[sizeof(buffer) - 1] = '\0';
+        Log(LOG_LEVEL_ERR, "Parent recv() trampled buffer: %s", buffer);
+    }
+    else
+    {
+        buffer[msglen] = '\0';
+
+        if (message ? strcmp(buffer, message) == 0 :
+            (buffer[0] == '\0' &&
+             strcmp(buffer + 1, FALLBACK + 1) == 0))
+        {
+            return true;
+        }
+        Log(LOG_LEVEL_ERR,
+            "Parent received wrong text '%s' != '%s'",
+            (message || buffer[0]) ? buffer : (buffer + 1),
+            msg);
+    }
+
+    return false;
+}
+
+/* Dummy conversational partner for check_hail (used in child). */
+static void child_hail(int sock, const char *message)
+{
+    const size_t msglen = message ? strlen(message) : sizeof(FALLBACK);
+    char buffer[80];
+    if (wait_for_io(sock, false) &&
+        recv(sock, buffer, sizeof(buffer), 0) == 6 &&
+        strcmp(buffer, "hello") == 0 &&
+        wait_for_io(sock, true))
+    {
+        send(sock, message ? message : FALLBACK, msglen, 0);
+    }
+}
+
+/* Similar but for a parent talking to self after child died.
+ *
+ * For this one, we test two-way communications, since we're inside a
+ * single process, where that should all work fine.  OTOH, we don't
+ * bother with the buffer-overrun checks and other complications
+ * addressed by check_hail(). */
+
+static bool self_hail(int pair[2])
+{
+    /* We send these with sizeof(), so include the '\0' endings.
+     * They should thus be received with those endings at buffer[sent - 1].
+     */
+    const char exclaim[] = "Dead! Dead!",
+        lament[] = "And never called me mother";
+    char buffer[80];
+    ssize_t sent;
+    if (!wait_for_io(pair[0], true))
+    {
+        /* wait_for_io already Log()ged. */
+
+    }
+    else if (0 > (sent = send(pair[0], exclaim, sizeof(exclaim), 0)))
+    {
+        Log(LOG_LEVEL_ERR, "Failed to send exclamation (send: %s)",
+            GetErrorStr());
+    }
+    else if (sent != sizeof(exclaim))
+    {
+        Log(LOG_LEVEL_ERR, "Sent wrong-sized exclamation: %zd != %zu",
+            sent, sizeof(exclaim));
+    }
+    else if (!wait_for_io(pair[1], false))
+    {
+        /* wait_for_io already Log()ged. */
+
+    }
+    else if (0 > (sent = recv(pair[1], buffer, sizeof(buffer), 0)))
+    {
+        Log(LOG_LEVEL_ERR, "Failed to receive exclamation (recv: %s)",
+            GetErrorStr());
+    }
+    else if (sent != sizeof(exclaim) || buffer[sent - 1])
+    {
+        buffer[MIN(sent, sizeof(buffer) - 1)] = '\0';
+        Log(LOG_LEVEL_ERR, "Received wrong-sized exclamation (%zd != %zu): %s",
+            sent, sizeof(exclaim), buffer);
+    }
+    else if (strcmp(buffer, exclaim) != 0)
+    {
+        buffer[MIN(sent, sizeof(buffer) - 1)] = '\0';
+        Log(LOG_LEVEL_ERR, "Mismatch in exclamation: '%s' != '%s'",
+            buffer, exclaim);
+    }
+    else if (!wait_for_io(pair[1], true))
+    {
+        /* wait_for_io already Log()ged. */
+
+    }
+    else if (0 > (sent = send(pair[1], lament, sizeof(lament), 0)))
+    {
+        Log(LOG_LEVEL_ERR, "Failed to send lament (send: %s)",
+            GetErrorStr());
+    }
+    else if (sent != sizeof(lament))
+    {
+        Log(LOG_LEVEL_ERR, "Sent wrong-sized lament: %zd != %zu",
+            sent, sizeof(lament));
+    }
+    else if (!wait_for_io(pair[0], false))
+    {
+        /* wait_for_io already Log()ged. */
+
+    }
+    else if (0 > (sent = recv(pair[0], buffer, sizeof(buffer), 0)))
+    {
+        Log(LOG_LEVEL_ERR, "Failed to receive lament (recv: %s)",
+            GetErrorStr());
+    }
+    else if (sent != sizeof(lament))
+    {
+        buffer[MIN(sent, sizeof(buffer) - 1)] = '\0';
+        Log(LOG_LEVEL_ERR, "Received wrong-sized lament (%zd != %zu): %s",
+            sent, sizeof(lament), buffer);
+    }
+    else if (strcmp(buffer, lament) != 0)
+    {
+        Log(LOG_LEVEL_ERR, "Mismatch in lament: '%s' != '%s'",
+            buffer, lament);
+    }
+    else
+    {
+        return true;
+    }
+    return false;
+}
+
+/* Variants on the child/parent process.
+ *
+ * In each case the sending process creates a socket pair (setup_pipe)
+ * and passes both ends to the other process; after that, they have
+ * the conversation above (see *_hail) using these sockets.
+ *
+ * For the two-process tests, three things are tested (each setting a
+ * bool variable for the parent): sending a descriptor attending to
+ * any accompanying message (word), sending a descriptor ignoring
+ * message (none) and using one each of the shared descriptors to
+ * communicate between processes (chat).  For the test by a parent
+ * after its child has died, only success of the conversation is
+ * recorded to pass back to the parent.
+ *
+ * Naturally, the details (particularly synchronisation) are trickier
+ * than that.  See REUSE_UDS, above, for one complication.
+ *
+ * We have one parent_*()/child_*() pair for the parent as sending
+ * process with the child receiving, one pair the other way round and
+ * one for the parent that outlives its child.  In each test, one of
+ * parent and child is passed a listening socket on which to accept()
+ * UDS connections; the other is passed -1 and connect()s to it.  The
+ * former has a duty to close the listening socket.  For each of the
+ * resulting combinations, the two-process tests then have one test in
+ * which the non-ignored message is NULL (*_silent) and another in
+ * which it has some content (*_message). */
+
+static void child_for_outlive(int server)
+{
+    /* Parent takes, so the child must send. */
+    int pipe[2];
+    if (setup_pipe(pipe))
+    {
+        int uds = setup_uds(server, true);
+        if (uds >= 0)
+        {
+            PassOpenFile_Put(uds, pipe[1], NULL);
+#ifndef REUSE_UDS
+            cf_closesocket(uds);
+        }
+        uds = setup_uds(server, true);
+        if (uds >= 0)
+        {
+#endif /* REUSE_UDS */
+#ifdef REUSE_UDS
+            wait_for_io(uds, true) &&
+#endif
+                PassOpenFile_Put(uds, pipe[0], NULL);
+            cf_closesocket(uds);
+        }
+        close_pipe(pipe);
+    }
+
+    if (server != -1)
+    {
+        cf_closesocket(server);
+    }
+}
+
+static bool parent_outlive(int server, bool *chat)
+{
+    int pair[2] = { -1, -1 };
+    bool result = true;
+    *chat = false;
+
+    int uds = setup_uds(server, false);
+#ifdef REUSE_UDS
+    if (server != -1)
+    {
+        cf_closesocket(server);
+    }
+#endif
+    if (uds < 0)
+    {
+        result = false;
+    }
+    else
+    {
+        char *text = NULL;
+        pair[1] = PassOpenFile_Get(uds, &text);
+        free(text);
+        text = NULL;
+#ifndef REUSE_UDS
+        cf_closesocket(uds);
+    }
+    uds = setup_uds(server, false);
+    if (server != -1)
+    {
+        cf_closesocket(server);
+    }
+
+    if (uds < 0)
+    {
+        result = false;
+    }
+    else
+    {
+#endif /* REUSE_UDS */
+        pair[0] =
+#ifdef REUSE_UDS
+            !wait_for_io(uds, false) ? -1 :
+#endif
+            PassOpenFile_Get(uds, NULL);
+
+        cf_closesocket(uds);
+        if (pair[0] < 0)
+        {
+            Log(LOG_LEVEL_ERR,
+                "Parent failed to receive descriptor (ignoring text)");
+        }
+        else if (pair[1] >= 0)
+        {
+            Log(LOG_LEVEL_VERBOSE, "Parent received both descriptors");
+            wait_for_child(false); /* Don't kill, be patient. */
+            *chat = self_hail(pair);
+        }
+    }
+
+    close_pipe(pair);
+    return result;
+}
+
+/* Child sends descriptors to parent.
+ *
+ * In this case, verifying we get the right message can be done
+ * directly by the parent on receiving the message. */
+
+static void child_for_take(int server, const char *message)
+{
+    /* Of course, for the parent to take, the child must send. */
+    int pipe[2];
+    if (setup_pipe(pipe))
+    {
+        bool sent = false;
+        int uds = setup_uds(server, true);
+        if (uds >= 0)
+        {
+            sent = PassOpenFile_Put(uds, pipe[1], message);
+#ifndef REUSE_UDS
+            cf_closesocket(uds);
+        }
+        uds = setup_uds(server, true);
+        if (uds >= 0)
+        {
+#endif /* REUSE_UDS */
+            sent =
+#ifdef REUSE_UDS
+                wait_for_io(uds, true) &&
+#endif
+                PassOpenFile_Put(uds, pipe[0], message) && sent;
+            cf_closesocket(uds);
+        }
+        if (sent)
+        {
+            Log(LOG_LEVEL_VERBOSE, "Child delivered both descriptors");
+            child_hail(pipe[0], message);
+        }
+        close_pipe(pipe);
+    }
+
+    if (server != -1)
+    {
+        cf_closesocket(server);
+    }
+}
+
+static bool parent_take(int server, const char *message,
+                        bool *word, bool *none, bool *chat)
+{
+    int pair[2] = { -1, -1 };
+    bool result = true;
+    *word = *none = *chat = false;
+
+    int uds = setup_uds(server, false);
+#ifdef REUSE_UDS
+    if (server != -1)
+    {
+        cf_closesocket(server);
+    }
+#endif
+    if (uds < 0)
+    {
+        result = false;
+    }
+    else
+    {
+        char *text = NULL;
+        pair[1] = PassOpenFile_Get(uds, &text);
+        *word = pair[1] >= 0 && (message ? text && strcmp(text, message) == 0 : !text);
+        free(text);
+        text = NULL;
+#ifndef REUSE_UDS
+        cf_closesocket(uds);
+    }
+    uds = setup_uds(server, false);
+    if (server != -1)
+    {
+        cf_closesocket(server);
+    }
+
+    if (uds < 0)
+    {
+        result = false;
+    }
+    else
+    {
+#endif /* REUSE_UDS */
+        pair[0] =
+#ifdef REUSE_UDS
+            !wait_for_io(uds, false) ? -1 :
+#endif
+            PassOpenFile_Get(uds, NULL);
+
+        cf_closesocket(uds);
+        if (pair[0] < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Parent failed to receive descriptor (ignoring text)");
+        }
+        else
+        {
+            *none = true;
+            if (pair[1] >= 0)
+            {
+                Log(LOG_LEVEL_VERBOSE, "Parent received both descriptors");
+                *chat = check_hail(pair[1], message);
+            }
+        }
+    }
+
+    close_pipe(pair);
+    return result;
+}
+
+/* Parent sends to child.
+ *
+ * Verifying the message is transmitted correctly depends on the child
+ * sending the message back as part of the conversation after we
+ * exchange descriptors. */
+
+static void child_for_send(int server)
+{
+    /* Of course, for the parent to send, the child must take. */
+    int pair[2] = { -1, -1 };
+
+    int uds = setup_uds(server, false);
+#ifdef REUSE_UDS
+    if (server != -1)
+    {
+        cf_closesocket(server);
+    }
+#endif
+    if (uds >= 0)
+    {
+        pair[1] = PassOpenFile_Get(uds, NULL);
+        if (pair[1] < 0)
+        {
+            Log(LOG_LEVEL_ERR,
+                "Child failed to receive descriptor (ignoring text)");
+        }
+#ifndef REUSE_UDS
+        cf_closesocket(uds);
+    }
+
+    uds = setup_uds(server, false);
+    if (server >= 0)
+    {
+        cf_closesocket(server);
+    }
+
+    if (uds >= 0)
+    {
+#endif /* REUSE_UDS */
+        char *text = NULL;
+        pair[0] =
+#ifdef REUSE_UDS
+            !wait_for_io(uds, false) ? -1 :
+#endif
+            PassOpenFile_Get(uds, &text);
+        cf_closesocket(uds);
+        if (pair[0] < 0)
+        {
+            Log(LOG_LEVEL_ERR,
+                "Child failed to receive descriptor");
+        }
+        else if (pair[1] >= 0)
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Child received both descriptors (%s %s)",
+                text ? "text:" : "no",
+                text ? text : "text");
+
+            child_hail(pair[1], text);
+        }
+        free(text);
+    }
+    close_pipe(pair);
+}
+
+static bool parent_send(int server, const char *message,
+                        bool *word, bool *none, bool *chat)
+{
+    /* We have a duty to close(server) if not -1 */
+    bool result = false;
+    int pipe[2];
+    *word = *none = *chat = false;
+
+    if (setup_pipe(pipe))
+    {
+        result = true;
+        *word = *none = *chat = false;
+        int uds = setup_uds(server, true);
+        if (uds < 0)
+        {
+            result = false;
+        }
+        else
+        {
+            *none = PassOpenFile_Put(uds, pipe[1], message);
+#ifndef REUSE_UDS
+            cf_closesocket(uds);
+        }
+        uds = setup_uds(server, true);
+        if (uds < 0)
+        {
+            result = false;
+        }
+        else
+        {
+#endif /* REUSE_UDS */
+            *word =
+#ifdef REUSE_UDS
+                wait_for_io(uds, true) &&
+#endif
+                PassOpenFile_Put(uds, pipe[0], message);
+            cf_closesocket(uds);
+        }
+
+        if (*word && *none)
+        {
+            Log(LOG_LEVEL_VERBOSE, "Parent delivered both descriptors");
+            *chat = check_hail(pipe[0], message);
+        }
+        close_pipe(pipe);
+    }
+
+    if (server != -1)
+    {
+        cf_closesocket(server);
+    }
+
+    return result;
+}
+
+/* The actual tests, built on those tools.
+ *
+ * Classified according to whether parent is listen()ing or
+ * connect()ing, with the child doing the other, and whether parent is
+ * sending or taking descriptors from child.  The parent is
+ * responsible for all testing, although the child helps out via the
+ * chatter on exchanged sockets. */
+
+static void test_take_listen_message(void)
+{
+    wait_for_child(true);
+    const char message[] = "verbiage";
+    pid_t new_pid = fork();
+    if (new_pid == 0)
+    {
+        /* child */
+        child_for_take(-1, message);
+        exit(0);
+    }
+    else if (new_pid > 0)
+    {
+        SPAWNED_PID = new_pid;
+
+        /* parent */
+        int server = setup_listener();
+        if (server < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Parent failed to set up listener");
+        }
+        else
+        {
+            bool word, none, chat;
+            if (parent_take(server, message, &word, &none, &chat))
+            {
+                assert_true(word && "can receive fd with a message");
+                assert_true(none && "can receive fd ignoring message");
+                assert_true(chat && "can use the received fds");
+
+                if (waitpid(new_pid, NULL, 1) > 0);
+                {
+                    SPAWNED_PID = -1;
+                }
+                return;
+            }
+            Log(LOG_LEVEL_ERR, "Failed to set up UDS");
+        }
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed fork: %s", GetErrorStr());
+    }
+    assert_true(false);
+}
+
+static void test_take_connect_message(void)
+{
+    wait_for_child(true);
+    const char message[] = "waffle";
+    pid_t new_pid = fork();
+    if (new_pid == 0)
+    {
+        /* child */
+        int server = setup_listener();
+        if (server < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Child failed to set up listener");
+        }
+        else
+        {
+            child_for_take(server, message);
+        }
+        exit(0);
+    }
+    else if (new_pid > 0)
+    {
+        SPAWNED_PID = new_pid;
+
+        /* parent */
+        bool word, none, chat;
+        if (parent_take(-1, message, &word, &none, &chat))
+        {
+            assert_true(word && "can receive fd with a message");
+            assert_true(none && "can receive fd ignoring message");
+            assert_true(chat && "can use the received fds");
+
+            if (waitpid(new_pid, NULL, 1) > 0)
+            {
+                SPAWNED_PID = -1;
+            }
+            return;
+        }
+        Log(LOG_LEVEL_ERR, "Failed to set up parent");
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed fork: %s", GetErrorStr());
+    }
+    assert_true(false);
+}
+
+static void test_send_listen_message(void)
+{
+    wait_for_child(true);
+    pid_t new_pid = fork();
+    if (new_pid == 0)
+    {
+        /* child */
+        child_for_send(-1);
+        exit(0);
+    }
+    else if (new_pid > 0)
+    {
+        SPAWNED_PID = new_pid;
+
+        /* parent */
+        int server = setup_listener();
+        if (server < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Parent failed to set up listener");
+        }
+        else
+        {
+            bool word, none, chat;
+            if (parent_send(server, "mumble", &word, &none, &chat))
+            {
+                assert_true(word && "can transmit fd with a message");
+                assert_true(none && "can transmit fd ignoring message");
+                assert_true(chat && "can use the transmitted fds");
+
+                if (waitpid(new_pid, NULL, 1) > 0)
+                {
+                    SPAWNED_PID = -1;
+                }
+                return;
+            }
+            Log(LOG_LEVEL_ERR, "Failed to set up parent");
+        }
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed fork: %s", GetErrorStr());
+    }
+    assert_true(false);
+}
+
+static void test_send_connect_message(void)
+{
+    wait_for_child(true);
+    pid_t new_pid = fork();
+    if (new_pid == 0)
+    {
+        /* child */
+        int server = setup_listener();
+        if (server < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Child failed to set up listener");
+        }
+        else
+        {
+            child_for_send(server);
+        }
+        exit(0);
+    }
+    else if (new_pid > 0)
+    {
+        SPAWNED_PID = new_pid;
+
+        /* parent */
+        bool word, none, chat;
+        if (parent_send(-1, "mutter", &word, &none, &chat))
+        {
+            assert_true(word && "can transmit fd with a message");
+            assert_true(none && "can transmit fd ignoring message");
+            assert_true(chat && "can use the transmitted fds");
+
+            if (waitpid(new_pid, NULL, 1) > 0)
+            {
+                SPAWNED_PID = -1;
+            }
+            return;
+        }
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed fork: %s", GetErrorStr());
+    }
+    assert_true(false);
+}
+
+static void test_take_listen_silent(void)
+{
+    wait_for_child(true);
+    pid_t new_pid = fork();
+    if (new_pid == 0)
+    {
+        /* child */
+        child_for_take(-1, NULL);
+        exit(0);
+    }
+    else if (new_pid > 0)
+    {
+        SPAWNED_PID = new_pid;
+
+        /* parent */
+        int server = setup_listener();
+        if (server < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Parent failed to set up listener");
+        }
+        else
+        {
+            bool word, none, chat;
+            if (parent_take(server, NULL, &word, &none, &chat))
+            {
+                assert_true(word && "can receive fd with no message");
+                assert_true(none && "can receive fd ignoring no message");
+                assert_true(chat && "can use the received fds");
+
+                if (waitpid(new_pid, NULL, 1) > 0);
+                {
+                    SPAWNED_PID = -1;
+                }
+                return;
+            }
+            Log(LOG_LEVEL_ERR, "Failed to set up UDS");
+        }
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed fork: %s", GetErrorStr());
+    }
+    assert_true(false);
+}
+
+static void test_take_connect_silent(void)
+{
+    wait_for_child(true);
+    pid_t new_pid = fork();
+    if (new_pid == 0)
+    {
+        /* child */
+        int server = setup_listener();
+        if (server < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Child failed to set up listener");
+        }
+        else
+        {
+            child_for_take(server, NULL);
+        }
+        exit(0);
+    }
+    else if (new_pid > 0)
+    {
+        SPAWNED_PID = new_pid;
+
+        /* parent */
+        bool word, none, chat;
+        if (parent_take(-1, NULL, &word, &none, &chat))
+        {
+            assert_true(word && "can receive fd with no message");
+            assert_true(none && "can receive fd ignoring no message");
+            assert_true(chat && "can use the received fds");
+
+            if (waitpid(new_pid, NULL, 1) > 0)
+            {
+                SPAWNED_PID = -1;
+            }
+            return;
+        }
+        Log(LOG_LEVEL_ERR, "Failed to set up parent");
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed fork: %s", GetErrorStr());
+    }
+    assert_true(false);
+}
+
+static void test_send_listen_silent(void)
+{
+    wait_for_child(true);
+    pid_t new_pid = fork();
+    if (new_pid == 0)
+    {
+        /* child */
+        child_for_send(-1);
+        exit(0);
+    }
+    else if (new_pid > 0)
+    {
+        SPAWNED_PID = new_pid;
+
+        /* parent */
+        int server = setup_listener();
+        if (server < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Parent failed to set up listener");
+        }
+        else
+        {
+            bool word, none, chat;
+            if (parent_send(server, NULL, &word, &none, &chat))
+            {
+                assert_true(word && "can transmit fd with no message");
+                assert_true(none && "can transmit fd ignoring no message");
+                assert_true(chat && "can use the transmitted fds");
+
+                if (waitpid(new_pid, NULL, 1) > 0)
+                {
+                    SPAWNED_PID = -1;
+                }
+                return;
+            }
+            Log(LOG_LEVEL_ERR, "Failed to set up parent");
+        }
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed fork: %s", GetErrorStr());
+    }
+    assert_true(false);
+}
+
+static void test_send_connect_silent(void)
+{
+    wait_for_child(true);
+    pid_t new_pid = fork();
+    if (new_pid == 0)
+    {
+        /* child */
+        int server = setup_listener();
+        if (server < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Child failed to set up listener");
+        }
+        else
+        {
+            child_for_send(server);
+        }
+        exit(0);
+    }
+    else if (new_pid > 0)
+    {
+        SPAWNED_PID = new_pid;
+
+        /* parent */
+        bool word, none, chat;
+        if (parent_send(-1, NULL, &word, &none, &chat))
+        {
+            assert_true(word && "can transmit fd with no message");
+            assert_true(none && "can transmit fd ignoring no message");
+            assert_true(chat && "can use the transmitted fds");
+
+            if (waitpid(new_pid, NULL, 1) > 0)
+            {
+                SPAWNED_PID = -1;
+            }
+            return;
+        }
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed fork: %s", GetErrorStr());
+    }
+    assert_true(false);
+}
+
+static void test_connect_outlive(void)
+{
+    wait_for_child(true);
+    pid_t new_pid = fork();
+    if (new_pid == 0)
+    {
+        /* child */
+        child_for_outlive(-1);
+        exit(0);
+    }
+    else if (new_pid > 0)
+    {
+        SPAWNED_PID = new_pid;
+
+        /* parent */
+        bool chat;
+        int server = setup_listener();
+        if (server < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Parent failed to set up listener");
+        }
+        else if (parent_outlive(server, &chat))
+        {
+            assert_true(chat && "can use received fds after sender exits");
+            return;
+        }
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed fork: %s", GetErrorStr());
+    }
+    assert_true(false);
+}
+
+static void test_listen_outlive(void)
+{
+    wait_for_child(true);
+    pid_t new_pid = fork();
+    if (new_pid == 0)
+    {
+        /* child */
+        int server = setup_listener();
+        if (server < 0)
+        {
+            Log(LOG_LEVEL_ERR, "Child failed to set up listener");
+        }
+        else
+        {
+            child_for_outlive(server);
+        }
+        exit(0);
+    }
+    else if (new_pid > 0)
+    {
+        SPAWNED_PID = new_pid;
+
+        /* parent */
+        bool chat;
+        if (parent_outlive(-1, &chat))
+        {
+            assert_true(chat && "can use received fds after sender exits");
+            return;
+        }
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed fork: %s", GetErrorStr());
+    }
+    assert_true(false);
+}
+
+/* The driver */
+
+int main(void)
+{
+    PRINT_TEST_BANNER();
+    const UnitTest tests[] =
+    {
+        unit_test(test_take_listen_message),
+        unit_test(test_take_connect_message),
+        unit_test(test_send_listen_message),
+        unit_test(test_send_connect_message),
+        unit_test(test_take_listen_silent),
+        unit_test(test_take_connect_silent),
+        unit_test(test_send_listen_silent),
+        unit_test(test_send_connect_silent),
+        unit_test(test_connect_outlive),
+        unit_test(test_listen_outlive)
+    };
+#if 0 /* 1: toggle as needed. */
+    LogSetGlobalLevel(LOG_LEVEL_VERBOSE);
+#endif
+
+    int res = setup_dialup() ? run_tests(tests) : 1;
+
+    /* Make sure no child is left behind. */
+    if (SPAWNED_PID >= 0)
+    {
+        kill(SPAWNED_PID, SIGKILL);
+    }
+    return res;
+}


### PR DESCRIPTION
<s>This is a preview, not yet a real pull request; I still need to fix some problems with the test.
I *shall* push -f a replacement branch before I'm ready to suggest merging this.
In particular, the Makefile.am changes need to move to the end, once the test is passing (and I've verified it fails before implementing the feature), so that git bisect never hits a point in the middle where tests fail.</s>
Tested on Jenkins and in our scale-test environment.  We need to test on MS-Win (but at least it compiles there, now).