### PR TITLE
Redmine#7281: rename version_after macro to minimum_version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,7 +20,7 @@
         - Ability to expand the iteration *key* in Mustache templates with @
         - Canonical JSON output: JSON output has reliably sorted keys so the
           same data structure will produce the same JSON every time.
-        - New "@if version_after(x.x)" syntax in order to hide future language
+        - New "@if minimum_version(x.x)" syntax in order to hide future language
           improvements from versions that don't understand them.
         - compile time option (--with-statedir) to
           override the default state/ directory path.

--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -79,7 +79,7 @@ line       ^.*$
 
 comment    #[^\n]*
 
-macro_if    ^@if\ version_after\([0-9]{1,10}\.[0-9]{1,10}\)
+macro_if    ^@if\ minimum_version\([0-9]{1,10}\.[0-9]{1,10}\)
 macro_endif ^@endif
 
 promises   bundle
@@ -140,7 +140,7 @@ promise_type   [a-zA-Z_]+:
                       }
 
 {macro_if}            {
-                        const char* version_text = yytext+18;
+                        const char* version_text = yytext+20;
                         ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, version_text);
                         {
                           int request_major = 0;

--- a/tests/acceptance/00_basics/macros/if.cf
+++ b/tests/acceptance/00_basics/macros/if.cf
@@ -13,22 +13,22 @@ body common control
 
 bundle common test
 {
-@if version_after(3.7)
+@if minimum_version(3.7)
   classes:
       "expected" expression => "any";
 @endif
 
-@if version_after(3.6)
+@if minimum_version(3.6)
   classes:
       "expected2" expression => "any";
 @endif
 
-@if version_after(2.100)
+@if minimum_version(2.100)
   classes:
       "expected_2_100" expression => "any";
 @endif
 
-@if version_after(300.700)
+@if minimum_version(300.700)
   classes:
       "not_expected" expression => "any";
 @endif
@@ -42,7 +42,7 @@ bundle agent check
                                          $(this.promise_filename));
 }
 
-@if version_after(300.600)
+@if minimum_version(300.600)
 
 This text should never be seen, it's completely ignored
 @endif

--- a/tests/acceptance/00_basics/macros/if_eof_without_endif.x.cf
+++ b/tests/acceptance/00_basics/macros/if_eof_without_endif.x.cf
@@ -19,6 +19,6 @@ bundle agent check
                                          $(this.promise_filename));
 }
 
-@if version_after(300.100)
+@if minimum_version(300.100)
 
 This text should never be seen, it's completely ignored

--- a/tests/acceptance/00_basics/macros/if_eof_without_endif2.x.cf
+++ b/tests/acceptance/00_basics/macros/if_eof_without_endif2.x.cf
@@ -19,6 +19,6 @@ bundle agent check
                                          $(this.promise_filename));
 }
 
-@if version_after(1.1)
+@if minimum_version(1.1)
 
 # just testing for EOF

--- a/tests/acceptance/00_basics/macros/if_mismatched.x.cf
+++ b/tests/acceptance/00_basics/macros/if_mismatched.x.cf
@@ -13,8 +13,8 @@ body common control
 
 bundle common test
 {
-@if version_after(3.7)
-@if version_after(3.6)
+@if minimum_version(3.7)
+@if minimum_version(3.6)
   classes:
       "expected" expression => "any";
 @endif
@@ -23,13 +23,13 @@ bundle common test
 @endif
 @endif
 
-@if version_after(3.6)
+@if minimum_version(3.6)
   classes:
       "expected2" expression => "any";
 @endif
 
-@if version_after(300.700)
-@if version_after(3.6)
+@if minimum_version(300.700)
+@if minimum_version(3.6)
   classes:
       "not_expected" expression => "any";
 @endif
@@ -44,7 +44,7 @@ bundle agent check
                                          $(this.promise_filename));
 }
 
-@if version_after(300.600)
+@if minimum_version(300.600)
 
 This text should never be seen, it's completely ignored
 @endif

--- a/tests/acceptance/00_basics/macros/if_multiple_endif.x.cf
+++ b/tests/acceptance/00_basics/macros/if_multiple_endif.x.cf
@@ -13,18 +13,18 @@ body common control
 
 bundle common test
 {
-@if version_after(3.7)
+@if minimum_version(3.7)
   classes:
       "expected" expression => "any";
 @endif
 @endif
 
-@if version_after(3.6)
+@if minimum_version(3.6)
   classes:
       "expected2" expression => "any";
 @endif
 
-@if version_after(300.700)
+@if minimum_version(300.700)
   classes:
       "not_expected" expression => "any";
 @endif
@@ -38,7 +38,7 @@ bundle agent check
                                          $(this.promise_filename));
 }
 
-@if version_after(300.600)
+@if minimum_version(300.600)
 
 This text should never be seen, it's completely ignored
 @endif

--- a/tests/acceptance/00_basics/macros/if_nested.x.cf
+++ b/tests/acceptance/00_basics/macros/if_nested.x.cf
@@ -13,19 +13,19 @@ body common control
 
 bundle common test
 {
-@if version_after(3.7)
-@if version_after(3.6)
+@if minimum_version(3.7)
+@if minimum_version(3.6)
   classes:
       "expected" expression => "any";
 @endif
 @endif
 
-@if version_after(3.6)
+@if minimum_version(3.6)
   classes:
       "expected2" expression => "any";
 @endif
 
-@if version_after(300.700)
+@if minimum_version(300.700)
   classes:
       "not_expected" expression => "any";
 @endif
@@ -39,7 +39,7 @@ bundle agent check
                                          $(this.promise_filename));
 }
 
-@if version_after(300.600)
+@if minimum_version(300.600)
 
 This text should never be seen, it's completely ignored
 @endif


### PR DESCRIPTION
See https://dev.cfengine.com/issues/7281