### PR TITLE
Improve networking errors handling

### DIFF
--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -726,13 +726,7 @@ static void HailExec(AgentConnection *conn, char *peer)
     {
         memset(recvbuffer, 0, sizeof(recvbuffer));
 
-        int n_read = ReceiveTransaction(conn->conn_info, recvbuffer, NULL);
-
-        if (n_read == -1)
-        {
-            break;
-        }
-        if (n_read == 0)                               /* connection closed */
+        if (ReceiveTransaction(conn->conn_info, recvbuffer, NULL) == -1)
         {
             break;
         }

--- a/cf-serverd/server_classic.c
+++ b/cf-serverd/server_classic.c
@@ -783,14 +783,6 @@ RSA *newkey = RSA_new();
         return false;
     }
 
-    if (len_n == 0)
-    {
-        Log(LOG_LEVEL_ERR, "Authentication failure: "
-            "connection was closed while receiving public key modulus");
-        RSA_free(newkey);
-        return false;
-    }
-
     if ((newkey->n = BN_mpi2bn(recvbuffer, len_n, NULL)) == NULL)
     {
         Log(LOG_LEVEL_ERR, "Authentication failure: "
@@ -808,13 +800,6 @@ RSA *newkey = RSA_new();
     {
         Log(LOG_LEVEL_ERR, "Authentication failure: "
             "error while receiving public key exponent");
-        RSA_free(newkey);
-        return false;
-    }
-    if (len_e == 0)
-    {
-        Log(LOG_LEVEL_ERR, "Authentication failure: "
-            "connection was closed while receiving public key exponent");
         RSA_free(newkey);
         return false;
     }
@@ -929,15 +914,10 @@ RSA *newkey = RSA_new();
     int recv_len = ReceiveTransaction(conn->conn_info, recv_buf, NULL);
     if (recv_len < digestLen)
     {
-        if (recv_len < 0)
+        if (recv_len == -1)
         {
             Log(LOG_LEVEL_ERR, "Authentication failure: "
                 "error receiving counter-challenge response");
-        }
-        else if (recv_len == 0)
-        {
-            Log(LOG_LEVEL_ERR, "Authentication failure: "
-                "connection was closed while receiving counter-challenge response");
         }
         else                                      /* 0 < recv_len < expected_len */
         {
@@ -976,25 +956,18 @@ RSA *newkey = RSA_new();
         "should decrypt to %d bytes",
         keylen, session_key_size);
 
-    if ((keylen <= 0) || (keylen > CF_BUFSIZE / 2))
+    if (keylen == -1)
     {
-        if (keylen == 0)
-        {
-            Log(LOG_LEVEL_ERR, "Authentication failure: "
-                "connection was closed while receiving session key");
-        }
-        else if (keylen > CF_BUFSIZE / 2)
-        {
-            Log(LOG_LEVEL_ERR, "Authentication failure: "
-                "session key received is too long (%d bytes)",
-                keylen);
-        }
-        else                                                  /* keylen < 0 */
-        {
-            Log(LOG_LEVEL_ERR, "Authentication failure: "
-                "error receiving session key");
-        }
+        Log(LOG_LEVEL_ERR, "Authentication failure: "
+            "error receiving session key");
+        return false;
+    }
 
+    if (keylen > CF_BUFSIZE / 2)
+    {
+        Log(LOG_LEVEL_ERR, "Authentication failure: "
+            "session key received is too long (%d bytes)",
+            keylen);
         return false;
     }
 
@@ -1055,7 +1028,7 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
     memset(&get_args, 0, sizeof(get_args));
 
     received = ReceiveTransaction(conn->conn_info, recvbuffer, NULL);
-    if (received == -1 || received == 0)
+    if (received == -1)
     {
         return false;
     }

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -579,16 +579,17 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
     const int received = ReceiveTransaction(conn->conn_info,
                                             recvbuffer, NULL);
 
+    if (received == -1)
+    {
+        /* Already logged in case of error. */
+        return false;
+    }
     if (received > CF_BUFSIZE - 1)
     {
         UnexpectedError("Received transaction of size %d", received);
         return false;
     }
-    if (received == -1 || received == 0)
-    {
-        /* Already logged in case of error. */
-        return false;
-    }
+
     if (strlen(recvbuffer) == 0)
     {
         Log(LOG_LEVEL_WARNING,

--- a/libcfnet/classic.c
+++ b/libcfnet/classic.c
@@ -107,8 +107,7 @@ int RecvSocketStream(int sd, char buffer[CF_BUFSIZE], int toget)
                 "Peer closed connection early (received=%dB, expecting=%dB)",
                 already, toget);
             buffer[already] = '\0';
-            /* TODO Why return 0? Early close is an error so -1 is better. */
-            return 0;
+            return -1;
         }
     }
     assert(already == toget);
@@ -119,6 +118,18 @@ int RecvSocketStream(int sd, char buffer[CF_BUFSIZE], int toget)
 
 /*************************************************************************/
 
+/**
+ * @brief Send #tosend bytes from buffer to sd.
+ * @param sd Socket descriptor
+ * @param buffer Buffer from which to read data
+ * @param tosend Number of bytes to write.
+ *
+ * @return number of bytes actually sent, must be equal to #tosend
+ *         -1  in case of timeout or error - socket is unusable
+ *         -1  also in case of early proper connection close
+ *         0        NEVER
+ *         <tosend  NEVER
+ */
 int SendSocketStream(int sd, const char buffer[CF_BUFSIZE], int tosend)
 {
     int sent, already = 0;
@@ -143,12 +154,13 @@ int SendSocketStream(int sd, const char buffer[CF_BUFSIZE], int tosend)
 
         if (sent == -1)
         {
-            Log(LOG_LEVEL_VERBOSE, "Couldn't send. (send: %s)", GetErrorStr());
+            Log(LOG_LEVEL_ERR, "Couldn't send. (send: %s)", GetErrorStr());
             return -1;
         }
 
         already += sent;
     } while (already < tosend);
+    assert(already == tosend);
 
     return already;
 }

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -342,7 +342,7 @@ Item *RemoteDirList(const char *dirname, bool encrypt, AgentConnection *conn)
         int nbytes = ReceiveTransaction(conn->conn_info, recvbuffer, NULL);
 
         /* If recv error or socket closed before receiving CFD_TERMINATOR. */
-        if (nbytes == -1 || nbytes == 0)
+        if (nbytes == -1)
         {
             /* TODO mark connection in the cache as closed. */
             goto err;

--- a/libcfnet/client_protocol.c
+++ b/libcfnet/client_protocol.c
@@ -378,7 +378,7 @@ int AuthenticateAgent(AgentConnection *conn, bool trust_key)
     memset(in, 0, CF_BUFSIZE);
     encrypted_len = ReceiveTransaction(conn->conn_info, in, NULL);
 
-    if (encrypted_len <= 0)
+    if (encrypted_len == -1)
     {
         Log(LOG_LEVEL_ERR, "Protocol transaction sent illegal cipher length");
         RSA_free(server_pubkey);
@@ -426,7 +426,7 @@ int AuthenticateAgent(AgentConnection *conn, bool trust_key)
         Log(LOG_LEVEL_VERBOSE, "Collecting public key from server!");
 
         /* proposition S4 - conditional */
-        if ((len = ReceiveTransaction(conn->conn_info, in, NULL)) <= 0)
+        if ((len = ReceiveTransaction(conn->conn_info, in, NULL)) == -1)
         {
             Log(LOG_LEVEL_ERR, "Protocol error in RSA authentation from IP '%s'", conn->this_server);
             return false;
@@ -443,7 +443,7 @@ int AuthenticateAgent(AgentConnection *conn, bool trust_key)
 
         /* proposition S5 - conditional */
 
-        if ((len = ReceiveTransaction(conn->conn_info, in, NULL)) <= 0)
+        if ((len = ReceiveTransaction(conn->conn_info, in, NULL)) == -1)
         {
             Log(LOG_LEVEL_INFO, "Protocol error in RSA authentation from IP '%s'",
                  conn->this_server);

--- a/libcfnet/net.c
+++ b/libcfnet/net.c
@@ -38,13 +38,11 @@ extern char BINDINTERFACE[];                  /* cf3globals.c, cf3.extern.h */
 
 /**
  * @param len is the number of bytes to send, or 0 if buffer is a
- *        '\0'-terminated string so strlen(buffer) can used.
+ *        '\0'-terminated string so strlen(buffer) can be used.
  * @return -1 in case of error or connection closed
  *         (also currently returns 0 for success but don't count on it)
  * @NOTE #buffer can't be of zero length, our protocol
- *       does not allow empty transactions! The reason is that
- *       ReceiveTransaction() can't differentiate between that
- *       and connection closed.
+ *       does not allow empty transactions!
  * @NOTE (len <= CF_BUFSIZE - CF_INBAND_OFFSET)
  *
  * @TODO Currently only transactions up to CF_BUFSIZE-CF_INBAND_OFFSET are
@@ -65,8 +63,7 @@ int SendTransaction(const ConnectionInfo *conn_info,
         len = strlen(buffer);
     }
 
-    /* Not allowed to send zero-payload packets, because
-       (ReceiveTransaction() == 0) currently means connection closed. */
+    /* Not allowed to send zero-payload packets */
     assert(len > 0);
 
     if (len > CF_BUFSIZE - CF_INBAND_OFFSET)
@@ -127,8 +124,8 @@ int SendTransaction(const ConnectionInfo *conn_info,
  *
  *  @param #buffer must be of size at least CF_BUFSIZE.
  *
- *  @return 0 in case of socket closed, -1 in case of other error or timeout.
- *              In both cases the connection MAY NOT BE FINALISED!
+ *  @return -1 in case of closed socket, other error or timeout.
+ *              The connection MAY NOT BE FINALISED!
  *          >0 the number of bytes read, transaction was successfully received.
  *
  *  @TODO shutdown() the connection in all cases were this function returns -1,
@@ -156,7 +153,7 @@ int ReceiveTransaction(ConnectionInfo *conn_info, char *buffer, int *more)
 
     /* If error occured or recv() timeout or if connection was gracefully
      * closed. Connection has been finalised. */
-    if (ret == -1 || ret == 0)
+    if (ret == -1)
     {
         /* We are experiencing problems with receiving data from server.
          * This might lead to packages being not delivered in correct
@@ -165,7 +162,7 @@ int ReceiveTransaction(ConnectionInfo *conn_info, char *buffer, int *more)
          * In order to make sure that file transfer is reliable we have to
          * close connection to avoid broken packages being received. */
         conn_info->status = CONNECTIONINFO_STATUS_BROKEN;
-        return ret;
+        return -1;
     }
     else if (ret != CF_INBAND_OFFSET)
     {
@@ -246,10 +243,10 @@ int ReceiveTransaction(ConnectionInfo *conn_info, char *buffer, int *more)
         ret = -1;
     }
 
-    if (ret <= 0)
+    if (ret == -1)
     {
         conn_info->status = CONNECTIONINFO_STATUS_BROKEN;
-        return ret;
+        return -1;
     }
     else if (ret != len)
     {

--- a/libcfnet/net.h
+++ b/libcfnet/net.h
@@ -34,7 +34,7 @@
 extern uint32_t bwlimit_kbytes;
 
 
-int SendTransaction(const ConnectionInfo *conn_info, const char *buffer, int len, char status);
+int SendTransaction(ConnectionInfo *conn_info, const char *buffer, int len, char status);
 int ReceiveTransaction(ConnectionInfo *conn_info, char *buffer, int *more);
 
 int SetReceiveTimeout(int fd, unsigned long ms);

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -640,7 +640,7 @@ int TLSSend(SSL *ssl, const char *buffer, int length)
     {
         if ((SSL_get_shutdown(ssl) & SSL_RECEIVED_SHUTDOWN) != 0)
         {
-            Log(LOG_LEVEL_VERBOSE,
+            Log(LOG_LEVEL_ERR,
                 "Remote peer terminated TLS session (SSL_write)");
             return 0;
         }
@@ -717,7 +717,7 @@ int TLSRecv(SSL *ssl, char *buffer, int toget)
     {
         if ((SSL_get_shutdown(ssl) & SSL_RECEIVED_SHUTDOWN) != 0)
         {
-            Log(LOG_LEVEL_VERBOSE,
+            Log(LOG_LEVEL_ERR,
                 "Remote peer terminated TLS session (SSL_read)");
         }
         else


### PR DESCRIPTION
Follows #2356.

* Fail on networking errors during file copy (this avoids continuing the copy when the
  file in error was the last evaluated in a directory)
* Free dirh in case of networking error
* Mark connection broken in SendTransaction
* ReceiveTransaction should always returns -1 in case of error (some calls to it test this value for errors)