### PR TITLE
bugfix PromiseHash(): RvalHash() should use hash yielded by StringHash() as its seed

### DIFF
--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -164,7 +164,7 @@ static unsigned PromiseHash(const Promise *pp, unsigned seed, unsigned max)
     unsigned hash = seed;
 
     hash = StringHash(pp->promiser, seed, max);
-    hash = RvalHash(pp->promisee, seed, max);
+    hash = RvalHash(pp->promisee, hash, max);
 
     for (size_t i = 0; i < SeqLength(pp->conlist); i++)
     {


### PR DESCRIPTION
Currently line# 166 is useless in `PromiseHash()`.
`RvalHash()` in line# 167 should be using hash generated by `StringHash()` as its seed.