### PR TITLE
Redmine #7933: Fix timing bug when grabbing global package lock.

### DIFF
--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/package_lock.cf
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/package_lock.cf
@@ -1,0 +1,56 @@
+# Test whether successive package locks can be grabbed, both immediately
+# following each other and after a time delay. (Redmine #7933).
+
+body common control
+{
+    inputs => { "../../../default.cf.sub" };
+    bundlesequence => { default("$(this.promise_filename)") };
+}
+
+bundle agent init
+{
+  meta:
+      # "no_fds" won't work correctly on Windows.
+      # Also Solaris 9 and 10 don't seem to handle the backgrounding used in
+      # this test. But it seems unrelated to the actual fix.
+      "test_skip_needs_work" string => "windows|sunos_5_9|sunos_5_10";
+
+      # The backgrounding doesn't work well under fakeroot.
+      "test_skip_unsupported" string => "using_fakeroot";
+
+  files:
+    test_pass_1::
+      "$(sys.workdir)/modules/packages/."
+        create => "true";
+      "$(sys.workdir)/modules/packages/test_module"
+        copy_from => local_cp("$(this.promise_filename).module"),
+        perms => m("ugo+x");
+}
+
+bundle agent test
+{
+  commands:
+    test_pass_1::
+      # Note: No -K. We need locks.
+      # Also get rid of file descriptor ties to the parent with no_fds.
+      # Note that we need to redirect descriptors 0, 1 and 2, since there is
+      # apparently some unrelated bug in the output if we close them (otherwise
+      # we would have used --no-std argument to no_fds).
+      "$(G.no_fds) $(sys.cf_agent) -f $(this.promise_filename).sub < /dev/null > /dev/null 2>&1 &"
+        contain => in_shell;
+}
+
+bundle agent check
+{
+  methods:
+    test_pass_1::
+      # We wait 61 seconds in the sub invocation, but in practice test platforms
+      # experience all sorts of timing delays, let's give it plenty of time to
+      # make sure it finishes.
+      "any" usebundle => dcs_wait($(this.promise_filename), 120);
+
+    test_pass_2::
+      "any" usebundle => dcs_check_diff($(G.testfile),
+                                        "$(this.promise_filename).expected",
+                                        $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/package_lock.cf.expected
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/package_lock.cf.expected
@@ -1,0 +1,12 @@
+Name=first_pkg
+Version=1.0
+Architecture=generic
+Name=second_pkg
+Version=1.0
+Architecture=generic
+Name=third_pkg
+Version=1.0
+Architecture=generic
+Name=fourth_pkg
+Version=1.0
+Architecture=generic

--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/package_lock.cf.module
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/package_lock.cf.module
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    supports-api-version)
+        echo 1
+        ;;
+    get-package-data)
+        while read line; do
+            case "$line" in
+                File=*)
+                    echo PackageType=repo
+                    echo Name=${line#File=}
+                    ;;
+                *)
+                    true
+                    ;;
+            esac
+        done
+        ;;
+    list-installed)
+        while read line; do
+            case "$line" in
+                options=*)
+                    OUTPUT=${line#options=}
+                    ;;
+                *)
+                    exit 1
+                    ;;
+            esac
+        done
+        if [ -f "$OUTPUT" ]; then
+            cat "$OUTPUT"
+        fi
+        ;;
+    list-*)
+        # Drain input.
+        cat > /dev/null
+        ;;
+    repo-install)
+        while read line; do
+            case "$line" in
+                options=*)
+                    OUTPUT=${line#options=}
+                    ;;
+                Name=*)
+                    NAME=${line#Name=}
+                    ;;
+                *)
+                    exit 1
+                    ;;
+            esac
+        done
+        echo "Name=$NAME" >> "$OUTPUT"
+        echo "Version=1.0" >> "$OUTPUT"
+        echo "Architecture=generic" >> "$OUTPUT"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/package_lock.cf.sub
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/package_lock.cf.sub
@@ -1,0 +1,66 @@
+body common control
+{
+    inputs => { "../../../default.cf.sub" };
+    bundlesequence => { "test" };
+}
+
+bundle agent test
+{
+  methods:
+    debug_package_lock::
+      # Normally done by parent test.
+      "debug_init";
+    any::
+      "test1";
+      "test2";
+      "test3";
+}
+
+body package_module test_module
+{
+    query_installed_ifelapsed => "60";
+    query_updates_ifelapsed => "14400";
+    default_options => { "$(G.testfile)" };
+}
+
+bundle agent debug_init
+{
+  files:
+      "$(sys.workdir)/modules/packages/."
+        create => "true";
+      "$(sys.workdir)/modules/packages/test_module"
+        copy_from => local_cp("$(this.promise_dirname)/package_lock.cf.module"),
+        perms => m("ugo+x");
+}
+
+bundle agent test1
+{
+  packages:
+      "first_pkg"
+        policy => "present",
+        package_module => test_module,
+        action => immediate;
+      "second_pkg"
+        policy => "present",
+        package_module => test_module,
+        action => immediate;
+}
+
+bundle agent test2
+{
+  commands:
+      "$(G.sleep) 61";
+}
+
+bundle agent test3
+{
+  packages:
+      "third_pkg"
+        policy => "present",
+        package_module => test_module,
+        action => immediate;
+      "fourth_pkg"
+        policy => "present",
+        package_module => test_module,
+        action => immediate;
+}


### PR DESCRIPTION
Normally, when CFEngine grabs a promise lock, that exact lock is not
expected to be grabbed again for the duration of the cf-agent run. And
in fact, this is made impossible by the promise lock cache (see
EvalContextPromiseLockCacheContains()). If a promise is in fact
reevaluated, it is always because some part of the promise has
changed, even something as simple as the promise comment. This alters
the lock name, and hence it will count as a new lock. This behavior
sometimes requires specific workarounds to rerun promises inside
often-used bundles.

However, the global package lock works a bit differently: Since we
want to it to be a truly global lock, we need to reuse it. The first
step in this process is to remove it from the promise lock cache. This
is already done.

However, we run into a subtle issue when it comes to `ifelapsed`
values: `ifelapsed` is set to zero in the global package lock in order
for timing not to get in the way. But the logic in locks.c to deal
with ifelapsed is a bit flawed: The time counted as "now" is the start
time of cf-agent, but the time recorded as "last time this lock was
used" is the actual current time, which means that from the
perspective of "now", the last used time of the lock may be in the
future. This causes strange effects when cf-agent has been executing
for more than a minute, `elapsedtime` inside `AcquireLock` turns
negative, and this causes CFEngine to think that another agent is
executing and it skips grabbing the lock altogether.

And this is okay for locks with a nonzero ifelapsed value, since they
are not generally expected to be executed more than once inside one
cf-agent run, or when mutiple agents are executing in parallel, even
if the value is 1, and that run takes longer than one minute.

But for `ifelapsed == 0`, this check doesn't make sense because such
locks should be grabbed regardless of whether it was grabbed before,
or whether other agents have executed the same promise. Note that we
are still protected against executing the same promise *at the same
time*, this only introduces the capability to grab a promise lock that
was executed earlier in the same run, or earlier by a different agent.

Effects this has on the locks:

* Executing the same promise concurrently:
  NO (no change). You still cannot grab a currently held lock.

* Executing the exact same promise twice in the same run:
  NO (no change). If you got to the `elapsedtime` check this might
  happen, but we never get there because the promise lock cache will
  exit from the function early.

* Executing the exact same promise in concurrent agents with
  `ifelapsed >= 1`:
  NO (no change). For `ifelapsed >= 0` the logic is unchanged.

* Executing the exact same promise in concurrent agents with
  `ifelapsed == 0`:
  YES (CHANGED). This can now happen, since we don't check if another
  agent has executed the promise. I believe this is perfectly okay and
  even expected, since `ifelapsed == 0`.

* Grabbing the exact same promise lock twice in the same run, if lock
  is removed from promise lock cache and `ifelapsed == 0`:
  YES (CHANGED). Currently *only* the global package lock does this,
  and it is a requirement for it to work correctly. This case is what
  the bugfix is about, the others are just possible side effects.

Changelog: Fix a bug which sometimes caused package promises to be
skipped with "XX Another cf-agent seems to have done this since I
started" messages in the log, most notably in long running cf-agent
runs (longer than one minute).