### PR TITLE
Redmine#7633: processexists() and findprocesses()

### DIFF
--- a/tests/acceptance/01_vars/02_functions/findprocesses.cf
+++ b/tests/acceptance/01_vars/02_functions/findprocesses.cf
@@ -1,0 +1,34 @@
+###########################################################
+#
+# Test findprocesses()
+#
+###########################################################
+
+body common control
+{
+    inputs => { "../../default.cf.sub" };
+    bundlesequence => { default($(this.promise_filename)) };
+    version => "1.0";
+}
+
+###########################################################
+
+bundle common test
+{
+  classes:
+      # this will be set only if we find our own exact PID
+      "descartes" expression => strcmp($(found_pids), $(this.promiser_pid));
+  vars:
+      # find our own PID, using \b to make sure we match whole words
+      "found" data => findprocesses(".+\b$(this.promiser_pid)\b.+");
+      # pluck the "pid" field out into a list
+      "found_pids" data => mapdata("none", "$(found[$(this.k)][pid])", found);
+}
+
+###########################################################
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_passif_expected("descartes", "", $(this.promise_filename));
+}

--- a/tests/acceptance/01_vars/02_functions/processexists.cf
+++ b/tests/acceptance/01_vars/02_functions/processexists.cf
@@ -1,0 +1,28 @@
+###########################################################
+#
+# Test processexists()
+#
+###########################################################
+
+body common control
+{
+    inputs => { "../../default.cf.sub" };
+    bundlesequence => { default($(this.promise_filename)) };
+    version => "1.0";
+}
+
+###########################################################
+
+bundle common test
+{
+  classes:
+      "descartes" expression => processexists(".+agent.+");
+}
+
+###########################################################
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_passif_expected("descartes", "", $(this.promise_filename));
+}


### PR DESCRIPTION
See https://dev.cfengine.com/issues/7633

Example with body extension commented out:

```
bundle agent main
{
  methods:
      "test";

  vars:
      "test_state" data => bundlestate(test);
      "test_string" string => storejson(test_state);

  reports:
      "$(this.bundle): state of things = $(test_string)";
}

# body process_select myps
# {
#         pid => irange("1","1024");
#         process_result => "pid";
# }

bundle agent test
{
  vars:
      # "procs" data => findprocesses(".*", myps);
      "procs2" data => findprocesses(".*");
}
```

Output: all the processes on that system in a data container array holding key-value maps:

```
...
    {
      "line": "root     31292     2     0  0.0  0.0      0   0         0    1 Oct18  3-01:49:21 00:00:00 [kworker/3:0]",
      "pid": 31292
    },
...
```