### PR TITLE
Small networking errors handling improvements

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -828,6 +828,7 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
             {
                 cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_INTERRUPTED, pp,
                      attr, "connection error");
+                AbstractDirClose(dirh);
                 return PROMISE_RESULT_INTERRUPTED;
             }
             else
@@ -869,6 +870,7 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
                 {
                     cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_INTERRUPTED, pp,
                          attr, "connection error");
+                    AbstractDirClose(dirh);
                     return PROMISE_RESULT_INTERRUPTED;
                 }
                 else
@@ -888,6 +890,7 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
                     cfPS(ctx, LOG_LEVEL_INFO,
                          PROMISE_RESULT_INTERRUPTED, pp, attr,
                          "connection error");
+                    AbstractDirClose(dirh);
                     return PROMISE_RESULT_INTERRUPTED;
                 }
                 else

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -837,8 +837,9 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
             }
         }
 
-        if (attr.copy.purge)    /* Purge this file */
+        if (attr.copy.purge)
         {
+            /* Append this file to the list of files not to purge */
             AppendItem(&namecache, dirp->d_name, NULL);
         }
 
@@ -973,6 +974,15 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
         else
         {
             result = PromiseResultUpdate(result, VerifyCopy(ctx, newfrom, newto, attr, pp, inode_cache, conn));
+        }
+        
+        if (conn != NULL &&
+            conn->conn_info->status != CONNECTIONINFO_STATUS_ESTABLISHED)
+        {
+            cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_INTERRUPTED, pp,
+                 attr, "connection error");
+            AbstractDirClose(dirh);
+            return PROMISE_RESULT_INTERRUPTED;
         }
     }
 


### PR DESCRIPTION
* Fail on networking errors during file copy (this avoids continuing the copy when the file in error was the last evaluated in a directory)
* Free dirh in case of networking error