### PR TITLE
Add this.callers_promisers variable

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -998,6 +998,36 @@ void EvalContextClear(EvalContext *ctx)
 
 }
 
+Rlist *EvalContextGetPromiseCallerMethods(EvalContext *ctx) {
+	Rlist *callers = NULL;
+
+	for (size_t i = 0; i < SeqLength(ctx->stack); i++)
+	{
+	    StackFrame *frame = SeqAt(ctx->stack, i);
+	    switch (frame->type)
+	    {
+	    case STACK_FRAME_TYPE_BODY:
+	        break;
+
+	    case STACK_FRAME_TYPE_BUNDLE:
+	        break;
+
+	    case STACK_FRAME_TYPE_PROMISE_ITERATION:
+	        break;
+
+	    case STACK_FRAME_TYPE_PROMISE:
+	     	if (strcmp(frame->data.promise.owner->parent_promise_type->name, "methods") == 0) {
+	     		RlistAppendScalar(&callers, frame->data.promise.owner->promiser);
+	      	}
+	        break;
+
+	    case STACK_FRAME_TYPE_PROMISE_TYPE:
+	      	break;
+	    }
+	}
+	return callers;
+}
+
 void EvalContextSetBundleArgs(EvalContext *ctx, const Rlist *args)
 {
     if (ctx->args)
@@ -1242,6 +1272,7 @@ void EvalContextStackPushPromiseFrame(EvalContext *ctx, const Promise *owner, bo
     xsnprintf(v, sizeof(v), "%d", (int) ctx->ppid);
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promiser_ppid", v, CF_DATA_TYPE_INT, "source=agent");
 
+    EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "callers_promisers", EvalContextGetPromiseCallerMethods(ctx), CF_DATA_TYPE_STRING_LIST, "source=promise");
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "bundle", PromiseGetBundle(owner)->name, CF_DATA_TYPE_STRING, "source=promise");
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "namespace", PromiseGetNamespace(owner), CF_DATA_TYPE_STRING, "source=promise");
 }

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -131,6 +131,8 @@ ClassTableIterator *EvalContextClassTableIteratorNewLocal(const EvalContext *ctx
 
 void EvalContextClear(EvalContext *ctx);
 
+Rlist *EvalContextGetPromiseCallerMethods(EvalContext *ctx);
+
 void EvalContextStackPushBundleFrame(EvalContext *ctx, const Bundle *owner, const Rlist *args, bool inherits_previous);
 void EvalContextStackPushBodyFrame(EvalContext *ctx, const Promise *caller, const Body *body, const Rlist *args);
 void EvalContextStackPushPromiseTypeFrame(EvalContext *ctx, const PromiseType *owner);

--- a/tests/acceptance/21_methods/callers/01.cf
+++ b/tests/acceptance/21_methods/callers/01.cf
@@ -1,0 +1,51 @@
+#######################################################
+#
+# Test the variable this.callers_promisers with one bundle
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init {
+}
+
+bundle agent test {
+  methods:
+    "test" usebundle => "caller";
+}
+
+bundle agent check {
+  reports:
+    success::
+      "$(this.promise_filename) Pass";
+    !success::
+      "$(this.promise_filename) FAIL";
+}
+
+bundle agent caller {
+  methods:
+    "first call" usebundle => dummy;
+}
+
+bundle agent dummy {
+  vars:
+    "callers_promisers_expect" string => "any, any, test, first call";
+    "callers_promisers_actual" string => join(", ", "this.callers_promisers");
+
+  classes:
+    "success"  expression => strcmp("${callers_promisers_expect}", "${callers_promisers_actual}"),
+      scope => "namespace";
+
+  reports:
+    DEBUG::
+      "EXPECT: callers_promisers_string = ${callers_promisers_expect}";
+      "ACTUAL: callers_promisers_string = ${callers_promisers_actual}";
+}
+

--- a/tests/acceptance/21_methods/callers/02.cf
+++ b/tests/acceptance/21_methods/callers/02.cf
@@ -1,0 +1,70 @@
+#######################################################
+#
+# Test the variable this.callers_promisers with one bundle called twice
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init {
+}
+
+bundle agent test {
+  methods:
+    "test" usebundle => "caller";
+}
+
+bundle agent check {
+  reports:
+    success_first.success_second::
+      "$(this.promise_filename) Pass";
+    !(success_first.success_second)::
+      "$(this.promise_filename) FAIL";
+}
+
+bundle agent caller {
+
+  methods:
+    "first call" usebundle => dummy;
+    "second call" usebundle => dummy_inter;
+
+}
+
+bundle agent dummy_inter {
+
+  methods:
+    "inter" usebundle => dummy;
+
+}
+
+bundle agent dummy {
+
+  vars:
+    # This bundle gets called twice, once directly, and once via dummy_inter
+
+    "callers_promisers_expect_first" string => "any, any, test, first call";
+    "callers_promisers_expect_second" string => "any, any, test, second call, inter";
+    "callers_promisers_actual" string => join(", ", "this.callers_promisers");
+
+  classes:
+    "success_first"  expression => strcmp("${callers_promisers_expect_first}", "${callers_promisers_actual}"),
+      scope => "namespace";
+    "success_second" expression => strcmp("${callers_promisers_expect_second}", "${callers_promisers_actual}"),
+      scope => "namespace";
+
+  reports:
+    DEBUG::
+      "EXPECT (first in ${this.bundle}): callers_promisers_string = ${callers_promisers_expect_first}";
+      "ACTUAL (first in ${this.bundle}): callers_promisers_string = ${callers_promisers_actual}";
+
+      "EXPECT (second in ${this.bundle}): callers_promisers_string = ${callers_promisers_expect_second}";
+      "ACTUAL (second in ${this.bundle}): callers_promisers_string = ${callers_promisers_actual}";
+}
+


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/7493

With methods, we can re-utilize common configuration pieces from different places. But it is currently impossible to identify, within the called bundle, what is the
context of the call, and hence difficult to produce meaningful logs or reporting, particularly when bundles are called with the same arguments.

A way to make it possible to know the context would be to create a new context variable, for example called *this.callers_promisers*, which would be a list of the parents promisers of the current bundle.

This way we can use the full call stack to identify uniquely the current action.