### PR TITLE
libutils/mustache.c: add {{#-top-}} {{/-top-}} for iteration over top container

### DIFF
--- a/libutils/mustache.c
+++ b/libutils/mustache.c
@@ -150,6 +150,11 @@ static JsonElement *LookupVariable(Seq *hash_stack, const char *name, size_t nam
         StringRef base_comp = StringGetToken(name, name_len, 0, ".");
         char *base_comp_str = xstrndup(base_comp.data, base_comp.len);
 
+        if (0 == strcmp("-top-", base_comp_str))
+        {
+            base_var = SeqAt(hash_stack, 0);
+        }
+
         for (ssize_t i = SeqLength(hash_stack) - 1; i >= 0; i--)
         {
             JsonElement *hash = SeqAt(hash_stack, i);

--- a/tests/acceptance/10_files/templating/mustache_top_level_iteration.cf
+++ b/tests/acceptance/10_files/templating/mustache_top_level_iteration.cf
@@ -1,0 +1,35 @@
+#######################################################
+#
+# Demo of Mustache templates with top-level iteration
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "mydata1" data => '{ "a": 100 }';
+      "mydata2" data => '[ "p", "q" ]';
+
+      "actual1" string => string_mustache("{{#-top-}}key {{@}} value {{.}} {{/-top-}}", mydata1);
+      "actual2" string => string_mustache("{{#-top-}}value {{.}} {{/-top-}}", mydata2);
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
+}

--- a/tests/acceptance/10_files/templating/mustache_top_level_iteration.cf.expected.json
+++ b/tests/acceptance/10_files/templating/mustache_top_level_iteration.cf.expected.json
@@ -1,0 +1,11 @@
+{
+  "actual1": "key a value 100 ",
+  "actual2": "value p value q ",
+  "mydata1": {
+    "a": 100
+  },
+  "mydata2": [
+    "p",
+    "q"
+  ]
+}


### PR DESCRIPTION
As discussed in #2273 

For https://dev.cfengine.com/issues/6545 I also added the ability to iterate over the top-level Mustache object with the custom `{{#-top-}} ... {{/-top-}}` extension. The `-top-` string seemed reasonable for that purpose. This improvement has been requested many times so I hope it's useful.

The acceptance tests were adjusted accordingly.