### PR TITLE
Clean up ConsiderFile

### DIFF
--- a/cf-agent/files_properties.c
+++ b/cf-agent/files_properties.c
@@ -48,12 +48,26 @@ static const char *const SKIPFILES[] =
 static bool ConsiderFile(const char *nodename, const char *path, struct stat *stat)
 {
     int i;
-    const char *sp;
+    
+    if (stat != NULL)
+    {
+        if (S_ISLNK(stat->st_mode))
+        {
+            Log(LOG_LEVEL_INFO, "'%s' is a symbolic link", nodename);
+        }
+        else if (S_ISDIR(stat->st_mode))
+        {
+            Log(LOG_LEVEL_INFO, "'%s' is a directory", nodename);
+        }
+        
+        Log(LOG_LEVEL_VERBOSE, "'%s' has size %ld and full mode %o", nodename, (unsigned long) (stat->st_size),
+              (unsigned int) (stat->st_mode));
+    }
 
     if (strlen(nodename) < 1)
     {
         Log(LOG_LEVEL_ERR, "Empty (null) filename detected in '%s'", path);
-        return true;
+        return false;
     }
 
     if (stat != NULL && (S_ISREG(stat->st_mode) || S_ISLNK(stat->st_mode)) &&
@@ -78,54 +92,6 @@ static bool ConsiderFile(const char *nodename, const char *path, struct stat *st
         }
     }
 
-    if ((strcmp("[", nodename) == 0) && (strcmp("/usr/bin", path) == 0))
-    {
-#if defined(__linux__)
-            return true;
-#endif
-    }
-
-    for (sp = nodename; *sp != '\0'; sp++)
-    {
-        if ((*sp > 31) && (*sp < 127))
-        {
-            break;
-        }
-    }
-
-    for (sp = nodename; *sp != '\0'; sp++)      /* Check for files like ".. ." */
-    {
-        if ((*sp != '.') && (!isspace((int)*sp)))
-        {
-            return true;
-        }
-    }
-
-    if (stat == NULL)
-    {
-        /* stat is NULL so we can't make more checks, call this function again
-         * but pass the stat info as well. */
-        return true;
-    }
-
-    if ((stat->st_size == 0) && LogGetGlobalLevel() < LOG_LEVEL_INFO)   /* No sense in warning about empty files */
-    {
-        return false;
-    }
-
-    Log(LOG_LEVEL_ERR, "Suspicious looking file object '%s' masquerading as hidden file in '%s'", nodename, path);
-
-    if (S_ISLNK(stat->st_mode))
-    {
-        Log(LOG_LEVEL_INFO, "'%s' is a symbolic link", nodename);
-    }
-    else if (S_ISDIR(stat->st_mode))
-    {
-        Log(LOG_LEVEL_INFO, "'%s' is a directory", nodename);
-    }
-
-    Log(LOG_LEVEL_VERBOSE, "'%s' has size %ld and full mode %o", nodename, (unsigned long) (stat->st_size),
-          (unsigned int) (stat->st_mode));
     return true;
 }
 


### PR DESCRIPTION
This intends to make ConsiderFile more readable, and should be functionally equivalent, except
* Remove the test relying on the verbosity level. For example, in the current version, if you copy a directory containing afile named ". . .", it will be copied only at some verbosity levels.
* Do not consider a file with an empty name
* Display information first, so that it is always displayed.
