### PR TITLE
Redmine #7808: Do not drop privileges when changes permissions on non fifo

### DIFF
--- a/m4/fchmodat.m4
+++ b/m4/fchmodat.m4
@@ -17,7 +17,7 @@ AC_DEFUN([cf3_FUNC_FCHMODAT],
   # when executing as an alternative user. We need to be an alternative user
   # for security reasons, so check that feature here. See file_lib.c for more
   # information.
-  AC_CACHE_CHECK([whether chmod works with seteuid], [cf3_cv_func_chmod_seteuid_works],
+  AC_CACHE_CHECK([whether chmod works with seteuid], [cf3_cv_func_chmod_seteuid_highbits_work],
     [AC_RUN_IFELSE([
       AC_LANG_PROGRAM([[#include <sys/types.h>
                         #include <sys/stat.h>
@@ -107,14 +107,14 @@ cleanup:
   unlink(TEST_FILE);
 
   return ret;]])],
-      [cf3_cv_func_chmod_seteuid_works=yes],
-      [cf3_cv_func_chmod_seteuid_works=no],
+      [cf3_cv_func_chmod_seteuid_highbits_work=yes],
+      [cf3_cv_func_chmod_seteuid_highbits_work=no],
       [
          AS_CASE([$host_os],
            [aix|hpux], [
-             cf3_cv_func_chmod_seteuid_works=yes
+             cf3_cv_func_chmod_seteuid_highbits_work=yes
            ], [
-             cf3_cv_func_chmod_seteuid_works=no
+             cf3_cv_func_chmod_seteuid_highbits_work=no
            ]
          )
       ]
@@ -122,9 +122,9 @@ cleanup:
     ]
   )
 
-  AS_CASE([$cf3_cv_func_chmod_seteuid_works],
+  AS_CASE([$cf3_cv_func_chmod_seteuid_highbits_work],
     [yes], [
-      AC_DEFINE(CHMOD_SETEUID_WORKS, 1, [Whether chmod supports higher bit flags in mode argument when running as alternative user.])
+      AC_DEFINE(CHMOD_SETEUID_HIGHBITS_WORK, 1, [Whether chmod supports higher bit flags in mode argument when running as alternative user.])
     ]
   )
 ])

--- a/tests/acceptance/10_files/02_maintain/perms_recurse.cf
+++ b/tests/acceptance/10_files/02_maintain/perms_recurse.cf
@@ -1,0 +1,98 @@
+# https://dev.cfengine.com/issues/7808
+#
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+bundle agent init
+{
+  meta:
+      # Permissions test doesn't work with fakeroot.
+      # It also doesn't work on non-Linux due to the use of GNU specific find
+      # options.
+      "test_skip_needs_work" string => "using_fakeroot|!linux";
+
+  vars:
+      "directory" string => "$(G.testdir)";
+
+      "mode"      string => "750";
+      "owner"     string => "bin";
+      "group"     string => "bin";
+
+  files:
+      "$(directory)/."
+          perms  => mog("000", "root", "0"),
+          create => "true";
+
+      "$(directory)/dir1/."
+          perms  => mog("000", "root", "0"),
+          create => "true";
+
+      "$(directory)/dir2/."
+          perms  => mog("000", "root", "0"),
+          create => "true";
+
+}
+
+bundle agent test
+{
+  files:
+      "$(init.directory)"
+          create       => "false",
+          perms        => mog("${init.mode}", "${init.owner}", "${init.group}"),
+          depth_search => recurse_with_base("inf"),
+          file_select  => dirs;
+}
+
+body file_select dirs
+# @brief Select directories
+{
+    file_types  => { "dir" };
+    file_result => "file_types";
+}
+
+
+bundle agent check
+{
+
+  vars:
+    "permissions_test_mode"  string => "/usr/bin/test \"`/usr/bin/find ${init.directory} -perm ${init.mode} | wc -l`\" = \"3\"";
+    "permissions_test_owner" string => "/usr/bin/test \"`/usr/bin/find ${init.directory} -user ${init.owner} | wc -l`\" = \"3\"";
+    "permissions_test_group" string => "/usr/bin/test \"`/usr/bin/find ${init.directory} -group ${init.group} | wc -l`\" = \"3\"";
+
+  commands:
+    "${permissions_test_mode}"
+        contain => in_shell,
+        classes => ok("permissions_test_mode_ok");
+    "${permissions_test_owner}"
+        contain => in_shell,
+        classes => ok("permissions_test_owner_ok");
+    "${permissions_test_group}"
+        contain => in_shell,
+        classes => ok("permissions_test_group_ok");
+
+  reports:
+    DEBUG.!permissions_test_mode_ok::
+      "Didn't find 3 files with mode ${init.mode}";
+    DEBUG.!permissions_test_owner_ok::
+      "Didn't find 3 files with owner${init.owner}";
+    DEBUG.!permissions_test_group_ok::
+      "Didn't find 3 files with group ${init.group}";
+    permissions_test_mode_ok.permissions_test_owner_ok.permissions_test_group_ok::
+      "$(this.promise_filename) Pass";
+    !(permissions_test_mode_ok.permissions_test_owner_ok.permissions_test_group_ok)::
+      "$(this.promise_filename) FAIL";
+
+}
+
+body classes ok(classname)
+{
+    promise_repaired => { "$(classname)" };
+    promise_kept => { "$(classname)" };
+}
+
+

--- a/tests/unit/file_lib_test.c
+++ b/tests/unit/file_lib_test.c
@@ -1236,7 +1236,7 @@ static void test_safe_chmod_unsafe_link(void)
     assert_int_equal(stat(TEST_SUBDIR "/" TEST_FILE, &statbuf), 0);
     assert_int_equal(statbuf.st_mode & 0777, 0777);
     assert_int_equal(safe_chmod(TEST_FILE, 0644), -1);
-    assert_int_equal(errno, EPERM);
+    assert_int_equal(errno, ENOLINK);
     assert_int_equal(stat(TEST_SUBDIR "/" TEST_FILE, &statbuf), 0);
     assert_int_equal(statbuf.st_mode & 0777, 0777);
 
@@ -1320,8 +1320,7 @@ static void test_safe_chmod_chown_fifos(void)
     assert_int_equal(safe_chown(TEST_FILE, 100, 100), -1);
     assert_int_equal(errno, ENOLINK);
     assert_int_equal(safe_chmod(TEST_FILE, 0755), -1);
-    // Would be ENOLINK, but safe_chmod lacks support for detecting this.
-    assert_int_equal(errno, EPERM);
+    assert_int_equal(errno, ENOLINK);
     assert_int_equal(safe_chown(TEST_SUBDIR "/" TEST_FILE, 100, 100), 0);
 
     // Now the owner is correct


### PR DESCRIPTION
The reason is that dropping privileges has some unexpected
consequences: CFEngine operates recursively on a file tree in a way
that may leave the directory being operated on last (e.g. files inside
the directory are treated before the directory itself). This means
that if we drop privileges, we may not always have the permissions to
enter the directory. This is impossible to fix for FIFOs (other than
changing the order that CFEngine does things, but that is on a
different code level and has other implications), because FIFOs will
block if we try to open a file descriptor to them, but we can fix it
for regular files by switching back to the old method of opening the
file descriptor and doing fchmod on that.

An additional level of complexity in this case is that the path may
end in a symlink *pointing* to a FIFO, hence the code that opens the
true parent directory of the leaf.

Also rename the CHMOD_SETEUID_WORKS flag to CHMOD_SETEUID_HIGHBITS_WORK
to make it clearer that it is not seteuid support which is missing,
but support for seteuid together with high bit flags in permission
modes.

Changelog: Fix a regression which would sometimes cause "Permission
denied" errors on files inside directories with very restricted
permissions.

Based on a patch by Alexis Mousset <alexis.mousset@normation.com>.

Also include acceptance test from #2428.