### PR TITLE
Redmine #7030: Don't hang when operating on fifos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1026,7 +1026,8 @@ AC_REPLACE_FUNCS(pthread_sigmask)
 AC_CHECK_DECLS([openat], [], [], [[#include <fcntl.h>]])
 AC_CHECK_DECLS([fstatat], [], [], [[#include <sys/stat.h>]])
 AC_CHECK_DECLS([fchownat], [], [], [[#include <unistd.h>]])
-AC_REPLACE_FUNCS(openat fstatat fchownat)
+AC_CHECK_DECLS([fchmodat], [], [], [[#include <sys/stat.h>]])
+AC_REPLACE_FUNCS(openat fstatat fchownat fchmodat)
 
 AC_CHECK_DECLS([log2], [], [], [[#include <math.h>]])
 AC_REPLACE_FUNCS(log2)
@@ -1174,6 +1175,10 @@ case "$target_os" in
         ;;
    aix*)
         CPPFLAGS="$CPPFLAGS -w"
+        ;;
+   linux*)
+        AC_LIBSOURCE([fchmodat.c])
+        AC_LIBOBJ([fchmodat])
         ;;
    linux*|*bsd*gnu)
         AC_CHECK_LIB(nss_nis, yp_get_default_domain)

--- a/libcompat/fchmodat.c
+++ b/libcompat/fchmodat.c
@@ -1,0 +1,101 @@
+/*
+   Copyright (C) CFEngine AS
+
+   This file is part of CFEngine 3 - written and maintained by CFEngine AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <platform.h>
+#include <misc_lib.h>
+#include <logging.h>
+#include <generic_at.h>
+
+#include <fcntl.h>
+#include <grp.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef __MINGW32__
+
+typedef struct
+{
+    const char *pathname;
+    mode_t mode;
+    int dirfd;
+    int flags;
+} fchmodat_data;
+
+static int fchmodat_inner(void *generic_data)
+{
+    struct stat buf;
+    int ret = 0;
+    uid_t olduid = 0;
+
+    fchmodat_data *data = generic_data;
+    if (data->flags & AT_SYMLINK_NOFOLLOW)
+    {
+        errno = ENOTSUP;
+        return -1;
+    }
+
+    /* {l,}stat(2) is used here since we don't want to lock on the inner
+     * function
+     */
+    if ((ret = lstat(data->pathname, &buf)))
+    {
+        return ret;
+    }
+
+    /* save old euid */
+    olduid = geteuid();
+
+    if ((ret = seteuid(buf.st_uid)))
+    {
+        return ret;
+    }
+
+    ret = chmod(data->pathname, data->mode);
+
+    if (seteuid(olduid))
+    {
+        return -1;
+    }
+
+    return ret;
+}
+
+static void cleanup(ARG_UNUSED void *generic_data)
+{
+}
+
+int fchmodat(int dirfd, const char *pathname, mode_t mode, int flags)
+{
+    fchmodat_data data = {
+        .pathname = pathname,
+        .mode = mode,
+        .flags = flags,
+        .dirfd = dirfd,
+    };
+
+    return generic_at_function(dirfd, &fchmodat_inner, &cleanup, &data);
+}
+
+#endif // !__MINGW32__

--- a/tests/acceptance/10_files/02_maintain/fifos.cf
+++ b/tests/acceptance/10_files/02_maintain/fifos.cf
@@ -1,0 +1,41 @@
+# https://dev.cfengine.com/issues/7030
+#
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+bundle agent init
+{
+  vars:
+    "test_fifo" string => "$(G.testfile).fifo";
+
+  commands:
+    "/usr/bin/mkfifo $(test_fifo)";
+}
+
+bundle agent test
+{
+  files:
+    "$(init.test_fifo)"
+      create => "false",
+      perms => m("0700");
+}
+
+bundle agent check
+{
+  classes:
+    "ok" expression => isexecutable("$(init.test_fifo)");
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+
+}
+
+


### PR DESCRIPTION
Implemented using `seteuid` and `setegid` per @kacfengine's comments. Had to open new pull request due to some git fudgery on my end. See #2192 for discussion. Related to #2194.