### PR TITLE
Redmine#7413: minor fix for some overzealous lexers

### DIFF
--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -210,9 +210,9 @@ promise_type   [a-zA-Z_]+:
                                  P.if_depth--;
                                }
 
-<if_ignore_state>.*          {
+<if_ignore_state>[^@]      {
                                ParserDebug("\tL:inside macro @if, ignoring text:%s\n", yytext);
-                             }
+                           }
 
 {promises}            {
                           /* Note this has to come before "id" since it is a subset of id */
@@ -436,7 +436,7 @@ promise_type   [a-zA-Z_]+:
 <if_ignore_state><<EOF>>     {
                                if (P.if_depth > 0)
                                {
-                                 yyerror("EOF seen while @if was waiting for @endif");
+                                 yyerror("EOF seen while @if was waiting for @endif in ignore_state");
                                  return 0;
                                }
                              }
@@ -444,7 +444,7 @@ promise_type   [a-zA-Z_]+:
 <<EOF>>     {
               if (P.if_depth > 0)
               {
-                yyerror("EOF seen while @if was waiting for @endif");
+                yyerror("EOF seen while @if was waiting for @endif without ignore_state");
               }
               return 0; // loops forever without this
             }

--- a/tests/acceptance/00_basics/macros/if_ignore.cf
+++ b/tests/acceptance/00_basics/macros/if_ignore.cf
@@ -1,0 +1,30 @@
+######################################################
+#
+#  Test that @if works for greater versions
+#
+#####################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle common test
+{
+@if minimum_version(300.600)
+      Some new function here...
+
+
+      more text...
+@endif
+}
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_passif_expected("cfengine",
+                                         "",
+                                         $(this.promise_filename));
+}


### PR DESCRIPTION
The `@endif` line was ignored by some lexers, so we explicitly allow it now.