### PR TITLE
Fix incorrect failure reason when there is a typo in test outcome.

### DIFF
--- a/tests/acceptance/01_vars/02_functions/ifelse_isvariable.cf
+++ b/tests/acceptance/01_vars/02_functions/ifelse_isvariable.cf
@@ -1,0 +1,72 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  vars:
+      "passwd_file"
+        string => "/tmp/custom_passwd";
+}
+
+bundle agent test
+{
+  meta:
+      "description"
+        string => "Test that ifelse can use the result of isvariable
+                   as a class identifer";
+
+      "test_soft_fail"
+        string => "any",
+        meta => { "redmine7878" };
+
+  vars:
+      # Since init.passwd_file is defined, I expect the value to be
+      # the value of init.passwd_file
+      "use_passwd_file"
+        string => ifelse( isvariable("init.passwd_file"), $(init.passwd_file),
+                         "/etc/passwd");
+
+      # Since init.shadow_file is not defined, I expect that the value
+      # will be "/etc/shadow"
+      "use_shadow_file"
+        string => ifelse( isvariable("init.shadow_file"), $(init.shadow_file),
+                          "/etc/shadow");
+}
+
+bundle agent check
+{
+  classes:
+      "ok_passwd_file"
+        expression => strcmp( "/tmp/custom_passwd", $(init.passwd_file) );
+
+      "ok_shadow_file"
+        expression => strcmp( "/etc/shadow", $(init.use_shadow_file) );
+
+      "ok" and => { "ok_passwd_file", "ok_shadow_file" };
+
+  reports:
+    DEBUG::
+      "Found test.use_passwd_file = $(test.use_passwd_file) to be as expected"
+        if => "ok_passwd_file";
+
+      "Found test.use_shadow_file = $(test.use_shadow_filee) to be as expected"
+         if => "ok_shadow_file";
+
+      "Found value for test.use_passwd_file to be INCORRECT
+       expected '/tmp/custom_passwd' got '$(test.use_passwd_file)'"
+        unless => "ok_passwd_file";
+
+      "Found value for test.use_shadow_file to be INCORRECT
+       expected '/etc/shadow' got '$(test.use_shadow_file)'"
+        unless => "ok_shadow_file";
+
+    ok::
+      "$(this.promise_filename) Pass";
+
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -473,11 +473,16 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
             ESCAPED_TEST="$(echo "($TEST|dcs.cf.sub)" | sed -e 's/\./\\./g')"
             if egrep "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE > /dev/null && ! egrep "R: .*$ESCAPED_TEST Wait/" $OUTFILE > /dev/null
             then
-                # Check for other test case outcomes than fail. Should not happen.
-                if egrep "R: .*$ESCAPED_TEST " $OUTFILE | egrep -v "R: .*$ESCAPED_TEST [XS]?FAIL" > /dev/null
+                # Check for passed outcome, which should not happen.
+                if egrep "R: .*$ESCAPED_TEST " $OUTFILE | egrep "R: .*$ESCAPED_TEST Pass" > /dev/null
                 then
                     RESULT=FAIL
                     RESULT_MSG="${COLOR_FAILURE}FAIL (The test Passed, but failure was expected)${COLOR_NORMAL}"
+                elif egrep "R: .*$ESCAPED_TEST " $OUTFILE | egrep -v "R: .*$ESCAPED_TEST [XS]?FAIL" > /dev/null
+                then
+                    # Other test case outcomes than fail. Should not happen.
+                    RESULT=FAIL
+                    RESULT_MSG="${COLOR_FAILURE}FAIL (Failure was expected, but the test had an unexpected test outcome, check test output, Pass/FAIL need to match exactly)${COLOR_NORMAL}"
                 else
                     REDMINE="$(egrep "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE | sed -e "s,.*[XS]FAIL/redmine[^0-9]*\([0-9][0-9]*\).*,\1,")"
                     RESULT="$(egrep "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE | sed -e "s,.*\([XS]FAIL\).*,\1,")"


### PR DESCRIPTION
If the test outcome is not exactly "Pass" or "FAIL" the test script
would believe that the test had passed when it should have failed (in
the case of test_soft_fail). This is obviously wrong, it should say
that the test outcome was unknown and not expected.

Readd test that was reverted earlier because of this.