### PR TITLE
libpromises/generic_agent.c: allow def.json up to 5MB instead of 4K

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -97,7 +97,8 @@ static JsonElement *ReadJsonFile(const char *filename, LogLevel log_level)
     }
 
     JsonElement *doc = NULL;
-    JsonParseError err = JsonParseFile(filename, 4096, &doc);
+    // 5 MB should be enough for most reasonable def.json data
+    JsonParseError err = JsonParseFile(filename, 5 * 1024 *1024, &doc);
 
     if (err != JSON_PARSE_OK
         || NULL == doc)


### PR DESCRIPTION
Currently the maximum size for `def.json` is 4K. This increases it to 5MB, which I think is more reasonable.

See https://dev.cfengine.com/issues/7960 for more information (but it's not the primary bug report, so I didn't use it in the commit message).