### PR TITLE
returnszero() should not output the output of a command

### DIFF
--- a/tests/acceptance/02_classes/02_functions/silent_returnszero.cf
+++ b/tests/acceptance/02_classes/02_functions/silent_returnszero.cf
@@ -1,0 +1,18 @@
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+bundle agent check {
+  vars:
+    "command" string => "$(sys.cf_agent) -KIf $(this.promise_filename).sub -DAUTO";
+    "silent_command" string => "$(sys.cf_agent) -Kf $(this.promise_filename).sub -DAUTO";
+
+  methods:
+    "check"
+      usebundle => dcs_passif_output(".*Pass.*", "", $(command), $(this.promise_filename));
+    "check"
+      usebundle => dcs_passif_output("", ".*Pass.*", $(silent_command), $(this.promise_filename));
+}

--- a/tests/acceptance/02_classes/02_functions/silent_returnszero.cf.sub
+++ b/tests/acceptance/02_classes/02_functions/silent_returnszero.cf.sub
@@ -1,0 +1,11 @@
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence => { "main" };
+  version => "1.0";
+}
+
+bundle agent main {
+  classes:
+	"test" expression => returnszero("$(G.echo) Pass", "noshell");
+}

--- a/tests/acceptance/10_files/zendesk_1779/zendesk_1779.cf
+++ b/tests/acceptance/10_files/zendesk_1779/zendesk_1779.cf
@@ -32,7 +32,7 @@ bundle agent check
                   windows";
 
   vars:
-    "command" string => "$(sys.cf_agent) -Kf $(this.promise_filename).sub -DAUTO";
+    "command" string => "$(sys.cf_agent) -KIf $(this.promise_filename).sub -DAUTO";
 
   methods:
     "check"


### PR DESCRIPTION
`returnzero` is a common command used to generate classes based on the return value of a particular command. Users (at least here at LinkedIn) only care about the exit code of the command, and do not want the output mixed in with the output of CFEngine. This ends up being super confusing, and creating a lot of spurious output to wade through.

This has caused our CFEngine developers to pass `useshell` to all of their `returnszero` calls, introducing a more significant cost as well introducing the potential for issues related to shell parsing of commands and influential env vars.

This turns the behavior on its head, making no output the default, and allowing the user to drop to a shell if they want to capture the output somehow. This might be controversial.