### PR TITLE
Remove duplicate entry from the 3.8 ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,7 +22,6 @@
 	- Add: masterfiles-stage script to contrib
 	- Whitespace is now allowed in class expressions for
 	  readability, between class names and operators. (Redmine #7152)
-	- Add: New `results` classes body [Redmine#7481] (Redmine #7418)
 
 	Changes:
 	- Change: Clarify bootstrap/failsafe reports


### PR DESCRIPTION
"Add: New `results` classes body (Redmine #7418)"

was in there twice. I removed the second occurence, because it seemed to have a broken link syntax in there too.