### PR TITLE
Change: sys.libdir and sys.local_libdir to non version specific path

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -391,13 +391,13 @@ void DiscoverVersion(EvalContext *ctx)
         snprintf(workbuf, CF_MAXVARSIZE, "%d", patch);
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "cf_version_patch", workbuf, CF_DATA_TYPE_STRING, "source=agent");
 
-        snprintf(workbuf, CF_BUFSIZE, "%s%cinputs%clib%c%d.%d",
+        snprintf(workbuf, CF_BUFSIZE, "%s%cinputs%clib",
                  workdir, FILE_SEPARATOR, FILE_SEPARATOR,
                  FILE_SEPARATOR, major, minor);
 
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "libdir", workbuf, CF_DATA_TYPE_STRING, "source=agent");
 
-        snprintf(workbuf, CF_BUFSIZE, "lib%c%d.%d", FILE_SEPARATOR, major, minor);
+        snprintf(workbuf, CF_BUFSIZE, "lib", FILE_SEPARATOR, major, minor);
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "local_libdir", workbuf, CF_DATA_TYPE_STRING, "source=agent");
     }
     else


### PR DESCRIPTION
- sys.libdir now resolves to $(sys.inputdir)/lib
- sys.local_libdir now resolves to lib

Ref: https://dev.cfengine.com/issues/7559

Changelog: Title