### PR TITLE
Redmine #7634: Create failsafe.cf when not exists.

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -238,10 +238,19 @@ int main(int argc, char *argv[])
     {
         Log(LOG_LEVEL_ERR, "CFEngine was not able to get confirmation of promises from cf-promises, so going to failsafe");
         EvalContextClassPutHard(ctx, "failsafe_fallback", "attribute_name=Errors,source=agent");
-        GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
-        policy = LoadPolicy(ctx, config);
+        
+        if (CheckAndGenerateFailsafe(GetInputDir(), "failsafe.cf"))
+        {
+            GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
+            policy = LoadPolicy(ctx, config);
+        }
     }
-    assert(policy);
+    
+    if (!policy)
+    {
+        Log(LOG_LEVEL_ERR, "Error reading CFEngine policy. Exiting...");
+        exit(EXIT_FAILURE);
+    }
 
     GenericAgentPostLoadInit(ctx);
     ThisAgentInit();

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -143,8 +143,17 @@ int main(int argc, char *argv[])
     {
         Log(LOG_LEVEL_ERR, "CFEngine was not able to get confirmation of promises from cf-promises, so going to failsafe");
         EvalContextClassPutHard(ctx, "failsafe_fallback", "attribute_name=Errors,source=agent");
-        GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
-        policy = LoadPolicy(ctx, config);
+        if (CheckAndGenerateFailsafe(GetInputDir(), "failsafe.cf"))
+        {
+            GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
+            policy = LoadPolicy(ctx, config);
+        }
+    }
+    
+    if (!policy)
+    {
+        Log(LOG_LEVEL_ERR, "Error reading CFEngine policy. Exiting...");
+        exit(EXIT_FAILURE);
     }
 
     GenericAgentPostLoadInit(ctx);

--- a/cf-serverd/cf-serverd.c
+++ b/cf-serverd/cf-serverd.c
@@ -59,8 +59,17 @@ int main(int argc, char *argv[])
     {
         Log(LOG_LEVEL_ERR, "CFEngine was not able to get confirmation of promises from cf-promises, so going to failsafe");
         EvalContextClassPutHard(ctx, "failsafe_fallback", "attribute_name=Errors,source=agent");
-        GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
-        policy = LoadPolicy(ctx, config);
+        if (CheckAndGenerateFailsafe(GetInputDir(), "failsafe.cf"))
+        {
+            GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
+            policy = LoadPolicy(ctx, config);
+        }
+    }
+    
+    if (!policy)
+    {
+        Log(LOG_LEVEL_ERR, "Error reading CFEngine policy. Exiting...");
+        exit(EXIT_FAILURE);
     }
 
     GenericAgentPostLoadInit(ctx);

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -161,6 +161,7 @@ void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config)
                 "Error writing builtin failsafe to inputs prior to bootstrap");
             exit(EXIT_FAILURE);
         }
+        GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
 
         char canonified_ipaddr[strlen(bootstrap_arg) + 1];
         StringCanonify(canonified_ipaddr, bootstrap_arg);
@@ -759,20 +760,6 @@ void GenericAgentInitialize(EvalContext *ctx, GenericAgentConfig *config)
     }
 
     setlinebuf(stdout);
-
-    if (config->agent_specific.agent.bootstrap_policy_server)
-    {
-        snprintf(vbuff, CF_BUFSIZE, "%s%cfailsafe.cf", GetInputDir(), FILE_SEPARATOR);
-
-        if (stat(vbuff, &statbuf) == -1)
-        {
-            GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
-        }
-        else
-        {
-            GenericAgentConfigSetInputFile(config, GetInputDir(), vbuff);
-        }
-    }
 }
 
 void GenericAgentFinalize(EvalContext *ctx, GenericAgentConfig *config)
@@ -1634,6 +1621,30 @@ void GenericAgentConfigApply(EvalContext *ctx, const GenericAgentConfig *config)
     {
         EvalContextClassPutHard(ctx, "opt_dry_run", "cfe_internal,source=environment");
     }
+}
+
+bool CheckAndGenerateFailsafe(const char *inputdir, const char *input_file)
+{
+    char failsafe_path[CF_BUFSIZE];
+    
+    if (strlen(inputdir) + strlen(input_file) > sizeof(failsafe_path) - 2)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Unable to generate path for %s/%s file. Path too long.",
+            inputdir, input_file);
+        /* We could create dynamically allocated buffer able to hold the 
+           whole content of the path but this should be unlikely that we
+           will end up here. */
+        return false;
+    }
+    snprintf(failsafe_path, CF_BUFSIZE - 1, "%s/%s", inputdir, input_file);
+    MapName(failsafe_path);
+    
+    if (access(failsafe_path, R_OK) != 0)
+    {
+        return WriteBuiltinFailsafePolicyToPath(failsafe_path);
+    }
+    return true;
 }
 
 void GenericAgentConfigSetInputFile(GenericAgentConfig *config, const char *inputdir, const char *input_file)

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -121,6 +121,7 @@ GenericAgentConfig *GenericAgentConfigNewDefault(AgentType agent_type);
 void GenericAgentConfigDestroy(GenericAgentConfig *config);
 void GenericAgentConfigApply(EvalContext *ctx, const GenericAgentConfig *config);
 
+bool CheckAndGenerateFailsafe(const char *inputdir, const char *input_file);
 void GenericAgentConfigSetInputFile(GenericAgentConfig *config, const char *inputdir, const char *input_file);
 void GenericAgentConfigSetBundleSequence(GenericAgentConfig *config, const Rlist *bundlesequence);
 bool GenericAgentTagReleaseDirectory(const GenericAgentConfig *config, const char *dirname, bool write_validated, bool write_release);

--- a/tests/acceptance/00_basics/validation/validate_failsafe_creating.cf
+++ b/tests/acceptance/00_basics/validation/validate_failsafe_creating.cf
@@ -1,0 +1,35 @@
+# Test that failsafe.cf is created when dosn't exist
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence => { default("$(this.promise_filename)") };
+}
+
+bundle agent init
+{
+  classes:
+    "failsafe_before_test_not_exists" not => fileexists("$(sys.inputdir)/failsafe.cf"),
+    scope => "namespace";
+}
+
+bundle agent test
+{
+  commands:
+    "$(sys.cf_agent) -D AUTO -f $(this.promise_filename).sub";
+}
+
+bundle agent check
+{
+  classes:
+    "failsafe_after_test_exists" expression => fileexists("$(sys.inputdir)/failsafe.cf");
+    "ok" expression => "failsafe_after_test_exists.failsafe_before_test_not_exists";
+
+  reports:
+    DEBUG.!ok::
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/00_basics/validation/validate_failsafe_creating.cf.sub
+++ b/tests/acceptance/00_basics/validation/validate_failsafe_creating.cf.sub
@@ -1,0 +1,15 @@
+# Test that failsafe.cf is created when dosn't exist
+# This should contain policy errors so that cf-promises will fail 
+# validating the file and failsafe.cf will be created.
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence => { default("$(this.promise_filename)") };
+}
+
+bundle agent test
+{
+  my_non_existing_promise_type:
+    "non_existing" => "not_there";
+}


### PR DESCRIPTION
Before setting input file to be failsafe.cf first we are checking if
file exists. If failsafe.cf is not accessible we are creating it
the same way as during bootstrap.

Changelog: failsafe.cf will be created when needed. (Redmine #7634)