### PR TITLE
Allow nested container and slist function calls.

### DIFF
--- a/examples/appgroups.cf
+++ b/examples/appgroups.cf
@@ -100,7 +100,7 @@ bundle agent appgroups(name, g)
       "$(cname)_grouplist[$(groups_$(apps))]" string => "1",
       ifvarclass => "have_app_$(apps)";
 
-      "$(cname)_grouplist" slist => getvalues("$(cname)_grouplist");
+      "$(cname)_grouplist_slist" slist => getvalues("$(cname)_grouplist");
 
       # get the keys of the array and sort them, then join with spaces
       "$(cname)_list" slist => getindices("$(cname)_grouplist");

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7789,7 +7789,7 @@ static const FnCallArg EXPANDRANGE_ARGS[] =
 static const FnCallArg MAPARRAY_ARGS[] =
 {
     {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Pattern based on $(this.k) and $(this.v) as original text"},
-    {CF_IDRANGE, CF_DATA_TYPE_STRING, "CFEngine array or data container identifier, the array variable to map"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "CFEngine variable identifier or inline JSON, the array variable to map"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -173,7 +173,18 @@ static FnCallResult FnFailure(void)
 
 static VarRef* ResolveAndQualifyVarName(const FnCall *fp, const char *varname)
 {
-    VarRef *ref = VarRefParse(varname);
+    VarRef *ref = NULL;
+    if (NULL != varname && IsVarList(varname) && strlen(varname) < CF_MAXVARSIZE)
+    {
+        char naked[CF_MAXVARSIZE] = "";
+        GetNaked(naked, varname);
+        ref = VarRefParse(naked);
+    }
+    else
+    {
+        ref = VarRefParse(varname);
+    }
+
     if (!VarRefIsQualified(ref))
     {
         if (fp->caller)

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -249,8 +249,9 @@ static JsonElement* VarRefValueToJson(EvalContext *ctx, const FnCall *fp, const 
             break;
 
         case RVAL_TYPE_CONTAINER:
-            convert = (JsonElement*) value;
-            *allocated = false;
+            // TODO: look into optimizing this if necessary
+            convert = JsonCopy(value);
+            *allocated = true;
             break;
 
         case RVAL_TYPE_SCALAR:

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -97,7 +97,25 @@ static Rlist *NewExpArgs(EvalContext *ctx, const Policy *policy, const FnCall *f
             break;
         }
 
-        // Collect compound values into containers only if the function supports it
+        /*
+
+          Collect compound values into containers only if the function
+          supports it.
+
+          Functions without FNCALL_OPTION_COLLECTING don't collect
+          Rlist elements. So in the policy, you call
+          and(splitstring("a b")) and it ends up as and("a", "b").
+          This expansion happens once per FnCall, not for all
+          arguments.
+
+          Functions with FNCALL_OPTION_COLLECTING instead collect all
+          the results of a FnCall into a single JSON array object. It
+          requires functions to expect it, but it's the only
+          reasonable way to preserve backwards compatibility for
+          functions like and() and allow nesting of calls to functions
+          that take and return compound data types.
+
+        */
         RlistAppendAllTypes(&expanded_args, rval.item, rval.type,
                             (fn->options & FNCALL_OPTION_COLLECTING));
         RvalDestroy(rval);

--- a/libpromises/fncall.h
+++ b/libpromises/fncall.h
@@ -58,7 +58,8 @@ typedef enum
 {
     FNCALL_OPTION_NONE = 0,
     FNCALL_OPTION_VARARG = 1 << 0,
-    FNCALL_OPTION_CACHED = 1 << 1
+    FNCALL_OPTION_CACHED = 1 << 1,
+    FNCALL_OPTION_COLLECTING = 1 << 2
 } FnCallOption;
 
 typedef struct

--- a/libpromises/fncall.h
+++ b/libpromises/fncall.h
@@ -57,8 +57,15 @@ typedef struct
 typedef enum
 {
     FNCALL_OPTION_NONE = 0,
+    // Functions with variable arguments don't require a fixed number
+    // of arguments.
     FNCALL_OPTION_VARARG = 1 << 0,
+    // Cached functions are evaluated once per run (memoized). The
+    // hash key is the function name and all the arguments.
     FNCALL_OPTION_CACHED = 1 << 1,
+    // Collecting functions take a variable reference OR can accept a
+    // nested function call. Either way, those parameters are
+    // collected into a data container.
     FNCALL_OPTION_COLLECTING = 1 << 2
 } FnCallOption;
 

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -74,6 +74,12 @@ RvalType DataTypeToRvalType(DataType datatype)
     ProgrammingError("DataTypeToRvalType, unhandled");
 }
 
+bool RlistValueIsType(const Rlist *rlist, RvalType type)
+{
+    return (NULL != rlist &&
+            rlist->val.type == type);
+}
+
 char *RlistScalarValue(const Rlist *rlist)
 {
     if (rlist->val.type != RVAL_TYPE_SCALAR)
@@ -529,6 +535,7 @@ Rlist *RlistAppend(Rlist **start, const void *item, RvalType type)
     return RlistAppendAllTypes(start, item, type, false);
 }
 
+// See fncall.c for the usage of allow_all_types.
 Rlist *RlistAppendAllTypes(Rlist **start, const void *item, RvalType type, bool allow_all_types)
 {
     Rlist *lp = *start;

--- a/libpromises/rlist.h
+++ b/libpromises/rlist.h
@@ -37,6 +37,7 @@ struct Rlist_
 
 RvalType DataTypeToRvalType(DataType datatype);
 
+bool RlistValueIsType(const Rlist *rlist, RvalType type);
 char *RvalScalarValue(Rval rval);
 FnCall *RvalFnCallValue(Rval rval);
 Rlist *RvalRlistValue(Rval rval);

--- a/libpromises/rlist.h
+++ b/libpromises/rlist.h
@@ -61,6 +61,7 @@ unsigned RlistHash(const Rlist *list, unsigned seed, unsigned max);
 void RlistDestroy(Rlist *list);
 void RlistDestroyEntry(Rlist **liststart, Rlist *entry);
 char *RlistScalarValue(const Rlist *rlist);
+char *RlistScalarValueSafe(const Rlist *rlist);
 FnCall *RlistFnCallValue(const Rlist *rlist);
 Rlist *RlistRlistValue(const Rlist *rlist);
 Rlist *RlistParseShown(const char *string);
@@ -80,6 +81,7 @@ Rlist *RlistAppendScalar(Rlist **start, const char *scalar);
 
 Rlist *RlistPrepend(Rlist **start, const void *item, RvalType type);
 Rlist *RlistAppend(Rlist **start, const void *item, RvalType type);
+Rlist *RlistAppendAllTypes(Rlist **start, const void *item, RvalType type, bool all_types);
 
 Rlist *RlistFromSplitString(const char *string, char sep);
 Rlist *RlistFromSplitRegex(const char *string, const char *regex, size_t max_entries, bool allow_blanks);

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -1225,6 +1225,7 @@ static JsonElement *FnCallTypeToJson(const FnCallType *fn_syntax)
 
     JsonObjectAppendBool(json_fn, "variadic", fn_syntax->options & FNCALL_OPTION_VARARG);
     JsonObjectAppendBool(json_fn, "cached", fn_syntax->options & FNCALL_OPTION_CACHED);
+    JsonObjectAppendBool(json_fn, "collecting", fn_syntax->options & FNCALL_OPTION_COLLECTING);
     JsonObjectAppendString(json_fn, "category", FnCallCategoryToString(fn_syntax->category));
 
     return json_fn;

--- a/libpromises/vars.c
+++ b/libpromises/vars.c
@@ -43,6 +43,13 @@ bool RlistIsUnresolved(const Rlist *list)
 {
     for (const Rlist *rp = list; rp != NULL; rp = rp->next)
     {
+        // JSON data container values are never expanded, except with the
+        // data_expand() function which see.
+        if (rp->val.type == RVAL_TYPE_CONTAINER)
+        {
+            continue;
+        }
+
         if (rp->val.type != RVAL_TYPE_SCALAR)
         {
             return true;

--- a/tests/acceptance/01_vars/02_functions/wrap_container_fncalls.cf
+++ b/tests/acceptance/01_vars/02_functions/wrap_container_fncalls.cf
@@ -40,6 +40,13 @@ bundle agent test
       "concat_sort_mapdata_mergedata_inline_json" string => concat(sort(mapdata('none', $(mapdata_spec), '[1,2,3]'), lex));
       "concat_sort_mapdata_mergedata_slist" string => concat(sort(mapdata('none', $(mapdata_spec), mergedata(base_list)), lex));
       "concat_sort_mapdata_mergedata_data" string => concat(sort(mapdata('none', $(mapdata_spec), mergedata(base_data)), lex));
+
+      "nth_sort_mapdata_mergedata_inline_json" string => nth(sort(mapdata('none', $(mapdata_spec), '[1,2,3]'), lex), 0);
+      "nth_mapdata_mergedata_slist" string => nth(mapdata('none', $(mapdata_spec), mergedata(base_list)), 1);
+      "nth_inline_json" string => nth('{ "x": "88888888" }', "x");
+      "nth_missing_inline_json" string => nth('{ "x": "88888888" }', "y");
+      "nth_data" string => nth(base_data, "x");
+      "nth_list" string => nth(base_list, 3);
 }
 
 #######################################################

--- a/tests/acceptance/01_vars/02_functions/wrap_container_fncalls.cf
+++ b/tests/acceptance/01_vars/02_functions/wrap_container_fncalls.cf
@@ -1,0 +1,53 @@
+#######################################################
+#
+# Test wrapped fncalls that return data containers
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle common init
+{
+  classes:
+      "predefined" expression => "any";
+}
+
+bundle agent test
+{
+  vars:
+      "base_list" slist => { "a", "b", "c", "aaa", "bbb", "ccc" };
+      "base_data" data => '{ "x": 100, "y": "z"  }';
+      "mapdata_spec" string => "<<< $(this.k)=$(this.v) >>>";
+
+      "sort_mapdata_inline_json" slist => sort(mapdata('none', $(mapdata_spec), '[1,2,3]'), lex);
+      "sort_mapdata_slist" slist => sort(mapdata('none', $(mapdata_spec), base_list), lex);
+      "sort_mapdata_data" slist => sort(mapdata('none', $(mapdata_spec), base_data), lex);
+
+      "sort_mapdata_mergedata_inline_json" slist => sort(mapdata('none', $(mapdata_spec), '[1,2,3]'), lex);
+      "sort_mapdata_mergedata_slist" slist => sort(mapdata('none', $(mapdata_spec), mergedata(base_list)), lex);
+      "sort_mapdata_mergedata_data" slist => sort(mapdata('none', $(mapdata_spec), mergedata(base_data)), lex);
+
+      # we can nest functions that return slists too!
+      "sort_mapdata_sort_slist" slist => sort(mapdata('none', $(mapdata_spec), sort(base_list, int)), lex);
+      "sort_mapdata_mergedata_sort_slist" slist => sort(mapdata('none', $(mapdata_spec), mergedata(sort(base_list, int))), lex);
+      "reverse_sort_slist" slist => reverse(sort(base_list, int));
+
+      "concat_sort_mapdata_mergedata_inline_json" string => concat(sort(mapdata('none', $(mapdata_spec), '[1,2,3]'), lex));
+      "concat_sort_mapdata_mergedata_slist" string => concat(sort(mapdata('none', $(mapdata_spec), mergedata(base_list)), lex));
+      "concat_sort_mapdata_mergedata_data" string => concat(sort(mapdata('none', $(mapdata_spec), mergedata(base_data)), lex));
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
+}

--- a/tests/acceptance/01_vars/02_functions/wrap_container_fncalls.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/wrap_container_fncalls.cf.expected.json
@@ -1,0 +1,76 @@
+{
+  "base_data": {
+    "x": 100,
+    "y": "z"
+  },
+  "base_list": [
+    "a",
+    "b",
+    "c",
+    "aaa",
+    "bbb",
+    "ccc"
+  ],
+  "concat_sort_mapdata_mergedata_data": "<<< x=100 >>><<< y=z >>>",
+  "concat_sort_mapdata_mergedata_inline_json": "<<< 0=1 >>><<< 1=2 >>><<< 2=3 >>>",
+  "concat_sort_mapdata_mergedata_slist": "<<< 0=a >>><<< 1=b >>><<< 2=c >>><<< 3=aaa >>><<< 4=bbb >>><<< 5=ccc >>>",
+  "mapdata_spec": "<<< $(this.k)=$(this.v) >>>",
+  "reverse_sort_slist": [
+    "ccc",
+    "c",
+    "bbb",
+    "b",
+    "aaa",
+    "a"
+  ],
+  "sort_mapdata_data": [
+    "<<< x=100 >>>",
+    "<<< y=z >>>"
+  ],
+  "sort_mapdata_inline_json": [
+    "<<< 0=1 >>>",
+    "<<< 1=2 >>>",
+    "<<< 2=3 >>>"
+  ],
+  "sort_mapdata_mergedata_data": [
+    "<<< x=100 >>>",
+    "<<< y=z >>>"
+  ],
+  "sort_mapdata_mergedata_inline_json": [
+    "<<< 0=1 >>>",
+    "<<< 1=2 >>>",
+    "<<< 2=3 >>>"
+  ],
+  "sort_mapdata_mergedata_slist": [
+    "<<< 0=a >>>",
+    "<<< 1=b >>>",
+    "<<< 2=c >>>",
+    "<<< 3=aaa >>>",
+    "<<< 4=bbb >>>",
+    "<<< 5=ccc >>>"
+  ],
+  "sort_mapdata_mergedata_sort_slist": [
+    "<<< 0=a >>>",
+    "<<< 1=aaa >>>",
+    "<<< 2=b >>>",
+    "<<< 3=bbb >>>",
+    "<<< 4=c >>>",
+    "<<< 5=ccc >>>"
+  ],
+  "sort_mapdata_slist": [
+    "<<< 0=a >>>",
+    "<<< 1=b >>>",
+    "<<< 2=c >>>",
+    "<<< 3=aaa >>>",
+    "<<< 4=bbb >>>",
+    "<<< 5=ccc >>>"
+  ],
+  "sort_mapdata_sort_slist": [
+    "<<< 0=a >>>",
+    "<<< 1=aaa >>>",
+    "<<< 2=b >>>",
+    "<<< 3=bbb >>>",
+    "<<< 4=c >>>",
+    "<<< 5=ccc >>>"
+  ]
+}

--- a/tests/acceptance/01_vars/02_functions/wrap_container_fncalls.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/wrap_container_fncalls.cf.expected.json
@@ -15,6 +15,11 @@
   "concat_sort_mapdata_mergedata_inline_json": "<<< 0=1 >>><<< 1=2 >>><<< 2=3 >>>",
   "concat_sort_mapdata_mergedata_slist": "<<< 0=a >>><<< 1=b >>><<< 2=c >>><<< 3=aaa >>><<< 4=bbb >>><<< 5=ccc >>>",
   "mapdata_spec": "<<< $(this.k)=$(this.v) >>>",
+  "nth_data": "100",
+  "nth_inline_json": "88888888",
+  "nth_list": "aaa",
+  "nth_mapdata_mergedata_slist": "<<< 1=b >>>",
+  "nth_sort_mapdata_mergedata_inline_json": "<<< 0=1 >>>",
   "reverse_sort_slist": [
     "ccc",
     "c",

--- a/tests/acceptance/01_vars/02_functions/wrap_invalid_container_fncalls.x.cf
+++ b/tests/acceptance/01_vars/02_functions/wrap_invalid_container_fncalls.x.cf
@@ -1,0 +1,29 @@
+#######################################################
+#
+# Test wrapped fncalls with mismatched data types
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  vars:
+      "base_list" slist => { "a", "b", "c", "aaa", "bbb", "ccc" };
+
+      # this should be a function call failure
+      "canonify" string => canonify(reverse(base_list));
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "check" usebundle => dcs_pass($(this.promise_filename));
+}

--- a/tests/acceptance/02_classes/02_functions/function_args_flattening.cf
+++ b/tests/acceptance/02_classes/02_functions/function_args_flattening.cf
@@ -17,40 +17,38 @@ body common control
 
 #######################################################
 
-bundle agent init
-{
-}
-
-#######################################################
-
-bundle agent test
+bundle common init
 {
   classes:
 
     "one" expression => "any";
+}
 
+#######################################################
 
-  reports:
-    "both_elements_are_classes"
-      classes => if_ok("fail"),
-      ifvarclass => and("one", "non_existing_class");
+bundle common test
+{
+  classes:
+      "fail_direct" expression => "any",
+        ifvarclass => and("one", "non_existing_class");
 
-    "each_split_element_is_class"
-      classes => if_ok("fail"),
-      ifvarclass => and(splitstring("one,non_existing_class", ",", "20"));
+      "fail_split" expression => "any",
+        ifvarclass => and(splitstring("one,non_existing_class", ",", "20"));
+
+      "pass_direct" expression => "any",
+        ifvarclass => or("one", "non_existing_class");
+
+      "pass_split" expression => "any",
+        ifvarclass => or(splitstring("one,non_existing_class", ",", "20"));
+
+      "pass_split1" expression => "any",
+        ifvarclass => not(splitstring("non_existing_class", ",", "20"));
 }
 
 #######################################################
 
 bundle agent check
 {
-  classes:
-      "ok" expression => "!fail";
-
-  reports:
-    ok::
-      "$(this.promise_filename) Pass";
-
-    !ok::
-      "$(this.promise_filename) FAIL";
+  methods:
+      "" usebundle => dcs_passif_expected("pass_direct,pass_split,pass_split1", "fail_direct,fail_split", $(this.promise_filename));
 }

--- a/tests/acceptance/02_classes/02_functions/makerule.cf
+++ b/tests/acceptance/02_classes/02_functions/makerule.cf
@@ -55,13 +55,13 @@ bundle agent check
       "ok4" expression => makerule("$(G.testfile).nosuchfile", "$(G.etc_passwd)");
 
       # A new file does not need to be rebuilt from an older file (fails)
-      "ok5" expression => makerule("$(G.testfile)", "@(test.lold)");
+      "ok5" expression => makerule("$(G.testfile)", "test.lold");
 
       # An old file does need to be rebuilt from an newer file in a list
-      "ok6" expression => makerule("$(G.etc_passwd)", "@(test.lnew)");
+      "ok6" expression => makerule("$(G.etc_passwd)", "test.lnew");
 
       # An old file does not need to be rebuilt from sources with a missing file (fails)
-      "ok7" expression => makerule("$(G.etc_passwd)", "@(test.lnon)");
+      "ok7" expression => makerule("$(G.etc_passwd)", "test.lnon");
 
       "ok" and => { "!ok1", "ok2", "!ok3", "ok4", "!ok5", "ok6", "!ok7" };
 


### PR DESCRIPTION
This change allows CFEngine functions that return slists or data containers to be used as arguments to functions that expect slists or data containers. Since this work follows https://dev.cfengine.com/issues/7871 I marked some functions (but not all) as `COLLECTING` to indicate that they can accept data containers and slists this way.

The acceptance test shows the intended usage; the important part is quoted below.

All the pieces work as expected in my testing. This is a huge usability win for CFEngine users in my opinion.

```
bundle agent test
{
  vars:
      "base_list" slist => { "a", "b", "c", "aaa", "bbb", "ccc" };
      "base_data" data => '{ "x": 100, "y": "z"  }';
      "mapdata_spec" string => "<<< $(this.k)=$(this.v) >>>";

      "sort_mapdata_inline_json" slist => sort(mapdata('none', $(mapdata_spec), '[1,2,3]'), lex);
      "sort_mapdata_slist" slist => sort(mapdata('none', $(mapdata_spec), base_list), lex);
      "sort_mapdata_data" slist => sort(mapdata('none', $(mapdata_spec), base_data), lex);

      "sort_mapdata_mergedata_inline_json" slist => sort(mapdata('none', $(mapdata_spec), '[1,2,3]'), lex);
      "sort_mapdata_mergedata_slist" slist => sort(mapdata('none', $(mapdata_spec), mergedata(base_list)), lex);
      "sort_mapdata_mergedata_data" slist => sort(mapdata('none', $(mapdata_spec), mergedata(base_data)), lex);

      # we can nest functions that return slists too!
      "sort_mapdata_sort_slist" slist => sort(mapdata('none', $(mapdata_spec), sort(base_list, int)), lex);
      "sort_mapdata_mergedata_sort_slist" slist => sort(mapdata('none', $(mapdata_spec), mergedata(sort(base_list, int))), lex);
      "reverse_sort_slist" slist => reverse(sort(base_list, int));
}
```