### PR TITLE
contrib/cfengine.el: minor regex improvement for the macro syntax

### DIFF
--- a/contrib/cfengine.el
+++ b/contrib/cfengine.el
@@ -856,7 +856,7 @@ This includes those for cfservd as well as cfagent.")
                                             )
     "Regexp matching full defun declaration (excluding argument list).")
 
-  (defconst cfengine3-macro-regex "\\(@.+\\)")
+  (defconst cfengine3-macro-regex "\\(@[a-zA-Z].+\\)")
 
   (defconst cfengine3-class-selector-regex "\\([\"']?[[:alnum:]_().$&|!:]+[\"']?\\)::")
 


### PR DESCRIPTION
Minor fix to avoid indenting a `@(myvar)` like the below to the beginning of the line.  Safe to merge.

```
mybundle(
                 @(myvar)
);
```