### PR TITLE
Report failure to close the socket.

### DIFF
--- a/libcfnet/misc.c
+++ b/libcfnet/misc.c
@@ -25,6 +25,7 @@
 #include <cfnet.h>
 
 #include <misc_lib.h>
+#include <logging.h>                                         /* GetErrorStr */
 
 
 int cf_closesocket(int sd)
@@ -33,8 +34,20 @@ int cf_closesocket(int sd)
 
 #ifdef __MINGW32__
     res = closesocket(sd);
+    if (res == SOCKET_ERROR)
+    {
+        Log(LOG_LEVEL_VERBOSE,
+            "Failed to close socket (closesocket: %s)",
+            GetErrorStrFromCode(WSAGetLastError()));
+    }
 #else
     res = close(sd);
+    if (res == -1)
+    {
+        Log(LOG_LEVEL_VERBOSE,
+            "Failed to close socket (close: %s)",
+            GetErrorStr());
+    }
 #endif
 
     return res;

--- a/libpromises/item_lib.c
+++ b/libpromises/item_lib.c
@@ -540,6 +540,8 @@ void InsertAfter(Item **filestart, Item *ptr, const char *string)
  *  @NOTE backslashes can be used to escape either the separator, or the
  *        backslash itself, e.g. "\:" or "\\" (ofcourse proper C strings need
  *        double backslash).
+ *
+ *  @NOTE separator can't be the backslash.
  */
 Item *SplitString(const char *string, char sep)
 {
@@ -574,7 +576,7 @@ Item *SplitString(const char *string, char sep)
             buf[buf_len] = string[z];
             buf_len++;
 
-            /* Find next backslash or separator. */
+            /* SKIP, find next backslash or separator. */
             string     += z + 1;
             string_len -= z + 1;
             continue;

--- a/tests/unit/item_test.c
+++ b/tests/unit/item_test.c
@@ -351,6 +351,26 @@ static void test_split_string(void)
     DeleteItemList(expected); expected = NULL;
     test_progress();
 
+    /* Backslash as separator - CURRENTLY NOT SUPPORTED! */
+    /* TODO FIX. */
+
+    actual = SplitString("C:\\blah\\blue\\", '\\');
+    /*
+    for (Item *ip = actual; ip != NULL; ip = ip->next)
+    {
+        printf("%s\n", ip->name);
+    }
+    */
+    AppendItem(&expected, "C:\\blah\\blue\\", NULL);           /* TODO FIX! */
+    /* AppendItem(&expected, "C:", NULL); */
+    /* AppendItem(&expected, "blah", NULL); */
+    /* AppendItem(&expected, "blue", NULL); */
+    /* AppendItem(&expected, "", NULL); */
+    assert_true(ListsCompare(actual, expected));
+    DeleteItemList(actual);   actual   = NULL;
+    DeleteItemList(expected); expected = NULL;
+    test_progress();
+
     test_progress_end();
 }
 


### PR DESCRIPTION
I'm suspecting some CLOSE_WAIT problems, especially on windows, could be related to not properly closed sockets. So with this pull request, such failure is logged in verbose.