### PR TITLE
redmine#7732: cf-agent -K is now allowed even for remote execution

### DIFF
--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -1681,12 +1681,9 @@ bool DoExec2(const EvalContext *ctx,
     char   cmdbuf[CF_BUFSIZE] = "";
     size_t cmdbuf_len         = 0;
 
-    const char standard_args[] = " -I -Dcfruncommand";
-
     assert(sizeof(CFRUNCOMMAND) <= sizeof(cmdbuf));
 
     StrCat(cmdbuf, sizeof(cmdbuf), &cmdbuf_len, CFRUNCOMMAND, 0);
-    StrCat(cmdbuf, sizeof(cmdbuf), &cmdbuf_len, standard_args, 0);
 
     exec_args += strspn(exec_args,  " \t");                  /* skip spaces */
     while (exec_args[0] != '\0')

--- a/tests/acceptance/22_cf-runagent/serial/bundles_all_allowed_regex_disallowed_admitted.cf
+++ b/tests/acceptance/22_cf-runagent/serial/bundles_all_allowed_regex_disallowed_admitted.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand --bundlesequence bundle");
+                                   "--bundlesequence bundle");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/cfruncommand_argv0_quoted.cf
+++ b/tests/acceptance/22_cf-runagent/serial/cfruncommand_argv0_quoted.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand");
+                                   "");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/cfruncommand_open.cf
+++ b/tests/acceptance/22_cf-runagent/serial/cfruncommand_open.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand");
+                                   "");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-B_bundle1_admitted_1.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-B_bundle1_admitted_1.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand --bundlesequence bundle1");
+                                   "--bundlesequence bundle1");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-B_bundle1_bundle2_admitted_1.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-B_bundle1_bundle2_admitted_1.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand --bundlesequence bundle1,bundle2");
+                                   "--bundlesequence bundle1,bundle2");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-B_bundle2_admitted.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-B_bundle2_admitted.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand --bundlesequence bundle2");
+                                   "--bundlesequence bundle2");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1-B_bundle1_admitted_1.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1-B_bundle1_admitted_1.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand -D role1 --bundlesequence bundle1");
+                                   "-D role1 --bundlesequence bundle1");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_-D_role2_admitted.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_-D_role2_admitted.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand -D role1,role2");
+                                   "-D role1,role2");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_admitted_1.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_admitted_1.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand -D role1");
+                                   "-D role1");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_admitted_2.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_admitted_2.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand -D role1");
+                                   "-D role1");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_admitted_3.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_admitted_3.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand -D role1");
+                                   "-D role1");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_role2_admitted_1.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_role2_admitted_1.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand -D role1,role2");
+                                   "-D role1,role2");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_role2_admitted_2.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-D_role1_role2_admitted_2.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand -D role1,role2");
+                                   "-D role1,role2");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-D_role2_-B_bundle2_admitted.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-D_role2_-B_bundle2_admitted.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand -D role2 --bundlesequence bundle2");
+                                   "-D role2 --bundlesequence bundle2");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-D_role2_admitted_1.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-D_role2_admitted_1.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand -D role2");
+                                   "-D role2");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 

--- a/tests/acceptance/22_cf-runagent/serial/runagent_-D_role2_admitted_2.cf
+++ b/tests/acceptance/22_cf-runagent/serial/runagent_-D_role2_admitted_2.cf
@@ -12,7 +12,7 @@ bundle agent init
   methods:
       # Expected output in the exec_args.txt file
       "any" usebundle => file_make("$(G.testdir)/expected_args.txt",
-                                   "-I -Dcfruncommand -D role2");
+                                   "-D role2");
       # Ensure execution output file is not there
       "any" usebundle => dcs_fini("$(G.testdir)/exec_args.txt");
 


### PR DESCRIPTION
cf-agent is now allowed all arguments, even when the "cfruncommand"
class is set. Additionally cf-serverd no longer appends
"-I -Dcfruncommand" to cfruncommand, this has to be done manually in
masterfiles body server control. This way configuration is fully
up to the sysadmin, as there are no hard-coded options any more.

Security is still enforced because arbitrary options can't be passed via
the EXEC command, they have to be set in policy body server control.

Changelog: cf-serverd no longer appends "-I -Dcfruncommand" to
           cfruncommand, this has to be done manually in masterfiles
           body server control.