### PR TITLE
Fix init_script_test_helper not being cleaned properly.

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -437,7 +437,7 @@ queue_test_SOURCES = queue_test.c
 
 if !NT
 init_script_test_helper_SOURCES = init_script_test_helper.c
-init_script_test.sh: init_script_test_helper
+noinst_PROGRAMS = init_script_test_helper
 endif
 EXTRA_DIST += init_script_test_helper.c
 EXTRA_DIST += init_script_test.sh

--- a/tests/unit/init_script_test.sh
+++ b/tests/unit/init_script_test.sh
@@ -78,10 +78,10 @@ fi
 # Fail on any error.
 set -e
 
-cp init_script_test_helper $CFTEST_PREFIX/bin/cf-test-execd
-cp init_script_test_helper $CFTEST_PREFIX/bin/cf-test-serverd
-cp init_script_test_helper $CFTEST_PREFIX/bin/cf-test-monitord
-cp init_script_test_helper $CFTEST_PREFIX/bin/cf-test-agent
+cp .libs/init_script_test_helper $CFTEST_PREFIX/bin/cf-test-execd
+cp .libs/init_script_test_helper $CFTEST_PREFIX/bin/cf-test-serverd
+cp .libs/init_script_test_helper $CFTEST_PREFIX/bin/cf-test-monitord
+cp .libs/init_script_test_helper $CFTEST_PREFIX/bin/cf-test-agent
 
 touch $CFTEST_PREFIX/inputs/promises.cf
 


### PR DESCRIPTION
Instead of making a separate clean target, list it in PROGRAMS
instead, which is better automake style. This implicitly invokes
libtool as well, so adapt the test to account for that.