### PR TITLE
libenv: simplify and improve the removal of time-based classes

### DIFF
--- a/libenv/time_classes.c
+++ b/libenv/time_classes.c
@@ -25,115 +25,26 @@
 #include <time_classes.h>
 #include <eval_context.h>
 
-static void RemoveTimeClass(EvalContext *ctx, time_t time)
+static void RemoveTimeClass(EvalContext *ctx, const char* tags)
 {
-    // The first element is the local timezone
-    const char* tz_prefix[2] = { "", "GMT_" };
-    const char* tz_function[2] = { "localtime_r", "gmtime_r" };
-    struct tm tz_parsed_time[2];
-    const struct tm* tz_tm[2] = {
-        localtime_r(&time, &(tz_parsed_time[0])),
-        gmtime_r(&time, &(tz_parsed_time[1]))
-    };
+    Rlist *tags_rlist = RlistFromSplitString(tags, ',');
+    ClassTableIterator *iter = EvalContextClassTableIteratorNewGlobal(ctx, NULL, true, true);
+    StringSet *global_matches = ClassesMatching(ctx, iter, ".*", tags_rlist, false);
+    ClassTableIteratorDestroy(iter);
 
-    for (int tz = 0; tz < 2; tz++)
+    StringSetIterator it = StringSetIteratorInit(global_matches);
+    const char *element = NULL;
+    while ((element = StringSetIteratorNext(&it)))
     {
-        int i, j;
-        char buf[CF_BUFSIZE];
-
-        if (tz_tm[tz] == NULL)
-        {
-            Log(LOG_LEVEL_ERR, "Unable to parse passed time. (%s: %s)", tz_function[tz], GetErrorStr());
-            return;
-        }
-
-/* Lifecycle */
-
-        for( i = 0; i < 3; i++ )
-        {
-            snprintf(buf, CF_BUFSIZE, "%sLcycle_%d", tz_prefix[tz], i);
-            EvalContextClassRemove(ctx, NULL, buf);
-        }
-
-/* Year */
-
-        snprintf(buf, CF_BUFSIZE, "%sYr%04d", tz_prefix[tz], tz_parsed_time[tz].tm_year - 1 + 1900);
-        EvalContextClassRemove(ctx, NULL, buf);
-        snprintf(buf, CF_BUFSIZE, "%sYr%04d", tz_prefix[tz], tz_parsed_time[tz].tm_year + 1900);
-        EvalContextClassRemove(ctx, NULL, buf);
-
-/* Month */
-
-        for( i = 0; i < 12; i++ )
-        {
-            snprintf(buf, CF_BUFSIZE, "%s%s", tz_prefix[tz], MONTH_TEXT[i]);
-            EvalContextClassRemove(ctx, NULL, buf);
-        }
-
-/* Day of week */
-
-        for( i = 0; i < 7; i++ )
-        {
-            snprintf(buf, CF_BUFSIZE, "%s%s", tz_prefix[tz], DAY_TEXT[i]);
-            EvalContextClassRemove(ctx, NULL, buf);
-        }
-
-/* Day */
-
-        for( i = 1; i < 32; i++ )
-        {
-            snprintf(buf, CF_BUFSIZE, "%sDay%d", tz_prefix[tz], i);
-            EvalContextClassRemove(ctx, NULL, buf);
-        }
-
-/* Shift */
-
-        for( i = 0; i < 4; i++ )
-        {
-            snprintf(buf, CF_BUFSIZE, "%s%s", tz_prefix[tz], SHIFT_TEXT[i]);
-            EvalContextClassRemove(ctx, NULL, buf);
-        }
-
-/* Hour */
-
-        for( i = 0; i < 24; i++ )
-        {
-            snprintf(buf, CF_BUFSIZE, "%sHr%02d", tz_prefix[tz], i);
-            EvalContextClassRemove(ctx, NULL, buf);
-            snprintf(buf, CF_BUFSIZE, "%sHr%d", tz_prefix[tz], i);
-            EvalContextClassRemove(ctx, NULL, buf);
-        }
-
-/* Quarter */
-
-        for( i = 1; i <= 4; i++ )
-        {
-            snprintf(buf, CF_BUFSIZE, "%sQ%d", tz_prefix[tz], i);
-            EvalContextClassRemove(ctx, NULL, buf);
-            for( j = 0; j < 24; j++ )
-            {
-                snprintf(buf, CF_BUFSIZE, "%sHr%02d_Q%d", tz_prefix[tz], j, i);
-                EvalContextClassRemove(ctx, NULL, buf);
-            }
-        }
-
-/* Minute */
-
-        for( i = 0; i < 60; i++ )
-        {
-            snprintf(buf, CF_BUFSIZE, "%sMin%02d", tz_prefix[tz], i);
-            EvalContextClassRemove(ctx, NULL, buf);
-        }
-
-        for( i = 0; i < 60; i += 5 )
-        {
-            snprintf(buf, CF_BUFSIZE, "%sMin%02d_%02d", tz_prefix[tz], i, (i + 5) % 60);
-            EvalContextClassRemove(ctx, NULL, buf);
-        }
+        EvalContextClassRemove(ctx, NULL, element);
     }
+
+    StringSetDestroy(global_matches);
+
+    RlistDestroy(tags_rlist);
 }
 
-static void AddTimeClass(EvalContext *ctx, time_t time)
+static void AddTimeClass(EvalContext *ctx, time_t time, const char* tags)
 {
     // The first element is the local timezone
     const char* tz_prefix[2] = { "", "GMT_" };
@@ -158,17 +69,17 @@ static void AddTimeClass(EvalContext *ctx, time_t time)
 /* Lifecycle */
 
         snprintf(buf, CF_BUFSIZE, "%sLcycle_%d", tz_prefix[tz], ((tz_parsed_time[tz].tm_year + 1900) % 3));
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
 
 /* Year */
 
         snprintf(buf, CF_BUFSIZE, "%sYr%04d", tz_prefix[tz], tz_parsed_time[tz].tm_year + 1900);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
 
 /* Month */
 
         snprintf(buf, CF_BUFSIZE, "%s%s", tz_prefix[tz], MONTH_TEXT[tz_parsed_time[tz].tm_mon]);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
 
 /* Day of week */
 
@@ -178,50 +89,49 @@ static void AddTimeClass(EvalContext *ctx, time_t time)
    Sunday  is 0 in tm_wday, 6 in DAY_TEXT */
         day_text_index = (tz_parsed_time[tz].tm_wday + 6) % 7;
         snprintf(buf, CF_BUFSIZE, "%s%s", tz_prefix[tz], DAY_TEXT[day_text_index]);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
 
 /* Day */
 
         snprintf(buf, CF_BUFSIZE, "%sDay%d", tz_prefix[tz], tz_parsed_time[tz].tm_mday);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
 
 /* Shift */
 
         snprintf(buf, CF_BUFSIZE, "%s%s", tz_prefix[tz], SHIFT_TEXT[tz_parsed_time[tz].tm_hour / 6]);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
 
 /* Hour */
 
         snprintf(buf, CF_BUFSIZE, "%sHr%02d", tz_prefix[tz], tz_parsed_time[tz].tm_hour);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
         snprintf(buf, CF_BUFSIZE, "%sHr%d", tz_prefix[tz], tz_parsed_time[tz].tm_hour);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
 
 /* Quarter */
 
         quarter = tz_parsed_time[tz].tm_min / 15 + 1;
 
         snprintf(buf, CF_BUFSIZE, "%sQ%d", tz_prefix[tz], quarter);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
         snprintf(buf, CF_BUFSIZE, "%sHr%02d_Q%d", tz_prefix[tz], tz_parsed_time[tz].tm_hour, quarter);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
 
 /* Minute */
 
         snprintf(buf, CF_BUFSIZE, "%sMin%02d", tz_prefix[tz], tz_parsed_time[tz].tm_min);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
 
         interval_start = (tz_parsed_time[tz].tm_min / 5) * 5;
         interval_end = (interval_start + 5) % 60;
 
         snprintf(buf, CF_BUFSIZE, "%sMin%02d_%02d", tz_prefix[tz], interval_start, interval_end);
-        EvalContextClassPutHard(ctx, buf, "time_based,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
     }
 }
 
 void UpdateTimeClasses(EvalContext *ctx, time_t t)
 {
-    RemoveTimeClass(ctx, t);
-    AddTimeClass(ctx, t);
+    RemoveTimeClass(ctx, "cfengine_internal_time_based_autoremove");
+    AddTimeClass(ctx, t, "time_based,cfengine_internal_time_based_autoremove,source=agent");
 }
-


### PR DESCRIPTION
This greatly simplifies the removal of time-based classes and makes it much faster and more reliable by using tags instead of blindly shooting down class names.