### PR TITLE
contrib/cfengine.el: 3.7 indentation and JSON improvements

### DIFF
--- a/contrib/cfengine.el
+++ b/contrib/cfengine.el
@@ -100,7 +100,7 @@ will use a fallback syntax definition."
   :group 'cfengine
   :type '(choice file (const nil)))
 
-(defcustom cfengine-parameters-indent '(promise pname 0)
+(defcustom cfengine-parameters-indent '(promise pname 2)
   "Indentation of CFEngine3 promise parameters (hanging indent).
 
 For example, say you have this code:
@@ -121,15 +121,15 @@ You can also choose to indent the start of the word
 
 Finally, you can choose the amount of the indent.
 
-The default is to anchor at promise, indent parameter name, and offset 0:
+The default is to anchor at promise, indent parameter name, and offset 2:
 
 bundle agent rcfiles
 {
   files:
     any::
       \"/tmp/netrc\"
-      comment => \"my netrc\",
-      perms => mog(\"600\", \"tzz\", \"tzz\");
+        comment => \"my netrc\",
+        perms => mog(\"600\", \"tzz\", \"tzz\");
 }
 
 Here we anchor at beginning of line, indent arrow, and offset 10:

--- a/contrib/cfengine.el
+++ b/contrib/cfengine.el
@@ -50,6 +50,15 @@
 
 ;; (add-hook 'cfengine3-mode-hook 'eldoc-mode)
 
+;; You may also find the command `cfengine3-reformat-json-string'
+;; useful, just bind it to a key you prefer. It will take the current
+;; string and reformat it as JSON. So if you're editing JSON inside
+;; the policy, it's a quick way to make it more legible without
+;; manually reindenting it.  For instance:
+
+;; (global-set-key [(control f4)] 'cfengine3-reformat-json-string)
+
+
 ;; It's *highly* recommended that you use this mode with the latest
 ;; Emacs, or at least 24.1.
 

--- a/contrib/cfengine.el
+++ b/contrib/cfengine.el
@@ -1159,15 +1159,15 @@ Intended as the value of `indent-line-function'."
 (defun cfengine3-reformat-json-string ()
   "Reformat the current string as JSON using `json-pretty-print'."
   (interactive)
-  ;; Are we inside a string?
-  (let* ((parse (parse-partial-sexp (point-min) (point)))
-         (terminator (nth 3 parse)))
-    (when terminator
-      (json-pretty-print
-       (1+ (nth 8 parse))
-       (save-excursion
-         (search-forward (char-to-string terminator))
-         (1- (point)))))))
+  (let ((ppss (syntax-ppss)))
+    (when (nth 3 ppss)                  ;inside a string
+      (save-excursion
+        (goto-char (nth 8 ppss))
+        (forward-char 1)
+        (let ((start (point)))
+          (forward-sexp 1)
+          (json-pretty-print start
+                             (point)))))))
 
 ;; CFEngine 3.x grammar
 

--- a/contrib/cfengine.el
+++ b/contrib/cfengine.el
@@ -1265,18 +1265,22 @@ Intended as the value of `indent-line-function'."
               "???")
             (propertize f 'face 'font-lock-function-name-face)
             (mapconcat (lambda (p)
-                         (let ((type (cdr (assq 'type p)))
+                         (let* ((type (cdr (assq 'type p)))
+                                (description (cdr (assq 'description p)))
+                                (desc-string (if (stringp description)
+                                                 (concat " /" description "/")
+                                               ""))
                                (range (cdr (assq 'range p))))
                            (cond
                             ((not (stringp type)) "???type???")
                             ((not (stringp range)) "???range???")
                             ;; options are lists of possible keywords
                             ((equal type "option")
-                             (propertize (concat "[" range "]")
+                             (propertize (concat "[" range "]" desc-string)
                                          'face
                                          'font-lock-keyword-face))
                             ;; anything else is a type name as a variable
-                            (t (propertize type
+                            (t (propertize (concat type desc-string)
                                            'face
                                            'font-lock-variable-name-face)))))
                        plist

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -1217,6 +1217,7 @@ static JsonElement *FnCallTypeToJson(const FnCallType *fn_syntax)
             JsonElement *json_param = JsonObjectCreate(2);
             JsonObjectAppendString(json_param, "type", DataTypeToString(param->dtype));
             JsonObjectAppendString(json_param, "range", param->pattern);
+            JsonObjectAppendString(json_param, "description", param->description);
             JsonArrayAppendObject(params, json_param);
         }
         JsonObjectAppendArray(json_fn, "parameters", params);


### PR DESCRIPTION
@ediosyncratic @leoliu please take a look.  This will be merged into Emacs as well, later.

Test case, indented correctly:

```
bundle agent main
{
@if version_after(3.7)
  reports:
    any::
    "any"::
    '$(any)'::
    'any'::
      "hello 3.7!
  @this should stay indented a few spaces";

  vars:
      "mything" data => '{
  "a": 100,
  "b": [
    "c",
    200
  ]
}';
@endif
}
```

Changes:

* recognize macros like `@anything`, apply the correct syntax, and indent to column 0 (unless inside a string, note `@this should stay indented` stays indented)
* when macro `@anything` is not at column 0, apply the warning face
* allow class selectors to look like `"myclass.$(myvar)"::` (but they still have string appearance, that's very hard to override)
* new interactive function `cfengine3-reformat-json-string` will, when inside a string, reformat it as JSON.  This is very handy when you're editing.  I hesitated to make it more DWIM.  It's not bound to a key, should it be by default?  I'm also not sure about the way it finds the closing character; maybe it should be smarter about EOB and errors.

Let me know if you have further suggestions or ideas.