### PR TITLE
Fix regex for matching BSD and GNU tagets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1181,7 +1181,7 @@ case "$target_os" in
    aix*)
         CPPFLAGS="$CPPFLAGS -w"
         ;;
-   linux*|*bsd*gnu)
+   linux*|*bsd*|*gnu*)
         AC_CHECK_LIB(nss_nis, yp_get_default_domain)
         ;;
    freebsd*|dragonfly*)
@@ -1195,8 +1195,6 @@ case "$target_os" in
    qnx*)
         ;;
    openbsd*|obsd*)
-        ;;
-   gnu*)
         ;;
    sysv4.2MP|unix_sv*)
         ;;


### PR DESCRIPTION
Fix a typo which was resulted in the check for yp_get_default_domain being skipped on BSD and GNU targets

Standardize the regex used to check for a GNU target