### PR TITLE
Redmine#7453: parse def.json vars, classes, and inputs in C

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1690,6 +1690,7 @@ static VariableTable *GetVariableTableForScope(const EvalContext *ctx,
     switch (SpecialScopeFromString(scope))
     {
     case SPECIAL_SCOPE_SYS:
+    case SPECIAL_SCOPE_DEF:
     case SPECIAL_SCOPE_MON:
     case SPECIAL_SCOPE_CONST:
         assert(!ns || strcmp("default", ns) == 0);
@@ -2622,4 +2623,128 @@ void EvalContextSetIgnoreLocks(EvalContext *ctx, bool ignore)
 bool EvalContextIsIgnoringLocks(const EvalContext *ctx)
 {
     return ctx->ignore_locks;
+}
+
+StringSet *ClassesMatching(const EvalContext *ctx, ClassTableIterator *iter, const char* regex, const Rlist *tags, bool first_only)
+{
+    StringSet *matching = StringSetNew();
+
+    pcre *rx = CompileRegex(regex);
+
+    Class *cls;
+    while ((cls = ClassTableIteratorNext(iter)))
+    {
+        char *expr = ClassRefToString(cls->ns, cls->name);
+
+        /* FIXME: review this strcmp. Moved out from StringMatch */
+        if (!strcmp(regex, expr) ||
+            (rx && StringMatchFullWithPrecompiledRegex(rx, expr)))
+        {
+            bool pass = false;
+            StringSet *tagset = EvalContextClassTags(ctx, cls->ns, cls->name);
+
+            if (tags)
+            {
+                for (const Rlist *arg = tags; arg; arg = arg->next)
+                {
+                    const char *tag_regex = RlistScalarValue(arg);
+                    const char *element;
+                    StringSetIterator it = StringSetIteratorInit(tagset);
+                    while ((element = StringSetIteratorNext(&it)))
+                    {
+                        /* FIXME: review this strcmp. Moved out from StringMatch */
+                        if (strcmp(tag_regex, element) == 0 ||
+                            StringMatchFull(tag_regex, element))
+                        {
+                            pass = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            else                        // without any tags queried, accept class
+            {
+                pass = true;
+            }
+
+            if (pass)
+            {
+                StringSetAdd(matching, expr);
+            }
+            else
+            {
+                free(expr);
+            }
+        }
+        else
+        {
+            free(expr);
+        }
+
+        if (first_only && StringSetSize(matching) > 0)
+        {
+            break;
+        }
+    }
+
+    if (rx)
+    {
+        pcre_free(rx);
+    }
+
+    return matching;
+}
+
+JsonElement* JsonExpandElement(EvalContext *ctx, const JsonElement *source)
+{
+    if (JsonGetElementType(source) == JSON_ELEMENT_TYPE_PRIMITIVE)
+    {
+        Buffer *expbuf;
+        JsonElement *expanded_json;
+
+        switch (JsonGetPrimitiveType(source))
+        {
+        case JSON_PRIMITIVE_TYPE_STRING:
+            expbuf = BufferNew();
+            ExpandScalar(ctx, NULL, "this", JsonPrimitiveGetAsString(source), expbuf);
+            expanded_json = JsonStringCreate(BufferData(expbuf));
+            BufferDestroy(expbuf);
+            return expanded_json;
+            break;
+
+        default:
+            return JsonCopy(source);
+            break;
+        }
+    }
+    else if (JsonGetElementType(source) == JSON_ELEMENT_TYPE_CONTAINER)
+    {
+        if (JsonGetContainerType(source) == JSON_CONTAINER_TYPE_OBJECT)
+        {
+            JsonElement *dest = JsonObjectCreate(JsonLength(source));
+            JsonIterator iter = JsonIteratorInit(source);
+            const char *key;
+            while ((key = JsonIteratorNextKey(&iter)))
+            {
+                Buffer *expbuf = BufferNew();
+                ExpandScalar(ctx, NULL, "this", key, expbuf);
+                JsonObjectAppendElement(dest, BufferData(expbuf), JsonExpandElement(ctx, JsonObjectGet(source, key)));
+                BufferDestroy(expbuf);
+            }
+
+            return dest;
+        }
+        else
+        {
+            JsonElement *dest = JsonArrayCreate(JsonLength(source));
+            for (size_t i = 0; i < JsonLength(source); i++)
+            {
+                JsonArrayAppendElement(dest, JsonExpandElement(ctx, JsonArrayGet(source, i)));
+            }
+            return dest;
+        }
+    }
+
+    ProgrammingError("JsonExpandElement: unexpected container type");
+    return NULL;
 }

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -187,6 +187,7 @@ Seq *EvalContextResolveBodyExpression(const EvalContext *ctx, const Policy *poli
 /* - Parsing/evaluating expressions - */
 void ValidateClassSyntax(const char *str);
 bool IsDefinedClass(const EvalContext *ctx, const char *context);
+StringSet *ClassesMatching(const EvalContext *ctx, ClassTableIterator *iter, const char* regex, const Rlist *tags, bool first_only);
 
 bool EvalProcessResult(const char *process_result, StringSet *proc_attr);
 bool EvalFileResult(const char *file_result, StringSet *leaf_attr);
@@ -240,5 +241,6 @@ ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, EvalContextSetupMissionPortalLogHook,
                                   EvalContext *, ctx);
 char *MissionPortalLogHook(LoggingPrivContext *pctx, LogLevel level, const char *message);
 
+JsonElement* JsonExpandElement(EvalContext *ctx, const JsonElement *source);
 
 #endif

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -88,7 +88,6 @@ static JsonElement *CURL_CACHE = NULL;
 #endif
 
 static FnCallResult FilterInternal(EvalContext *ctx, const FnCall *fp, const char *regex, const char *name, bool do_regex, bool invert, long max);
-static char* JsonPrimitiveToString(const JsonElement *el);
 
 static char *StripPatterns(char *file_buffer, const char *pattern, const char *filename);
 static void CloseStringHole(char *s, int start, int end);
@@ -848,72 +847,6 @@ static FnCallResult FnCallIfElse(EvalContext *ctx,
 
 /*********************************************************************/
 
-static StringSet *ClassesMatching(const EvalContext *ctx, ClassTableIterator *iter, const Rlist *args)
-{
-    StringSet *matching = StringSetNew();
-
-    const char *regex = RlistScalarValue(args);
-    pcre *rx = CompileRegex(regex);
-
-    Class *cls;
-    while ((cls = ClassTableIteratorNext(iter)))
-    {
-        char *expr = ClassRefToString(cls->ns, cls->name);
-
-        /* FIXME: review this strcmp. Moved out from StringMatch */
-        if (!strcmp(regex, expr) ||
-            (rx && StringMatchFullWithPrecompiledRegex(rx, expr)))
-        {
-            bool pass = false;
-            StringSet *tagset = EvalContextClassTags(ctx, cls->ns, cls->name);
-
-            if (args->next)
-            {
-                for (const Rlist *arg = args->next; arg; arg = arg->next)
-                {
-                    const char *tag_regex = RlistScalarValue(arg);
-                    const char *element;
-                    StringSetIterator it = StringSetIteratorInit(tagset);
-                    while ((element = StringSetIteratorNext(&it)))
-                    {
-                        /* FIXME: review this strcmp. Moved out from StringMatch */
-                        if (strcmp(tag_regex, element) == 0 ||
-                            StringMatchFull(tag_regex, element))
-                        {
-                            pass = true;
-                            break;
-                        }
-                    }
-                }
-            }
-            else                        // without any tags queried, accept class
-            {
-                pass = true;
-            }
-
-            if (pass)
-            {
-                StringSetAdd(matching, expr);
-            }
-            else
-            {
-                free(expr);
-            }
-        }
-        else
-        {
-            free(expr);
-        }
-    }
-
-    if (rx)
-    {
-        pcre_free(rx);
-    }
-
-    return matching;
-}
-
 static FnCallResult FnCallClassesMatching(EvalContext *ctx, ARG_UNUSED const Policy *policy, const FnCall *fp, const Rlist *finalargs)
 {
     bool count_only = false;
@@ -954,7 +887,7 @@ static FnCallResult FnCallClassesMatching(EvalContext *ctx, ARG_UNUSED const Pol
 
     {
         ClassTableIterator *iter = EvalContextClassTableIteratorNewGlobal(ctx, NULL, true, true);
-        StringSet *global_matches = ClassesMatching(ctx, iter, finalargs);
+        StringSet *global_matches = ClassesMatching(ctx, iter, RlistScalarValue(finalargs), finalargs->next, check_only);
 
         StringSetIterator it = StringSetIteratorInit(global_matches);
         const char *element = NULL;
@@ -963,11 +896,6 @@ static FnCallResult FnCallClassesMatching(EvalContext *ctx, ARG_UNUSED const Pol
             if (count_only || check_only)
             {
                 count++;
-
-                if (check_only)
-                {
-                    break;
-                }
             }
             else
             {
@@ -986,7 +914,7 @@ static FnCallResult FnCallClassesMatching(EvalContext *ctx, ARG_UNUSED const Pol
 
     {
         ClassTableIterator *iter = EvalContextClassTableIteratorNewLocal(ctx);
-        StringSet *local_matches = ClassesMatching(ctx, iter, finalargs);
+        StringSet *local_matches = ClassesMatching(ctx, iter, RlistScalarValue(finalargs), finalargs->next, check_only);
 
         StringSetIterator it = StringSetIteratorInit(local_matches);
         const char *element = NULL;
@@ -995,11 +923,6 @@ static FnCallResult FnCallClassesMatching(EvalContext *ctx, ARG_UNUSED const Pol
             if (count_only || check_only)
             {
                 count++;
-
-                if (check_only)
-                {
-                    break;
-                }
             }
             else
             {
@@ -2135,40 +2058,6 @@ static FnCallResult FnCallRegArray(EvalContext *ctx, ARG_UNUSED const Policy *po
 
 /*********************************************************************/
 
-static char* JsonPrimitiveToString(const JsonElement *el)
-{
-    if (JsonGetElementType(el) != JSON_ELEMENT_TYPE_PRIMITIVE)
-    {
-        return NULL;
-    }
-
-    switch (JsonGetPrimitiveType(el))
-    {
-    case JSON_PRIMITIVE_TYPE_BOOL:
-        return xstrdup(JsonPrimitiveGetAsBool(el) ? "true" : "false");
-        break;
-
-    case JSON_PRIMITIVE_TYPE_INTEGER:
-        return StringFromLong(JsonPrimitiveGetAsInteger(el));
-        break;
-
-    case JSON_PRIMITIVE_TYPE_REAL:
-        return StringFromDouble(JsonPrimitiveGetAsReal(el));
-        break;
-
-    case JSON_PRIMITIVE_TYPE_STRING:
-        return xstrdup(JsonPrimitiveGetAsString(el));
-        break;
-
-    case JSON_PRIMITIVE_TYPE_NULL: // redundant
-        break;
-    }
-
-    return NULL;
-}
-
-/*********************************************************************/
-
 static FnCallResult FnCallGetIndices(EvalContext *ctx, ARG_UNUSED const Policy *policy, const FnCall *fp, const Rlist *finalargs)
 {
     VarRef *ref = ResolveAndQualifyVarName(fp, RlistScalarValue(finalargs));
@@ -2281,6 +2170,8 @@ void CollectContainerValues(EvalContext *ctx, Rlist **values, const JsonElement 
         }
     }
 }
+
+/*********************************************************************/
 
 static FnCallResult FnCallGetValues(EvalContext *ctx, ARG_UNUSED const Policy *policy, const FnCall *fp, const Rlist *finalargs)
 {
@@ -6303,60 +6194,6 @@ static FnCallResult DataRead(EvalContext *ctx, const FnCall *fp, const Rlist *fi
 
 /*********************************************************************/
 
-JsonElement* DataExpandElement(EvalContext *ctx, const JsonElement *source)
-{
-    if (JsonGetElementType(source) == JSON_ELEMENT_TYPE_PRIMITIVE)
-    {
-        Buffer *expbuf;
-        JsonElement *expanded_json;
-
-        switch (JsonGetPrimitiveType(source))
-        {
-        case JSON_PRIMITIVE_TYPE_STRING:
-            expbuf = BufferNew();
-            ExpandScalar(ctx, NULL, "this", JsonPrimitiveGetAsString(source), expbuf);
-            expanded_json = JsonStringCreate(BufferData(expbuf));
-            BufferDestroy(expbuf);
-            return expanded_json;
-            break;
-
-        default:
-            return JsonCopy(source);
-            break;
-        }
-    }
-    else if (JsonGetElementType(source) == JSON_ELEMENT_TYPE_CONTAINER)
-    {
-        if (JsonGetContainerType(source) == JSON_CONTAINER_TYPE_OBJECT)
-        {
-            JsonElement *dest = JsonObjectCreate(JsonLength(source));
-            JsonIterator iter = JsonIteratorInit(source);
-            const char *key;
-            while ((key = JsonIteratorNextKey(&iter)))
-            {
-                Buffer *expbuf = BufferNew();
-                ExpandScalar(ctx, NULL, "this", key, expbuf);
-                JsonObjectAppendElement(dest, BufferData(expbuf), DataExpandElement(ctx, JsonObjectGet(source, key)));
-                BufferDestroy(expbuf);
-            }
-
-            return dest;
-        }
-        else
-        {
-            JsonElement *dest = JsonArrayCreate(JsonLength(source));
-            for (size_t i = 0; i < JsonLength(source); i++)
-            {
-                JsonArrayAppendElement(dest, DataExpandElement(ctx, JsonArrayGet(source, i)));
-            }
-            return dest;
-        }
-    }
-
-    ProgrammingError("DataExpandElement: unexpected container type");
-    return NULL;
-}
-
 static FnCallResult FnCallDataExpand(EvalContext *ctx,
                                      ARG_UNUSED const Policy *policy,
                                      ARG_UNUSED const FnCall *fp,
@@ -6377,7 +6214,7 @@ static FnCallResult FnCallDataExpand(EvalContext *ctx,
         return FnFailure();
     }
 
-    JsonElement *expanded = DataExpandElement(ctx, container);
+    JsonElement *expanded = JsonExpandElement(ctx, container);
     JsonDestroy(container);
 
     return (FnCallResult) { FNCALL_SUCCESS, (Rval) { expanded, RVAL_TYPE_CONTAINER } };

--- a/libpromises/feature.c
+++ b/libpromises/feature.c
@@ -14,7 +14,7 @@ static const char* features[] = {
 #ifdef HAVE_LIBCURL
     "curl",
 #endif
-
+    "def_json_preparse",
     NULL
 };
 

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -64,6 +64,7 @@
 #include <ornaments.h>
 #include <cf-windows-functions.h>
 #include <loading.h>
+#include <iteration.h>
 
 static pthread_once_t pid_cleanup_once = PTHREAD_ONCE_INIT; /* GLOBAL_T */
 
@@ -85,6 +86,27 @@ static bool MissingInputFile(const char *input_file);
 #if !defined(__MINGW32__)
 static void OpenLog(int facility);
 #endif
+
+static JsonElement *ReadJsonFile(const char *filename, LogLevel log_level)
+{
+    struct stat sb;
+    if (stat(filename, &sb) == -1)
+    {
+        Log(log_level, "Could not open JSON file %s", filename);
+        return NULL;
+    }
+
+    JsonElement *doc = NULL;
+    JsonParseError err = JsonParseFile(filename, 4096, &doc);
+
+    if (err != JSON_PARSE_OK
+        || NULL == doc)
+    {
+        Log(log_level, "Could not parse JSON file %s: %s", filename, JsonParseErrorToString(err));
+    }
+
+    return doc;
+}
 
 /*****************************************************************************/
 
@@ -143,6 +165,245 @@ Policy *SelectAndLoadPolicy(GenericAgentConfig *config, EvalContext *ctx, bool v
         }
     }
     return policy;
+}
+
+bool CheckContextOrClassmatch(EvalContext *ctx, const char* c)
+{
+    ClassTableIterator *iter = EvalContextClassTableIteratorNewGlobal(ctx, NULL, true, true);
+    StringSet *global_matches = ClassesMatching(ctx, iter, c, NULL, true); // returns early
+
+    bool found = (StringSetSize(global_matches) > 0);
+
+    StringSetDestroy(global_matches);
+    ClassTableIteratorDestroy(iter);
+
+    if (found)
+    {
+        return found;
+    }
+
+    // does it look like a regex? It's not a class expression then
+    // (these characters are invalid in class expressions and will
+    // give errors)
+    if (strchr(c, '*') ||
+        strchr(c, '+') ||
+        strchr(c, '['))
+    {
+        return false;
+    }
+
+    return IsDefinedClass(ctx, c);
+}
+
+void LoadAugmentsData(EvalContext *ctx, const Buffer* filename_buffer, const JsonElement* augment)
+{
+    if (JsonGetElementType(augment) != JSON_ELEMENT_TYPE_CONTAINER ||
+        JsonGetContainerType(augment) != JSON_CONTAINER_TYPE_OBJECT)
+    {
+        Log(LOG_LEVEL_ERR, "Invalid augments file contents in '%s', must be a JSON object", BufferData(filename_buffer));
+    }
+    else
+    {
+        Log(LOG_LEVEL_VERBOSE, "Loaded augments file '%s', installing contents", BufferData(filename_buffer));
+
+        JsonIterator iter = JsonIteratorInit(augment);
+        const char *key;
+        while ((key = JsonIteratorNextKey(&iter)))
+        {
+            if (0 == strcmp("vars", key))
+            {
+                // load variables
+                JsonElement* vars = JsonExpandElement(ctx, JsonObjectGet(augment, key));
+
+                if (NULL == vars ||
+                    JsonGetElementType(vars) != JSON_ELEMENT_TYPE_CONTAINER ||
+                    JsonGetContainerType(vars) != JSON_CONTAINER_TYPE_OBJECT)
+                {
+                    Log(LOG_LEVEL_ERR, "Invalid augments vars in '%s', must be a JSON object", BufferData(filename_buffer));
+                    goto vars_cleanup;
+                }
+
+                JsonIterator iter = JsonIteratorInit(vars);
+                const char *vkey;
+                while ((vkey = JsonIteratorNextKey(&iter)))
+                {
+                    JsonElement *data = JsonObjectGet(vars, vkey);
+                    if (JsonGetElementType(data) == JSON_ELEMENT_TYPE_PRIMITIVE)
+                    {
+                        char *value = JsonPrimitiveToString(data);
+                        Log(LOG_LEVEL_VERBOSE, "Installing augments variable '%s.%s=%s' from file '%s'",
+                            SpecialScopeToString(SPECIAL_SCOPE_DEF), vkey, value, BufferData(filename_buffer));
+                        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_DEF, vkey, value, CF_DATA_TYPE_STRING, "source=augments_file");
+                        free(value);
+                    }
+                    else if (JsonGetElementType(data) == JSON_ELEMENT_TYPE_CONTAINER &&
+                             JsonGetContainerType(data) == JSON_CONTAINER_TYPE_ARRAY &&
+                             JsonArrayContainsOnlyPrimitives(data))
+                    {
+                        // map to slist if the data only has primitives
+                        Log(LOG_LEVEL_VERBOSE, "Installing augments slist variable '%s.%s' from file '%s'",
+                            SpecialScopeToString(SPECIAL_SCOPE_DEF), vkey, BufferData(filename_buffer));
+                        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_DEF,
+                                                      vkey, ContainerToRlist(data),
+                                                      CF_DATA_TYPE_STRING_LIST,
+                                                      "source=augments_file");
+                    }
+                    else // install as a data container
+                    {
+                        Log(LOG_LEVEL_VERBOSE, "Installing augments data container variable '%s.%s' from file '%s'",
+                            SpecialScopeToString(SPECIAL_SCOPE_DEF), vkey, BufferData(filename_buffer));
+                        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_DEF,
+                                                      vkey, data,
+                                                      CF_DATA_TYPE_CONTAINER,
+                                                      "source=augments_file");
+                    }
+                }
+
+              vars_cleanup:
+                JsonDestroy(vars);
+            }
+            else if (0 == strcmp("classes", key))
+            {
+                // load classes
+                JsonElement* classes = JsonExpandElement(ctx, JsonObjectGet(augment, key));
+
+                if (JsonGetElementType(classes) != JSON_ELEMENT_TYPE_CONTAINER ||
+                    JsonGetContainerType(classes) != JSON_CONTAINER_TYPE_OBJECT)
+                {
+                    Log(LOG_LEVEL_ERR, "Invalid augments classes in '%s', must be a JSON object", BufferData(filename_buffer));
+                    goto classes_cleanup;
+                }
+
+                const char tags[] = "source=augments_file";
+                JsonIterator iter = JsonIteratorInit(classes);
+                const char *ckey;
+                while ((ckey = JsonIteratorNextKey(&iter)))
+                {
+                    JsonElement *data = JsonObjectGet(classes, ckey);
+                    if (JsonGetElementType(data) == JSON_ELEMENT_TYPE_PRIMITIVE)
+                    {
+                        char *check = JsonPrimitiveToString(data);
+                        // check if class is true
+                        if (CheckContextOrClassmatch(ctx, check))
+                        {
+                            Log(LOG_LEVEL_VERBOSE, "Installing augments class '%s' (checked '%s') from file '%s'",
+                                ckey, check, BufferData(filename_buffer));
+                            EvalContextClassPutHard(ctx, ckey, tags);
+                        }
+                        free(check);
+                    }
+                    else if (JsonGetElementType(data) == JSON_ELEMENT_TYPE_CONTAINER &&
+                             JsonGetContainerType(data) == JSON_CONTAINER_TYPE_ARRAY &&
+                             JsonArrayContainsOnlyPrimitives(data))
+                    {
+                        // check if each class is true
+                        JsonIterator iter = JsonIteratorInit(data);
+                        const JsonElement *el;
+                        while ((el = JsonIteratorNextValueByType(&iter, JSON_ELEMENT_TYPE_PRIMITIVE, true)))
+                        {
+                            char *check = JsonPrimitiveToString(el);
+                            if (CheckContextOrClassmatch(ctx, check))
+                            {
+                                Log(LOG_LEVEL_VERBOSE, "Installing augments class '%s' (checked array entry '%s') from file '%s'",
+                                    ckey, check, BufferData(filename_buffer));
+                                EvalContextClassPutHard(ctx, ckey, tags);
+                                free(check);
+                                break;
+                            }
+
+                            free(check);
+                        }
+                    }
+                    else
+                    {
+                        Log(LOG_LEVEL_ERR, "Invalid augments class data for class '%s' in '%s', must be a JSON object",
+                            ckey, BufferData(filename_buffer));
+                    }
+                }
+
+              classes_cleanup:
+                JsonDestroy(classes);
+            }
+            else if (0 == strcmp("inputs", key))
+            {
+                // load inputs
+                JsonElement* inputs = JsonExpandElement(ctx, JsonObjectGet(augment, key));
+
+                if (JsonGetElementType(inputs) == JSON_ELEMENT_TYPE_CONTAINER &&
+                    JsonGetContainerType(inputs) == JSON_CONTAINER_TYPE_ARRAY &&
+                    JsonArrayContainsOnlyPrimitives(inputs))
+                {
+                    Log(LOG_LEVEL_VERBOSE, "Installing augments def.augment_inputs from file '%s'",
+                        BufferData(filename_buffer));
+                    EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_DEF,
+                                                  "augment_inputs", JsonCopy(inputs),
+                                                  CF_DATA_TYPE_CONTAINER,
+                                                  "source=augments_file");
+                }
+                else
+                {
+                    Log(LOG_LEVEL_ERR, "Trying to augment inputs in '%s' but the value was not a list of strings",
+                        BufferData(filename_buffer));
+                }
+
+                JsonDestroy(inputs);
+            }
+            else
+            {
+                Log(LOG_LEVEL_VERBOSE, "Unknown augments key '%s' in file '%s', skipping it",
+                    key, BufferData(filename_buffer));
+            }
+        }
+    }
+}
+
+void LoadAugmentsFiles(EvalContext *ctx, const char* filename)
+{
+    Buffer *filebuf = BufferNewFrom(filename, strlen(filename));
+    Buffer *expbuf = BufferNew();
+    ExpandScalar(ctx, NULL, "this", BufferData(filebuf), expbuf);
+    if (strstr(BufferData(expbuf), "/.json"))
+    {
+        Log(LOG_LEVEL_DEBUG, "Skipping augments file '%s' because it failed to expand the base filename, resulting in '%s'",
+            BufferData(filebuf),
+            BufferData(expbuf));
+    }
+    else
+    {
+        Log(LOG_LEVEL_DEBUG, "Searching for augments file '%s'", BufferData(expbuf));
+        if (FileCanOpen(BufferData(expbuf), "r"))
+        {
+            JsonElement* augment = ReadJsonFile(BufferData(expbuf), LOG_LEVEL_ERR);
+            if (NULL != augment )
+            {
+                LoadAugmentsData(ctx, expbuf, augment);
+                JsonDestroy(augment);
+            }
+        }
+        else
+        {
+            Log(LOG_LEVEL_VERBOSE, "could not load JSON augments from '%s'", BufferData(expbuf));
+        }
+    }
+    BufferDestroy(filebuf);
+    BufferDestroy(expbuf);
+}
+
+void LoadAugments(EvalContext *ctx, GenericAgentConfig *config)
+{
+    // LoadAugmentsFiles(ctx, "$(sys.workdir)/def/$(sys.flavor).json");
+    // LoadAugmentsFiles(ctx, "$(sys.workdir)/def/$(sys.ostype).json");
+    // LoadAugmentsFiles(ctx, "$(sys.workdir)/def/$(sys.domain).json");
+    // LoadAugmentsFiles(ctx, "$(sys.workdir)/def/$(sys.uqhost).json");
+    // LoadAugmentsFiles(ctx, "$(sys.workdir)/def/$(sys.fqhost).json");
+    // LoadAugmentsFiles(ctx, "$(sys.workdir)/def/$(sys.key_digest).json");
+    // LoadAugmentsFiles(ctx, "$(sys.workdir)/def.json");
+    // LoadAugmentsFiles(ctx, "$(sys.inputdir)/def.json");
+
+    char* def_json = StringFormat("%s%c%s", config->input_dir, FILE_SEPARATOR, "def.json");
+    Log(LOG_LEVEL_VERBOSE, "Loading JSON augments from '%s' (input dir '%s', input file '%s'", def_json, config->input_dir, config->input_file);
+    LoadAugmentsFiles(ctx, def_json);
+    free(def_json);
 }
 
 void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config)
@@ -328,27 +589,6 @@ bool GenericAgentCheckPolicy(GenericAgentConfig *config, bool force_validation, 
     return false;
 }
 
-static JsonElement *ReadJsonFile(const char *filename)
-{
-    struct stat sb;
-    if (stat(filename, &sb) == -1)
-    {
-        Log(LOG_LEVEL_DEBUG, "Could not open JSON file %s", filename);
-        return NULL;
-    }
-
-    JsonElement *doc = NULL;
-    JsonParseError err = JsonParseFile(filename, 4096, &doc);
-
-    if (err != JSON_PARSE_OK
-        || NULL == doc)
-    {
-        Log(LOG_LEVEL_DEBUG, "Could not parse JSON file %s", filename);
-    }
-
-    return doc;
-}
-
 static JsonElement *ReadPolicyValidatedFile(const char *filename)
 {
     bool missing = true;
@@ -358,7 +598,7 @@ static JsonElement *ReadPolicyValidatedFile(const char *filename)
         missing = false;
     }
 
-    JsonElement *validated_doc = ReadJsonFile(filename);
+    JsonElement *validated_doc = ReadJsonFile(filename, LOG_LEVEL_DEBUG);
     if (NULL == validated_doc)
     {
         Log(missing ? LOG_LEVEL_DEBUG : LOG_LEVEL_VERBOSE, "Could not parse policy_validated JSON file '%s', using dummy data", filename);
@@ -788,6 +1028,7 @@ void GenericAgentInitialize(EvalContext *ctx, GenericAgentConfig *config)
         GenericAgentConfigSetInputFile(config, GetInputDir(), "promises.cf");
     }
 
+    LoadAugments(ctx, config);
     setlinebuf(stdout);
 }
 
@@ -988,7 +1229,7 @@ static JsonElement *ReadReleaseIdFileFromMasterfiles(const char *maybe_dirname)
     GetReleaseIdFile(NULL == maybe_dirname ? GetMasterDir() : maybe_dirname,
                      filename, sizeof(filename));
 
-    JsonElement *doc = ReadJsonFile(filename);
+    JsonElement *doc = ReadJsonFile(filename, LOG_LEVEL_DEBUG);
     if (NULL == doc)
     {
         Log(LOG_LEVEL_VERBOSE, "Could not parse release_id JSON file %s", filename);

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -71,7 +71,7 @@ static void RlistAppendContainerPrimitive(Rlist **list, const JsonElement *primi
     }
 }
 
-static Rlist *ContainerToRlist(const JsonElement *container)
+Rlist *ContainerToRlist(const JsonElement *container)
 {
     Rlist *list = NULL;
 

--- a/libpromises/iteration.h
+++ b/libpromises/iteration.h
@@ -32,6 +32,7 @@
 
 typedef struct PromiseIterator_ PromiseIterator;
 
+Rlist *ContainerToRlist(const JsonElement *container);
 PromiseIterator *PromiseIteratorNew(EvalContext *ctx, const Promise *pp, const Rlist *lists, const Rlist *containers);
 void PromiseIteratorDestroy(PromiseIterator *iter_ctx);
 

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -311,6 +311,35 @@ static Policy *LoadPolicyFile(EvalContext *ctx, GenericAgentConfig *config, cons
 
     PolicyResolve(ctx, policy, config);
 
+    DataType def_inputs_type = CF_DATA_TYPE_NONE;
+    VarRef *inputs_ref = VarRefParse("def.augment_inputs");
+    const void *def_inputs = EvalContextVariableGet(ctx, inputs_ref, &def_inputs_type);
+    VarRefDestroy(inputs_ref);
+
+    if (RVAL_TYPE_CONTAINER == DataTypeToRvalType(def_inputs_type) && NULL != def_inputs)
+    {
+        const JsonElement *el;
+        JsonIterator iter = JsonIteratorInit((JsonElement*) def_inputs);
+        while ((el = JsonIteratorNextValueByType(&iter, JSON_ELEMENT_TYPE_PRIMITIVE, true)))
+        {
+            char *input = JsonPrimitiveToString(el);
+
+            Log(LOG_LEVEL_VERBOSE, "Loading augments from def.augment_inputs: %s", input);
+
+            Rlist* inputs_rlist = NULL;
+            RlistAppendScalar(&inputs_rlist, input);
+            Policy *aux_policy = LoadPolicyInputFiles(ctx, config, inputs_rlist,
+                                                      parsed_files_and_checksums, failed_files);
+            if (aux_policy)
+            {
+                policy = PolicyMerge(policy, aux_policy);
+            }
+
+            RlistDestroy(inputs_rlist);
+            free(input);
+        }
+    }
+
     Body *body_common_control = PolicyGetBody(policy, NULL, "common", "control");
     Body *body_file_control = PolicyGetBody(policy, NULL, "file", "control");
 

--- a/libpromises/scope.c
+++ b/libpromises/scope.c
@@ -54,6 +54,8 @@ const char *SpecialScopeToString(SpecialScope scope)
         return "mon";
     case SPECIAL_SCOPE_SYS:
         return "sys";
+    case SPECIAL_SCOPE_DEF:
+        return "def";
     case SPECIAL_SCOPE_THIS:
         return "this";
     case SPECIAL_SCOPE_BODY:
@@ -84,6 +86,10 @@ SpecialScope SpecialScopeFromString(const char *scope)
     else if (strcmp("sys", scope) == 0)
     {
         return SPECIAL_SCOPE_SYS;
+    }
+    else if (strcmp("def", scope) == 0)
+    {
+        return SPECIAL_SCOPE_DEF;
     }
     else if (strcmp("this", scope) == 0)
     {

--- a/libpromises/scope.h
+++ b/libpromises/scope.h
@@ -38,6 +38,7 @@ typedef enum
     SPECIAL_SCOPE_SYS,
     SPECIAL_SCOPE_THIS,
     SPECIAL_SCOPE_BODY,
+    SPECIAL_SCOPE_DEF,
 
     SPECIAL_SCOPE_NONE
 } SpecialScope;

--- a/libutils/json.c
+++ b/libutils/json.c
@@ -617,6 +617,38 @@ const char *JsonPrimitiveGetAsString(const JsonElement *primitive)
     return primitive->primitive.value;
 }
 
+char* JsonPrimitiveToString(const JsonElement *primitive)
+{
+    if (JsonGetElementType(primitive) != JSON_ELEMENT_TYPE_PRIMITIVE)
+    {
+        return NULL;
+    }
+
+    switch (JsonGetPrimitiveType(primitive))
+    {
+    case JSON_PRIMITIVE_TYPE_BOOL:
+        return xstrdup(JsonPrimitiveGetAsBool(primitive) ? "true" : "false");
+        break;
+
+    case JSON_PRIMITIVE_TYPE_INTEGER:
+        return StringFromLong(JsonPrimitiveGetAsInteger(primitive));
+        break;
+
+    case JSON_PRIMITIVE_TYPE_REAL:
+        return StringFromDouble(JsonPrimitiveGetAsReal(primitive));
+        break;
+
+    case JSON_PRIMITIVE_TYPE_STRING:
+        return xstrdup(JsonPrimitiveGetAsString(primitive));
+        break;
+
+    case JSON_PRIMITIVE_TYPE_NULL: // redundant
+        break;
+    }
+
+    return NULL;
+}
+
 bool JsonPrimitiveGetAsBool(const JsonElement *primitive)
 {
     assert(primitive);
@@ -1137,6 +1169,26 @@ JsonElement *JsonArrayGet(const JsonElement *array, size_t index)
     assert(array->container.type == JSON_CONTAINER_TYPE_ARRAY);
 
     return JsonAt(array, index);
+}
+
+bool JsonArrayContainsOnlyPrimitives(JsonElement *array)
+{
+    assert(array);
+    assert(array->type == JSON_ELEMENT_TYPE_CONTAINER);
+    assert(array->container.type == JSON_CONTAINER_TYPE_ARRAY);
+
+
+    for (size_t i = 0; i < JsonLength(array); i++)
+    {
+        JsonElement *child = JsonArrayGet(array, i);
+
+        if (child->type != JSON_ELEMENT_TYPE_PRIMITIVE)
+        {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 void JsonContainerReverse(JsonElement *array)

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -162,6 +162,7 @@ JsonContainerType JsonGetContainerType(const JsonElement *container);
 
 JsonPrimitiveType JsonGetPrimitiveType(const JsonElement *primitive);
 const char *JsonPrimitiveGetAsString(const JsonElement *primitive);
+char* JsonPrimitiveToString(const JsonElement *primitive);
 bool JsonPrimitiveGetAsBool(const JsonElement *primitive);
 long JsonPrimitiveGetAsInteger(const JsonElement *primitive);
 double JsonPrimitiveGetAsReal(const JsonElement *primitive);
@@ -346,6 +347,12 @@ JsonElement *JsonArrayGetAsObject(JsonElement *array, size_t index);
 
 JsonElement *JsonArrayGet(const JsonElement *array, size_t index);
 
+/**
+  @brief Check if an array contains only primitives
+  @param array [in] The JSON array parent
+  @returns true if the array contains only primitives, false otherwise
+  */
+bool JsonArrayContainsOnlyPrimitives(JsonElement *array);
 
 /**
   @brief Parse a string to create a JsonElement
@@ -400,7 +407,5 @@ JsonElementType JsonIteratorCurrentElementType(const JsonIterator *iter);
 JsonContainerType JsonIteratorCurrentContainerType(const JsonIterator *iter);
 JsonPrimitiveType JsonIteratorCurrentPrimitiveType(const JsonIterator *iter);
 bool JsonIteratorHasMore(const JsonIterator *iter);
-
-
 
 #endif

--- a/tests/acceptance/00_basics/def.json/bad-json.cf
+++ b/tests/acceptance/00_basics/def.json/bad-json.cf
@@ -1,0 +1,26 @@
+# test of the def.json facility: complain if a bad JSON file is found
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) -v|$(G.grep) JSON";
+
+  methods:
+      "" usebundle => dcs_passif_output(".*Could not parse JSON file $(sys.inputdir)/def.json.*", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/bad-json.cf.json
+++ b/tests/acceptance/00_basics/def.json/bad-json.cf.json
@@ -1,0 +1,3 @@
+bad
+JSON
+data

--- a/tests/acceptance/00_basics/def.json/classes.cf
+++ b/tests/acceptance/00_basics/def.json/classes.cf
@@ -1,0 +1,27 @@
+# basic test of the def.json facility: classes
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf|$(G.grep) test_class";
+
+  methods:
+      "" usebundle => dcs_passif_output("test_class_29665402e2b4331f10b8d767b512cd916eeb5db9\s+source=augments_file,hardclass", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/classes.cf.json
+++ b/tests/acceptance/00_basics/def.json/classes.cf.json
@@ -1,0 +1,7 @@
+{
+ "classes":
+ {
+  "test_class_29665402e2b4331f10b8d767b512cd916eeb5db9": [ "one", "of", "these", "matches_classmatch", "any" ],
+  "my_other_example": [ "server[34]", "debian.*" ],
+ }
+}

--- a/tests/acceptance/00_basics/def.json/def.json
+++ b/tests/acceptance/00_basics/def.json/def.json
@@ -1,0 +1,10 @@
+{
+ "vars": {
+  "domain": "mydomain",
+  "acl": [ ".*$(def.domain) note this will remain unexpanded!!!" ],
+
+  "input_name_patterns": [ ".*\\.cf",".*\\.dat",".*\\.txt", ".*\\.conf", ".*\\.mustache",
+                           ".*\\.sh", ".*\\.pl", ".*\\.py", ".*\\.rb",
+                           "cf_promises_release_id", ".*\\.json", ".*\\.yaml", ".*\\.js" ]
+ }
+}

--- a/tests/acceptance/00_basics/def.json/inputs.cf
+++ b/tests/acceptance/00_basics/def.json/inputs.cf
@@ -1,0 +1,35 @@
+# basic test of the def.json facility: inputs
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+      "" usebundle => file_make("$(sys.inputdir)/secondary.cf", '
+bundle common x
+{
+  classes:
+    "test_class_9f606e44752ce34ef39ee7d4754c5c84890d2b14" expression => "any";
+ }
+');
+
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf|$(G.grep) test_class";
+
+  methods:
+      "" usebundle => dcs_passif_output("test_class_9f606e44752ce34ef39ee7d4754c5c84890d2b14\s+source=promise", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/inputs.cf.json
+++ b/tests/acceptance/00_basics/def.json/inputs.cf.json
@@ -1,0 +1,3 @@
+{
+ "inputs": [ "$(sys.inputdir)/secondary.cf" ]
+}

--- a/tests/acceptance/00_basics/def.json/state.cf
+++ b/tests/acceptance/00_basics/def.json/state.cf
@@ -1,0 +1,20 @@
+# full test of the def.json facility
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_check_state(def,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
+  reports:
+      "augments policy = $(this.promise_filename)";
+      "domain = $(def.domain)";
+}

--- a/tests/acceptance/00_basics/def.json/state.cf.expected.json
+++ b/tests/acceptance/00_basics/def.json/state.cf.expected.json
@@ -1,0 +1,21 @@
+{
+  "acl": [
+    ".*$(def.domain) note this will remain unexpanded!!!"
+  ],
+  "domain": "mydomain",
+  "input_name_patterns": [
+    ".*\\.cf",
+    ".*\\.dat",
+    ".*\\.txt",
+    ".*\\.conf",
+    ".*\\.mustache",
+    ".*\\.sh",
+    ".*\\.pl",
+    ".*\\.py",
+    ".*\\.rb",
+    "cf_promises_release_id",
+    ".*\\.json",
+    ".*\\.yaml",
+    ".*\\.js"
+  ]
+}

--- a/tests/acceptance/00_basics/def.json/vars.cf
+++ b/tests/acceptance/00_basics/def.json/vars.cf
@@ -1,0 +1,27 @@
+# basic test of the def.json facility: vars
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) --show-vars -f $(sys.inputdir)/promises.cf|$(G.grep) test_variable";
+
+  methods:
+      "" usebundle => dcs_passif_output("default:def.test_variable\s+37bff81c825bd57a613ff4770b7a0679ff147bdf\s+source=augments_file", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/vars.cf.json
+++ b/tests/acceptance/00_basics/def.json/vars.cf.json
@@ -1,0 +1,11 @@
+{
+ "classes":
+ {
+  "class_to_define_if": [ "one", "of", "these", "matches_classmatch" ],
+  "my_other_example": [ "server[34]", "debian.*" ],
+ },
+
+ "vars": {
+  "test_variable": "37bff81c825bd57a613ff4770b7a0679ff147bdf"
+ }
+}

--- a/tests/acceptance/README
+++ b/tests/acceptance/README
@@ -88,6 +88,11 @@ bundles:
 Look in default.cf for some standard check bundles (for example, to compare
 files when testing file edits, or for cleaning up temporary files).
 
+For a test named XYZ, if the test runner finds the file XYZ.def.json,
+that file will be copied to the input directory so it will be loaded
+on startup. That lets you set hard classes and def variables and add
+inputs before the test ever runs.
+
 Tests should be named with short names describing what they test, using lower-
 case letters and underscores only. If the test is expected to generate an error
 (that is, if they contan syntax errors or other faults), it should have an


### PR DESCRIPTION
See https://dev.cfengine.com/issues/7453

This work does the following:

* define the hard class `feature_augments` so in the masterfiles we can see if we need to load `def.json` or not (which means this can go into 3.7.1 seamlessly)
* look for `def.json` in several locations as specified in the ticket
* use the current format of `def.json`
* define a new special `def` system scope and use it
* verify and load variables, converting primitives to CFEngine strings; simple string lists to CFEngine slists; and any other data types to CFEngine data containers.  Note that all keys and values are expanded (like `data_expand` would do it).
* verify and load classes, accepting either context or classmatch regex expressions
* load inputs into `def.loaded_inputs` which is then used in `loading.c` as if it was part of the `body common control` inputs, but loaded beforehand (duplicates are OK, we already use a hash map to prevent loading them)
* move `ClassesMatching` to `eval_context.c` and change the signature a little
* move `JsonPrimitiveToString` to `json.c`
* move `DataExpandElement` to `eval_context.c` and rename it to `JsonExpandElement`
* expose `ContainerToRlist` from `iteration.h`

The behavior, after all of this, is almost the same as the current `def.json` parsing, except for the new locations and that variables and inputs are evaluated correctly.

Acceptance tests and docs upon acceptance.