### PR TITLE
Change: Improve git based release id

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -816,11 +816,11 @@ static bool GeneratePolicyReleaseIDFromGit(char *release_id_out,
     {
         char git_head[128];
         int scanned = fscanf(git_file, "ref: %127s", git_head);
-        fclose(git_file);
 
         if (scanned == 1)
         // Found HEAD Reference which means we are on a checked out branch
         {
+            fclose(git_file);
             snprintf(git_filename, PATH_MAX, "%s/.git/%s", policy_dir, git_head);
             git_file = fopen(git_filename, "r");
             Log(LOG_LEVEL_DEBUG, "Found a git HEAD ref");
@@ -829,14 +829,14 @@ static bool GeneratePolicyReleaseIDFromGit(char *release_id_out,
         {
             Log(LOG_LEVEL_DEBUG, "Unable to find HEAD ref in %s. Looking for commit", git_file);
             assert(out_size > 40);
-            git_file = fopen(git_filename, "r");
+            fseek(git_file, 0, SEEK_SET);
             scanned = fscanf(git_file, "%40s", release_id_out);
             fclose(git_file);
 
             if (scanned == 1)
             {
                 Log(LOG_LEVEL_DEBUG, "Found current git checkout pointing to %s", release_id_out);
-                return scanned == 1;
+                return true;
             }
             else
             // We didnt find a commit sha in .git/HEAD, so we assume the git information is invalid

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -809,6 +809,8 @@ static bool GeneratePolicyReleaseIDFromGit(char *release_id_out,
     snprintf(git_filename, PATH_MAX, "%s/.git/HEAD", policy_dir);
     MapName(git_filename);
 
+    // Note: Probably we should not be reading all of these filenames directly,
+    // and should instead use git plumbing commands to retrieve the data.
     FILE *git_file = fopen(git_filename, "r");
     if (git_file)
     {
@@ -817,13 +819,30 @@ static bool GeneratePolicyReleaseIDFromGit(char *release_id_out,
         fclose(git_file);
 
         if (scanned == 1)
+        // Found HEAD Reference which means we are on a checked out branch
         {
             snprintf(git_filename, PATH_MAX, "%s/.git/%s", policy_dir, git_head);
             git_file = fopen(git_filename, "r");
+            Log(LOG_LEVEL_DEBUG, "Found a git HEAD ref");
         }
         else
         {
-            git_file = NULL;
+            Log(LOG_LEVEL_DEBUG, "Unable to find HEAD ref in %s. Looking for commit", git_file);
+            assert(out_size > 40);
+            git_file = fopen(git_filename, "r");
+            scanned = fscanf(git_file, "%40s", release_id_out);
+            fclose(git_file);
+
+            if (scanned == 1)
+            {
+                Log(LOG_LEVEL_DEBUG, "Found current git checkout pointing to %s", release_id_out);
+                return scanned == 1;
+            }
+            else
+            // We didnt find a commit sha in .git/HEAD, so we assume the git information is invalid
+            {
+                git_file = NULL;
+            }
         }
         if (git_file)
         {


### PR DESCRIPTION
Now cf-promises -T is not limited to working when you are on a checked out
branch. Now you get the commit that is checked out as the release id even if
you are checked out from a specific commit or tag.

It would be really nice if this goes into 3.7.0. I also think it should be backported to 3.6.x

Ref: https://dev.cfengine.com/issues/7332