### PR TITLE
Add "canonify" mode to mapdata().

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -2708,7 +2708,8 @@ static FnCallResult FnCallMapData(EvalContext *ctx, ARG_UNUSED const Policy *pol
         varname = RlistScalarValue(finalargs->next);
     }
 
-    bool jsonmode = 0 == strcmp(conversion, "json");
+    bool jsonmode = (0 == strcmp(conversion, "json"));
+    bool canonifymode = (0 == strcmp(conversion, "canonify"));
 
     VarRef *ref = ResolveAndQualifyVarName(fp, varname);
     if (!ref)
@@ -2773,6 +2774,11 @@ static FnCallResult FnCallMapData(EvalContext *ctx, ARG_UNUSED const Policy *pol
                 return FnFailure();
             }
 
+            if (canonifymode)
+            {
+                BufferCanonify(expbuf);
+            }
+
             RlistAppendScalar(&returnlist, BufferData(expbuf));
             EvalContextVariableRemoveSpecial(ctx, SPECIAL_SCOPE_THIS, "v");
 
@@ -2816,6 +2822,11 @@ static FnCallResult FnCallMapData(EvalContext *ctx, ARG_UNUSED const Policy *pol
                     BufferDestroy(expbuf);
                     JsonDestroy(container);
                     return FnFailure();
+                }
+
+                if (canonifymode)
+                {
+                    BufferCanonify(expbuf);
                 }
 
                 RlistAppendScalarIdemp(&returnlist, BufferData(expbuf));
@@ -7916,7 +7927,7 @@ static const FnCallArg MAPARRAY_ARGS[] =
 
 static const FnCallArg MAPDATA_ARGS[] =
 {
-    {"none,json", CF_DATA_TYPE_OPTION, "Conversion to apply to the mapped string"},
+    {"none,canonify,json", CF_DATA_TYPE_OPTION, "Conversion to apply to the mapped string"},
     {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Pattern based on $(this.k) and $(this.v) as original text"},
     {CF_IDRANGE, CF_DATA_TYPE_STRING, "CFEngine array or data container identifier, the array variable to map"},
     {NULL, CF_DATA_TYPE_NONE, NULL}

--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -428,19 +428,6 @@ bool ChopLastNode(char *str)
 
 /*********************************************************************/
 
-void CanonifyNameInPlace(char *s)
-{
-    for (; *s != '\0'; s++)
-    {
-        if (!isalnum((unsigned char) *s))
-        {
-            *s = '_';
-        }
-    }
-}
-
-/*********************************************************************/
-
 void TransformNameInPlace(char *s, char from, char to)
 {
     for (; *s != '\0'; s++)
@@ -454,7 +441,7 @@ void TransformNameInPlace(char *s, char from, char to)
 
 /*********************************************************************/
 
-/* TODO remove, kill, burn this function! */
+/* TODO remove, kill, burn this function! Replace with BufferCanonify or CanonifyNameInPlace */
 char *CanonifyName(const char *str)
 {
     static char buffer[CF_BUFSIZE]; /* GLOBAL_R, no initialization needed */

--- a/libpromises/files_names.h
+++ b/libpromises/files_names.h
@@ -49,7 +49,6 @@ const char *FirstFileSeparator(const char *str);
 const char *LastFileSeparator(const char *str);
 bool ChopLastNode(char *str);
 char *CanonifyName(const char *str);
-void CanonifyNameInPlace(char *str);
 void TransformNameInPlace(char *s, char from, char to);
 char *CanonifyChar(const char *str, char ch);
 const char *ReadLastNode(const char *str);

--- a/libutils/buffer.c
+++ b/libutils/buffer.c
@@ -27,6 +27,7 @@
 #include <refcount.h>
 #include <misc_lib.h>
 #include <pcre_wrap.h>
+#include <string_lib.h>
 
 Buffer *BufferNewWithCapacity(unsigned int initial_capacity)
 {
@@ -505,6 +506,15 @@ const char *BufferData(const Buffer *buffer)
 {
     assert(buffer);
     return buffer ? buffer->buffer : NULL;
+}
+
+void BufferCanonify(Buffer *buffer)
+{
+    assert(buffer);
+    if (NULL != buffer && NULL != buffer->buffer)
+    {
+        CanonifyNameInPlace(buffer->buffer);
+    }
 }
 
 BufferBehavior BufferMode(const Buffer *buffer)

--- a/libutils/buffer.h
+++ b/libutils/buffer.h
@@ -281,9 +281,17 @@ void BufferRewrite(Buffer *buffer, BufferFilterFn filter, const bool invert);
 
   @param buffer
   @param max the maximum number of bytes to trim to
-  @return A const char pointer to the data contained on the buffer.
   */
 void BufferTrimToMaxLength(Buffer *buffer, unsigned int max);
+
+/**
+  @brief Canonify a buffer in place: replace [^0-9a-zA-Z] with '_'
+
+  @see CanonifyNameInPlace
+
+  @param buffer
+  */
+void BufferCanonify(Buffer *buffer);
 
 /**
   @brief Provides a pointer to the internal data.

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -1171,3 +1171,16 @@ void StrCatDelim(char *dst, size_t dst_size, size_t *dst_len,
         *dst_len = needed_len;
     }
 }
+
+/*********************************************************************/
+
+void CanonifyNameInPlace(char *s)
+{
+    for (; *s != '\0'; s++)
+    {
+        if (!isalnum((unsigned char) *s))
+        {
+            *s = '_';
+        }
+    }
+}

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -201,5 +201,6 @@ void StrCat(char *dst, size_t dst_size, size_t *dst_len,
 void StrCatDelim(char *dst, size_t dst_size, size_t *dst_len,
                  const char *src, char sep);
 
+void CanonifyNameInPlace(char *str);
 
 #endif

--- a/tests/acceptance/01_vars/02_functions/maparray_mapdata.cf
+++ b/tests/acceptance/01_vars/02_functions/maparray_mapdata.cf
@@ -57,6 +57,7 @@ bundle agent test
 
       "maparray_$(X)_$(Y)" slist => maparray("$(spec$(Y))", "load$(X)");
       "mapdata_none_$(X)_$(Y)" data => mapdata("none", "$(spec$(Y))", "load$(X)");
+      "mapdata_canonify_$(X)_$(Y)" data => mapdata("canonify", "$(spec$(Y))", "load$(X)");
       "mapdata_json_$(X)_$(Y)" data => mapdata("json", "$(jsonspec$(Y))", "load$(X)");
 
       "bad1" data => mapdata("json", "", missingvar);

--- a/tests/acceptance/01_vars/02_functions/maparray_mapdata.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/maparray_mapdata.cf.expected.json
@@ -146,6 +146,98 @@
   "maparray_6_4": [
     "xvalue should be avalue"
   ],
+  "mapdata_canonify_1_1": [
+    "key___0",
+    "key___1",
+    "key___2"
+  ],
+  "mapdata_canonify_1_2": [
+    "key___0__value___1",
+    "key___1__value___2",
+    "key___2__value___3"
+  ],
+  "mapdata_canonify_1_3": [
+    "key___0__key2_____this_k_1____value___1",
+    "key___1__key2_____this_k_1____value___2",
+    "key___2__key2_____this_k_1____value___3"
+  ],
+  "mapdata_canonify_1_4": [
+    "xvalue_should_be_0value",
+    "xvalue_should_be_1value",
+    "xvalue_should_be_2value"
+  ],
+  "mapdata_canonify_2_1": [
+    "key___0",
+    "key___1",
+    "key___2"
+  ],
+  "mapdata_canonify_2_2": [
+    "key___0__value___eleme_nt1",
+    "key___1__value___element2",
+    "key___2__value___element3"
+  ],
+  "mapdata_canonify_2_3": [
+    "key___0__key2_____this_k_1____value___eleme_nt1",
+    "key___1__key2_____this_k_1____value___element2",
+    "key___2__key2_____this_k_1____value___element3"
+  ],
+  "mapdata_canonify_2_4": [
+    "xvalue_should_be_0value",
+    "xvalue_should_be_1value",
+    "xvalue_should_be_2value"
+  ],
+  "mapdata_canonify_3_1": [
+    "key___x_x"
+  ],
+  "mapdata_canonify_3_2": [
+    "key___x_x__value___y_y"
+  ],
+  "mapdata_canonify_3_3": [
+    "key___x_x__key2_____this_k_1____value___y_y"
+  ],
+  "mapdata_canonify_3_4": [
+    "xvalue_should_be_xxvalue"
+  ],
+  "mapdata_canonify_4_1": [],
+  "mapdata_canonify_4_2": [],
+  "mapdata_canonify_4_3": [],
+  "mapdata_canonify_4_4": [],
+  "mapdata_canonify_5_1": [
+    "key___mykey",
+    "key___lastkey_",
+    "key___anotherkey"
+  ],
+  "mapdata_canonify_5_2": [
+    "key___mykey__value___myvalue",
+    "key___lastkey___value___o_ne",
+    "key___lastkey___value___two",
+    "key___lastkey___value___three",
+    "key___anotherkey__value___anothervalue"
+  ],
+  "mapdata_canonify_5_3": [
+    "key___mykey__key2_____this_k_1____value___myvalue",
+    "key___lastkey___key2_____this_k_1____value___o_ne",
+    "key___lastkey___key2_____this_k_1____value___two",
+    "key___lastkey___key2_____this_k_1____value___three",
+    "key___anotherkey__key2_____this_k_1____value___anothervalue"
+  ],
+  "mapdata_canonify_5_4": [
+    "xvalue_should_be_myvalue",
+    "xvalue_should_be_lastvalue",
+    "xvalue_should_be_anothervalue"
+  ],
+  "mapdata_canonify_6_1": [
+    "key___a"
+  ],
+  "mapdata_canonify_6_2": [
+    "key___a__value___c"
+  ],
+  "mapdata_canonify_6_3": [
+    "key___a__key2___b__value___c"
+  ],
+  "mapdata_canonify_6_4": [
+    "xvalue_should_be_avalue"
+  ],
   "mapdata_json_1_1": [],
   "mapdata_json_1_2": [
     {


### PR DESCRIPTION
This change includes acceptance tests, showing usage and effect.

It addresses a very common need: canonify a list without intermediate arrays.  See https://dev.cfengine.com/issues/2377 for one of many requests for it.

Syntax:
```
"canonified" data => mapdata("canonify", "any use of $(this.k) and $(this.v)", any_list_or_container_var);
```

This is 100% backwards compatible and very safe.  Please consider merging to 3.7 and 3.8 as well, even though it's a feature.

In addition to implementing the feature, this PR:

* adds a general `BufferCanonify` function to simplify code
* adds a note to `CanonifyName` (which has a `CF_BUFSIZE` limitation) that it should be replaced with `BufferCanonify` or `CanonifyNameInPlace`
* moves `CanonifyNameInPlace` to `string_lib.[ch]` because it's more appropriate there instead of `files_names.[ch]`
* fixed the doc of `BufferRewrite` because it doesn't return anything
