### PR TITLE
improve error message seen from cf-key -r

### DIFF
--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -693,7 +693,7 @@ int RemoveKeysFromLastSeen(const char *input, bool must_be_coherent,
         is_coherent = IsLastSeenCoherent();
         if (is_coherent == false)
         {
-            Log(LOG_LEVEL_ERR, "Lastseen database is incoherent. Will not proceed to remove entries from it.");
+            Log(LOG_LEVEL_ERR, "Lastseen database is incoherent (there is not a 1-to-1 relationship between hosts and keys) and coherence check is enforced. Will not proceed to remove entries from it.");
             return 254;
         }
     }


### PR DESCRIPTION
cf-key -r may output a message that lastseen is not coherent, but this does not mean db-level corruption.
Running cf-key -r -x skips coherence check but this function is generic so it did not seem appropriate to mention this.

https://cfengine.zendesk.com/agent/tickets/1964