### PR TITLE
Deal with perverse ps output

### DIFF
--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -339,8 +339,9 @@ static int SelectProcTimeCounterRangeMatch(char *name1, char *name2, time_t min,
 
         if (value == CF_NOINT)
         {
-            Log(LOG_LEVEL_INFO, "Failed to extract a valid integer from %c => '%s' in process list", name1[i],
-                  line[i]);
+            Log(LOG_LEVEL_INFO,
+                "Failed to extract a valid integer from %c => '%s' in process list",
+                name1[i], line[i]);
             return false;
         }
 
@@ -841,6 +842,12 @@ static int SplitProcLine(const char *proc, time_t pstime,
                 free(line[j]);
                 xasprintf(line + j, "%ld", value);
             }
+        }
+        else if (line[k])
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Parsing problem was in ELAPSED field of '%s'",
+                proc);
         }
     }
 

--- a/tests/acceptance/05_processes/01_matching/inverse_ttime_inverse_found.cf
+++ b/tests/acceptance/05_processes/01_matching/inverse_ttime_inverse_found.cf
@@ -23,14 +23,9 @@ bundle agent init
 
 bundle agent test
 {
-  
   meta:
       "test_suppress_fail" string => "windows",
         meta => { "redmine4747" };
-      # Test keeps alternating between pass and fail. There is probably a bug
-      # here, but we can't afford to hold up the build pipeline all the time.
-      "test_skip_needs_work" string => "solaris",
-        meta => { "redmine6809" };
 
   processes:
       ".*"

--- a/tests/unit/split_process_line_test.c
+++ b/tests/unit/split_process_line_test.c
@@ -2,6 +2,40 @@
 
 #include <processes_select.c>
 
+/* Actual ps output witnessed, that we probably can't hope to robustly
+ * parse. */
+static void test_split_line_challenges(void)
+{
+#if 0 /* Enable to see how many we actually get right ! */
+    /* Collect all test data in one array to make alignments visible: */
+    static const char *lines[] = {
+        "USER       PID    SZ    VSZ   RSS NLWP STIME     ELAPSED     TIME COMMAND",
+        "operatic 14338 1042534 4170136 2122012 9 Sep15 4-06:11:34 2-09:27:49 /usr/lib/opera/opera"
+        /* It's unlikely we'll realise NLWP is 9 ! */
+    };
+    char *name[CF_PROCCOLS]; /* Headers */
+    char *field[CF_PROCCOLS]; /* Content */
+    int start[CF_PROCCOLS] = { 0 };
+    int end[CF_PROCCOLS] = { 0 };
+    int i, user = 0, nlwp = 5;
+
+    /* Prepare data needed by tests and assert things tests can then assume: */
+    GetProcessColumnNames(lines[0], name, start, end);
+    assert_string_equal(name[user], "USER");
+    assert_string_equal(name[nlwp], "NLWP");
+
+    assert_true(SplitProcLine(lines[1], pstime, name, start, end, field));
+    assert_string_equal(field[user], "operatic");
+    assert_string_equal(field[nlwp], "9");
+
+    /* Finally, tidy away headers: */
+    for (i = 0; name[i] != NULL; i++)
+    {
+        free(name[i]);
+    }
+#endif
+}
+
 static void test_split_line_elapsed(void)
 {
     /* Collect all test data in one array to make alignments visible: */
@@ -329,6 +363,7 @@ int main(void)
     PRINT_TEST_BANNER();
     const UnitTest tests[] =
         {
+            unit_test(test_split_line_challenges),
             unit_test(test_split_line_noelapsed),
             unit_test(test_split_line_elapsed),
             unit_test(test_split_line_longcmd),


### PR DESCRIPTION
This adds a `#if`-ed out unit test in which to document (and be ready for any brave soul who thinks they can fix the parser to handle) real-world ps output lines that our parser can't presently handle.

A second commit re-enables a known failing-on-Solaris test and adds a diagnostic log message in one place that shall *hopefully* shed some light on why the test fails, when it (seldom) does.
It's a single commit to make it easier to revert once that's reported the hideous ps line that causes the problem (and added it to the first commit's test), while someone thinks about how to fix it.

None of this is urgent but it would make sense to include in master at some point when you can endure a failing test on Solaris for a short while.