### PR TITLE
Redmine #6027: Directories randomly changed to files.

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -823,7 +823,16 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
         /* This sends 1st STAT command. */
         if (!ConsiderAbstractFile(dirp->d_name, from, attr.copy, conn))
         {
-            continue;
+            if (conn->conn_info->is_broken)
+            {
+                cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_INTERRUPTED, pp,
+                     attr, "connection timeout");
+                return PROMISE_RESULT_INTERRUPTED;
+            }
+            else
+            {
+                continue;
+            }
         }
 
         if (attr.copy.purge)    /* Purge this file */
@@ -854,7 +863,16 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
             if (cf_stat(newfrom, &sb, attr.copy, conn) == -1)
             {
                 Log(LOG_LEVEL_VERBOSE, "Can't stat '%s'. (cf_stat: %s)", newfrom, GetErrorStr());
-                continue;                                       /* TODO FAIL? */
+                if (conn->conn_info->is_broken)
+                {
+                    cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_INTERRUPTED, pp,
+                         attr, "connection timeout");
+                    return PROMISE_RESULT_INTERRUPTED;
+                }
+                else
+                {
+                    continue;
+                }
             }
         }
         else
@@ -862,7 +880,17 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
             if (cf_lstat(newfrom, &sb, attr.copy, conn) == -1)
             {
                 Log(LOG_LEVEL_VERBOSE, "Can't stat '%s'. (cf_stat: %s)", newfrom, GetErrorStr());
-                continue;                                       /* TODO FAIL? */
+                if (conn->conn_info->is_broken)
+                {
+                    cfPS(ctx, LOG_LEVEL_INFO,
+                         PROMISE_RESULT_INTERRUPTED, pp, attr,
+                         "connection timeout");
+                    return PROMISE_RESULT_INTERRUPTED;
+                }
+                else
+                {
+                    continue;
+                }
             }
         }
 
@@ -1032,7 +1060,16 @@ static PromiseResult VerifyCopy(EvalContext *ctx,
             if (!ConsiderAbstractFile(dirp->d_name, sourcedir,
                                       attr.copy, conn))
             {
-                continue;
+                if (conn->conn_info->is_broken)
+                {
+                    cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_INTERRUPTED,
+                         pp, attr, "connection timeout");
+                    return PROMISE_RESULT_INTERRUPTED;
+                }
+                else
+                {
+                    continue;
+                }
             }
 
             strcpy(sourcefile, sourcedir);

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -754,7 +754,7 @@ int CopyRegularFileNet(const char *source, const char *dest, off_t size,
     {
         int toget = MIN(size - n_read_total, buf_size);
 
-        assert(toget != 0);
+        assert(toget > 0);
 
         /* Stage C1 - receive */
         int n_read;

--- a/libcfnet/connection_info.h
+++ b/libcfnet/connection_info.h
@@ -56,6 +56,7 @@ struct ConnectionInfo {
     socklen_t ss_len;
     struct sockaddr_storage ss;
     bool is_call_collect;       /* Maybe replace with a bitfield later ... */
+    bool is_broken; /* used to propagate connection errors up in function calls */
 };
 
 typedef struct ConnectionInfo ConnectionInfo;

--- a/libcfnet/net.h
+++ b/libcfnet/net.h
@@ -35,7 +35,7 @@ extern uint32_t bwlimit_kbytes;
 
 
 int SendTransaction(const ConnectionInfo *conn_info, const char *buffer, int len, char status);
-int ReceiveTransaction(const ConnectionInfo *conn_info, char *buffer, int *more);
+int ReceiveTransaction(ConnectionInfo *conn_info, char *buffer, int *more);
 
 int SetReceiveTimeout(int fd, unsigned long ms);
 

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -674,8 +674,11 @@ int TLSSend(SSL *ssl, const char *buffer, int length)
  */
 int TLSRecv(SSL *ssl, char *buffer, int toget)
 {
-    assert(toget > 0);
-    assert(toget < CF_BUFSIZE);
+    if (toget > CF_BUFSIZE || toget <= 0)
+    {
+        Log(LOG_LEVEL_ERR, "Bad software request to receive %d bytes", toget);
+        return -1;
+    }
     assert_SSLIsBlocking(ssl);
 
     /* TODO what is the return value of SSL_read in case of socket timeout? */


### PR DESCRIPTION
This is quite nasty and border case scenario. For recursive file
copying if connection was timeouted recourse copying was continued.
In some cases timeouted package was sent by the server (usually under
heavy load) and was wrongly interpreted as response for next request.

Usually (if not always) directories were created first and then files,
so most often directory was replaced with a file and content of the file
was corrupted protocol leftovers (t 74OK: 0 432 0 0 20010 1302 140197032)
which is CFEngine copy file protocol transaction header and data.

The fix is to drop connection immediately after experiencing timeouts in
all cases where files and/or directories are copied recursively in loop.

Changelog: Redmine #6027 Directories should no more be changed randomly
into files.