### PR TITLE
Redmine #7460: Unable to edit the same value in multiple regions.

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -888,7 +888,10 @@ static int InsertMultipleLinesToRegion(EvalContext *ctx, Item **start, Item *beg
 
     if (a.location.before_after == EDIT_ORDER_BEFORE)
     {
-        for (ip = *start; ip != NULL; ip = ip->next)
+        /* As region was already selected by SelectRegion() and we know
+         * what are the region boundaries (begin_ptr and end_ptr) there
+         * is no reason to iterate over whole file. */
+        for (ip = begin_ptr; ip != NULL; ip = ip->next)
         {
             if (ip == begin_ptr)
             {
@@ -903,7 +906,13 @@ static int InsertMultipleLinesToRegion(EvalContext *ctx, Item **start, Item *beg
 
     if (a.location.before_after == EDIT_ORDER_AFTER)
     {
-        for (ip = *start; ip != NULL; ip = ip->next)
+        /* As region was already selected by SelectRegion() and we know
+         * what are the region boundaries (begin_ptr and end_ptr) there
+         * is no reason to iterate over whole file. It is safe to start from
+         * begin_ptr. 
+         * As a bonus Redmine #7640 is fixed as we are not interested in
+         * matching values outside of the region we are iterating over. */
+        for (ip = begin_ptr; ip != NULL; ip = ip->next)
         {
             if (!allow_multi_lines && MatchRegion(ctx, pp->promiser, ip, end_ptr, false))
             {

--- a/tests/acceptance/10_files/09_insert_lines/same_text_in_two_regions.cf
+++ b/tests/acceptance/10_files/09_insert_lines/same_text_in_two_regions.cf
@@ -8,10 +8,6 @@ body common control
 
 bundle agent init
 {
-  meta:
-      "test_soft_fail" string => "any",
-        meta => { "redmine7460" };
-
   methods:
       "any" usebundle => file_make("$(G.testfile)", "block1
 block2


### PR DESCRIPTION
The issue was that even though we've been editing value in selected
region the whole file was checked to see if value was already edited.
This was broken by commit f8c7dca55ed8d99212564ea130666de4bd5e0931 when
check if line exists in region was added.

As a bonus some optimizations are added. Instead of iterating
through whole file we can now iterate only over selected region as
any operations will be done inside the region (no need to check whole
file).

Changelog: It is possible to edit the same value in multiple regions
of one file. (Redmine #7460)