### PR TITLE
cf-promises: allows --show-vars and --show-classes to take an optional filter

### DIFF
--- a/cf-agent/Makefile.am
+++ b/cf-agent/Makefile.am
@@ -73,7 +73,6 @@ libcf_agent_la_SOURCES = \
         cf_sql.c cf_sql.h \
 	files_changes.c files_changes.h \
         promiser_regex_resolver.c promiser_regex_resolver.h \
-        match_scope.c match_scope.h \
         retcode.c retcode.h \
         verify_acl.c verify_acl.h \
         verify_files.c verify_files.h \

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -34,12 +34,14 @@
 #include <bootstrap.h>
 #include <string_lib.h>
 #include <loading.h>
+#include <regex.h>                                        /* CompileRegex */
+#include <match_scope.h>
 
 #include <time.h>
 
 static GenericAgentConfig *CheckOpts(int argc, char **argv);
-static void ShowContextsFormatted(EvalContext *ctx);
-static void ShowVariablesFormatted(EvalContext *ctx);
+static void ShowContextsFormatted(EvalContext *ctx, const char *regexp);
+static void ShowVariablesFormatted(EvalContext *ctx, const char *regexp);
 
 /*******************************************************************/
 /* Command line options                                            */
@@ -66,8 +68,8 @@ static const struct option OPTIONS[] =
 {
     {"workdir", required_argument, 0, 'w'},
     {"eval-functions", optional_argument, 0, OPT_EVAL_FUNCTIONS },
-    {"show-classes", no_argument, 0, OPT_SHOW_CLASSES },
-    {"show-vars", no_argument, 0, OPT_SHOW_VARS },
+    {"show-classes", optional_argument, 0, OPT_SHOW_CLASSES },
+    {"show-vars", optional_argument, 0, OPT_SHOW_VARS },
     {"help", no_argument, 0, 'h'},
     {"bundlesequence", required_argument, 0, 'b'},
     {"debug", no_argument, 0, 'd'},
@@ -95,8 +97,8 @@ static const char *const HINTS[] =
 {
     "Override the work directory for testing (same as setting CFENGINE_TEST_OVERRIDE_WORKDIR)",
     "Evaluate functions during syntax checking (may catch more run-time errors). Possible values: 'yes', 'no'. Default is 'yes'",
-    "Show discovered classes, including those defined in common bundles in policy",
-    "Show discovered variables, including those defined without dependency to user-defined classes in policy",
+    "Show discovered classes, including those defined in common bundles in policy. Optionally can take a regular expression.",
+    "Show discovered variables, including those defined without dependency to user-defined classes in policy. Optionally can take a regular expression.",
     "Print the help message",
     "Use the specified bundlesequence for verification",
     "Enable debugging output",
@@ -213,12 +215,12 @@ int main(int argc, char *argv[])
 
     if(config->agent_specific.common.show_classes)
     {
-        ShowContextsFormatted(ctx);
+        ShowContextsFormatted(ctx, config->agent_specific.common.show_classes);
     }
 
     if(config->agent_specific.common.show_variables)
     {
-        ShowVariablesFormatted(ctx);
+        ShowVariablesFormatted(ctx, config->agent_specific.common.show_variables);
     }
 
     PolicyDestroy(policy);
@@ -244,7 +246,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
         switch (c)
         {
         case OPT_EVAL_FUNCTIONS:
-            if (!optarg)
+            if (optarg == NULL)
             {
                 optarg = "yes";
             }
@@ -252,11 +254,19 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
             break;
 
         case OPT_SHOW_CLASSES:
-            config->agent_specific.common.show_classes = true;
+            if (optarg == NULL)
+            {
+                optarg = ".*";
+            }
+            config->agent_specific.common.show_classes = optarg;
             break;
 
         case OPT_SHOW_VARS:
-            config->agent_specific.common.show_variables = true;
+            if (optarg == NULL)
+            {
+                optarg = ".*";
+            }
+            config->agent_specific.common.show_variables = optarg;
             break;
 
         case 'w':
@@ -477,16 +487,33 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
     return config;
 }
 
-static void ShowContextsFormatted(EvalContext *ctx)
+static void ShowContextsFormatted(EvalContext *ctx, const char *regexp)
 {
+    assert(regexp != NULL);
+
     ClassTableIterator *iter = EvalContextClassTableIteratorNewGlobal(ctx, NULL, true, true);
     Class *cls = NULL;
 
     Seq *seq = SeqNew(1000, free);
 
+    pcre *rx = CompileRegex(regexp);
+
+    if (rx == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Sorry, we could not compile regular expression %s", regexp);
+        return;
+    }
+
     while ((cls = ClassTableIteratorNext(iter)))
     {
         char *class_name = ClassRefToString(cls->ns, cls->name);
+
+        if (!PartialMatch(rx, class_name))
+        {
+            free(class_name);
+            continue;
+        }
+
         StringSet *tagset = EvalContextClassTags(ctx, cls->ns, cls->name);
         Buffer *tagbuf = StringSetToBuffer(tagset, ',');
 
@@ -497,6 +524,8 @@ static void ShowContextsFormatted(EvalContext *ctx)
         BufferDestroy(tagbuf);
         free(class_name);
     }
+
+    pcre_free(rx);
 
     SeqSort(seq, (SeqItemComparator)strcmp, NULL);
 
@@ -513,16 +542,32 @@ static void ShowContextsFormatted(EvalContext *ctx)
     ClassTableIteratorDestroy(iter);
 }
 
-static void ShowVariablesFormatted(EvalContext *ctx)
+static void ShowVariablesFormatted(EvalContext *ctx, const char *regexp)
 {
+    assert(regexp != NULL);
+
     VariableTableIterator *iter = EvalContextVariableTableIteratorNew(ctx, NULL, NULL, NULL);
     Variable *v = NULL;
 
     Seq *seq = SeqNew(2000, free);
 
+    pcre *rx = CompileRegex(regexp);
+
+    if (rx == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Sorry, we could not compile regular expression %s", regexp);
+        return;
+    }
+
     while ((v = VariableTableIteratorNext(iter)))
     {
         char *varname = VarRefToString(v->ref, true);
+
+        if (!PartialMatch(rx, varname))
+        {
+            free(varname);
+            continue;
+        }
 
         Writer *w = StringWriter();
 
@@ -559,6 +604,8 @@ static void ShowVariablesFormatted(EvalContext *ctx)
         WriterClose(w);
         free(varname);
     }
+
+    pcre_free(rx);
 
     SeqSort(seq, (SeqItemComparator)strcmp, NULL);
 

--- a/libpromises/Makefile.am
+++ b/libpromises/Makefile.am
@@ -99,6 +99,7 @@ libpromises_la_SOURCES = \
         locks.c locks.h \
         logic_expressions.c logic_expressions.h \
         matching.c matching.h \
+        match_scope.c match_scope.h \
         math_eval.c math_eval.h math.pc \
         mod_access.c mod_access.h \
         mod_common.c mod_common.h \

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -77,8 +77,8 @@ typedef struct
             unsigned int parser_warnings;
             unsigned int parser_warnings_error;
             bool eval_functions;
-            bool show_classes;
-            bool show_variables;
+            char *show_classes;
+            char *show_variables;
         } common;
         struct
         {

--- a/libpromises/match_scope.c
+++ b/libpromises/match_scope.c
@@ -84,6 +84,18 @@ static int RegExMatchFullString(EvalContext *ctx, pcre *rx, const char *teststri
     }
 }
 
+/*
+ * This is a fast partial match function. It checks that the compiled rx matches
+ * anywhere inside teststring. It does not allocate or free rx!
+ */
+bool PartialMatch(const pcre *rx, const char *teststring)
+{
+    int ovector[OVECCOUNT];
+    int rc = pcre_exec(rx, NULL, teststring, strlen(teststring), 0, 0, ovector, OVECCOUNT);
+
+    return rc >= 0;
+}
+
 int FullTextMatch(EvalContext *ctx, const char *regexp, const char *teststring)
 {
     pcre *rx;

--- a/libpromises/match_scope.h
+++ b/libpromises/match_scope.h
@@ -26,6 +26,10 @@
 #define CFENGINE_MATCH_SCOPE_H
 
 #include <cf3.defs.h>
+#include <regex.h>
+
+/* Does not free rx! */
+bool PartialMatch(const pcre *rx, const char *teststring);
 
 int FullTextMatch(EvalContext *ctx, const char *regptr, const char *cmpptr); /* Sets variables */
 int BlockTextMatch(EvalContext *ctx, const char *regexp, const char *teststring, int *s, int *e); /* Sets variables */

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -261,7 +261,7 @@ buffer_test_CPPFLAGS = $(AM_CPPFLAGS)
 csv_parser_test_SOURCES = csv_parser_test.c ../../libutils/csv_parser.c
 csv_parser_test_LDADD = libtest.la ../../libutils/libutils.la
 
-regex_test_SOURCES = regex_test.c ../../cf-agent/match_scope.c
+regex_test_SOURCES = regex_test.c ../../libpromises/match_scope.c
 
 ipaddress_test_SOURCES = ipaddress_test.c
 
@@ -317,7 +317,7 @@ lastseen_migration_test_LDADD = libdb.la ../../libpromises/libpromises.la
 
 CLEANFILES = *.gcno *.gcda cfengine-enterprise.so
 
-package_versions_compare_test_SOURCES = package_versions_compare_test.c ../../cf-agent/package_module.c ../../cf-agent/verify_packages.c ../../cf-agent/verify_new_packages.c ../../cf-agent/vercmp.c ../../cf-agent/vercmp_internal.c ../../cf-agent/retcode.c ../../cf-agent/match_scope.c
+package_versions_compare_test_SOURCES = package_versions_compare_test.c ../../cf-agent/package_module.c ../../cf-agent/verify_packages.c ../../cf-agent/verify_new_packages.c ../../cf-agent/vercmp.c ../../cf-agent/vercmp_internal.c ../../cf-agent/retcode.c ../../libpromises/match_scope.c
 
 #package_versions_compare_test_CPPFLAGS = $(AM_CPPFLAGS)
 package_versions_compare_test_LDADD = ../../libpromises/libpromises.la libtest.la


### PR DESCRIPTION
Effect:
- just `--show-vars` and `--show-classes` work like before
- `--show-vars=default:sys` shows only variable names that contain that filter
- `--show-classes=foo` shows only class names that contain that filter
- ~~with a filter, the header is not printed~~
