### PR TITLE
Redmine #6957: Move /var/cfengine/cf3.<host>.runlog log to debug output.

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -266,7 +266,7 @@ Bundle *MakeTemporaryBundleFromTemplate(EvalContext *ctx, Policy *policy, Attrib
                 }
 
                 int nl = StripTrailingNewline(promiser, size);
-                assert(nl != -1);
+                CF_ASSERT(nl != -1, "StripTrailingNewline failure");
 
                 np = PromiseTypeAppendPromise(tp, promiser, (Rval) { NULL, RVAL_TYPE_NOPROMISEE }, context, NULL);
                 np->offset.line = lineno;

--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -396,7 +396,7 @@ void DoExec(const ServerConnectionState *conn, const char *args)
                     !StringAppendDelimited(authorized_classes,
                                            &authorized_classes_len,
                                            CF_BUFSIZE, class, ',');
-                assert(!truncated);                 /* CF_BUFSIZE is enough */
+                CF_ASSERT(!truncated, "Overflow in authorized_classes"); /* CF_BUFSIZE is enough */
 
                 class = class_end + 1;
             }

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -869,7 +869,6 @@ typedef struct
 {
     char *last;
     char *lock;
-    char *log;
     bool is_dummy;
 } CfLock;
 

--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -604,8 +604,8 @@ void DBPrivCloseCursor(DBCursorPriv *cursor)
 {
     DBTxn *txn;
     int rc = GetWriteTransaction(cursor->db, &txn);
-    assert(rc == MDB_SUCCESS);
-    assert(txn->cursor_open);
+    CF_ASSERT(rc == MDB_SUCCESS, "Could not get write transaction");
+    CF_ASSERT(txn->cursor_open, "Transaction not open");
     txn->cursor_open = false;
 
     if (cursor->curkv)

--- a/libpromises/known_dirs.c
+++ b/libpromises/known_dirs.c
@@ -89,7 +89,7 @@ const char *GetDefault##FUNC##Dir(void)                             \
 }                                                                   \
 
 GET_DEFAULT_DIRECTORY_DEFINE(Work, work, WORKDIR, NULL)
-GET_DEFAULT_DIRECTORY_DEFINE(Log, log, LOGDIR, NULL)
+GET_DEFAULT_DIRECTORY_DEFINE(Log, log, LOGDIR, "log")
 GET_DEFAULT_DIRECTORY_DEFINE(Pid, pid, PIDDIR, NULL)
 GET_DEFAULT_DIRECTORY_DEFINE(Master, master, MASTERDIR, "masterfiles")
 GET_DEFAULT_DIRECTORY_DEFINE(Input, input, INPUTDIR, "inputs")

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -48,18 +48,16 @@
 typedef struct CfLockStack_ {
     char lock[CF_BUFSIZE];
     char last[CF_BUFSIZE];
-    char log[CF_BUFSIZE];
     struct CfLockStack_ *previous;
 } CfLockStack;
 
 static CfLockStack *LOCK_STACK = NULL;
 
-static void PushLock(char *lock, char *last, char *log)
+static void PushLock(char *lock, char *last)
 {
     CfLockStack *new_lock = malloc(sizeof(CfLockStack));
     strlcpy(new_lock->lock, lock, CF_BUFSIZE);
     strlcpy(new_lock->last, last, CF_BUFSIZE);
-    strlcpy(new_lock->log, log, CF_BUFSIZE);
 
     new_lock->previous = LOCK_STACK;
     LOCK_STACK = new_lock;
@@ -348,40 +346,6 @@ static pid_t FindLockPid(char *name)
     }
 }
 
-static void LogLockCompletion(char *cflog, int pid, char *str, char *op, char *operand)
-{
-    FILE *fp;
-    char buffer[CF_MAXVARSIZE];
-    time_t tim;
-
-    if (cflog == NULL)
-    {
-        return;
-    }
-
-    if ((fp = fopen(cflog, "a")) == NULL)
-    {
-        Log(LOG_LEVEL_ERR, "Can't open lock-log file '%s'. (fopen: %s)", cflog, GetErrorStr());
-        exit(EXIT_FAILURE);
-    }
-
-    if ((tim = time((time_t *) NULL)) == -1)
-    {
-        Log(LOG_LEVEL_DEBUG, "Couldn't read system clock");
-    }
-
-    snprintf(buffer, sizeof(buffer), "%s", ctime(&tim));
-
-    if (Chop(buffer, CF_EXPANDSIZE) == -1)
-    {
-        Log(LOG_LEVEL_ERR, "Chop was called on a string that seemed to have no terminator");
-    }
-
-    fprintf(fp, "%s:%s:pid=%d:%s:%s\n", buffer, str, pid, op, operand);
-
-    fclose(fp);
-}
-
 static void LocksCleanup(void)
 {
     CfLockStack *lock;
@@ -390,7 +354,6 @@ static void LocksCleanup(void)
         CfLock best_guess = {
             .lock = xstrdup(lock->lock),
             .last = xstrdup(lock->last),
-            .log = xstrdup(lock->log)
         };
         YieldCurrentLock(best_guess);
         free(lock);
@@ -612,12 +575,11 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt, unsigned char diges
 /* Digest length stored in md_len */
 }
 
-static CfLock CfLockNew(const char *last, const char *lock, const char *log, bool is_dummy)
+static CfLock CfLockNew(const char *last, const char *lock, bool is_dummy)
 {
     return (CfLock) {
         .last = last ? xstrdup(last) : NULL,
         .lock = lock ? xstrdup(lock) : NULL,
-        .log = log ? xstrdup(log) : NULL,
         .is_dummy = is_dummy
     };
 }
@@ -627,7 +589,6 @@ static CfLock CfLockNull(void)
     return (CfLock) {
         .last = NULL,
         .lock = NULL,
-        .log = NULL,
         .is_dummy = false
     };
 }
@@ -657,7 +618,7 @@ CfLock AcquireLock(EvalContext *ctx, const char *operand, const char *host, time
     // Finally if we're supposed to ignore locks ... do the remaining stuff
     if (EvalContextIsIgnoringLocks(ctx))
     {
-        return CfLockNew(NULL, "dummy", NULL, true);
+        return CfLockNew(NULL, "dummy", true);
     }
 
     char *promise = BodyName(pp);
@@ -682,9 +643,6 @@ CfLock AcquireLock(EvalContext *ctx, const char *operand, const char *host, time
     {
         sum = (CF_MACROALPHABET * sum + cc_operand[i]) % CF_HASHTABLESIZE;
     }
-
-    char cflog[CF_BUFSIZE] = "";
-    snprintf(cflog, CF_BUFSIZE, "%s/cf3.%.40s.runlog", GetLogDir(), host);
 
     char cflock[CF_BUFSIZE] = "";
     snprintf(cflock, CF_BUFSIZE, "lock.%.100s.%s.%.100s_%d_%s", PromiseGetBundle(pp)->name, cc_operator, cc_operand, sum, str_digest);
@@ -734,14 +692,12 @@ CfLock AcquireLock(EvalContext *ctx, const char *operand, const char *host, time
 
                 if (KillLockHolder(cflock))
                 {
-                    LogLockCompletion(cflog, pid,
-                                      "Lock expired, process killed",
-                                      cc_operator, cc_operand);
+                    Log(LOG_LEVEL_INFO, "Lock expired, process with PID %jd killed", (intmax_t)pid);
                     unlink(cflock);
                 }
                 else
                 {
-                    Log(LOG_LEVEL_VERBOSE,
+                    Log(LOG_LEVEL_ERR,
                         "Unable to kill expired process %jd from lock %s"
                         " (probably process not found or permission denied)",
                         (intmax_t) pid, cflock);
@@ -772,9 +728,9 @@ CfLock AcquireLock(EvalContext *ctx, const char *operand, const char *host, time
     ReleaseCriticalSection(CF_CRITIAL_SECTION);
 
     // Keep this as a global for signal handling
-    PushLock(cflock, cflast, cflog);
+    PushLock(cflock, cflast);
 
-    return CfLockNew(cflast, cflock, cflog, false);
+    return CfLockNew(cflast, cflock, false);
 }
 
 void YieldCurrentLock(CfLock lock)
@@ -797,7 +753,6 @@ void YieldCurrentLock(CfLock lock)
         Log(LOG_LEVEL_VERBOSE, "Unable to remove lock %s", lock.lock);
         free(lock.last);
         free(lock.lock);
-        free(lock.log);
         return;
     }
 
@@ -806,7 +761,6 @@ void YieldCurrentLock(CfLock lock)
         Log(LOG_LEVEL_ERR, "Unable to create '%s'. (creat: %s)", lock.last, GetErrorStr());
         free(lock.last);
         free(lock.lock);
-        free(lock.log);
         return;
     }
 
@@ -818,8 +772,7 @@ void YieldCurrentLock(CfLock lock)
     while (stack)
     {
         if ((strcmp(stack->lock, lock.lock) == 0)
-         && (strcmp(stack->last, lock.last) == 0)
-         && (strcmp(stack->log, lock.log) == 0))
+         && (strcmp(stack->last, lock.last) == 0))
         {
             CfLockStack *delete_me = stack;
             stack = stack->previous;
@@ -837,11 +790,8 @@ void YieldCurrentLock(CfLock lock)
         stack = stack->previous;
     }
 
-    LogLockCompletion(lock.log, getpid(), "Lock removed normally ", lock.lock, "");
-
     free(lock.last);
     free(lock.lock);
-    free(lock.log);
 }
 
 void YieldCurrentLockAndRemoveFromCache(EvalContext *ctx, CfLock lock,


### PR DESCRIPTION
It contains detailed locking messages which is very developer oriented
and not useful as a separate log.

Changelog: Title