### PR TITLE
Fixes #6961 - bad option nlwp to vzps on Proxmox

### DIFF
--- a/libpromises/systype.c
+++ b/libpromises/systype.c
@@ -88,7 +88,7 @@ const char *const VPSCOMM[] =
 const char *const VPSOPTS[] =
 {
     [PLATFORM_CONTEXT_UNKNOWN] = "",
-    [PLATFORM_CONTEXT_OPENVZ] = "-E 0 -o user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,stime,time,args",   /* virt_host_vz_vzps (with vzps, the -E 0 replace the -e) */
+    [PLATFORM_CONTEXT_OPENVZ] = "-E 0 -o user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,thcount,stime,time,args",   /* virt_host_vz_vzps (with vzps, the -E 0 replace the -e) */
     [PLATFORM_CONTEXT_HP] = "-ef",                    /* hpux */
     [PLATFORM_CONTEXT_AIX] =  "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args",       /* aix */
     [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss:9,nlwp,stime,time,args",        /* linux */


### PR DESCRIPTION
See https://dev.cfengine.com/issues/6961 for rationale

If accepted, this should be backported to currently maintained versions.