### PR TITLE
Redmine #7455: fix build with musl libc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -596,6 +596,8 @@ AC_CHECK_HEADERS(sys/jail.h, [], [], [AC_INCLUDES_DEFAULT
 # include <sys/param.h>
 #endif
 ])
+AC_CHECK_HEADERS(net/route.h netinet/in.h netinet/ip.h)
+
 
 AC_HEADER_STDC
 AC_HEADER_TIME

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -370,13 +370,21 @@ union mpinfou
 #endif
 
 #ifdef __linux__
-# if defined(__GLIBC__) || defined(__BIONIC__)
+# ifdef HAVE_NET_ROUTE_H
 #  include <net/route.h>
-#  include <netinet/in.h>
-#  include <netinet/ip.h>
 # else
 #  include <linux/route.h>
+# endif
+
+# ifdef HAVE_NETINET_IN_H
+#  include <netinet/in.h>
+# else
 #  include <linux/in.h>
+# endif
+
+# ifdef HAVE_NETINET_IP_H
+#  include <netinet/ip.h>
+# else
 #  include <linux/ip.h>
 # endif
 #endif


### PR DESCRIPTION
Check for each header with AC_HEADER_CHECK instead assuming that needed
headers only exist on GNU libc and bionic.

This fixes the following build error when building on linux with musl libc:
In file included from ../libutils/platform.h:358:0,
                 from generic_at.c:25:
/usr/include/linux/if.h:71:2: error: expected identifier before numeric
constant
  IFF_UP    = 1<<0,  /* sysfs */
  ^
In file included from /usr/include/linux/route.h:26:0,
                 from ../libutils/platform.h:378,
                 from generic_at.c:25:
/usr/include/linux/if.h:169:8: error: redefinition of 'struct ifmap'
 struct ifmap {
        ^

Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>