### PR TITLE
Redmine#7152: Allow whitespace in class expressions inside strings

### DIFF
--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -34,6 +34,7 @@
 #include <cf3parse.h>
 #include <parser_state.h>
 #include <file_lib.h>
+#include <regex.h>
 
 /* yyinput/input are generated and unused */
 
@@ -51,6 +52,8 @@
 
 //#define ParserDebug if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG) printf
 #define ParserDebug(...) ((void) 0)
+
+static pcre *context_expression_whitespace_rx = NULL;
 
 static int DeEscapeQuotedString(const char *from, char *to);
 
@@ -121,7 +124,7 @@ arrow      ->
 
 qstring        \"((\\(.|\n))|[^"\\])*\"|\'((\\(.|\n))|[^'\\])*\'|`[^`]*`
 
-class          [.|&!()a-zA-Z0-9_\200-\377:]+::
+class          [.|&!()a-zA-Z0-9_\200-\377:][\t .|&!()a-zA-Z0-9_\200-\377:]*::
 varclass       (\"[^"]*\"|\'[^']*\')::
 
 promise_type   [a-zA-Z_]+:
@@ -324,6 +327,20 @@ promise_type   [a-zA-Z_]+:
                         
                           P.line_pos += yyleng;
                           ParserDebug("\tL:class %s %d\n", yytext, P.line_pos);
+                          if (NULL == context_expression_whitespace_rx)
+                          {
+                              context_expression_whitespace_rx = CompileRegex(CFENGINE_REGEX_WHITESPACE_IN_CONTEXTS);
+                          }
+
+                          if (NULL == context_expression_whitespace_rx)
+                          {
+                              yyerror("The context expression whitespace regular expression could not be compiled, aborting.");
+                          }
+
+                          if (StringMatchFullWithPrecompiledRegex(context_expression_whitespace_rx, yytext))
+                          {
+                              yyerror("class names can't be separated by whitespace without an intervening operator");
+                          }
 
                           tmp = xstrdup(yytext);
                           tmp[yyleng-2] = '\0';

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -441,6 +441,11 @@ static char *EvalVarRef(ARG_UNUSED const char *varname, ARG_UNUSED VarRefType ty
 
 /**********************************************************************/
 
+bool ClassCharIsWhitespace(char ch)
+{
+    return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
+}
+
 bool IsDefinedClass(const EvalContext *ctx, const char *context)
 {
     ParseResult res;
@@ -450,7 +455,10 @@ bool IsDefinedClass(const EvalContext *ctx, const char *context)
         return true;
     }
 
-    res = ParseExpression(context, 0, strlen(context));
+    Buffer *condensed = BufferNewFrom(context, strlen(context));
+    BufferRewrite(condensed, &ClassCharIsWhitespace, true);
+    res = ParseExpression(BufferData(condensed), 0, BufferSize(condensed));
+    BufferDestroy(condensed);
 
     if (!res.result)
     {

--- a/libutils/buffer.c
+++ b/libutils/buffer.c
@@ -445,6 +445,37 @@ void BufferSetMode(Buffer *buffer, BufferBehavior mode)
     buffer->mode = mode;
 }
 
+Buffer* BufferFilter(Buffer *buffer, BufferFilterFn filter, const bool invert)
+{
+    assert(buffer);
+
+    Buffer *filtered = BufferNew();
+    for (unsigned int i = 0; i < buffer->used; ++i)
+    {
+        bool test = (*filter)(buffer->buffer[i]);
+        if (invert)
+        {
+            test = !test;
+        }
+
+        if (test)
+        {
+            BufferAppendChar(filtered, buffer->buffer[i]);
+        }
+    }
+
+    return filtered;
+}
+
+void BufferRewrite(Buffer *buffer, BufferFilterFn filter, const bool invert)
+{
+    assert(buffer);
+
+    Buffer *rewrite = BufferFilter(buffer, filter, invert);
+    BufferSet(buffer, BufferData(rewrite), BufferSize(rewrite));
+    BufferDestroy(rewrite);
+}
+
 unsigned BufferCapacity(const Buffer *buffer)
 {
     assert(buffer);

--- a/libutils/buffer.h
+++ b/libutils/buffer.h
@@ -56,6 +56,7 @@ typedef struct
 } Buffer;
 
 
+typedef bool (*BufferFilterFn)(char item);
 
 /**
   @brief Buffer initialization routine.
@@ -221,6 +222,24 @@ BufferBehavior BufferMode(const Buffer *buffer);
   @param mode The new mode of operation.
   */
 void BufferSetMode(Buffer *buffer, BufferBehavior mode);
+
+/**
+  @brief Returns a filtered copy of a Buffer
+
+  @param buffer The buffer to operate on.
+  @param filter a function to test for inclusion
+  @param invert Whether the test should be inverted
+  */
+Buffer* BufferFilter(Buffer *buffer, BufferFilterFn filter, const bool invert);
+
+/**
+  @brief Filters a Buffer in place
+
+  @param buffer The buffer to operate on.
+  @param filter a function to test for inclusion
+  @param invert Whether the test should be inverted
+  */
+void BufferRewrite(Buffer *buffer, BufferFilterFn filter, const bool invert);
 
 /**
   @brief Provides a pointer to the internal data.

--- a/libutils/regex.c
+++ b/libutils/regex.c
@@ -32,7 +32,6 @@
 
 #include <buffer.h>
 
-
 #define STRING_MATCH_OVECCOUNT 30
 #define NULL_OR_EMPTY(str) ((str == NULL) || (str[0] == '\0'))
 

--- a/libutils/regex.h
+++ b/libutils/regex.h
@@ -33,6 +33,7 @@
 
 #include <sequence.h>                                           /* Seq */
 
+#define CFENGINE_REGEX_WHITESPACE_IN_CONTEXTS ".*[_A-Za-z0-9][ \\t]+[_A-Za-z0-9].*"
 
 /* Try to use CompileRegex() and StringMatchWithPrecompiledRegex(). */
 pcre *CompileRegex(const char *regex);

--- a/tests/acceptance/00_basics/01_compiler/string_contexts.cf
+++ b/tests/acceptance/00_basics/01_compiler/string_contexts.cf
@@ -53,7 +53,26 @@ bundle agent test
       "iterated_$(mylist)" string => "iteration class $(mylist)";
 
     "myclass . cfengine | any"::
-      "whitespace1" string => "$(this.promiser)";
+      "whitespace1" string => "$(this.promiser): quoted with spaces";
+
+    myclass . cfengine | any::
+      "whitespace2" string => "$(this.promiser): unquoted with spaces, starts with valid class";
+
+    nosuchclass . any::
+      "whitespace3" string => "$(this.promiser): unquoted with spaces, should be missing";
+
+    nosuchclass | any::
+      "whitespace4" string => "$(this.promiser): unquoted with spaces, starts with missing class but is true";
+
+    any	 |	 ( cfengine | linux )::
+      "whitespace5" string => "$(this.promiser): remove spaces and tabs from an expression";
+
+    any	 .	 ( nosuchclass . any )::
+      "whitespace6" string => "$(this.promiser): remove spaces and tabs from an expression that is false in the end, should be missing";
+
+    "cf engine"::
+      "whitespace7" string => "$(this.promiser): quoted with spaces but no operators, should be missing with an error";
+
 }
 
 #######################################################

--- a/tests/acceptance/00_basics/01_compiler/string_contexts.cf
+++ b/tests/acceptance/00_basics/01_compiler/string_contexts.cf
@@ -10,12 +10,6 @@ body common control
 
 #######################################################
 
-bundle agent init
-{
-}
-
-#######################################################
-
 bundle agent test
 {
   defaults:
@@ -57,44 +51,17 @@ bundle agent test
       ifvarclass => "nonesuch";
     "$(mylist).cfengine"::
       "iterated_$(mylist)" string => "iteration class $(mylist)";
+
+    "myclass . cfengine | any"::
+      "whitespace1" string => "$(this.promiser)";
 }
 
 #######################################################
 
 bundle agent check
 {
-  vars:
-      "expected" string => "
-hello, this is me
-any hello
-string hello
-variable context hello!!!
-variable context hello!!!
-compound variable context hello!!!
-6
-augmented variable context hello!!!
-8
-iteration class a
-iteration class b
-iteration class c
-";
-      "actual" string => "
-$(test.s1)
-$(test.s2)
-$(test.s3)
-$(test.s4)
-$(test.s4_2)
-$(test.s5)
-$(test.s6)
-$(test.s7)
-$(test.s8)
-$(test.iterated_a)
-$(test.iterated_b)
-$(test.iterated_c)
-";
   methods:
-      "" usebundle => dcs_check_strcmp($(expected),
-                                      $(actual),
-                                      $(this.promise_filename),
-                                      "no");
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
 }

--- a/tests/acceptance/00_basics/01_compiler/string_contexts.cf.expected.json
+++ b/tests/acceptance/00_basics/01_compiler/string_contexts.cf.expected.json
@@ -18,5 +18,8 @@
   "s6": "6",
   "s7": "augmented variable context hello!!!",
   "s8": "8",
-  "whitespace1": "whitespace1"
+  "whitespace1": "whitespace1: quoted with spaces",
+  "whitespace2": "whitespace2: unquoted with spaces, starts with valid class",
+  "whitespace4": "whitespace4: unquoted with spaces, starts with missing class but is true",
+  "whitespace5": "whitespace5: remove spaces and tabs from an expression"
 }

--- a/tests/acceptance/00_basics/01_compiler/string_contexts.cf.expected.json
+++ b/tests/acceptance/00_basics/01_compiler/string_contexts.cf.expected.json
@@ -1,0 +1,22 @@
+{
+  "iterated_a": "iteration class a",
+  "iterated_b": "iteration class b",
+  "iterated_c": "iteration class c",
+  "myclass": "any",
+  "mylist": [
+    "a",
+    "b",
+    "c"
+  ],
+  "myvar": "me",
+  "s1": "hello, this is me",
+  "s2": "any hello",
+  "s3": "string hello",
+  "s4": "variable context hello!!!",
+  "s4_2": "variable context hello!!!",
+  "s5": "compound variable context hello!!!",
+  "s6": "6",
+  "s7": "augmented variable context hello!!!",
+  "s8": "8",
+  "whitespace1": "whitespace1"
+}

--- a/tests/acceptance/00_basics/01_compiler/string_contexts.x.cf
+++ b/tests/acceptance/00_basics/01_compiler/string_contexts.x.cf
@@ -1,0 +1,30 @@
+# fixes https://dev.cfengine.com/issues/2504
+# using variables in string contexts
+# should fail: class names in string contexts must be separated by operators
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  reports:
+    cf e ngine::
+      "hello";
+
+    cf engine::
+      "hello";
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_pass($(this.promise_filename));
+}


### PR DESCRIPTION
See https://dev.cfengine.com/issues/7152

This change applies **only** to contexts inside strings.  So anything passed to `if/unless/ifvarclass` will be stripped of whitespaces.  Also, quoted string contexts like the below full example will be likewise stripped.  But something like `linux | cfengine::` without quotes will not be OK.

This does not change the parser, only the treatment of context strings **after** syntax parsing and **before** expression parsing.  Thus, I believe it's a safe change.  We can remove `\r` and `\n` from the allowed characters if you think they are too much.

```
bundle agent main
{
  reports:
    'any | (cfengine | linux)'::
      "hello!";
}
```

If this is acceptable, I'll write tests and docs.