### PR TITLE
Test workdir refactor

### DIFF
--- a/tests/unit/generic_agent_test.c
+++ b/tests/unit/generic_agent_test.c
@@ -10,7 +10,7 @@
 #include <crypto.h>
 #include <string_lib.h>
 
-char CFWORKDIR[CF_BUFSIZE];
+char TEMPDIR[] = "/tmp/generic_agent_test_XXXXXX";
 
 void test_load_masterfiles(void)
 {
@@ -102,30 +102,34 @@ void test_resolve_absolute_input_path(void)
 
 void test_resolve_non_anchored_base_path(void)
 {
-    static char inputdir[CF_BUFSIZE] = "";
+    char inputdir[CF_BUFSIZE] = "";
 
-    /*
-     * Can not use GetInputDir() because that will return the configured $(sys.inputdir) as
-     * the environment variable CFENGINE_TEST_OVERRIDE_WORKDIR is not set.
-    */
-    xsnprintf(inputdir, CF_BUFSIZE, "%s%cinputs", CFWORKDIR, FILE_SEPARATOR);
+    strlcpy(inputdir, GetInputDir(), sizeof(inputdir));
 
     GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_COMMON, false);
     GenericAgentConfigSetInputFile(config, inputdir, "promises.cf");
 
-    assert_string_equal("/workdir/inputs", config->input_dir);
-    assert_string_equal("/workdir/inputs/promises.cf", config->input_file);
+    char testpath[CF_BUFSIZE];
 
-    assert_string_equal("/workdir/inputs/aux.cf", GenericAgentResolveInputPath(config, "aux.cf"));
-    assert_string_equal("/workdir/inputs/rel/aux.cf", GenericAgentResolveInputPath(config, "rel/aux.cf"));
-    assert_string_equal("/workdir/inputs/./aux.cf", GenericAgentResolveInputPath(config, "./aux.cf"));
-    assert_string_equal("/workdir/inputs/./rel/aux.cf", GenericAgentResolveInputPath(config, "./rel/aux.cf"));
+    xsnprintf(testpath, sizeof(testpath), "%s%s", TEMPDIR, "/inputs");
+    assert_string_equal(testpath, config->input_dir);
+    xsnprintf(testpath, sizeof(testpath), "%s%s", TEMPDIR, "/inputs/promises.cf");
+    assert_string_equal(testpath, config->input_file);
+
+    xsnprintf(testpath, sizeof(testpath), "%s%s", TEMPDIR, "/inputs/aux.cf");
+    assert_string_equal(testpath, GenericAgentResolveInputPath(config, "aux.cf"));
+    xsnprintf(testpath, sizeof(testpath), "%s%s", TEMPDIR, "/inputs/rel/aux.cf");
+    assert_string_equal(testpath, GenericAgentResolveInputPath(config, "rel/aux.cf"));
+    xsnprintf(testpath, sizeof(testpath), "%s%s", TEMPDIR, "/inputs/./aux.cf");
+    assert_string_equal(testpath, GenericAgentResolveInputPath(config, "./aux.cf"));
+    xsnprintf(testpath, sizeof(testpath), "%s%s", TEMPDIR, "/inputs/./rel/aux.cf");
+    assert_string_equal(testpath, GenericAgentResolveInputPath(config, "./rel/aux.cf"));
 }
 
 void test_resolve_relative_base_path(void)
 {
     GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_COMMON, false);
-    GenericAgentConfigSetInputFile(config, CFWORKDIR, "./inputs/promises.cf");
+    GenericAgentConfigSetInputFile(config, GetWorkDir(), "./inputs/promises.cf");
 
     assert_string_equal("./inputs/aux.cf", GenericAgentResolveInputPath(config, "aux.cf"));
     assert_string_equal("./inputs/rel/aux.cf", GenericAgentResolveInputPath(config, "rel/aux.cf"));
@@ -135,7 +139,20 @@ void test_resolve_relative_base_path(void)
 
 int main()
 {
-    strcpy(CFWORKDIR, "/workdir");
+    if (mkdtemp(TEMPDIR) == NULL)
+    {
+        fprintf(stderr, "Could not create temporary directory\n");
+        return 1;
+    }
+    char *inputs = NULL;
+    xasprintf(&inputs, "%s/inputs", TEMPDIR);
+    mkdir(inputs, 0755);
+    free(inputs);
+
+    char *env_var = NULL;
+    xasprintf(&env_var, "CFENGINE_TEST_OVERRIDE_WORKDIR=%s", TEMPDIR);
+    // Will leak, but that's how crappy putenv() is.
+    putenv(env_var);
 
     PRINT_TEST_BANNER();
     const UnitTest tests[] =
@@ -146,10 +163,15 @@ int main()
         unit_test(test_resolve_non_anchored_base_path),
         unit_test(test_resolve_relative_base_path),
         unit_test(test_have_tty_interactive_failsafe_is_not_created),
-        //skip creating failsafe test for now as this is broken in Jenkins
-        //because of lack of /var/cfengine/inputs directory to create failsafe.cf there.
-        //unit_test(test_dont_have_tty_interactive_failsafe_is_created),
+        unit_test(test_dont_have_tty_interactive_failsafe_is_created),
     };
 
-    return run_tests(tests);
+    int ret = run_tests(tests);
+
+    char rm_rf[] = "rm -rf ";
+    char cmd[sizeof(rm_rf) + sizeof(TEMPDIR)];
+    sprintf(cmd, "%s%s", rm_rf, TEMPDIR);
+    ARG_UNUSED int ignore = system(cmd);
+
+    return ret;
 }

--- a/tests/unit/generic_agent_test.c
+++ b/tests/unit/generic_agent_test.c
@@ -12,23 +12,6 @@
 
 char TEMPDIR[] = "/tmp/generic_agent_test_XXXXXX";
 
-void test_load_masterfiles(void)
-{
-    EvalContext *ctx = EvalContextNew();
-    DiscoverVersion(ctx);
-
-    GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_COMMON, false);
-
-    GenericAgentConfigSetInputFile(config, NULL,
-                                   ABS_TOP_SRCDIR "/masterfiles/promises.cf");
-
-    Policy *masterfiles = LoadPolicy(ctx, config);
-    assert_true(masterfiles);
-
-    PolicyDestroy(masterfiles);
-    GenericAgentFinalize(ctx, config);
-}
-
 void test_have_tty_interactive_failsafe_is_not_created(void)
 {
      CryptoInitialize();
@@ -157,8 +140,6 @@ int main()
     PRINT_TEST_BANNER();
     const UnitTest tests[] =
     {
-        // disabled masterfiles load test for now
-        /* unit_test(test_load_masterfiles),*/
         unit_test(test_resolve_absolute_input_path),
         unit_test(test_resolve_non_anchored_base_path),
         unit_test(test_resolve_relative_base_path),


### PR DESCRIPTION
```
commit ebd9cdcc552ca6804e15b97a9b1e5f9ba617abde
Author: Kristian Amlie <kristian.amlie@cfengine.com>
Date:   Thu Feb 25 09:49:54 2016

    Remove test that is no longer relevant.
    
    This is tested in the masterfiles repository.

commit b673a01394ba07ffa7c0d3b9af423f6efdceb622
Author: Kristian Amlie <kristian.amlie@cfengine.com>
Date:   Thu Feb 25 09:48:26 2016

    Refactor generic_agent_test to use temporary workdir.
    
    This means we can enable some tests that were not enabled before, and
    is also more resilient against spurious failures in cases where
    /var/cfengine/inputs already exists on the disk.
```