### PR TITLE
Redmine #7362: Fix asprintf/vasprintf being misdetected as compliant.

### DIFF
--- a/m4/snprintf.m4
+++ b/m4/snprintf.m4
@@ -203,8 +203,13 @@ AC_DEFUN([HW_FUNC_SNPRINTF],
 AC_DEFUN([HW_FUNC_VASPRINTF],
 [
   AC_REQUIRE([HW_FUNC_VSNPRINTF])dnl Our vasprintf(3) calls vsnprintf(3).
-  AC_CHECK_FUNCS([vasprintf],
-    [hw_cv_func_vasprintf=yes],
+  # Don't even bother checking for vasprintf if snprintf was standards
+  # incompliant, this one is going to be too.
+  AS_IF([test "$hw_cv_func_snprintf_c99" = yes],
+    [AC_CHECK_FUNCS([vasprintf],
+      [hw_cv_func_vasprintf=yes],
+      [hw_cv_func_vasprintf=no])
+    ],
     [hw_cv_func_vasprintf=no])
   AS_IF([test "$hw_cv_func_vasprintf" = no],
     [AC_DEFINE([vasprintf], [rpl_vasprintf],
@@ -224,8 +229,13 @@ AC_DEFUN([HW_FUNC_VASPRINTF],
 AC_DEFUN([HW_FUNC_ASPRINTF],
 [
   AC_REQUIRE([HW_FUNC_VASPRINTF])dnl Our asprintf(3) calls vasprintf(3).
-  AC_CHECK_FUNCS([asprintf],
-    [hw_cv_func_asprintf=yes],
+  # Don't even bother checking for asprintf if snprintf was standards
+  # incompliant, this one is going to be too.
+  AS_IF([test "$hw_cv_func_snprintf_c99" = yes],
+    [AC_CHECK_FUNCS([asprintf],
+      [hw_cv_func_asprintf=yes],
+      [hw_cv_func_asprintf=no])
+    ],
     [hw_cv_func_asprintf=no])
   AS_IF([test "$hw_cv_func_asprintf" = no],
     [AC_DEFINE([asprintf], [rpl_asprintf],


### PR DESCRIPTION
They were not being tested as compliant, and hence were omitted from
the build simply if they were available. We fix it not by testing for
compliance, but by reusing the result from the snprintf test, it's
almost certainly going to be the same result.

This fixes Windows builds, where this is a problem on certain MinGW
versions.