### PR TITLE
Redmine#7912: Implement Murmur3 32bit hash & hash collision handling

### DIFF
--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -77,6 +77,80 @@ unsigned int StringHash(const char *str, unsigned int seed, unsigned int max)
     return (h & (max - 1));
 }
 
+/**
+ * Murmur3 32bit hash: https://en.wikipedia.org/wiki/MurmurHash
+ *
+ * Original C++ implementation of Murmur Hash v3:
+ * https://code.google.com/p/smhasher/wiki/MurmurHash3
+ *
+ * This 32bit C implementation can be found here:
+ * https://github.com/wolkykim/qlibc/blob/master/src/utilities/qhash.c#L258
+ *
+ * @parram #str   String to be hashed
+ * @parama #seed  Initial hash value
+ */
+uint32_t MurmurHash3_32(const char *str, uint32_t seed)
+{
+    if (str == NULL)
+    {
+        return 0;
+    }
+
+    size_t nbytes = strlen(str);
+    if (nbytes == 0)
+    {
+        return 0;
+    }
+
+    const uint32_t c1 = 0xcc9e2d51;
+    const uint32_t c2 = 0x1b873593;
+
+    const int nblocks = nbytes / 4;
+    const uint32_t *blocks = (const uint32_t *) (str);
+    const uint8_t *tail = (const uint8_t *) (str + (nblocks * 4));
+
+    uint32_t h = seed;
+
+    int i;
+    uint32_t k;
+    for (i = 0; i < nblocks; i++)
+    {
+        k = blocks[i];
+
+        k *= c1;
+        k = (k << 15) | (k >> (32 - 15));
+        k *= c2;
+
+        h ^= k;
+        h = (h << 13) | (h >> (32 - 13));
+        h = (h * 5) + 0xe6546b64;
+    }
+
+    k = 0;
+    switch (nbytes & 3)
+    {
+        case 3:
+            k ^= tail[2] << 16;
+        case 2:
+            k ^= tail[1] << 8;
+        case 1:
+            k ^= tail[0];
+            k *= c1;
+            k = (k << 15) | (k >> (32 - 15));
+            k *= c2;
+            h ^= k;
+    }
+
+    h ^= nbytes;
+
+    h ^= h >> 16;
+    h *= 0x85ebca6b;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35;
+    h ^= h >> 16;
+
+    return h;
+}
 
 char ToLower(char ch)
 {

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -29,6 +29,7 @@
 #include <compiler.h>
 #include <sequence.h>
 #include <pcre_include.h>
+#include <stdint.h>
 
 
 typedef struct
@@ -38,6 +39,7 @@ typedef struct
 } StringRef;
 
 unsigned int StringHash(const char *str, unsigned int seed, unsigned int max);
+uint32_t MurmurHash3_32(const char *str, uint32_t seed);
 
 char ToLower(char ch);
 char ToUpper(char ch);


### PR DESCRIPTION
###### Summary
This patch implements Murmur3 32bit hash for calculating hashes used in class hash tables. We tested Murmur3 and StringHash against **1004441 unique class names** in our infrastructure (LinkedIn) and found that **Murmur3 yields 117 collisions, whereas StringHash yielded 653 collisions**. This patch also implements very cheap (in terms of computation) collision handling; combined with Murmur3 and the collision resolution technique, we were able to achieve **0 (zero) hash collisions** when tested against 1 million classes.

The C snippet used to measure the collisions is here:

```
#include <stdlib.h>
#include <stdio.h>
#include <stdbool.h>
#include <string.h>
#include <class.h>

static unsigned int GetHash(ClassTable *t, const char *name)
{
    ClassTablePut(t, NULL, name, false, CONTEXT_SCOPE_NAMESPACE, NULL);
    Class *cls = ClassTableGet(t, NULL, name);

    return (cls ? cls->hash : 0);
}


int main(int argc, char **argv)
{
    if (argc < 2)
    {
        printf("Usage: ./demo_cfe_patch filename\n");
        exit(EXIT_FAILURE);
    }

    FILE *fp = fopen(argv[1], "r");
    if ( fp == NULL)
    {
        perror(argv[1]);
        exit(EXIT_FAILURE);
    }

    //assuming class names can be 1024 characters long at max
    char line[1024] = {'\0'};

    ClassTable *t = ClassTableNew();
    if(!t)
    {
        printf("Could not create ClassTable, exiting\n");
        exit(EXIT_FAILURE);
    }

    while (fgets(line, sizeof line, fp) != NULL)
    {
        line[strcspn(line, "\n")] = '\0';
        printf("%s\t%u\n", line, GetHash(t, line));
    }

    //clean up
    fclose(fp);
    ClassTableDestroy(t);
    exit(EXIT_SUCCESS);
}
```
This was compiled against patched as well as original libpromises and libutils for comparative studies.

Detailed discussions are in [Redmine#7912](https://dev.cfengine.com/issues/7912)

###### Changes Made:
1. MurmurHash3_32() is added in ibutils/string_lib.c. It is a 32 bit Murmur3 implementation
2. ClassRefHash() in libpromises/class.c now calculates hashes using MurmurHash3_32(). It now uses a concatenated string of class name and namespace as a string to be hashed. Calls MurmurHash3_32() only once to produce a hash. Previously it used to call StringHash() 2 times: one to hash namespace and another to hash class name.
3. ClassRefHash() now takes an additional argument, is_collision boolean. If true, it will use "classname""namespace""__" string
4. ClassInit() now takess an additional argument "hash". This is to stop duplicate call of ClassRefHash() during class initialization. Previously ClassRefHash() was called 2 times: one by ClassTableGet(), another by ClassInit() while creating a new class.
5. ClassTableGet() now calls a new function ClassTableGetCollision() which takes an additional argument "hashp", a pointer to an unsigned int. It's used to hold the calculated hash value, which can later be used by ClassTablePut() to avoid duplication of hash function calls.
ClassTableGetCollision() detects hash collisions and provides 1st level resolution. This is how it detects a collision:

    A. calculate hash of class and namespace using ClassRefHash()

    B. Try to find if the key already exists in the RB tree using the hash of step A

    C. If found, verify class name and namespace match with those in the class node found in the tree

    C.1. If step C is true, return address of the node
    D. Generate a new hash using "classname""namespace""__" string

    E. Try to find a node using the hash generated in step D.

    F. If a match was found in step B, return class with hash key generated in step E(during collision), 
else return class with hash key generated in step A (when a class is not set i.e not found in the tree).

6. ClassTablePut() calls ClassTableGetCollision() to search through class table before putting in a new class.

```
[smahapat@lva1-cfe-guppy03 ~]$ wc -l file
1004441 file
```
With StringHash():
```
[smahapat@lva1-cfe-guppy03 ~]$ time ./calc_hash_classes ./file str >/dev/null

real	0m0.670s
user	0m0.659s
sys	0m0.010s
```
With Murmur3:
```
[smahapat@lva1-cfe-guppy03 ~]$ time ./calc_hash_classes ./file mur >/dev/null

real	0m0.525s
user	0m0.475s
sys	0m0.050s
```


