### PR TITLE
Reduce usage of test_suppress_fail.

### DIFF
--- a/tests/acceptance/01_vars/02_functions/sort.cf
+++ b/tests/acceptance/01_vars/02_functions/sort.cf
@@ -63,7 +63,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "hpux|sunos_5_9|windows",
+      "test_soft_fail" string => "hpux|sunos_5_9|windows",
         meta => { "redmine4934", "redmine5107" };
 
 

--- a/tests/acceptance/06_storage/01_local/001.cf
+++ b/tests/acceptance/06_storage/01_local/001.cf
@@ -24,7 +24,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "sunos_5_11",
+      "test_soft_fail" string => "sunos_5_11",
         meta => { "redmine5234" };
 
   vars:

--- a/tests/acceptance/10_files/09_insert_lines/017.cf
+++ b/tests/acceptance/10_files/09_insert_lines/017.cf
@@ -16,7 +16,7 @@ body common control
 
 bundle agent test {
   meta:
-      "test_suppress_fail" string => "aix|hpux|sunos_5_9|sunos_5_10",
+      "test_soft_fail" string => "aix|hpux|sunos_5_9|sunos_5_10",
         meta => { "redmine6336" };
 
   files:

--- a/tests/acceptance/17_users/unsafe/10_add_user_with_secondary_gid.cf
+++ b/tests/acceptance/17_users/unsafe/10_add_user_with_secondary_gid.cf
@@ -29,7 +29,7 @@ bundle agent init
 {
   # AIX useradd/usermod commands do not support numerical group arguments.
   meta:
-      "test_suppress_fail" string => "aix",
+      "test_soft_fail" string => "aix",
         meta => { "redmine6285" };
 
       # No GIDs on Windows.

--- a/tests/acceptance/README
+++ b/tests/acceptance/README
@@ -198,15 +198,16 @@ possible variable names:
       not be reported as a failure in the XML output, and is
       appropriate for test cases that document incoming bug reports.
       Suppressed failures will count as a failure, but it won't block
-      the build, and is appropriate for regressions or platform
-      differences.
+      the build, and is appropriate for regressions or bad test
+      failures.
 
 The rule of thumb is:
 
 * If you are writing an acceptance test for a (not yet fixed) bug in
-Redmine: Use test_soft_fail.
+  Redmine, use test_soft_fail.
 
-* If you are fixing failures on a specific platform: Use test_suppress_fail.
+* If you need the build to work, but the bug you are suppressing cannot
+  stay unfixed for long, use test_suppress_fail.
 
 In all cases, the variable is expected to be set to a class expression
 suitable for ifvarclass, where a positive match means that the test


### PR DESCRIPTION
It's not giving us useful test data to have the build contain
persistent failures. Better to save test_suppress_fail for the bad
cases and let the Jenkins build be green instead of yellow.

test_suppress_fail is still available if we need to suppress a really
bad bug.