### PR TITLE
Redmine #7235 Fix global promise locking.

### DIFF
--- a/cf-agent/package_module.c
+++ b/cf-agent/package_module.c
@@ -159,7 +159,7 @@ PackagePromiseGlobalLock AcquireGlobalPackagePromiseLock(EvalContext *ctx)
     
     package_promise_global_lock =
             AcquireLock(ctx, GLOBAL_PACKAGE_PROMISE_LOCK_NAME, VUQNAME, CFSTARTTIME,
-                        (TransactionContext) {.ifelapsed = VIFELAPSED,
+                        (TransactionContext) {.ifelapsed = 0,
                                               .expireafter = VEXPIREAFTER},
                         &pp, false);
                         


### PR DESCRIPTION
While cf-agent is run by cf-execd global promise lock is perceived
due to ifelapsed set by default to 1 minute. As global promise lock
should be available immediately for every new process it should be
set to 0.