### PR TITLE
libutils/json.c: support bareword keys in JSON parsing

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -954,6 +954,8 @@ static void BuiltinClasses(EvalContext *ctx)
 #ifdef HAVE_LIBYAML
     CreateHardClassesFromCanonification(ctx, "feature_yaml", "source=agent");
 #endif
+
+    CreateHardClassesFromCanonification(ctx, "feature_json_bareword_keys", "source=agent");
 }
 
 /*******************************************************************/

--- a/tests/acceptance/01_vars/04_containers/inline_json.cf
+++ b/tests/acceptance/01_vars/04_containers/inline_json.cf
@@ -31,6 +31,14 @@ bundle agent test
   "headers": [ "Foo: bar" ]
 }';
 
+      # same as options3 but with bareword keys
+      "options4" data => '
+{
+  max_content: 512,
+  verbose: "$(included)",
+  headers: [ "Foo: bar" ]
+}';
+
 }
 
 #######################################################

--- a/tests/acceptance/01_vars/04_containers/inline_json.cf.expected.json
+++ b/tests/acceptance/01_vars/04_containers/inline_json.cf.expected.json
@@ -13,5 +13,12 @@
     ],
     "max_content": 512,
     "verbose": "( included text )"
+  },
+  "options4": {
+    "headers": [
+      "Foo: bar"
+    ],
+    "max_content": 512,
+    "verbose": "( included text )"
   }
 }


### PR DESCRIPTION
This code supports bareword JSON keys, e.g.

```
{
  bar : "zulu",
  foo: [
    "alpha",
    "bravo"
  ]
}
```

It also defines a new hard class `feature_json_bareword_keys` to detect if this is enabled.

I believe the code is safe and correct but appreciate some review.  Upon acceptance I can write tests and docs.