### PR TITLE
Allow some functions to take inline JSON: mapdata, mergedata, and others

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -96,6 +96,7 @@ static int BuildLineArray(EvalContext *ctx, const Bundle *bundle, const char *ar
 static JsonElement* BuildData(EvalContext *ctx, const char *file_buffer,  const char *split, int maxent, bool make_array);
 static int ExecModule(EvalContext *ctx, char *command);
 
+static bool CheckIDChar(const char ch);
 static bool CheckID(const char *id);
 static const Rlist *GetListReferenceArgument(const EvalContext *ctx, const const FnCall *fp, const char *lval_str, DataType *datatype_out);
 static char *CfReadFile(const char *filename, int maxsize);
@@ -195,14 +196,18 @@ static VarRef* ResolveAndQualifyVarName(const FnCall *fp, const char *varname)
     return ref;
 }
 
-static JsonElement* VarRefValueToJson(EvalContext *ctx, const FnCall *fp, const VarRef *ref,
-                                      const DataType disallowed_datatypes[], size_t disallowed_count)
+static JsonElement* VarRefValueToJsonAllowingScalars(EvalContext *ctx, const FnCall *fp, const VarRef *ref,
+                                                     const DataType disallowed_datatypes[], size_t disallowed_count,
+                                                     bool allow_scalars)
 {
     assert(ref);
 
     DataType value_type = CF_DATA_TYPE_NONE;
     const void *value = EvalContextVariableGet(ctx, ref, &value_type);
     bool want_type = true;
+
+    // Convenience storage for the name of the function, since fp can be NULL
+    const char* fp_name = (fp ? fp->name : "VarRefValueToJson");
 
     for (int di = 0; di < disallowed_count; di++)
     {
@@ -234,6 +239,17 @@ static JsonElement* VarRefValueToJson(EvalContext *ctx, const FnCall *fp, const 
             convert = JsonCopy(value);
             break;
 
+        case RVAL_TYPE_SCALAR:
+            if (allow_scalars)
+            {
+                const char* data = value;
+                if (strcmp(data, CF_NULL_VALUE) != 0)
+                {
+                    convert = JsonStringCreate(data);
+                    break;
+                }
+            }
+
         default:
             {
                 VariableTableIterator *iter = EvalContextVariableTableFromRefIteratorNew(ctx, ref);
@@ -251,7 +267,8 @@ static JsonElement* VarRefValueToJson(EvalContext *ctx, const FnCall *fp, const 
                     }
                     else if (var->ref->num_indices - index_offset > 1)
                     {
-                        Log(LOG_LEVEL_DEBUG, "%s: got ref with starting depth %zd and index count %zd", fp->name, index_offset, var->ref->num_indices);
+                        Log(LOG_LEVEL_DEBUG, "%s: got ref with starting depth %zd and index count %zd",
+                            fp_name, index_offset, var->ref->num_indices);
                         for (int index = index_offset; index < var->ref->num_indices-1; index++)
                         {
                             JsonElement *local = JsonObjectGet(holder, var->ref->indices[index]);
@@ -300,7 +317,8 @@ static JsonElement* VarRefValueToJson(EvalContext *ctx, const FnCall *fp, const 
                 if (JsonLength(convert) < 1)
                 {
                     char *varname = VarRefToString(ref, true);
-                    Log(LOG_LEVEL_VERBOSE, "%s: argument '%s' does not resolve to a container or a list or a CFEngine array", fp->name, varname);
+                    Log(LOG_LEVEL_VERBOSE, "%s: argument '%s' does not resolve to a container or a list or a CFEngine array",
+                        fp_name, varname);
                     free(varname);
                     JsonDestroy(convert);
                     return NULL;
@@ -313,29 +331,71 @@ static JsonElement* VarRefValueToJson(EvalContext *ctx, const FnCall *fp, const 
     else // !wanted_type
     {
         char *varname = VarRefToString(ref, true);
-        Log(LOG_LEVEL_DEBUG, "%s: argument '%s' resolved to an undesired data type", fp->name, varname);
+        Log(LOG_LEVEL_DEBUG, "%s: argument '%s' resolved to an undesired data type",
+            fp_name, varname);
         free(varname);
     }
 
     return convert;
 }
 
+static JsonElement* VarRefValueToJson(EvalContext *ctx, const FnCall *fp, const VarRef *ref,
+                               const DataType disallowed_datatypes[], size_t disallowed_count)
+{
+    return VarRefValueToJsonAllowingScalars(ctx, fp, ref, disallowed_datatypes, disallowed_count, false);
+}
+
+static JsonElement *LookupVarRefToJson(void *ctx, const char **data)
+{
+    Buffer* varname = NULL;
+    Seq *s = StringMatchCaptures("^(([a-zA-Z0-9_]+\\.)?[a-zA-Z0-9._]+)(\\[[^\\[\\]]+\\])?", *data, false);
+
+    if (s && SeqLength(s) > 0) // got a variable name
+    {
+        varname = BufferCopy((const Buffer*) SeqAt(s, 0));
+    }
+
+    if (s)
+    {
+        SeqDestroy(s);
+    }
+
+    VarRef *ref = NULL;
+    if (varname)
+    {
+        ref = VarRefParse(BufferData(varname));
+        // advance to the last character of the matched variable name
+        *data += strlen(BufferData(varname))-1;
+        BufferDestroy(varname);
+    }
+
+    if (!ref)
+    {
+        return NULL;
+    }
+
+    JsonElement *vardata = VarRefValueToJsonAllowingScalars(ctx, NULL, ref, NULL, 0, true);
+    VarRefDestroy(ref);
+
+    return vardata;
+}
+
 static JsonElement* VarNameOrInlineToJson(EvalContext *ctx, const FnCall *fp, const char *data)
 {
     JsonElement *inline_data = NULL;
-    JsonParseError res = JsonParse(&data, &inline_data);
+    JsonParseError res = JsonParseWithLookup(ctx, &LookupVarRefToJson, &data, &inline_data);
 
-    if (res != JSON_PARSE_OK)
+    if (res == JSON_PARSE_OK)
     {
-    }
-    else if (JsonGetElementType(inline_data) == JSON_ELEMENT_TYPE_PRIMITIVE)
-    {
-        JsonDestroy(inline_data);
-        inline_data = NULL;
-    }
-    else
-    {
-        return inline_data;
+        if (JsonGetElementType(inline_data) == JSON_ELEMENT_TYPE_PRIMITIVE)
+        {
+            JsonDestroy(inline_data);
+            inline_data = NULL;
+        }
+        else
+        {
+            return inline_data;
+        }
     }
 
     VarRef *ref = ResolveAndQualifyVarName(fp, data);
@@ -2819,7 +2879,7 @@ static FnCallResult FnCallMapData(EvalContext *ctx, ARG_UNUSED const Policy *pol
             if (jsonmode)
             {
                 JsonElement *parsed = NULL;
-                if (JsonParse(&data, &parsed) == JSON_PARSE_OK)
+                if (JsonParseWithLookup(ctx, &LookupVarRefToJson, &data, &parsed) == JSON_PARSE_OK)
                 {
                     JsonArrayAppendElement(returnjson, parsed);
                 }
@@ -2989,91 +3049,19 @@ static FnCallResult FnCallMergeData(EvalContext *ctx, ARG_UNUSED const Policy *p
     for (const Rlist *arg = args; arg; arg = arg->next)
     {
         const char *name_str = RlistScalarValue(arg);
-        int name_len = strlen(name_str);
-        bool wrap_array_mode = false;
-        Buffer *wrap_map_key = NULL;
-        Buffer *name = NULL;
 
         // try to load directly
         JsonElement *json = VarNameOrInlineToJson(ctx, fp, name_str);
 
-        // if that failed, try the wrappers
-        if (NULL == json)
-        {
-            if (name_len > 2 && name_str[0] == '[')
-            {
-                Seq *s = StringMatchCaptures("^\\[ *([^ ]+) *\\]$", name_str, false);
-
-                if (s && SeqLength(s) == 2)
-                {
-                    wrap_array_mode = true;
-                    name = BufferCopy((const Buffer*) SeqAt(s, 1));
-                }
-
-                SeqDestroy(s);
-            }
-            else if (name_len > 0 && name_str[0] == '{' && name_str[name_len-1] == '}')
-            {
-                Seq *s = StringMatchCaptures("^\\{ *\"([^\"]+)\" *: *([^ ]+) *\\}$", name_str, false);
-
-                if (s && SeqLength(s) == 3)
-                {
-                    wrap_map_key = BufferCopy((const Buffer*) SeqAt(s, 1));
-                    name = BufferCopy((const Buffer*) SeqAt(s, 2));
-                }
-
-                SeqDestroy(s);
-            }
-            else
-            {
-                name = BufferNewFrom(name_str, name_len);
-            }
-        }
-
-        // try to use `name` a second time
-        if (NULL == json && NULL != name)
-        {
-            json = VarNameOrInlineToJson(ctx, fp, BufferData(name));
-        }
-
         // we failed to produce a valid JsonElement, so give up
         if (NULL == json)
         {
-            if (NULL != wrap_map_key)
-            {
-                BufferDestroy(wrap_map_key);
-            }
-
-            if (NULL != name)
-            {
-                BufferDestroy(name);
-            }
-
             SeqDestroy(containers);
 
             return FnFailure();
         }
 
-        if (wrap_array_mode)
-        {
-            JsonElement *parent = JsonArrayCreate(1);
-            JsonArrayAppendElement(parent, json);
-            json = parent;
-        }
-        else if (NULL != wrap_map_key)
-        {
-            JsonElement *parent = JsonObjectCreate(1);
-            JsonObjectAppendElement(parent, BufferData(wrap_map_key), json);
-            json = parent;
-        }
-        else
-        {
-            // do nothing, no wrapping
-        }
-
         SeqAppend(containers, json);
-
-        if (NULL != wrap_map_key) BufferDestroy(wrap_map_key);
 
     } // end of args loop
 
@@ -6116,7 +6104,7 @@ static FnCallResult FnCallParseJson(ARG_UNUSED EvalContext *ctx,
     }
     else
     {
-        res = JsonParse(&data, &json);
+        res = JsonParseWithLookup(ctx, &LookupVarRefToJson, &data, &json);
     }
 
     if (res != JSON_PARSE_OK)
@@ -7445,11 +7433,16 @@ void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print
 /* Level                                                             */
 /*********************************************************************/
 
+static bool CheckIDChar(const char ch)
+{
+    return isalnum((int) ch) || (ch == '.') || (ch == '-') || (ch == '_') || (ch == '[') || (ch == ']');
+}
+
 static bool CheckID(const char *id)
 {
     for (const char *sp = id; *sp != '\0'; sp++)
     {
-        if (!isalnum((int) *sp) && (*sp != '.') && (*sp != '-') && (*sp != '_') && (*sp != '[') && (*sp != ']'))
+        if (!CheckIDChar(*sp))
         {
             Log(LOG_LEVEL_ERR,
                   "Module protocol contained an illegal character '%c' in class/variable identifier '%s'.", *sp,

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -354,6 +354,8 @@ JsonElement *JsonArrayGet(const JsonElement *array, size_t index);
   */
 bool JsonArrayContainsOnlyPrimitives(JsonElement *array);
 
+typedef JsonElement *JsonLookup(void *ctx, const char **data);
+
 /**
   @brief Parse a string to create a JsonElement
   @param data [in] Pointer to the string to parse
@@ -361,6 +363,19 @@ bool JsonArrayContainsOnlyPrimitives(JsonElement *array);
   @returns See JsonParseError and JsonParseErrorToString
   */
 JsonParseError JsonParse(const char **data, JsonElement **json_out);
+
+/**
+  @brief Parse a string to create a JsonElement
+  @param lookup_data [in] Evaluation context for variable lookups
+  @param lookup_function [in] Callback function for variable lookups
+  @param data [in] Pointer to the string to parse
+  @param json_out Resulting JSON object
+  @returns See JsonParseError and JsonParseErrorToString
+
+  The lookup_context type is void so we don't have to include
+  eval_context.h from libpromises into libutil
+  */
+JsonParseError JsonParseWithLookup(void *lookup_data, JsonLookup *lookup_function, const char **data, JsonElement **json_out);
 
 /**
  * @brief Convenience function to parse JSON from a file

--- a/tests/acceptance/01_vars/02_functions/inline_json.cf
+++ b/tests/acceptance/01_vars/02_functions/inline_json.cf
@@ -1,0 +1,67 @@
+###########################################################
+#
+# Test inline JSON expansion
+#
+###########################################################
+
+body common control
+{
+    inputs => { "../../default.cf.sub" };
+    bundlesequence => { default($(this.promise_filename)) };
+    version => "1.0";
+}
+
+###########################################################
+
+bundle agent test
+{
+  vars:
+      "z" string => "100";
+      "foo" string => "bar";
+
+      # test mergedata() as well
+      "var" data => mergedata('[]', '["x"]');
+
+      # test mapdata() as well
+      "var2" data => mapdata("none", '$(this.v)', '["x"]');
+
+      # the basic building block
+      "var3" data => data_expand('["linux"]');
+
+      # variable references with a bundle
+      "var4" data => data_expand('[test.var3]');
+      "var5" data => data_expand('[test.var3,]');
+
+      # make sure bareword keys are not expanded
+      "var6" data => data_expand('[foo]');
+      "var7" data => data_expand('{foo:var3}');
+
+      # variable references without a bundle
+      "var8" data => data_expand('[var3]');
+      "var9" data => data_expand('{ "x": var3 }');
+
+      # regular lookup with bundle name into a map value
+      "varA" data => data_expand('{ "fullx": test.var3 }');
+
+      # try to trigger off-by-one errors
+      "varB" data => data_expand('[z]');
+
+      # intentionally broken to try to trigger off-by-one errors
+      "varC" data => data_expand('[z');
+
+      # inline array lookup
+      "varD" data => data_expand('[var3[0]]');
+      "varE" data => data_expand('[varA[fullx]]');
+      "varF" data => data_expand('[var9[x]]');
+
+}
+
+###########################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
+}

--- a/tests/acceptance/01_vars/02_functions/inline_json.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/inline_json.cf.expected.json
@@ -1,0 +1,62 @@
+{
+  "foo": "bar",
+  "var": [
+    "x"
+  ],
+  "var2": [
+    "x"
+  ],
+  "var3": [
+    "linux"
+  ],
+  "var4": [
+    [
+      "linux"
+    ]
+  ],
+  "var5": [
+    [
+      "linux"
+    ]
+  ],
+  "var6": [
+    "bar"
+  ],
+  "var7": {
+    "foo": [
+      "linux"
+    ]
+  },
+  "var8": [
+    [
+      "linux"
+    ]
+  ],
+  "var9": {
+    "x": [
+      "linux"
+    ]
+  },
+  "varA": {
+    "fullx": [
+      "linux"
+    ]
+  },
+  "varB": [
+    "100"
+  ],
+  "varD": [
+    "linux"
+  ],
+  "varE": [
+    [
+      "linux"
+    ]
+  ],
+  "varF": [
+    [
+      "linux"
+    ]
+  ],
+  "z": "100"
+}


### PR DESCRIPTION
Related to https://dev.cfengine.com/issues/7871 (when it's implemented, all CFEngine functions that take lists or data containers will be able to use this functionality).

With this patch, many functions will be able to take inline JSON instead of a list name or data container name. We simply try to parse the varname as JSON; since neither `@(listname)` nor `containername` are valid JSON, we end up with a reliable way to parse JSON.

`mergedata()` was a little more complicated because it supports symbolic wrapping, but it's a pretty trivial change otherwise. It also reduces line count, which is a good thing...

Example:
```
bundle agent test
{
  vars:
      "user3" data => data_expand('["$(sys.os)"]');
      "user2" data => mapdata("none", '$(this.v)', '["x"]');
      "user" data => mergedata('[]', '["x"]');
}
```

Result bundle state:

```json
{
  "user": [
    "x"
  ],
  "user2": [
    "x"
  ],
  "user3": [
    "linux"
  ]
}
```