### PR TITLE
Add: Test that parseyaml works with naked values starting with digits

### DIFF
--- a/tests/acceptance/01_vars/02_functions/parseyaml_with_unquoted_values_starting_with_digits.cf
+++ b/tests/acceptance/01_vars/02_functions/parseyaml_with_unquoted_values_starting_with_digits.cf
@@ -1,0 +1,32 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+}
+
+bundle agent test
+{
+   meta:
+     "test_soft_fail"
+       string => "any",
+       meta => { "redmine7372" };
+
+   vars:
+      "class" string => "1003_efl_test";
+      "d" data => parseyaml( "- class: ${class}" );
+
+   classes:
+      "PASS" expression => strcmp( ${d[0][class]}, "${class}" );
+      "FAIL" not        => strcmp( ${d[0][class]}, "${class}" );
+
+   reports:
+      PASS::
+         "$(this.promise_filename) Pass";
+      FAIL::
+         "$(this.promise_filename) FAIL";
+      PASS.FAIL::
+         "$(this.promise_filename) EXCEPTION";
+      DEBUG::
+         "version => ${sys.cf_version}"; 
+         "class   => ${d[0][class]}";
+}


### PR DESCRIPTION
Ref: https://dev.cfengine.com/issues/7372