### PR TITLE
log error the reason for failed connect to make it easier to diagnose why Zendesk #2126

### DIFF
--- a/libcfnet/net.c
+++ b/libcfnet/net.c
@@ -381,7 +381,7 @@ int SocketConnect(const char *host, const char *port,
     int ret = getaddrinfo(host, port, &query, &response);
     if (ret != 0)
     {
-        Log(LOG_LEVEL_INFO,
+        Log(LOG_LEVEL_ERR,
               "Unable to find host '%s' service '%s' (%s)",
               host, port, gai_strerror(ret));
         if (response != NULL)


### PR DESCRIPTION
Not sure if this one has unintendend consequences that will result in syslog spamming in some cases?
Was there a reason for inform mode previously (it should either be error or verbose, not inform, by the way)?