### PR TITLE
Change: Suppress warning from multiple cf-conusmer processes

### DIFF
--- a/misc/init.d/cfengine3.in
+++ b/misc/init.d/cfengine3.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # cfengine3
-# 
+#
 #
 # Created by Nakarin Phooripoom on 22/6/2011.
 # Copyright 2015 CFEngine AS. All rights reserved.
@@ -426,9 +426,13 @@ cf_status_daemon()
         echo "Warning: PID file '$pidfile' does not contain the right PID ('$pids' != '$daemon_status'). Should restart CFEngine."
     fi
 
-    # Lack of quotes around $pids is important to eliminate newlines.
-    if [ -n "$(echo $pids | grep '[^0-9]')" ]; then
-        echo "Warning: Multiple $base_daemon processes present. Should restart CFEngine."
+    # cf-consumer is expected to have multiple pids, so if checking status for
+    # cf-consumer, skip detection of multiple pids to avoid false alarms
+    if [ "${base_daemon}" != "cf-consumer" ]; then
+        # Lack of quotes around $pids is important to eliminate newlines.
+        if [ -n "$(echo $pids | grep '[^0-9]')" ]; then
+            echo "Warning: Multiple $base_daemon processes present. Should restart CFEngine."
+        fi
     fi
 
     if [ -n "$pids" ]; then


### PR DESCRIPTION
Multiple cf-consumer processes are expected so warning about the
expected state just creates a false alarm.