### PR TITLE
Isvariable arrays

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7768,7 +7768,7 @@ static const FnCallArg ISNEWERTHAN_ARGS[] =
 
 static const FnCallArg ISVARIABLE_ARGS[] =
 {
-    {CF_IDRANGE, CF_DATA_TYPE_STRING, "Variable identifier"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Variable identifier"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 

--- a/tests/acceptance/02_classes/01_basic/array_key_with_space_isvariable.cf
+++ b/tests/acceptance/02_classes/01_basic/array_key_with_space_isvariable.cf
@@ -1,0 +1,39 @@
+# isvariable should be able to check array indexes that have spaces
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  vars:
+    "array[one]" string => "1";
+    "array[twenty one]" string => "21";
+
+  classes:
+    "have_one"
+      expression => isvariable("array[one]"),
+      scope => "namespace";
+
+    "have_twenty_one"
+      expression => isvariable("array[twenty one]"),
+      scope => "namespace";
+
+  reports:
+    have_one.DEBUG::
+      "Have array key 'one' as expected containing value '$(array[one])'";
+    have_twenty_one.DEBUG::
+      "Have array key 'twenty one' as expected containing value '$(array[twenty one])'";
+}
+
+bundle agent check
+{
+  methods:
+    have_one.have_twenty_one::
+      "result" usebundle => dcs_pass("$(this.promise_filename)");
+
+    !(have_one.have_twenty_one)::
+      "result" usebundle => dcs_fail("$(this.promise_filename)");
+}


### PR DESCRIPTION
commit 3517e4833c276fcbdb4d1fc490bb0240c140bea4
Author: Nick Anderson <nick@cmdln.org>
Date:   Thu Apr 2 01:53:56 2015

    Add: Test that isvariable works with array keys that have spaces
    
    Arrays and data having spaces in a key is valid, so isvariable should be
    able to test for them like any other variable.

commit c02d57bef56ba22680f001ab4fc0b257aec7076f
Author: Kristian Amlie <kristian.amlie@cfengine.com>
Date:   Fri Feb 12 09:03:56 2016

    Redmine #7088: Fix isvariable() not accepting many valid arrays.
    
    The problem is that although variables themselves cannot contain many
    characters, such as '-', ' ' and '?', arrays indices can, therefore we
    need to be prepared for pretty much any string. And there should be no
    harm in accepting any string, since it will still fail the test if it
    isn't a variable.
    
    Changelog: The `isvariable()` function call now correctly accepts all
    array variables when specified inline. Previously it would not accept
    certain special characters, even though they could be specified
    indirectly by using a variable to hold it.

https://dev.cfengine.com/issues/7088