### PR TITLE
EvalContextClassPutSoft ought to be namespace-aware

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1507,7 +1507,17 @@ bool EvalContextClassPutHard(EvalContext *ctx, const char *name, const char *tag
 
 bool EvalContextClassPutSoft(EvalContext *ctx, const char *name, ContextScope scope, const char *tags)
 {
-    return EvalContextClassPut(ctx, EvalContextCurrentNamespace(ctx), name, true, scope, tags);
+    bool ret;
+    char *ns = NULL;
+
+    if (strchr(name, ':'))
+    {
+        ns = xstrndup(name, strchr(name, ':') - name);
+    }
+
+    ret = EvalContextClassPut(ctx, ns ? ns : EvalContextCurrentNamespace(ctx), ns ? strchr(name, ':') + 1 : name, true, scope, tags);
+    free(ns);
+    return ret;
 }
 
 


### PR DESCRIPTION
`EvalContextClassPutSoft` really ought to be namespace aware. This fixes bugs like not being able to specify a namespaced class on the command-line.