### PR TITLE
supersedes PR# 2400 evalfunction.c: file-size arg of readjson() and readyaml() should be optional

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -5990,14 +5990,20 @@ static FnCallResult FnCallReadData(ARG_UNUSED EvalContext *ctx,
                                    const FnCall *fp,
                                    const Rlist *args)
 {
-    const char *input_path = RlistScalarValue(args);
+    if (args == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Function '%s' requires at least one argument", fp->name);
+        return FnFailure();
+    }
 
+    const char *input_path = RlistScalarValue(args);
     size_t size_max;
     const char *requested_mode = NULL;
     if (0 == strcmp(fp->name, "readdata"))
     {
-        // readdata gets rid of the size
-        size_max = 0;
+        // readdata gets rid of the size, well almost
+        // csv still has 50MB restriction applied later
+        size_max = IntFromString("inf");
         requested_mode = RlistScalarValue(args->next);
         if (0 == strcmp("auto", requested_mode))
         {
@@ -6007,12 +6013,10 @@ static FnCallResult FnCallReadData(ARG_UNUSED EvalContext *ctx,
             }
             else if (StringEndsWithCase(input_path, ".yaml", true))
             {
-                size_max = IntFromString("inf");
                 requested_mode = "YAML";
             }
             else // always default to JSON
             {
-                size_max = IntFromString("inf");
                 requested_mode = "JSON";
             }
 
@@ -6021,7 +6025,8 @@ static FnCallResult FnCallReadData(ARG_UNUSED EvalContext *ctx,
     }
     else
     {
-        size_max = args->next ? IntFromString(RlistScalarValue(args->next)) : 0;
+        size_max = args->next ? IntFromString(RlistScalarValue(args->next)) : IntFromString("inf");
+
         if (0 == strcmp(fp->name, "readyaml"))
         {
             requested_mode = "YAML";
@@ -6101,13 +6106,6 @@ static FnCallResult FnCallReadData(ARG_UNUSED EvalContext *ctx,
     bool yaml_mode = (0 == strcmp(requested_mode, "YAML"));
     const char* data_type = requested_mode;
 
-    // TODO: eliminate truncation limits in json.c
-    if (0 == size_max)
-    {
-        size_max = 50 * (1024 * 1024);
-    }
-
-    /* FIXME: fail if truncated? */
     JsonElement *json = NULL;
     JsonParseError res;
     if (yaml_mode)
@@ -8606,7 +8604,7 @@ const FnCallType CF_FNCALL_TYPES[] =
     FnCallTypeNew("readintlist", CF_DATA_TYPE_INT_LIST, READSTRINGLIST_ARGS, &FnCallReadIntList, "Read and assign a list variable from a file of separated ints",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_IO, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("readjson", CF_DATA_TYPE_CONTAINER, READJSON_ARGS, &FnCallReadData, "Read a JSON data container from a file",
-                  FNCALL_OPTION_NONE, FNCALL_CATEGORY_IO, SYNTAX_STATUS_NORMAL),
+                  FNCALL_OPTION_VARARG, FNCALL_CATEGORY_IO, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("readrealarray", CF_DATA_TYPE_INT, READSTRINGARRAY_ARGS, &FnCallReadRealArray, "Read an array of real numbers from a file, indexed by first entry on line and sequentially on each line; return line count",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_IO, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("readreallist", CF_DATA_TYPE_REAL_LIST, READSTRINGLIST_ARGS, &FnCallReadRealList, "Read and assign a list variable from a file of separated real numbers",
@@ -8618,7 +8616,7 @@ const FnCallType CF_FNCALL_TYPES[] =
     FnCallTypeNew("readstringlist", CF_DATA_TYPE_STRING_LIST, READSTRINGLIST_ARGS, &FnCallReadStringList, "Read and assign a list variable from a file of separated strings",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_IO, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("readyaml", CF_DATA_TYPE_CONTAINER, READJSON_ARGS, &FnCallReadData, "Read a data container from a YAML file",
-                  FNCALL_OPTION_NONE, FNCALL_CATEGORY_IO, SYNTAX_STATUS_NORMAL),
+                  FNCALL_OPTION_VARARG, FNCALL_CATEGORY_IO, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("readtcp", CF_DATA_TYPE_STRING, READTCP_ARGS, &FnCallReadTcp, "Connect to tcp port, send string and assign result to variable",
                   FNCALL_OPTION_CACHED, FNCALL_CATEGORY_COMM, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("regarray", CF_DATA_TYPE_CONTEXT, REGARRAY_ARGS, &FnCallRegArray, "True if arg1 matches any item in the associative array with id=arg2",

--- a/tests/acceptance/01_vars/04_containers/readjson_new.cf
+++ b/tests/acceptance/01_vars/04_containers/readjson_new.cf
@@ -1,0 +1,68 @@
+#######################################################
+#
+# Test data creation through readjson() with just 1 arg
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(G.testfile).expected"
+      create => "true",
+      edit_line => init_insert_lines;
+
+      "$(G.testfile).json"
+      create => "true",
+      edit_line => init_insert_json;
+}
+
+bundle edit_line init_insert_json
+{
+  insert_lines:
+      '[ "hello", "there" ]';
+}
+
+bundle edit_line init_insert_lines
+{
+  insert_lines:
+      "hello";
+      "there";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "load" data => readjson("$(G.testfile).json");
+
+  files:
+      "$(G.testfile).actual"
+      create => "true",
+      edit_line => test_insert;
+}
+
+bundle edit_line test_insert
+{
+  insert_lines:
+      "$(test.load)";
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => sorted_check_diff("$(G.testfile).actual",
+                                           "$(G.testfile).expected",
+                                           "$(this.promise_filename)");
+}

--- a/tests/acceptance/01_vars/04_containers/readyaml_new.cf
+++ b/tests/acceptance/01_vars/04_containers/readyaml_new.cf
@@ -1,0 +1,100 @@
+#######################################################
+#
+# Test data creation through readyaml() with just 1 arg
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle common yaml_check
+{
+  classes:
+      "no_yaml_support"
+        not => regline(" *# *define *HAVE_LIBYAML.*", "$(this.promise_dirname)/../../../../libutils/config.h");
+}
+
+bundle agent init
+{
+  meta:
+      "test_skip_unsupported" string => "no_yaml_support";
+
+  files:
+      "$(G.testfile).expected"
+      create => "true",
+      edit_line => init_insert_lines;
+
+      "$(G.testfile).yaml"
+      create => "true",
+      edit_line => init_insert_yaml;
+}
+
+bundle edit_line init_insert_yaml
+{
+  insert_lines:
+      "- hello
+- there
+- where: 1
+- where_else: 1.0023E2
+- nowhere: true
+  boolean_spears: yes
+  string_spears: \"yes\"
+  bows: maybe";
+}
+
+bundle edit_line init_insert_lines
+{
+  insert_lines:
+      '[
+  "hello",
+  "there",
+  {
+    "where": 1
+  },
+  {
+    "where_else": 100.2300
+  },
+  {
+    "boolean_spears": true,
+    "bows": "maybe",
+    "nowhere": true,
+    "string_spears": "yes"
+  }
+]';
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "load" data => readyaml("$(G.testfile).yaml");
+      "load_s" string => storejson(load);
+
+  files:
+      "$(G.testfile).actual"
+      create => "true",
+      edit_line => test_insert;
+}
+
+bundle edit_line test_insert
+{
+  insert_lines:
+      "$(test.load_s)";
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => dcs_check_diff("$(G.testfile).actual",
+                                       "$(G.testfile).expected",
+                                       "$(this.promise_filename)");
+}


### PR DESCRIPTION
supersedes https://github.com/cfengine/core/pull/2400