### PR TITLE
tests/unit: Remove non-portable unneeded type casts

### DIFF
--- a/tests/unit/db_concurrent_test.c
+++ b/tests/unit/db_concurrent_test.c
@@ -64,7 +64,7 @@ struct arg_struct {
 static void *fct2(void *arguments)
 {
     struct arg_struct *args = (struct arg_struct *)arguments;
-    int base = (int)((Seq *)args->base);
+    int base = args->base;
 
     CF_DB *db;
     char key[256];


### PR DESCRIPTION
Casting between pointers and int results in compiler warnings.
It is not needed here, so simply remove it.

Signed-off-by: Stefan Weil <sw@weilnetz.de>