### PR TITLE
Add default body for all promise types

### DIFF
--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -176,6 +176,10 @@ const void  *EvalContextVariableControlCommonGet(const EvalContext *ctx, CommonC
  */
 const Bundle *EvalContextResolveBundleExpression(const EvalContext *ctx, const Policy *policy,
                                                  const char *callee_reference, const char *callee_type);
+
+const Body *EvalContextFindFirstMatchingBody(const Policy *policy, const char *type,
+                                             const char *namespace, const char *name);
+
 /**
   @brief Returns a Sequence of const Body* elements, first the body and then its parents
 

--- a/tests/acceptance/00_basics/03_bodies/default_files_action.cf
+++ b/tests/acceptance/00_basics/03_bodies/default_files_action.cf
@@ -1,0 +1,76 @@
+#######################################################
+#
+# Test default body action and overriding with specific action
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+body file control
+{
+   namespace => "bodydefault"; 
+}
+
+body action files_action
+{
+    action_policy => "warn";
+}
+
+body file control
+{
+    namespace => "default"; 
+}
+
+body action specific
+{
+    action_policy => "fix";
+}
+
+#######################################################
+
+bundle agent test_specified_action
+{
+  files:
+	  "$(G.testdir)/specified"
+	     create => "true",
+       action => specific;
+}
+
+bundle agent test_default_action
+{
+  files:
+	  "$(G.testdir)/default"
+	     create => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "specified"
+        usebundle => test_specified_action;
+      "default"
+        usebundle => test_default_action;
+}
+
+bundle agent check
+{
+  classes:
+    "default_created" expression => fileexists("$(G.testdir)/default");
+    "specified_created" expression => fileexists("$(G.testdir)/specified");
+    "ok" expression => "specified_created.!default_created";
+
+  reports:   
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Based on #2342.

* Use the `bodydefault` namespace instead of `default`
* Free `default_body_name`
* Add the test on files promises

The limitation when using a particular namespace for default bodies is that they cannot be applied to an arbitrary namespace, but only to `default`.