### PR TITLE
Namespaces allow some special characters which allows creation of

### DIFF
--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -398,7 +398,7 @@ const ConstraintSyntax CFH_CONTROLBODY[] =  /* enum cfh_control */
 
 const ConstraintSyntax file_control_constraints[] =  /* enum cfh_control */
 {
-    ConstraintSyntaxNewString("namespace", CF_IDRANGE, "Switch to a private namespace to protect current file from duplicate definitions", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewString("namespace", "[a-zA-Z_][a-zA-Z0-9_]*", "Switch to a private namespace to protect current file from duplicate definitions", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewStringList("inputs", ".*", "List of additional filenames to parse for promises", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewNull()
 };

--- a/tests/acceptance/00_basics/namespaces_can_not_contain_funny_characters.cf
+++ b/tests/acceptance/00_basics/namespaces_can_not_contain_funny_characters.cf
@@ -19,10 +19,6 @@ bundle agent test
       string => "Test that namespaces cannot be defined with
                  characters that are invalid in bundle names.";
 
-    "test_soft_fail"
-      string => "any",
-      meta => { "redmine7903" };
-
   vars:
      "command" string => "$(sys.cf_agent) -KI --define AUTO,DEBUG $(this.promise_filename).sub";
 


### PR DESCRIPTION
namespaces that cannot be reached. Redmine #7903.

ChangeLog: Allowed namespace names made more strict, to disallow
namespaces that cannot be reached.

Modified by: Kristian Amlie <kristian.amlie@cfengine.com>
- Made regex even more strict: Don't allow starting with numbers.