### PR TITLE
Optimise performance, don't call log_hook when not printing messages

### DIFF
--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -226,10 +226,11 @@ void VLog(LogLevel level, const char *fmt, va_list ap)
     bool log_to_console = ( level <= lctx->report_level );
     bool log_to_syslog  = ( level <= lctx->log_level &&
                             level < LOG_LEVEL_VERBOSE );
-    bool always_run_hook= ( lctx->pctx &&
-                            lctx->pctx->always );
+    bool force_hook     = ( lctx->pctx &&
+                            lctx->pctx->log_hook &&
+                            lctx->pctx->force_hook_level >= level );
 
-    if (!log_to_console && !log_to_syslog && !always_run_hook)
+    if (!log_to_console && !log_to_syslog && !force_hook)
     {
         return;                            /* early return - save resources */
     }

--- a/libutils/logging_priv.h
+++ b/libutils/logging_priv.h
@@ -37,9 +37,17 @@ struct LoggingPrivContext
 {
     LoggingPrivLogHook log_hook;
     void *param;
-    /* Call the log_hook even if the message is neither printed to syslog nor
-     * to console? */
-    bool always;
+
+    /**
+     * Generally the log_hook runs whenever the message is printed either to
+     * console or to syslog. You can set this to *additionally* run the hook
+     * when the message level is <= force_hook_level.
+     *
+     * @NOTE the default setting of 0 equals to CRIT level, which is good as
+     *       default since the CRIT messages are always printed anyway, so
+     *       the log_hook runs anyway.
+     */
+    LogLevel force_hook_level;
 };
 
 /**


### PR DESCRIPTION
In that case only call log_hook if
message_level <= force_hook_level.