### PR TITLE
Redmine #7193: Fix SIGTERM waking up the loop instead of ending it.

### DIFF
--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -313,6 +313,21 @@ void ThisAgentInit(void)
 
 /*****************************************************************************/
 
+// msg should include exactly one reference to unsigned int.
+static unsigned int MaybeSleepLog(LogLevel level, const char *msg, unsigned int seconds)
+{
+    if (IsPendingTermination())
+    {
+        return seconds;
+    }
+
+    Log(level, msg, seconds);
+
+    return sleep(seconds);
+}
+
+/*****************************************************************************/
+
 /* Might be called back from NovaWin_StartExecService */
 void StartServer(EvalContext *ctx, Policy *policy, GenericAgentConfig *config, ExecdConfig **execd_config, ExecConfig **exec_config)
 {
@@ -371,8 +386,14 @@ void StartServer(EvalContext *ctx, Policy *policy, GenericAgentConfig *config, E
         {
             if (ScheduleRun(ctx, &policy, config, execd_config, exec_config))
             {
-                Log(LOG_LEVEL_VERBOSE, "Sleeping for splaytime %d seconds", (*execd_config)->splay_time);
-                sleep((*execd_config)->splay_time);
+                MaybeSleepLog(LOG_LEVEL_VERBOSE, "Sleeping for splaytime %u seconds", (*execd_config)->splay_time);
+
+                // We are sleeping both above and inside ScheduleRun(), so make
+                // sure a terminating signal did not arrive during that time.
+                if (IsPendingTermination())
+                {
+                    break;
+                }
 
                 if (!LocalExecInThread(*exec_config))
                 {
@@ -516,8 +537,8 @@ static Reload CheckNewPromises(GenericAgentConfig *config)
 static bool ScheduleRun(EvalContext *ctx, Policy **policy, GenericAgentConfig *config,
                         ExecdConfig **execd_config, ExecConfig **exec_config)
 {
-    Log(LOG_LEVEL_VERBOSE, "Sleeping for pulse time %d seconds...", CFPULSETIME);
-    sleep(CFPULSETIME);         /* 1 Minute resolution is enough */
+    /* 1 Minute resolution is enough */
+    MaybeSleepLog(LOG_LEVEL_VERBOSE, "Sleeping for pulse time %u seconds...", CFPULSETIME);
 
     /*
      * FIXME: this logic duplicates the one from cf-serverd.c. Unify ASAP.


### PR DESCRIPTION
After all the sleeping we do, we need to make sure that we check if we
should terminate, otherwise the signal will simply spin the loop,
which triggers cf-agent, which spawns a new cf-execd, and we are back
where we started. At least by checking the flag, this probability is
drastically reduced.

Note that this does not fully fix the problem, since the signal
arrival is inherently a race condition, and this cannot be avoided. So
additional changes to the service scripts are still needed in order to
make sure that all daemons are stopped.

Also make sure that we do not enter yet another sleep after the first
has been interrupted. Again, this is a race condition, but it should
still improve things.