### PR TITLE
Reverse mapping from IP to interface and iprange() can look by interface

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -451,7 +451,7 @@ void GetInterfacesInfo(EvalContext *ctx)
                     assert(sizeof(ip) >= sizeof(VIPADDRESS) + sizeof("ipv4_"));
                     strcpy(ip, "ipv4_");
                     strcat(ip, VIPADDRESS);
-                    EvalContextAddIpAddress(ctx, VIPADDRESS);
+                    EvalContextAddIpAddress(ctx, VIPADDRESS, NULL); // we don't know the interface
                     RlistAppendScalar(&ips, VIPADDRESS);
 
                     for (sp = ip + strlen(ip) - 1; (sp > ip); sp--)
@@ -497,7 +497,7 @@ void GetInterfacesInfo(EvalContext *ctx)
                     address_set = true;
                 }
 
-                EvalContextAddIpAddress(ctx, txtaddr);
+                EvalContextAddIpAddress(ctx, txtaddr, CanonifyName(ifp->ifr_name));
                 RlistAppendScalar(&ips, txtaddr);
 
                 for (sp = ip + strlen(ip) - 1; (sp > ip); sp--)
@@ -649,7 +649,7 @@ static void FindV6InterfacesInfo(EvalContext *ctx)
                 if ((IsIPV6Address(ip->name)) && ((strcmp(ip->name, "::1") != 0)))
                 {
                     Log(LOG_LEVEL_VERBOSE, "Found IPv6 address %s", ip->name);
-                    EvalContextAddIpAddress(ctx, ip->name);
+                    EvalContextAddIpAddress(ctx, ip->name, NULL); // interface unknown
                     EvalContextClassPutHard(ctx, ip->name, "inventory,attribute_name=none,source=agent");
                 }
             }

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -517,6 +517,11 @@ void GetInterfacesInfo(EvalContext *ctx)
 
                 EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, name, ip, CF_DATA_TYPE_STRING, "source=agent");
 
+                // generate the reverse mapping
+                snprintf(name, sizeof(name), "ip2iface[%s]", txtaddr);
+
+                EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, name, CanonifyName(ifp->ifr_name), CF_DATA_TYPE_STRING, "source=agent");
+
                 i = 3;
 
                 for (sp = ip + strlen(ip) - 1; (sp > ip); sp--)

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -2592,9 +2592,9 @@ bool GetChecksumUpdatesDefault(const EvalContext *ctx)
     return ctx->checksum_updates_default;
 }
 
-void EvalContextAddIpAddress(EvalContext *ctx, const char *ip_address)
+void EvalContextAddIpAddress(EvalContext *ctx, const char *ip_address, const char *iface)
 {
-    AppendItem(&ctx->ip_addresses, ip_address, "");
+    AppendItem(&ctx->ip_addresses, ip_address, (NULL == iface ? "" : iface));
 }
 
 void EvalContextDeleteIpAddresses(EvalContext *ctx)

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -202,7 +202,7 @@ bool GetChecksumUpdatesDefault(const EvalContext *ctx);
 
 /* IP addresses */
 Item *EvalContextGetIpAddresses(const EvalContext *ctx);
-void EvalContextAddIpAddress(EvalContext *ctx, const char *address);
+void EvalContextAddIpAddress(EvalContext *ctx, const char *address, const char *iface);
 void EvalContextDeleteIpAddresses(EvalContext *ctx);
 
 /* - Rest - */

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -166,6 +166,16 @@ static FnCallResult FnReturnContext(bool result)
     return FnReturn(result ? "any" : "!any");
 }
 
+static FnCallResult FnReturnContextTrue()
+{
+    return FnReturnContext(true);
+}
+
+static FnCallResult FnReturnContextFalse()
+{
+    return FnReturnContext(false);
+}
+
 static FnCallResult FnFailure(void)
 {
     return (FnCallResult) { FNCALL_FAILURE };

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -4695,14 +4695,40 @@ static FnCallResult FnCallIPRange(EvalContext *ctx, ARG_UNUSED const Policy *pol
 
     for (const Item *ip = EvalContextGetIpAddresses(ctx); ip != NULL; ip = ip->next)
     {
-        if (FuzzySetMatch(range, VIPADDRESS) == 0 ||
-            FuzzySetMatch(range, ip->name) == 0)
+        Rlist *ifaces = finalargs->next;
+        // we match on VIPADDRESS iff no interfaces were requested
+        if (FuzzySetMatch(range, VIPADDRESS) == 0 && NULL == ifaces)
         {
-            return FnReturnContext(true);
+            Log(LOG_LEVEL_DEBUG, "%s: found range %s on hostip %s, no interface", fp->name, range, ip->name);
+            return FnReturnContextTrue();
+        }
+        else if (FuzzySetMatch(range, ip->name) == 0)
+        {
+            if (NULL == ifaces) // no interfaces requested
+            {
+                Log(LOG_LEVEL_DEBUG, "%s: found range %s on IP %s, any interface", fp->name, range, ip->name);
+                return FnReturnContextTrue();
+            }
+            else // check the specific interfaces given as arguments
+            {
+                for (; ifaces != NULL; ifaces = ifaces->next)
+                {
+                    Buffer *iface = BufferNewFrom(RlistScalarValue(ifaces), strlen(RlistScalarValue(ifaces)));
+                    BufferCanonify(iface);
+                    Log(LOG_LEVEL_DEBUG, "%s: checking range %s on IP %s, interface %s", fp->name, range, ip->name, RlistScalarValue(ifaces));
+                    if (0 == strcmp(BufferData(iface), ip->classes))
+                    {
+                        Log(LOG_LEVEL_DEBUG, "%s: found range %s on IP %s, interface %s", fp->name, range, ip->name, RlistScalarValue(ifaces));
+                        BufferDestroy(iface);
+                        return FnReturnContextTrue();
+                    }
+                    BufferDestroy(iface);
+                }
+            }
         }
     }
 
-    return FnReturnContext(false);
+    return FnReturnContextFalse();
 }
 
 /*********************************************************************/
@@ -8420,8 +8446,8 @@ const FnCallType CF_FNCALL_TYPES[] =
                   FNCALL_OPTION_VARARG, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("intersection", CF_DATA_TYPE_STRING_LIST, SETOP_ARGS, &FnCallSetop, "Returns all the unique elements of list arg1 that are also in list arg2",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
-    FnCallTypeNew("iprange", CF_DATA_TYPE_CONTEXT, IPRANGE_ARGS, &FnCallIPRange, "True if the current host lies in the range of IP addresses specified",
-                  FNCALL_OPTION_NONE, FNCALL_CATEGORY_COMM, SYNTAX_STATUS_NORMAL),
+    FnCallTypeNew("iprange", CF_DATA_TYPE_CONTEXT, IPRANGE_ARGS, &FnCallIPRange, "True if the current host lies in the range of IP addresses specified (can be narrowed to specific interfaces)",
+                  FNCALL_OPTION_VARARG, FNCALL_CATEGORY_COMM, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("irange", CF_DATA_TYPE_INT_RANGE, IRANGE_ARGS, &FnCallIRange, "Define a range of integer values for cfengine internal use",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("isdir", CF_DATA_TYPE_CONTEXT, FILESTAT_ARGS, &FnCallFileStat, "True if the named object is a directory",

--- a/tests/acceptance/02_classes/02_functions/iprange.cf
+++ b/tests/acceptance/02_classes/02_functions/iprange.cf
@@ -1,0 +1,67 @@
+#######################################################
+#
+# Test iprange()
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  classes:
+      "expected_missing" expression => iprange("8.8.8.8/31"),
+        meta => { "collect" };
+
+      "expected_missing" expression => iprange("8.8.8.8/24"),
+        meta => { "collect" };
+
+      "expected_missing" expression => iprange("8.8.8.8/31", $(sys.interfaces)),
+        meta => { "collect" };
+
+      "expected_missing" expression => iprange("8.8.8.8/24", $(sys.interfaces)),
+        meta => { "collect" };
+
+      "expected_missing" expression => iprange("0.0.0.0/0", "dummy"),
+        meta => { "collect" };
+
+      "all_zeroes" expression => iprange("0.0.0.0/0"),
+        meta => { "collect" };
+
+      "all_zeroes_some_interfaces" expression => iprange("0.0.0.0/0", $(sys.interfaces)),
+        meta => { "collect" };
+
+      "local_range" expression => iprange("0.0.0.0/1"),
+        meta => { "collect" };
+
+      "local_range" expression => iprange("128.0.0.0/1"),
+        meta => { "collect" };
+
+      "local_range2" expression => iprange("0.0.0.0/1", $(sys.interfaces)),
+        meta => { "collect" };
+
+      "local_range2" expression => iprange("128.0.0.0/1", $(sys.interfaces)),
+        meta => { "collect" };
+
+      "just_locals" expression => iprange("$(sys.ip_addresses)/32"),
+        meta => { "collect" };
+
+  vars:
+      "found" slist => classesmatching(".*", "collect");
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
+}

--- a/tests/acceptance/02_classes/02_functions/iprange.cf.expected.json
+++ b/tests/acceptance/02_classes/02_functions/iprange.cf.expected.json
@@ -1,0 +1,9 @@
+{
+  "found": [
+    "just_locals",
+    "local_range2",
+    "local_range",
+    "all_zeroes_some_interfaces",
+    "all_zeroes"
+  ]
+}

--- a/tests/unit/exec-config-test.c
+++ b/tests/unit/exec-config-test.c
@@ -29,8 +29,8 @@ static void run_test_in_policy(const char *policy_filename, TestFn fn)
     /* Setup global environment */
     strcpy(VFQNAME, "localhost.localdomain");
     strcpy(VIPADDRESS, "127.0.0.100");
-    EvalContextAddIpAddress(ctx, "127.0.0.100");
-    EvalContextAddIpAddress(ctx, "127.0.0.101");
+    EvalContextAddIpAddress(ctx, "127.0.0.100", "eth0");
+    EvalContextAddIpAddress(ctx, "127.0.0.101", "eth1");
 
     fn(ctx, policy);
 


### PR DESCRIPTION
Both of the changes in this PR relate to better support for network interface inventory.  I can split them if necessary.

The `sys.ip2iface` array (name is subject to change) maps every IP to its interface name if known.

The `iprange()` function can take N interface names after the IP range in the first parameter, and those parameters constrain the IP matching to those specific interfaces.  So for instance if you have `1.2.3.4` on `eth0`, `iprange('1.2.3.4', 'lo0')` will return false, but `iprange('1.2.3.4', 'eth0')` and `iprange('1.2.3.4')` will return true.  In order to provide this, the `classes` field in the IP address list in the system context stores the interface now, if known.  If unknown, it stores the empty string `""` as it did before.

Note that also `iprange('0.0.0.0/0', 'docker0')` will return true only if the `docker0` interface exists, so it's an indirect way to check for an interface.

I will add tests and documentation if this is acceptable.