### PR TITLE
Redmine #7149: Make sure file desc. inheritance is honored on Windows.

### DIFF
--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -227,16 +227,14 @@ void LocalExec(const ExecConfig *config)
         return;
     }
 
-#if !defined(__MINGW32__)
 /*
  * Don't inherit this file descriptor on fork/exec
  */
 
     if (fileno(fp) != -1)
     {
-        fcntl(fileno(fp), F_SETFD, FD_CLOEXEC);
+        SetCloseOnExec(fileno(fp), true);
     }
-#endif
 
     Log(LOG_LEVEL_VERBOSE, "Command => %s", cmd);
 

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -650,11 +650,11 @@ static void PrepareServer(int sd)
 
         ActAsDaemon();
     }
+#endif
 
     /* Close sd on exec, needed for not passing the socket to cf-runagent
      * spawned commands. */
-    fcntl(sd, F_SETFD, FD_CLOEXEC);
-#endif
+    SetCloseOnExec(sd, true);
 
     Log(LOG_LEVEL_NOTICE, "Server is starting...");
     WritePID("cf-serverd.pid"); /* Arranges for atexit() to tidy it away */

--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -759,6 +759,23 @@ int safe_creat(const char *pathname, mode_t mode)
     return safe_open(pathname, O_CREAT | O_WRONLY | O_TRUNC, mode);
 }
 
+// Windows implementation in Enterprise.
+#ifndef _WIN32
+bool SetCloseOnExec(int fd, bool enable)
+{
+    int flags = fcntl(fd, F_GETFD);
+    if (enable)
+    {
+        flags |= FD_CLOEXEC;
+    }
+    else
+    {
+        flags &= ~FD_CLOEXEC;
+    }
+    return (fcntl(fd, F_SETFD, flags) == 0);
+}
+#endif // !_WIN32
+
 static bool DeleteDirectoryTreeInternal(const char *basepath, const char *path)
 {
     Dir *dirh = DirOpen(path);

--- a/libutils/file_lib.h
+++ b/libutils/file_lib.h
@@ -97,6 +97,15 @@ int safe_lchown(const char *path, uid_t owner, gid_t group);
 int safe_creat(const char *pathname, mode_t mode);
 
 /**
+ * @brief Sets whether a file descriptor should be closed on
+ *        exec()/CreateProcess().
+ * @param fd      File descriptor.
+ * @param inherit Whether to enable close-on-exec or not.
+ * @return true on success, false otherwise.
+ */
+bool SetCloseOnExec(int fd, bool enable);
+
+/**
  * @brief Deletes directory path recursively. Symlinks are not followed.
  *        Note that this function only deletes the contents of the directory, not the directory itself.
  * @param path

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -893,11 +893,6 @@ struct timespec
 # define S_IXOTH 00001
 #endif
 
-/* Too bad we don't have FD_CLOEXEC -- but we can fake it */
-#ifndef FD_CLOEXEC
-# define FD_CLOEXEC 0
-#endif
-
 /* kill(2) on OS X returns ETIMEDOUT instead of ESRCH */
 #ifndef ETIMEDOUT
 # define ETIMEDOUT ESRCH


### PR DESCRIPTION
It's quite important because Windows does not allow you to do anything
to a file that is open for writing, and if the file descriptor is
inherited by a process that is long lived, you'll never be able to
delete it.

This particular case was related to cf-execd output logs, that could
not be rotated because of cf-agent inheriting a file descriptor from
cf-execd, and cf-agent then launching an unrelated and long lived
process.

Also remove our null definition of the FD_CLOEXEC flag. Since we now
have the wrapper, we don't want people to use it by mistake.