### PR TITLE
Fix HP-UX specific bug that caused a lot of log output to disappear.

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -635,6 +635,12 @@ void GenericAgentInitialize(EvalContext *ctx, GenericAgentConfig *config)
     InitializeWindows();
 #endif
 
+    /* Bug on HP-UX: Buffered output is discarded if you switch buffering mode
+       without flushing the buffered output first. This will happen anyway when
+       switching modes, so no performance is lost. */
+    fflush(stdout);
+    setlinebuf(stdout);
+
     DetermineCfenginePort();
 
     EvalContextClassPutHard(ctx, "any", "source=agent");
@@ -787,8 +793,6 @@ void GenericAgentInitialize(EvalContext *ctx, GenericAgentConfig *config)
     {
         GenericAgentConfigSetInputFile(config, GetInputDir(), "promises.cf");
     }
-
-    setlinebuf(stdout);
 }
 
 void GenericAgentFinalize(EvalContext *ctx, GenericAgentConfig *config)


### PR DESCRIPTION
Buffered output is discarded if you switch buffering mode without
flushing the buffered output first. This will happen anyway when
switching modes, so no performance is lost.

Also move it earlier in the initialization sequence, so that we start
line buffering sooner. This can come in handy later, since if there is
an early crash in cf-agent, the log output may be truncated unless we
have switched to line buffered mode.

Changelog: Title