### PR TITLE
cf-serverd with classic protocol should refuse to list directories...

### DIFF
--- a/cf-serverd/server_classic.c
+++ b/cf-serverd/server_classic.c
@@ -1340,7 +1340,7 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
             return false;
         }
 
-        if (!AccessControl(ctx, filename, conn, true))        /* opendir don't care about privacy */
+        if (!AccessControl(ctx, filename, conn, false))        /* opendir don't care about privacy */
         {
             Log(LOG_LEVEL_INFO, "DIR access error");
             RefuseAccess(conn, recvbuffer);


### PR DESCRIPTION
…under cleartext connections, if 'ifencrypted' is false.