### PR TITLE
CFE-2084: load multiple augments from "augments" string array in def.json

### DIFF
--- a/tests/acceptance/00_basics/def.json/augments.cf
+++ b/tests/acceptance/00_basics/def.json/augments.cf
@@ -1,0 +1,36 @@
+# basic test of the def.json facility: augments
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+      "" usebundle => file_make("$(sys.inputdir)/secondary.cf", '
+bundle common x
+{
+  classes:
+    "test_class_f03ab8289d0775ca821b39a724c6f6f08ef8fb17" expression => "any";
+ }
+');
+
+      "" usebundle => file_copy("$(this.promise_filename).augmenter.json", "$(sys.inputdir)/augmenter.json");
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf|$(G.grep) test_class";
+
+  methods:
+      "" usebundle => dcs_passif_output("test_class_f03ab8289d0775ca821b39a724c6f6f08ef8fb17\s+source=promise", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/augments.cf.augmenter.json
+++ b/tests/acceptance/00_basics/def.json/augments.cf.augmenter.json
@@ -1,0 +1,3 @@
+{
+ "inputs": [ "$(sys.inputdir)/secondary.cf" ]
+}

--- a/tests/acceptance/00_basics/def.json/augments.cf.json
+++ b/tests/acceptance/00_basics/def.json/augments.cf.json
@@ -1,0 +1,3 @@
+{
+ "augments": [ "$(sys.inputdir)/augmenter.json" ]
+}


### PR DESCRIPTION
See https://tracker.mender.io/browse/CFE-2084 (https://dev.cfengine.com/issues/7453)

Really simple logic currently:
- `augments` key contents (which must be an array of strings) are loaded. They can contain system variables like `sys.inputdir` (see acceptance test).
- `vars` and `classes` are merged because they are processed one by one
- `inputs` override other inputs
