### PR TITLE
Redmine #7399: Define result classes when package is already up to date

### DIFF
--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -1780,7 +1780,8 @@ static PromiseResult SchedulePackageOp(EvalContext *ctx, const char *name, const
             }
             else
             {
-                Log(LOG_LEVEL_VERBOSE, "Installed package is up to date, not updating");
+                cfPS_HELPER_1ARG(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a,
+                    "Installed packaged '%s' is up to date, not updating", pp->promiser);
                 break;
             }
         }


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/7399