### PR TITLE
Redmine #7075 Store absolute time with process information

### DIFF
--- a/libenv/sysinfo.h
+++ b/libenv/sysinfo.h
@@ -30,6 +30,7 @@
 void DetectEnvironment(EvalContext *ctx);
 
 void CreateHardClassesFromCanonification(EvalContext *ctx, const char *canonified, char *tags);
+time_t GetBootTime(void);
 int GetUptimeMinutes(time_t now);
 int GetUptimeSeconds(time_t now);
 

--- a/libpromises/process_linux.c
+++ b/libpromises/process_linux.c
@@ -27,7 +27,7 @@
 #include <process_lib.h>
 #include <process_unix_priv.h>
 #include <files_lib.h>
-
+#include <sysinfo.h>
 
 typedef struct
 {
@@ -121,6 +121,8 @@ static bool GetProcessStat(pid_t pid, ProcessStat *state)
 
     state->state = proc_state[0];
     state->starttime = (time_t)(starttime / sysconf(_SC_CLK_TCK));
+    /* Convert from seconds since boot to seconds since epoch (1970-01-01). */
+    state->starttime += GetBootTime();
 
     return true;
 }


### PR DESCRIPTION
<pre>
commit 203dd9a7328d4557b913d489e00e84d98a1ab77a
Author: Stefan Weil <sw@weilnetz.de>
Date:   Mon Mar 30 20:35:36 2015

    Redmine #7075 Store absolute time with process information
    
    Processes in CFEngine are identified by their OS process identifier (pid)
    and their start time.
    
    Up to now, the start time was relative to the boot time, so it was not
    unique across system restarts.
    
    Using an absolute start time assures that the combination of pid and
    start time is unique. This fixes bug #7075.
    
    Signed-off-by: Stefan Weil <sw@weilnetz.de>

commit fd5b4f7f91a264e1ddfa10cf4d376a75d6430dcf
Author: Stefan Weil <sw@weilnetz.de>
Date:   Mon Mar 30 20:27:08 2015

    Add new function GetBootTime
    
    The new function will be used for Linux in the following commit.
    
    The code was taken from the old implementation of GetUptimeSeconds
    which now uses GetBootTime.
    
    An implementation for Windows can be added later (when needed).
    
    Signed-off-by: Stefan Weil <sw@weilnetz.de>
</pre>