### PR TITLE
Allow multiple -D or -N flags to be specified on the command line

### DIFF
--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -196,11 +196,33 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             break;
 
         case 'D':
-            config->heap_soft = StringSetFromString(optarg, ',');
+            {
+                StringSet *defined_classes = StringSetFromString(optarg, ',');
+                if (! config->heap_soft)
+                {
+                    config->heap_soft = defined_classes;
+                }
+                else
+                {
+                    StringSetJoin(config->heap_soft, defined_classes);
+                    free(defined_classes);
+                }
+            }
             break;
 
         case 'N':
-            config->heap_negated = StringSetFromString(optarg, ',');
+            {
+                StringSet *negated_classes = StringSetFromString(optarg, ',');
+                if (! config->heap_negated)
+                {
+                    config->heap_negated = negated_classes;
+                }
+                else
+                {
+                    StringSetJoin(config->heap_negated, negated_classes);
+                    free(negated_classes);
+                }
+            }
             break;
 
         case 'I':

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -303,11 +303,33 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
             break;
 
         case 'D':
-            config->heap_soft = StringSetFromString(optarg, ',');
+            {
+                StringSet *defined_classes = StringSetFromString(optarg, ',');
+                if (! config->heap_soft)
+                {
+                    config->heap_soft = defined_classes;
+                }
+                else
+                {
+                    StringSetJoin(config->heap_soft, defined_classes);
+                    free(defined_classes);
+                }
+            }
             break;
 
         case 'N':
-            config->heap_negated = StringSetFromString(optarg, ',');
+            {
+                StringSet *negated_classes = StringSetFromString(optarg, ',');
+                if (! config->heap_negated)
+                {
+                    config->heap_negated = negated_classes;
+                }
+                else
+                {
+                    StringSetJoin(config->heap_negated, negated_classes);
+                    free(negated_classes);
+                }
+            }
             break;
 
         case 'I':

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -279,9 +279,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             break;
 
         case 's':
-            strlcpy(SENDCLASSES, optarg, CF_MAXVARSIZE);
-
-            if (strlen(optarg) > CF_MAXVARSIZE)
+            if (strlcat(SENDCLASSES, optarg, sizeof(SENDCLASSES)) >= sizeof(SENDCLASSES))
             {
                 Log(LOG_LEVEL_ERR, "Argument too long (-s)");
                 exit(EXIT_FAILURE);
@@ -289,9 +287,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             break;
 
         case 'D':
-            strlcpy(DEFINECLASSES, optarg, CF_MAXVARSIZE);
-
-            if (strlen(optarg) > CF_MAXVARSIZE)
+            if (strlcat(DEFINECLASSES, optarg, sizeof(DEFINECLASSES)) >= sizeof(DEFINECLASSES))
             {
                 Log(LOG_LEVEL_ERR, "Argument too long (-D)");
                 exit(EXIT_FAILURE);

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -165,11 +165,33 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
             break;
 
         case 'D':
-            config->heap_soft = StringSetFromString(optarg, ',');
+            {
+                StringSet *defined_classes = StringSetFromString(optarg, ',');
+                if (! config->heap_soft)
+                {
+                    config->heap_soft = defined_classes;
+                }
+                else
+                {
+                    StringSetJoin(config->heap_soft, defined_classes);
+                    free(defined_classes);
+                }
+            }
             break;
 
         case 'N':
-            config->heap_negated = StringSetFromString(optarg, ',');
+            {
+                StringSet *negated_classes = StringSetFromString(optarg, ',');
+                if (! config->heap_negated)
+                {
+                    config->heap_negated = negated_classes;
+                }
+                else
+                {
+                    StringSetJoin(config->heap_negated, negated_classes);
+                    free(negated_classes);
+                }
+            }
             break;
 
         case 'I':

--- a/libutils/set.c
+++ b/libutils/set.c
@@ -91,6 +91,22 @@ void *SetIteratorNext(SetIterator *i)
     return kv ? kv->key : NULL;
 }
 
+void SetJoin(Set *set, Set *otherset)
+{
+    assert(set != NULL);
+    assert(otherset != NULL);
+    if (set == otherset)
+        return;
+
+    SetIterator si = SetIteratorInit(otherset);
+    void *ptr = NULL;
+
+    for (ptr = SetIteratorNext(&si); ptr != NULL; ptr = SetIteratorNext(&si))
+    {
+        SetAdd(set, ptr);
+    }
+}
+
 Buffer *StringSetToBuffer(StringSet *set, const char delimiter)
 {
     assert(set != NULL);

--- a/libutils/set.h
+++ b/libutils/set.h
@@ -38,6 +38,7 @@ Set *SetNew(MapHashFn element_hash_fn,
 void SetDestroy(Set *set);
 
 void SetAdd(Set *set, void *element);
+void SetJoin(Set *set, Set *otherset);
 bool SetContains(const Set *set, const void *element);
 bool SetRemove(Set *set, const void *element);
 void SetClear(Set *set);
@@ -58,6 +59,7 @@ void *SetIteratorNext(SetIterator *i);
                                                                         \
     Prefix##Set *Prefix##SetNew(void);                                  \
     void Prefix##SetAdd(const Prefix##Set *set, ElementType element);   \
+    void Prefix##SetJoin(const Prefix##Set *set, const Prefix##Set *otherset); \
     bool Prefix##SetContains(const Prefix##Set *Set, const ElementType element);  \
     bool Prefix##SetRemove(const Prefix##Set *Set, const ElementType element);  \
     void Prefix##SetClear(Prefix##Set *set);                            \
@@ -79,6 +81,11 @@ void *SetIteratorNext(SetIterator *i);
     void Prefix##SetAdd(const Prefix##Set *set, ElementType element)    \
     {                                                                   \
         SetAdd(set->impl, (void *)element);                             \
+    }                                                                   \
+                                                                        \
+    void Prefix##SetJoin(const Prefix##Set *set, const Prefix##Set *otherset) \
+    {                                                                   \
+        SetJoin(set->impl, otherset->impl);                             \
     }                                                                   \
                                                                         \
     bool Prefix##SetContains(const Prefix##Set *set, const ElementType element)   \

--- a/tests/unit/set_test.c
+++ b/tests/unit/set_test.c
@@ -62,6 +62,60 @@ void test_stringset_serialization(void)
     }
 }
 
+void test_stringset_join(void)
+{
+    {
+        StringSet *set1 = StringSetNew();
+        StringSet *set2 = StringSetNew();
+        StringSetJoin(set1, set2);
+
+        assert_int_equal(0, StringSetSize(set1));
+
+        Buffer *buff = StringSetToBuffer(set1, ',');
+
+        assert_true(buff);
+        assert_string_equal(BufferData(buff), "");
+
+        BufferDestroy(buff);
+        StringSetDestroy(set1);
+        StringSetDestroy(set2);
+    }
+
+    {
+        StringSet *set = StringSetNew();
+        StringSetAdd(set, xstrdup("foo"));
+        StringSetJoin(set, set);
+
+        assert_int_equal(1, StringSetSize(set));
+
+        Buffer *buff = StringSetToBuffer(set, ',');
+
+        assert_true(buff);
+        assert_string_equal(BufferData(buff), "foo");
+
+        StringSetDestroy(set);
+        BufferDestroy(buff);
+    }
+
+    {
+        StringSet *set1 = StringSetNew();
+        StringSet *set2 = StringSetNew();
+        StringSetAdd(set1, xstrdup("foo"));
+        StringSetAdd(set2, xstrdup("bar"));
+        StringSetJoin(set1, set2);
+
+        assert_int_equal(2, StringSetSize(set1));
+
+        Buffer *buff = StringSetToBuffer(set1, ',');
+
+        assert_true(buff);
+        assert_string_equal(BufferData(buff), "foo,bar");
+
+        StringSetDestroy(set1);
+        BufferDestroy(buff);
+    }
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -69,7 +123,8 @@ int main()
     {
         unit_test(test_stringset_from_string),
         unit_test(test_stringset_serialization),
-        unit_test(test_stringset_clear)
+        unit_test(test_stringset_clear),
+        unit_test(test_stringset_join)
     };
 
     return run_tests(tests);


### PR DESCRIPTION
Currently, if multiple -D or -N flags are specified on the command-line, this causes all but the last to be ignored. These commits fixes this such that multiple flags can be used, adding more classes to be raised and lowered.

https://dev.cfengine.com/issues/7191