### PR TITLE
action_policy warn produces errors

### DIFF
--- a/cf-agent/acl_posix.c
+++ b/cf-agent/acl_posix.c
@@ -331,7 +331,7 @@ static int CheckPosixLinuxACEs(EvalContext *ctx, Rlist *aces, AclMethod method, 
         {
         case cfa_warn:
 
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a, "%s ACL on file '%s' needs to be updated", acl_type_str, file_path);
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a, "%s ACL on file '%s' needs to be updated", acl_type_str, file_path);
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
             break;
 
@@ -507,7 +507,7 @@ int CheckDefaultClearACL(EvalContext *ctx, const char *file_path, Attributes a, 
         {
         case cfa_warn:
 
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a, "Default ACL on '%s' needs to be cleared", file_path);
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a, "Default ACL on '%s' needs to be cleared", file_path);
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
             break;
 

--- a/cf-agent/files_edit.c
+++ b/cf-agent/files_edit.c
@@ -108,7 +108,7 @@ void FinishEditContext(EvalContext *ctx, EditContext *ec, Attributes a, const Pr
             !CompareToFile(ctx, ec->file_start, ec->filename, a, pp, result) &&
             ec->num_edits > 0)
         {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                  "Should edit file '%s' but only a warning promised",
                  ec->filename);
             *result = PROMISE_RESULT_WARN;

--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -1031,7 +1031,7 @@ static int DeletePromisedLinesMatching(EvalContext *ctx, Item **start, Item *beg
 
             if (a.transaction.action == cfa_warn)
             {
-                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+                cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                      "Need to delete line '%s' from %s - but only a warning was promised", ip->name,
                      edcontext->filename);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1183,7 +1183,7 @@ static int ReplacePatterns(EvalContext *ctx, Item *file_start, Item *file_end, A
 
         if (a.transaction.action == cfa_warn)
         {
-            cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_WARN, pp, a,
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                  "Need to replace line '%s' in '%s' - but only a warning was promised", pp->promiser,
                  edcontext->filename);
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1836,7 +1836,7 @@ static int InsertLineAtLocation(EvalContext *ctx, char *newline, Item **start, I
             {
                 if (a.transaction.action == cfa_warn)
                 {
-                    cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+                    cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                          "Need to insert the promised line '%s' in %s - but only a warning was promised", newline,
                          edcontext->filename);
                     *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1857,7 +1857,7 @@ static int InsertLineAtLocation(EvalContext *ctx, char *newline, Item **start, I
             {
                 if (a.transaction.action == cfa_warn)
                 {
-                    cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+                    cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                          "Need to prepend the promised line '%s' to %s - but only a warning was promised",
                          newline, edcontext->filename);
                     *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1894,7 +1894,7 @@ static int InsertLineAtLocation(EvalContext *ctx, char *newline, Item **start, I
         {
             if (a.transaction.action == cfa_warn)
             {
-                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+                cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                      "Need to insert line '%s' into '%s' but only a warning was promised", newline,
                      edcontext->filename);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1923,7 +1923,7 @@ static int InsertLineAtLocation(EvalContext *ctx, char *newline, Item **start, I
         {
             if (a.transaction.action == cfa_warn)
             {
-                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+                cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                      "Need to insert line '%s' in '%s' but only a warning was promised", newline, edcontext->filename);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
                 return true;
@@ -2012,7 +2012,7 @@ static int EditLineByColumn(EvalContext *ctx, Rlist **columns, Attributes a,
         {
             if (a.transaction.action == cfa_warn)
             {
-                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a, "Need to edit field in %s but only warning promised",
+                cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a, "Need to edit field in %s but only warning promised",
                      edcontext->filename);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
                 retval = false;
@@ -2044,7 +2044,7 @@ static int EditLineByColumn(EvalContext *ctx, Rlist **columns, Attributes a,
         {
             if (a.transaction.action == cfa_warn)
             {
-                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+                cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                      "Need to delete field field value %s in %s but only a warning was promised", RlistScalarValue(rp),
                      edcontext->filename);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -2065,7 +2065,7 @@ static int EditLineByColumn(EvalContext *ctx, Rlist **columns, Attributes a,
         {
             if (a.transaction.action == cfa_warn)
             {
-                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+                cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                      "Need to set column field value %s to %s in %s but only a warning was promised",
                      RlistScalarValue(rp), a.column.column_value, edcontext->filename);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);

--- a/cf-agent/files_editxml.c
+++ b/cf-agent/files_editxml.c
@@ -1061,7 +1061,7 @@ static bool InsertTreeInFile(EvalContext *ctx, char *rawtree, xmlDocPtr doc, Att
 
     if (a.transaction.action == cfa_warn)
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
              "Need to insert the promised tree '%s' into an empty XML document '%s' - but only a warning was promised",
              rawtree, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1134,7 +1134,7 @@ static bool DeleteTreeInNode(EvalContext *ctx, char *rawtree, xmlDocPtr doc, xml
 
     if (a.transaction.action == cfa_warn)
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
              "Need to delete the promised tree '%s' at XPath '%s' in XML document '%s' - but only a warning was promised",
              rawtree, a.xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1222,7 +1222,7 @@ static bool InsertTreeInNode(EvalContext *ctx, char *rawtree, xmlDocPtr doc, xml
 
     if (a.transaction.action == cfa_warn)
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
              "Need to insert the promised tree '%s' at XPath '%s' in XML document '%s' - but only a warning was promised",
              rawtree, a.xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1283,7 +1283,7 @@ static bool DeleteAttributeInNode(EvalContext *ctx, char *rawname, xmlNodePtr do
 
     if (a.transaction.action == cfa_warn)
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
              "Need to delete the promised attribute '%s', at XPath '%s' in XML document '%s' - but only a warning was promised",
              rawname, a.xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1354,7 +1354,7 @@ static bool SetAttributeInNode(EvalContext *ctx, char *rawname, char *rawvalue, 
 
     if (a.transaction.action == cfa_warn)
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
              "Need to set the promised attribute, with name '%s' and value '%s', at XPath '%s' in XML document '%s' - but only a warning was promised",
              rawname, rawvalue, a.xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1415,7 +1415,7 @@ static bool DeleteTextInNode(EvalContext *ctx, char *rawtext, xmlDocPtr doc, xml
 
     if (a.transaction.action == cfa_warn)
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
              "Need to delete the promised text '%s' at XPath '%s' in XML document '%s' - but only a warning was promised",
              rawtext, a.xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1486,7 +1486,7 @@ static bool SetTextInNode(EvalContext *ctx, char *rawtext, xmlDocPtr doc, xmlNod
 
     if (a.transaction.action == cfa_warn)
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
              "Need to set the promised text '%s' at XPath '%s' in XML document '%s' - but only a warning was promised",
              rawtext, a.xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
@@ -1557,7 +1557,7 @@ static bool InsertTextInNode(EvalContext *ctx, char *rawtext, xmlDocPtr doc, xml
 
     if (a.transaction.action == cfa_warn)
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
              "Need to insert the promised text '%s' at XPath '%s' in XML document '%s' - but only a warning was promised",
              rawtext, a.xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);

--- a/cf-agent/files_links.c
+++ b/cf-agent/files_links.c
@@ -493,7 +493,7 @@ static bool MakeLink(EvalContext *ctx, const char *from, const char *to, Attribu
 {
     if (DONTDO || (attr.transaction.action == cfa_warn))
     {
-        Log(LOG_LEVEL_ERR, "Need to link files '%s' -> '%s'", from, to);
+        Log(LOG_LEVEL_WARNING, "Need to link files '%s' -> '%s'", from, to);
         return false;
     }
     else

--- a/cf-agent/files_operators.c
+++ b/cf-agent/files_operators.c
@@ -363,21 +363,21 @@ static int ItemListsEqual(EvalContext *ctx, const Item *list1, const Item *list2
             {
                 if ((ip1 == list1) || (ip2 == list2))
                 {
-                    cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a, "File content wants to change from from/to full/empty but only a warning promised");
+                    cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a, "File content wants to change from from/to full/empty but only a warning promised");
                     *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
                 }
                 else
                 {
                     if (ip1 != NULL)
                     {
-                        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a, " ! edit_line change warning promised: (remove) %s",
+                        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a, " ! edit_line change warning promised: (remove) %s",
                              ip1->name);
                         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
                     }
 
                     if (ip2 != NULL)
                     {
-                        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a, " ! edit_line change warning promised: (add) %s", ip2->name);
+                        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a, " ! edit_line change warning promised: (add) %s", ip2->name);
                         *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
                     }
                 }

--- a/cf-agent/package_module.c
+++ b/cf-agent/package_module.c
@@ -1125,7 +1125,7 @@ PromiseResult FileInstallPackage(const char *package_file_path,
      
     if (action == cfa_warn || DONTDO)
     {
-         Log(LOG_LEVEL_NOTICE, "Should install file type package: %s",
+         Log(LOG_LEVEL_WARNING, "Should install file type package: %s",
              package_file_path);
         res = PROMISE_RESULT_FAIL;
     }
@@ -1244,7 +1244,7 @@ PromiseResult RepoInstall(EvalContext *ctx,
         }
         if (action == cfa_warn || DONTDO)
         {
-            Log(LOG_LEVEL_NOTICE, "Should install repo type package: %s",
+            Log(LOG_LEVEL_WARNING, "Should install repo type package: %s",
                 package_info->name);
             return PROMISE_RESULT_FAIL;
         }
@@ -1329,7 +1329,7 @@ PromiseResult RepoInstall(EvalContext *ctx,
             {
                 if (action == cfa_warn || DONTDO)
                 {
-                    Log(LOG_LEVEL_NOTICE, "Should install repo type package: %s",
+                    Log(LOG_LEVEL_WARNING, "Should install repo type package: %s",
                         package_info->name);
                     res = PromiseResultUpdate(res, PROMISE_RESULT_FAIL);
                     continue;
@@ -1594,7 +1594,7 @@ PromiseResult HandleAbsentPromiseAction(EvalContext *ctx,
         
         if (action == cfa_warn || DONTDO)
         {
-            Log(LOG_LEVEL_NOTICE, "Need to remove package: %s", package_name);
+            Log(LOG_LEVEL_WARNING, "Need to remove package: %s", package_name);
             res = PROMISE_RESULT_FAIL;
         }
         else

--- a/cf-agent/verify_databases.c
+++ b/cf-agent/verify_databases.c
@@ -306,7 +306,7 @@ static int VerifyDatabasePromise(CfdbConn *cfdb, char *database, Attributes a)
         }
         else
         {
-            Log(LOG_LEVEL_ERR, "Need to delete the database '%s' but only a warning was promised", database);
+            Log(LOG_LEVEL_WARNING, "Need to delete the database '%s' but only a warning was promised", database);
             return false;
         }
     }
@@ -322,7 +322,7 @@ static int VerifyDatabasePromise(CfdbConn *cfdb, char *database, Attributes a)
         }
         else
         {
-            Log(LOG_LEVEL_ERR, "Need to create the database '%s' but only a warning was promised", database);
+            Log(LOG_LEVEL_WARNING, "Need to create the database '%s' but only a warning was promised", database);
             return false;
         }
     }
@@ -533,7 +533,7 @@ static int VerifyTablePromise(EvalContext *ctx, CfdbConn *cfdb, char *table_path
             }
             else
             {
-                Log(LOG_LEVEL_ERR, "Database.table '%s' doesn't seem to exist, but only a warning was promised",
+                Log(LOG_LEVEL_WARNING, "Database.table '%s' doesn't seem to exist, but only a warning was promised",
                       table_path);
             }
         }
@@ -687,7 +687,7 @@ static int VerifyTablePromise(EvalContext *ctx, CfdbConn *cfdb, char *table_path
                 }
                 else
                 {
-                    cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+                    cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                          "Promised column '%s' missing from database table '%s' but only a warning was promised",
                          name_table[i], table);
                     *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -344,7 +344,7 @@ static PromiseResult CfCopyFile(EvalContext *ctx, char *sourcefile,
     {
         if (attr.transaction.action == cfa_warn)
         {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr,
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr,
                  "Image file '%s' is non-existent and should be a copy of '%s'",
                  destfile, sourcefile);
             return PromiseResultUpdate(result, PROMISE_RESULT_WARN);
@@ -520,7 +520,7 @@ static PromiseResult CfCopyFile(EvalContext *ctx, char *sourcefile,
 
         if (ok_to_copy && (attr.transaction.action == cfa_warn))
         {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr,
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr,
                  "Image file '%s' exists but is not up to date wrt '%s' "
                  "(only a warning has been promised)",
                  destfile, sourcefile);
@@ -682,7 +682,7 @@ static PromiseResult PurgeLocalFiles(EvalContext *ctx, Item *filelist, const cha
 
             if (DONTDO || attr.transaction.action == cfa_warn)
             {
-                Log(LOG_LEVEL_ERR, "Need to purge '%s' from copy dest directory", filename);
+                Log(LOG_LEVEL_WARNING, "Need to purge '%s' from copy dest directory", filename);
                 result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
             }
             else
@@ -1736,7 +1736,7 @@ static PromiseResult VerifyName(EvalContext *ctx, char *path, struct stat *sb, A
 
         if (attr.transaction.action == cfa_warn)
         {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "'%s' '%s' should be renamed",
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr, "'%s' '%s' should be renamed",
                  S_ISDIR(sb->st_mode) ? "Directory" : "File", path);
             result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
             return result;
@@ -1841,7 +1841,7 @@ static PromiseResult VerifyName(EvalContext *ctx, char *path, struct stat *sb, A
     {
         if (attr.transaction.action == cfa_warn)
         {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "File '%s' should be truncated", path);
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr, "File '%s' should be truncated", path);
             result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
         }
         else if (!DONTDO)
@@ -1861,7 +1861,7 @@ static PromiseResult VerifyName(EvalContext *ctx, char *path, struct stat *sb, A
     {
         if (attr.transaction.action == cfa_warn)
         {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "File '%s' should be rotated", path);
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr, "File '%s' should be rotated", path);
             result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
         }
         else if (!DONTDO)
@@ -1899,7 +1899,7 @@ static PromiseResult VerifyDelete(EvalContext *ctx,
     {
     case cfa_warn:
 
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr,
+        cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr,
              "%s '%s' should be deleted",
              S_ISDIR(sb->st_mode) ? "Directory" : "File", path);
         return PROMISE_RESULT_WARN;
@@ -2118,7 +2118,7 @@ PromiseResult VerifyFileAttributes(EvalContext *ctx, const char *file, struct st
         if (attr.transaction.action == cfa_warn || DONTDO)
         {
 
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr,
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr,
                  "'%s' has permission %04jo - [should be %04jo]", file,
                  (uintmax_t)dstat->st_mode & 07777, (uintmax_t)newperm & 07777);
             result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
@@ -2168,7 +2168,7 @@ PromiseResult VerifyFileAttributes(EvalContext *ctx, const char *file, struct st
         {
         case cfa_warn:
 
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr,
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr,
                  "'%s' has flags %jo - [should be %jo]",
                  file, (uintmax_t) (dstat->st_mode & CHFLAGS_MASK),
                  (uintmax_t) (newflags & CHFLAGS_MASK));
@@ -3215,7 +3215,7 @@ static PromiseResult VerifySetUidGid(EvalContext *ctx, const char *file, struct 
 
                 if (amroot)
                 {
-                    cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "WARNING setuid (root) flag on '%s'", file);
+                    cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr, "WARNING setuid (root) flag on '%s'", file);
                     result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
                 }
                 break;
@@ -3255,7 +3255,7 @@ static PromiseResult VerifySetUidGid(EvalContext *ctx, const char *file, struct 
 
             case cfa_warn:
 
-                cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_WARN, pp, attr, "WARNING setgid (root) flag on '%s'", file);
+                cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr, "WARNING setgid (root) flag on '%s'", file);
                 result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
                 break;
 
@@ -3364,7 +3364,7 @@ static int VerifyFinderType(EvalContext *ctx, const char *file, Attributes a, co
             return retval;
 
         case cfa_warn:
-            Log(LOG_LEVEL_ERR, "Darwin FinderType does not match -- not fixing.");
+            Log(LOG_LEVEL_WARNING, "Darwin FinderType does not match -- not fixing.");
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
             return 0;
 
@@ -3417,7 +3417,7 @@ static void RegisterAHardLink(int i, char *value, Attributes attr, CompressedArr
         {
             if (attr.transaction.action == cfa_warn)
             {
-                Log(LOG_LEVEL_VERBOSE, "Need to remove old hard link '%s' to preserve structure", value);
+                Log(LOG_LEVEL_WARNING, "Need to remove old hard link '%s' to preserve structure", value);
             }
             else
             {
@@ -3662,21 +3662,21 @@ bool VerifyOwner(EvalContext *ctx, const char *file, const Promise *pp, Attribut
 
             if ((pw = getpwuid(sb->st_uid)) == NULL)
             {
-                Log(LOG_LEVEL_ERR, "File '%s' is not owned by anybody in the passwd database", file);
-                Log(LOG_LEVEL_ERR, "(uid = %ju,gid = %ju)", (uintmax_t)sb->st_uid, (uintmax_t)sb->st_gid);
+                Log(LOG_LEVEL_WARNING, "File '%s' is not owned by anybody in the passwd database", file);
+                Log(LOG_LEVEL_WARNING, "(uid = %ju,gid = %ju)", (uintmax_t)sb->st_uid, (uintmax_t)sb->st_gid);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
                 break;
             }
 
             if ((gp = getgrgid(sb->st_gid)) == NULL)
             {
-                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "File '%s' is not owned by any group in group database",
+                cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr, "File '%s' is not owned by any group in group database",
                      file);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
                 break;
             }
 
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "File '%s' is owned by '%s', group '%s'", file, pw->pw_name,
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr, "File '%s' is owned by '%s', group '%s'", file, pw->pw_name,
                  gp->gr_name);
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
             break;
@@ -3729,7 +3729,7 @@ bool CfCreateFile(EvalContext *ctx, char *file, const Promise *pp, Attributes at
         }
         else
         {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "Warning promised, need to create directory '%s'", file);
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr, "Warning promised, need to create directory '%s'", file);
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
             return false;
         }
@@ -3786,7 +3786,7 @@ bool CfCreateFile(EvalContext *ctx, char *file, const Promise *pp, Attributes at
         }
         else
         {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, attr, "Warning promised, need to create file '%s'", file);
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr, "Warning promised, need to create file '%s'", file);
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_WARN);
             return false;
         }

--- a/cf-agent/verify_methods.c
+++ b/cf-agent/verify_methods.c
@@ -152,7 +152,7 @@ PromiseResult VerifyMethod(EvalContext *ctx, const Rval call, Attributes a, cons
         if (a.transaction.action == cfa_warn) // don't skip for dry-runs (ie ignore DONTDO)
         {
             result = PROMISE_RESULT_WARN;
-            cfPS(ctx, LOG_LEVEL_ERR, result, pp, a, "Bundle '%s' should be invoked, but only a warning was promised!", BufferData(method_name));
+            cfPS(ctx, LOG_LEVEL_WARNING, result, pp, a, "Bundle '%s' should be invoked, but only a warning was promised!", BufferData(method_name));
         }
         else
         {

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -1316,7 +1316,7 @@ static PromiseResult AddPackageToSchedule(EvalContext *ctx, const Attributes *a,
     {
     case cfa_warn:
 
-        cfPS_HELPER_3ARG(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, *a, "Need to repair promise '%s' by '%s' package '%s'",
+        cfPS_HELPER_3ARG(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, *a, "Need to repair promise '%s' by '%s' package '%s'",
              pp->promiser, PackageAction2String(pa), name);
         return PROMISE_RESULT_WARN;
 
@@ -1364,7 +1364,7 @@ static PromiseResult AddPatchToSchedule(EvalContext *ctx, const Attributes *a, c
     {
     case cfa_warn:
 
-        cfPS_HELPER_3ARG(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, *a, "Need to repair promise '%s' by '%s' package '%s'",
+        cfPS_HELPER_3ARG(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, *a, "Need to repair promise '%s' by '%s' package '%s'",
              pp->promiser, PackageAction2String(pa), name);
         return PROMISE_RESULT_WARN;
 

--- a/cf-agent/verify_processes.c
+++ b/cf-agent/verify_processes.c
@@ -239,7 +239,7 @@ static PromiseResult VerifyProcessOp(EvalContext *ctx, Item *procdata, Attribute
     {
         if (a.transaction.action == cfa_warn)
         {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_WARN, pp, a,
+            cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, a,
                  "Need to keep restart promise for '%s', but only a warning is promised", pp->promiser);
             result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
         }
@@ -365,14 +365,14 @@ static int FindPidMatches(Item *procdata, Item **killlist, Attributes a, const c
 
         if ((a.transaction.action == cfa_warn) && promised_zero)
         {
-            Log(LOG_LEVEL_ERR, "Process alert '%s'", procdata->name);     /* legend */
-            Log(LOG_LEVEL_ERR, "Process alert '%s'", ip->name);
+            Log(LOG_LEVEL_WARNING, "Process alert '%s'", procdata->name);     /* legend */
+            Log(LOG_LEVEL_WARNING, "Process alert '%s'", ip->name);
             continue;
         }
 
         if (a.transaction.action == cfa_warn)
         {
-            Log(LOG_LEVEL_ERR, "Matched '%s'", ip->name);
+            Log(LOG_LEVEL_WARNING, "Matched '%s'", ip->name);
         }
         else
         {

--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -1168,7 +1168,7 @@ static bool DoCreateUser(const char *puser, User u, enum cfopaction action,
 
     if (action == cfa_warn || DONTDO)
     {
-        Log(LOG_LEVEL_NOTICE, "Need to create user '%s'.", puser);
+        Log(LOG_LEVEL_WARNING, "Need to create user '%s'.", puser);
         return false;
     }
     else
@@ -1237,7 +1237,7 @@ static bool DoRemoveUser (const char *puser, enum cfopaction action)
 
     if (action == cfa_warn || DONTDO)
     {
-        Log(LOG_LEVEL_NOTICE, "Need to remove user '%s'.", puser);
+        Log(LOG_LEVEL_WARNING, "Need to remove user '%s'.", puser);
         return false;
     }
 
@@ -1306,7 +1306,7 @@ static bool DoModifyUser (const char *puser, User u, const struct passwd *passwd
     {
         if (action == cfa_warn || DONTDO)
         {
-            Log(LOG_LEVEL_NOTICE, "Need to change password for user '%s'.", puser);
+            Log(LOG_LEVEL_WARNING, "Need to change password for user '%s'.", puser);
             return false;
         }
         else
@@ -1322,7 +1322,7 @@ static bool DoModifyUser (const char *puser, User u, const struct passwd *passwd
     {
         if (action == cfa_warn || DONTDO)
         {
-            Log(LOG_LEVEL_NOTICE, "Need to %s account for user '%s'.",
+            Log(LOG_LEVEL_WARNING, "Need to %s account for user '%s'.",
                 (u.policy == USER_STATE_LOCKED) ? "lock" : "unlock", puser);
             return false;
         }
@@ -1355,7 +1355,7 @@ static bool DoModifyUser (const char *puser, User u, const struct passwd *passwd
     CFUSR_CLEARBIT(changemap, i_locked);
     if (action == cfa_warn || DONTDO)
     {
-        Log(LOG_LEVEL_NOTICE, "Need to update user attributes (command '%s').", cmd);
+        Log(LOG_LEVEL_WARNING, "Need to update user attributes (command '%s').", cmd);
         return false;
     }
     else if (changemap != 0)


### PR DESCRIPTION
The ``action_policy => warn`` allows to warn about non-kept promises without attempting to repair them, but a lot of log messages about un-kept promises in this case are ERROR messages (and sometimes INFO or VERBOSE), which can be surprising as we asked for a warning, and as it is not really an error.

This PR changes the loglevels of messages related to warn action_policy to WARNING. 