### PR TITLE
cf-promises/cf-promises.c: teach --show-vars to print JSON vars

### DIFF
--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -481,15 +481,19 @@ static void ShowVariablesFormatted(EvalContext *ctx)
         char *varname = VarRefToString(v->ref, true);
 
         Writer *w = StringWriter();
-        RvalWrite(w, v->rval);
 
-        StringSet *tagset = EvalContextVariableTags(ctx, v->ref);
-        Buffer *tagbuf = StringSetToBuffer(tagset, ',');
+        switch (DataTypeToRvalType(v->type))
+        {
+        case RVAL_TYPE_CONTAINER:
+            JsonWriteCompact(w, RvalContainerValue(v->rval));
+            break;
 
-        char *line;
+        default:
+            RvalWrite(w, v->rval);
+        }
+
         const char *var_value;
-
-        if(StringIsPrintable(StringWriterData(w)))
+        if (StringIsPrintable(StringWriterData(w)))
         {
             var_value = StringWriterData(w);
         }
@@ -498,6 +502,11 @@ static void ShowVariablesFormatted(EvalContext *ctx)
             var_value = "<non-printable>";
         }
 
+
+        StringSet *tagset = EvalContextVariableTags(ctx, v->ref);
+        Buffer *tagbuf = StringSetToBuffer(tagset, ',');
+
+        char *line;
         xasprintf(&line, "%-40s %-60s %-40s", varname, var_value, BufferData(tagbuf));
 
         SeqAppend(seq, line);

--- a/tests/acceptance/00_basics/def.json/show_vars_JSON.cf
+++ b/tests/acceptance/00_basics/def.json/show_vars_JSON.cf
@@ -1,0 +1,27 @@
+# basic test of the def.json facility: classes
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) --show-vars -w $(sys.workdir)|$(G.grep) test_var";
+
+  methods:
+      "" usebundle => dcs_passif_output('default:def.test_var\\s+\\{"387c108886725091c6fe2433a9fcafa0820dd61f":\\["8e92eeab70dbef876aeac9d97a74cfdde6f53e86"\\]\\}.*', "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/show_vars_JSON.cf.json
+++ b/tests/acceptance/00_basics/def.json/show_vars_JSON.cf.json
@@ -1,0 +1,6 @@
+{
+ "vars":
+ {
+  "test_var": { "387c108886725091c6fe2433a9fcafa0820dd61f": [ "8e92eeab70dbef876aeac9d97a74cfdde6f53e86" ] }
+ }
+}


### PR DESCRIPTION
Simple change, picked from #2245 

@kacf should be an easy merge, docs and acceptance tests will come if the code is OK.