### PR TITLE
Allow promiser to be a function call

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1030,7 +1030,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
             
             if (strcmp(cp->lval, CFA_CONTROLBODY[AGENT_CONTROL_SELECT_END_MATCH_EOF].lval) == 0)
             {
-                Log(LOG_LEVEL_VERBOSE, "SET select_end_match_eof %s", value);
+                Log(LOG_LEVEL_VERBOSE, "SET select_end_match_eof %s", (char*)value);
                 EvalContextSetSelectEndMatchEof(ctx, BooleanFromString(value));
             }
 

--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -268,9 +268,9 @@ Bundle *MakeTemporaryBundleFromTemplate(EvalContext *ctx, Policy *policy, Attrib
                 int nl = StripTrailingNewline(promiser, size);
                 CF_ASSERT(nl != -1, "StripTrailingNewline failure");
 
-                np = PromiseTypeAppendPromise(tp, promiser, (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, context, NULL);
+                np = PromiseTypeAppendPromise(tp, promiser, RvalNULL(), context, NULL);
                 np->offset.line = lineno;
-                PromiseAppendConstraint(np, "insert_type", RvalNew("preserve_all_lines", RVAL_TYPE_SCALAR), false);
+                PromiseAppendConstraint(np, "insert_type", RvalNewScalar("preserve_all_lines"), false);
 
                 DeleteItemList(lines);
                 free(promiser);
@@ -288,9 +288,9 @@ Bundle *MakeTemporaryBundleFromTemplate(EvalContext *ctx, Policy *policy, Attrib
                     {
                         //install independent promise line
                         StripTrailingNewline(buffer, buffer_size);
-                        np = PromiseTypeAppendPromise(tp, buffer, (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, context, NULL);
+                        np = PromiseTypeAppendPromise(tp, buffer, RvalNULL(), context, NULL);
                         np->offset.line = lineno;
-                        PromiseAppendConstraint(np, "insert_type", RvalNew("preserve_all_lines", RVAL_TYPE_SCALAR), false);
+                        PromiseAppendConstraint(np, "insert_type", RvalNewScalar("preserve_all_lines"), false);
                     }
                 }
             }

--- a/cf-agent/verify_methods.c
+++ b/cf-agent/verify_methods.c
@@ -68,7 +68,7 @@ PromiseResult VerifyMethodsPromise(EvalContext *ctx, const Promise *pp)
     }
     else
     {
-        method_name = RvalNew(pp->promiser, RVAL_TYPE_SCALAR);
+        method_name = RvalNewScalar(pp->promiser);
         destroy_name = true;
     }
 

--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -269,7 +269,7 @@ void MonitorStartServer(EvalContext *ctx, const Policy *policy)
         Bundle *bp = PolicyAppendBundle(monitor_cfengine_policy, NamespaceDefault(), "monitor_cfengine_bundle", "agent", NULL, NULL);
         PromiseType *tp = BundleAppendPromiseType(bp, "monitor_cfengine");
 
-        pp = PromiseTypeAppendPromise(tp, "the monitor daemon", (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, NULL, NULL);
+        pp = PromiseTypeAppendPromise(tp, "the monitor daemon", RvalNULL(), NULL, NULL);
     }
     assert(pp);
 

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -637,7 +637,7 @@ static CfLock AcquireServerLock(EvalContext *ctx,
         PromiseType *tp = BundleAppendPromiseType(bp, "server_cfengine");
 
         pp = PromiseTypeAppendPromise(tp, config->input_file,
-                                      (Rval) { NULL, RVAL_TYPE_NOPROMISEE },
+                                      RvalNULL(),
                                       NULL, NULL);
     }
     assert(pp);

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -102,7 +102,7 @@ bundletype:            bundletype_values
                            ParserDebug("P:bundle:%s\n", P.blocktype);
                            P.block = "bundle";
                            RvalDestroy(P.rval);
-                           P.rval = RvalNew(NULL, RVAL_TYPE_NOPROMISEE);
+                           P.rval = RvalNULL();
                            RlistDestroy(P.currentRlist);
                            P.currentRlist = NULL;
                            if (P.currentstring)
@@ -690,7 +690,7 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
                                }
 
                                RvalDestroy(P.rval);
-                               P.rval = RvalNew(NULL, RVAL_TYPE_NOPROMISEE);
+                               P.rval = RvalNULL();
                                strcpy(P.lval,"no lval");
                                RlistDestroy(P.currentRlist);
                                P.currentRlist = NULL;
@@ -698,7 +698,7 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
                            else
                            {
                                RvalDestroy(P.rval);
-                               P.rval = RvalNew(NULL, RVAL_TYPE_NOPROMISEE);
+                               P.rval = RvalNULL();
                            }
                        }
 
@@ -862,7 +862,7 @@ selection:             selection_id                         /* BODY ONLY */
                            else
                            {
                                RvalDestroy(P.rval);
-                               P.rval = RvalNew(NULL, RVAL_TYPE_NOPROMISEE);
+                               P.rval = RvalNULL();
                            }
 
                            if (strcmp(P.blockid,"control") == 0 && strcmp(P.blocktype,"file") == 0)
@@ -882,7 +882,7 @@ selection:             selection_id                         /* BODY ONLY */
                            }
                            
                            RvalDestroy(P.rval);
-                           P.rval = RvalNew(NULL, RVAL_TYPE_NOPROMISEE);
+                           P.rval = RvalNULL();
                        }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -977,14 +977,14 @@ rval:                  IDSYNTAX
                        {
                            ParserDebug("\tP:%s:%s:%s:%s id rval, %s = %s\n", P.block, P.blocktype, P.blockid, P.currentclasses ? P.currentclasses : "any", P.lval, P.currentid);
                            RvalDestroy(P.rval);
-                           P.rval = (Rval) { xstrdup(P.currentid), RVAL_TYPE_SCALAR };
+                           P.rval = RvalNewScalar(P.currentid);
                            P.references_body = true;
                        }
                      | BLOCKID
                        {
                            ParserDebug("\tP:%s:%s:%s:%s blockid rval, %s = %s\n", P.block, P.blocktype, P.blockid, P.currentclasses ? P.currentclasses : "any", P.lval, P.currentid);
                            RvalDestroy(P.rval);
-                           P.rval = (Rval) { xstrdup(P.currentid), RVAL_TYPE_SCALAR };
+                           P.rval = RvalNewScalar(P.currentid);
                            P.references_body = true;
                        }
                      | QSTRING

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1398,6 +1398,26 @@ Promise *EvalContextStackPushPromiseIterationFrame(EvalContext *ctx, const Promi
 
     EvalContextStackPushFrame(ctx, StackFrameNewPromiseIteration(pexp, iter_ctx));
 
+    for (size_t i = 0; i < SeqLength(pexp->conlist); i++)
+    {
+        Constraint *cp = SeqAt(pexp->conlist, i);
+
+        if (0 == strcmp(cp->lval, "promiser_attribute"))
+        {
+            if (RVAL_TYPE_SCALAR == cp->rval.type)
+            {
+                free(pexp->promiser);
+                pexp->promiser = xstrdup(RvalScalarValue(cp->rval));
+            }
+            else
+            {
+                free(pexp->promiser);
+                pexp->promiser = RvalToString(cp->rval);
+                CanonifyNameInPlace(pexp->promiser);
+            }
+        }
+    }
+
     LoggingPrivSetLevels(CalculateLogLevel(pexp), CalculateReportLevel(pexp));
 
     return pexp;

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1266,7 +1266,7 @@ void EvalContextStackPushBundleFrame(EvalContext *ctx, const Bundle *owner, cons
         Variable *var = NULL;
         while ((var = VariableTableIteratorNext(iter)))
         {
-            Rval retval = ExpandPrivateRval(ctx, owner->ns, owner->name, var->rval.item, var->rval.type);
+            Rval retval = ExpandPrivateRval(ctx, owner->ns, owner->name, var->rval);
             RvalDestroy(var->rval);
             var->rval = retval;
         }

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -3352,7 +3352,7 @@ static FnCallResult FnCallSelectServers(EvalContext *ctx,
                                         "select_server_bundle", "agent", NULL, NULL);
         PromiseType *tp = BundleAppendPromiseType(bp, "select_server");
 
-        PromiseTypeAppendPromise(tp, "function", (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, NULL, NULL);
+        PromiseTypeAppendPromise(tp, "function", RvalNULL(), NULL, NULL);
     }
 
     size_t count = 0;

--- a/libpromises/expand.h
+++ b/libpromises/expand.h
@@ -41,7 +41,7 @@ bool IsExpandable(const char *str);
 char *ExpandScalar(const EvalContext *ctx, const char *ns, const char *scope,
                    const char *string, Buffer *out);
 Rval ExpandBundleReference(EvalContext *ctx, const char *ns, const char *scope, Rval rval);
-Rval ExpandPrivateRval(EvalContext *ctx, const char *ns, const char *scope, const void *rval_item, RvalType rval_type);
+Rval ExpandPrivateRval(EvalContext *ctx, const char *ns, const char *scope, Rval rval);
 Rlist *ExpandList(EvalContext *ctx, const char *ns, const char *scope, const Rlist *list, int expandnaked);
 Rval EvaluateFinalRval(EvalContext *ctx, const Policy *policy, const char *ns, const char *scope, Rval rval, bool forcelist, const Promise *pp);
 

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -92,7 +92,7 @@ static Rlist *NewExpArgs(EvalContext *ctx, const Policy *policy, const FnCall *f
             }
             break;
         default:
-            rval = ExpandPrivateRval(ctx, NULL, NULL, rp->val.item, rp->val.type);
+            rval = ExpandPrivateRval(ctx, NULL, NULL, rp->val);
             assert(rval.item);
             break;
         }

--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -493,6 +493,7 @@ const ConstraintSyntax CF_COMMON_BODIES[] =
     ConstraintSyntaxNewString("if", "", "Extended classes ANDed with context", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("unless", "", "Negated 'if'", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewStringList("meta", "", "User-data associated with policy, e.g. key=value strings", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewString("promiser_attribute", "", "Specify the promiser as an attribute", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewNull()
 };
 

--- a/libpromises/parser_state.h
+++ b/libpromises/parser_state.h
@@ -59,6 +59,7 @@ typedef struct
     bool references_body;
 
     char *promiser;
+    Rval promiser_attribute;
     void *promisee;
 
     char *current_namespace;

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -1312,7 +1312,8 @@ PromiseType *BundleAppendPromiseType(Bundle *bundle, const char *name)
 
 /*******************************************************************/
 
-Promise *PromiseTypeAppendPromise(PromiseType *type, const char *promiser, Rval promisee, const char *classes, const char *varclasses)
+
+Promise *PromiseTypeAppendPromiseWithPromiserAttribute(PromiseType *type, const char *promiser, Rval promisee, const char *classes, const char *varclasses, Rval promiser_attribute)
 {
     assert(promiser && "Missing promiser");
     assert(type && "Missing promise type");
@@ -1340,10 +1341,20 @@ Promise *PromiseTypeAppendPromise(PromiseType *type, const char *promiser, Rval 
 
     if (varclasses != NULL)
     {
-        PromiseAppendConstraint(pp, "ifvarclass", RvalNew(varclasses, RVAL_TYPE_SCALAR), true);
+        PromiseAppendConstraint(pp, "ifvarclass", RvalNewScalar(varclasses), true);
+    }
+
+    if (promiser_attribute.item)
+    {
+        PromiseAppendConstraint(pp, "promiser_attribute", RvalCopy(promiser_attribute), false);
     }
 
     return pp;
+}
+
+Promise *PromiseTypeAppendPromise(PromiseType *type, const char *promiser, Rval promisee, const char *classes, const char *varclasses)
+{
+    return PromiseTypeAppendPromiseWithPromiserAttribute(type, promiser, promisee, classes, varclasses, RvalNULL());
 }
 
 static void BundleDestroy(Bundle *bundle)

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -1272,8 +1272,8 @@ Body *PolicyAppendBody(Policy *policy, const char *ns, const char *name, const c
     if (strcmp("service_method", body->name) == 0)
     {
         Rlist *args = NULL;
-        RlistAppendRval(&args, RvalNew("$(this.promiser)", RVAL_TYPE_SCALAR));
-        RlistAppendRval(&args, RvalNew("$(this.service_policy)", RVAL_TYPE_SCALAR));
+        RlistAppendRval(&args, RvalNewScalar("$(this.promiser)"));
+        RlistAppendRval(&args, RvalNewScalar("$(this.service_policy)"));
 
         FnCall *service_bundle = FnCallNew("standard_services", args);
         BodyAppendConstraint(body, "service_bundle", (Rval) { service_bundle, RVAL_TYPE_FNCALL }, "any", false);
@@ -1458,7 +1458,7 @@ Constraint *PromiseAppendConstraint(Promise *pp, const char *lval, Rval rval, bo
                                   RvalScalarValue(old_cp->rval),
                                   RvalScalarValue(rval));
                     RvalDestroy(cp->rval);
-                    rval = RvalNew(BufferData(grow), RVAL_TYPE_SCALAR);
+                    rval = RvalNewScalar(BufferData(grow));
                     BufferDestroy(grow);
                     cp->rval = rval;
                 }
@@ -2100,7 +2100,7 @@ static Promise *PromiseTypeAppendPromiseJson(PromiseType *promise_type, JsonElem
 {
     const char *promiser = JsonObjectGetAsString(json_promise, "promiser");
 
-    Promise *promise = PromiseTypeAppendPromise(promise_type, promiser, (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, context, NULL);
+    Promise *promise = PromiseTypeAppendPromise(promise_type, promiser, RvalNULL(), context, NULL);
 
     JsonElement *json_attributes = JsonObjectGetAsArray(json_promise, "attributes");
     for (size_t i = 0; i < JsonLength(json_attributes); i++)

--- a/libpromises/policy.h
+++ b/libpromises/policy.h
@@ -266,6 +266,7 @@ bool BodyHasConstraint(const Body *body, const char *lval);
 const char *ConstraintGetNamespace(const Constraint *cp);
 
 Promise *PromiseTypeAppendPromise(PromiseType *type, const char *promiser, Rval promisee, const char *classes, const char *varclasses);
+Promise *PromiseTypeAppendPromiseWithPromiserAttribute(PromiseType *type, const char *promiser, Rval promisee, const char *classes, const char *varclasses, Rval promiser_attribute);
 void PromiseTypeDestroy(PromiseType *promise_type);
 
 void PromiseDestroy(Promise *pp);

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -164,8 +164,7 @@ static void AppendExpandedBodies(EvalContext *ctx, Promise *pcopy,
                 /* Expand body vars; note it has to happen ONLY ONCE. */
                 if (expand_body_vars)
                 {
-                    Rval newrv2 = ExpandPrivateRval(ctx, NULL, "body",
-                                                    newrv.item, newrv.type);
+                    Rval newrv2 = ExpandPrivateRval(ctx, NULL, "body", newrv);
                     RvalDestroy(newrv);
                     newrv = newrv2;
                 }
@@ -567,15 +566,32 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
 
     *excluded = false;
 
-    Rval returnval = ExpandPrivateRval(ctx, NULL, "this", pp->promiser, RVAL_TYPE_SCALAR);
+    const Constraint *promiser_attribute = PromiseGetConstraint(pp, "promiser_attribute");
+
+    Rval returnval = promiser_attribute ?
+        ExpandPrivateRval(ctx, NULL, "this", promiser_attribute->rval) :
+        ExpandPrivateRval(ctx, NULL, "this", (Rval) {pp->promiser, RVAL_TYPE_SCALAR});
+
+
     if (!returnval.item || (strcmp(returnval.item, CF_NULL_VALUE) == 0))
     {
         RvalDestroy(returnval);
         *excluded = true;
         return NULL;
     }
+
     Promise *pcopy = xcalloc(1, sizeof(Promise));
-    pcopy->promiser = RvalScalarValue(returnval);
+
+    // if expanding the promiser_attribute did something, use it as the promiser now
+    if (RVAL_TYPE_SCALAR == returnval.type)
+    {
+        pcopy->promiser = xstrdup(RvalScalarValue(returnval));
+    }
+    else
+    {
+        pcopy->promiser = RvalToString(promiser_attribute->rval);
+        CanonifyNameInPlace(pcopy->promiser);
+    }
 
     if ((strcmp("files", pp->parent_promise_type->name) != 0) &&
         (strcmp("storage", pp->parent_promise_type->name) != 0))

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -48,8 +48,7 @@ void CopyBodyConstraintsToPromise(EvalContext *ctx, Promise *pp,
 
         if (IsDefinedClass(ctx, scp->classes))
         {
-            Rval returnval = ExpandPrivateRval(ctx, NULL, "body",
-                                               scp->rval.item, scp->rval.type);
+            Rval returnval = ExpandPrivateRval(ctx, NULL, "body", scp->rval);
             PromiseAppendConstraint(pp, scp->lval, returnval, false);
         }
     }

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -453,6 +453,17 @@ Rval RvalCopyRewriter(Rval rval, JsonElement *map)
     return RvalNewRewriter(rval.item, rval.type, map);
 }
 
+Rval RvalNULL()
+{
+    return RvalNew(NULL, RVAL_TYPE_NOPROMISEE);
+}
+
+
+Rval RvalNewScalar(const void *item)
+{
+    return RvalNew(item, RVAL_TYPE_SCALAR);
+}
+
 Rval RvalCopy(Rval rval)
 {
     return RvalNew(rval.item, rval.type);
@@ -691,7 +702,7 @@ typedef enum
 } state;
 
 #define CLASS_BLANK(x)  (((x)==' ')||((x)=='\t'))
-#define CLASS_START1(x) (((x)=='\'')) 
+#define CLASS_START1(x) (((x)=='\''))
 #define CLASS_START2(x) (((x)=='"'))
 #define CLASS_END1(x)   ((CLASS_START1(x)))
 #define CLASS_END2(x)   ((CLASS_START2(x)))
@@ -711,7 +722,7 @@ typedef enum
 
 /**
  @brief parse elements in a list passed through use_module
- 
+
  @param[in] str: is the string to parse
  @param[out] newlist: rlist of elements found
 
@@ -740,7 +751,7 @@ static int LaunchParsingMachine(const char *str, Rlist **newlist)
                 {
                     current_state = ST_OPENED;
                 }
-                else if (CLASS_BRA1(*s)) 
+                else if (CLASS_BRA1(*s))
                 {
                     current_state = ST_IO;
                 }
@@ -1553,4 +1564,3 @@ bool RlistEqual_untyped(const void *list1, const void *list2)
 {
     return RlistEqual(list1, list2);
 }
-

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -464,6 +464,11 @@ Rval RvalNewScalar(const void *item)
     return RvalNew(item, RVAL_TYPE_SCALAR);
 }
 
+Rval RvalNewUseScalar(const void *item)
+{
+    return (Rval) { item, RVAL_TYPE_SCALAR };
+}
+
 Rval RvalCopy(Rval rval)
 {
     return RvalNew(rval.item, rval.type);

--- a/libpromises/rlist.h
+++ b/libpromises/rlist.h
@@ -45,7 +45,10 @@ JsonElement *RvalContainerValue(Rval rval);
 
 const char *RvalTypeToString(RvalType type);
 
-Rval RvalNew(const void *item, RvalType type);
+Rval RvalNULL(void);
+Rval RvalNew(const void *item, RvalType type); // copies
+Rval RvalNewScalar(const void *item);    // copies
+Rval RvalNewUseScalar(const void *item); // doesn't copy
 Rval RvalNewRewriter(const void *item, RvalType type, JsonElement *map);
 Rval RvalCopy(Rval rval);
 Rval RvalCopyRewriter(Rval rval, JsonElement *map);

--- a/libpromises/verify_classes.c
+++ b/libpromises/verify_classes.c
@@ -336,7 +336,7 @@ static bool EvalClassExpression(EvalContext *ctx, Constraint *cp, const Promise 
         break;
 
     default:
-        rval = ExpandPrivateRval(ctx, NULL, "this", cp->rval.item, cp->rval.type);
+        rval = ExpandPrivateRval(ctx, NULL, "this", cp->rval);
         RvalDestroy(cp->rval);
         cp->rval = rval;
         break;

--- a/tests/acceptance/00_basics/01_compiler/rval-promiser.cf
+++ b/tests/acceptance/00_basics/01_compiler/rval-promiser.cf
@@ -1,0 +1,34 @@
+###########################################################
+#
+# Test rvals in the promiser
+#
+###########################################################
+
+body common control
+{
+    inputs => { "../../default.cf.sub" };
+    bundlesequence => { default($(this.promise_filename)) };
+    version => "1.0";
+}
+
+###########################################################
+
+bundle agent test
+{
+  vars:
+      "iter" slist => { "1", "2", "3" };
+      canonify(concat("promiser ", canonify("addition"))) string => "";
+      canonify("clean") string => "";
+      canonify("my name is canonified") string => "";
+      concat("iter_canon_", canonify($(iter))) string => "iter = $(iter)";
+}
+
+###########################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/01_compiler/rval-promiser.cf.expected.json
+++ b/tests/acceptance/00_basics/01_compiler/rval-promiser.cf.expected.json
@@ -1,0 +1,13 @@
+{
+  "clean": "",
+  "iter": [
+    "1",
+    "2",
+    "3"
+  ],
+  "iter_canon_1": "iter = 1",
+  "iter_canon_2": "iter = 2",
+  "iter_canon_3": "iter = 3",
+  "my_name_is_canonified": "",
+  "promiser_addition": ""
+}

--- a/tests/unit/expand_test.c
+++ b/tests/unit/expand_test.c
@@ -410,7 +410,7 @@ static void test_expand_promise_array_with_scalar_arg(void **state)
     Policy *policy = PolicyNew();
     Bundle *bundle = PolicyAppendBundle(policy, NamespaceDefault(), "bundle", "agent", NULL, NULL);
     PromiseType *promise_type = BundleAppendPromiseType(bundle, "dummy");
-    Promise *promise = PromiseTypeAppendPromise(promise_type, "$(foo[$(bar)])", (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, "any", NULL);
+    Promise *promise = PromiseTypeAppendPromise(promise_type, "$(foo[$(bar)])", RvalNULL(), "any", NULL);
 
     EvalContextStackPushBundleFrame(ctx, bundle, NULL, false);
     EvalContextStackPushPromiseTypeFrame(ctx, promise_type);
@@ -465,7 +465,7 @@ static void test_expand_promise_slist(void **state)
     Policy *policy = PolicyNew();
     Bundle *bundle = PolicyAppendBundle(policy, NamespaceDefault(), "bundle", "agent", NULL, NULL);
     PromiseType *promise_type = BundleAppendPromiseType(bundle, "dummy");
-    Promise *promise = PromiseTypeAppendPromise(promise_type, "$(foo)", (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, "any", NULL);
+    Promise *promise = PromiseTypeAppendPromise(promise_type, "$(foo)", RvalNULL(), "any", NULL);
 
     EvalContextStackPushBundleFrame(ctx, bundle, NULL, false);
     EvalContextStackPushPromiseTypeFrame(ctx, promise_type);
@@ -533,7 +533,7 @@ static void test_expand_promise_array_with_slist_arg(void **state)
     Policy *policy = PolicyNew();
     Bundle *bundle = PolicyAppendBundle(policy, NamespaceDefault(), "bundle", "agent", NULL, NULL);
     PromiseType *promise_type = BundleAppendPromiseType(bundle, "dummy");
-    Promise *promise = PromiseTypeAppendPromise(promise_type, "$(arr[$(keys)])", (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, "any", NULL);
+    Promise *promise = PromiseTypeAppendPromise(promise_type, "$(arr[$(keys)])", RvalNULL(), "any", NULL);
 
     EvalContextStackPushBundleFrame(ctx, bundle, NULL, false);
     EvalContextStackPushPromiseTypeFrame(ctx, promise_type);

--- a/tests/unit/syntax_test.c
+++ b/tests/unit/syntax_test.c
@@ -104,7 +104,7 @@ static void test_copy_from_servers(void)
 
 static void test_typecheck_null_rval(void)
 {
-    SyntaxTypeMatch err = CheckConstraintTypeMatch("whatever", (Rval) { NULL, RVAL_TYPE_NOPROMISEE },
+    SyntaxTypeMatch err = CheckConstraintTypeMatch("whatever", RvalNULL(),
                                                    CF_DATA_TYPE_STRING, "abc", 0);
     assert_int_equal(SYNTAX_TYPE_MATCH_ERROR_GOT_NULL, err);
 }


### PR DESCRIPTION
Fixes https://tracker.mender.io/browse/CFE-1092

This code creates a new `promiser_attribute` promise attribute.  When the promiser is a function call, that attribute is auto-filled with the fncall Rval, and the promiser itself is set to the canonified unique string version of the fncall until the right time inside `EvalContextStackPushPromiseIterationFrame`.

In `EvalContextStackPushPromiseIterationFrame` the expanded `promiser_attribute` is written back into the promiser, if it's a scalar string.

I've tried to be very careful about how this code works but it definitely will need review and, if acceptable, good tests.

The test I used is in `00_basics/01_compiler/rval-promiser.cf` and `00_basics/01_compiler/rval-promiser.cf.expected.json`.

The debugging commit, which adds debugging output to chase the rval state of the `promiser_attribute` attribute, will not be a part of the final commit, but it's really useful to trace the chain of events.

Mailing list discussion: https://groups.google.com/d/msg/dev-cfengine/kDt0tAAcUis/VCbdhqBj4HcJ
