### PR TITLE
Add: Test that classes without constraints fails

### DIFF
--- a/tests/acceptance/00_basics/01_compiler/cf-promises-classes-promise-without-constraint.cf
+++ b/tests/acceptance/00_basics/01_compiler/cf-promises-classes-promise-without-constraint.cf
@@ -1,0 +1,26 @@
+# Ref: https://dev.cfengine.com/issues/7308
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent check
+{
+  meta:
+    "test_soft_fail"
+      string => "any",
+      meta => { "redmine7308" };
+
+  classes:
+    "ok"
+      not => returnszero("$(sys.workdir)/bin/cf-promises -f $(this.promise_filename).sub", "useshell");
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/00_basics/01_compiler/cf-promises-classes-promise-without-constraint.cf.sub
+++ b/tests/acceptance/00_basics/01_compiler/cf-promises-classes-promise-without-constraint.cf.sub
@@ -1,0 +1,11 @@
+bundle agent test
+{
+  classes:
+    "my_class"
+      scope => "namespace",
+      meta => { "inventory", "attribute_name=Something" };
+
+  reports:
+    my_class::
+      "HI there";
+}


### PR DESCRIPTION
Classes without constraints should fail cf-promises and cause it to return
nonzero.

Ref: https://dev.cfengine.com/issues/7308