### PR TITLE
Add a default body action

### DIFF
--- a/tests/acceptance/00_basics/03_bodies/default_action.cf
+++ b/tests/acceptance/00_basics/03_bodies/default_action.cf
@@ -1,0 +1,66 @@
+#######################################################
+#
+# Test default body action and overriding with specific action
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+body action files_default_action
+{
+    action_policy => "warn";
+}
+
+body action specific
+{
+    action_policy => "fix";
+}
+
+#######################################################
+
+bundle agent test_specified_action
+{
+  files:
+	  "$(G.testdir)/specified"
+	     create => "true",
+       action => specific;
+}
+
+bundle agent test_default_action
+{
+  files:
+	  "$(G.testdir)/default"
+	     create => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "specified"
+        usebundle => test_specified_action;
+      "default"
+        usebundle => test_default_action;
+}
+
+bundle agent check
+{
+  classes:
+    "default_created" expression => fileexists("$(G.testdir)/default");
+    "specified_created" expression => fileexists("$(G.testdir)/specified");
+    "ok" expression => "specified_created.!default_created";
+
+  reports:   
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
This PR allows to define a default body action, useful to avoid having to define explicitly an action for each promise to alter the general behavior of the agent.

For each promise:
* if it has a defined action, use it
* if not, test if there is an existing *promise_type***_default_action** body
  * if it exists, use it
  * if not, use the default values

It is similar to the generic package_method mechanism.