### PR TITLE
Add function cache hits, misses, and size to timing instrumentation output

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1469,7 +1469,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = VerifyProcessesPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
-            EndMeasurePromise(start, pp);
+            EndMeasurePromise(ctx, start, pp);
         }
     }
     else if (strcmp("storage", pp->parent_promise_type->name) == 0)
@@ -1477,7 +1477,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = FindAndVerifyStoragePromises(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
-            EndMeasurePromise(start, pp);
+            EndMeasurePromise(ctx, start, pp);
         }
     }
     else if (strcmp("packages", pp->parent_promise_type->name) == 0)
@@ -1485,7 +1485,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = VerifyPackagesPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
-            EndMeasurePromise(start, pp);
+            EndMeasurePromise(ctx, start, pp);
         }
     }
     else if (strcmp("users", pp->parent_promise_type->name) == 0)
@@ -1493,7 +1493,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = VerifyUsersPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
-            EndMeasurePromise(start, pp);
+            EndMeasurePromise(ctx, start, pp);
         }
     }
 
@@ -1502,7 +1502,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = ParallelFindAndVerifyFilesPromises(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
-            EndMeasurePromise(start, pp);
+            EndMeasurePromise(ctx, start, pp);
         }
     }
     else if (strcmp("commands", pp->parent_promise_type->name) == 0)
@@ -1510,7 +1510,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = VerifyExecPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
-            EndMeasurePromise(start, pp);
+            EndMeasurePromise(ctx, start, pp);
         }
     }
     else if (strcmp("databases", pp->parent_promise_type->name) == 0)
@@ -1518,7 +1518,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = VerifyDatabasePromises(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
-            EndMeasurePromise(start, pp);
+            EndMeasurePromise(ctx, start, pp);
         }
     }
     else if (strcmp("methods", pp->parent_promise_type->name) == 0)
@@ -1526,7 +1526,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = VerifyMethodsPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
-            EndMeasurePromise(start, pp);
+            EndMeasurePromise(ctx, start, pp);
         }
     }
     else if (strcmp("services", pp->parent_promise_type->name) == 0)
@@ -1534,7 +1534,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = VerifyServicesPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
-            EndMeasurePromise(start, pp);
+            EndMeasurePromise(ctx, start, pp);
         }
     }
     else if (strcmp("guest_environments", pp->parent_promise_type->name) == 0)
@@ -1542,7 +1542,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = VerifyEnvironmentsPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
-            EndMeasurePromise(start, pp);
+            EndMeasurePromise(ctx, start, pp);
         }
     }
     else if (strcmp("reports", pp->parent_promise_type->name) == 0)

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -163,8 +163,11 @@ VariableTableIterator *EvalContextVariableTableFromRefIteratorNew(const EvalCont
 bool EvalContextPromiseLockCacheContains(const EvalContext *ctx, const char *key);
 void EvalContextPromiseLockCachePut(EvalContext *ctx, const char *key);
 void EvalContextPromiseLockCacheRemove(EvalContext *ctx, const char *key);
-bool EvalContextFunctionCacheGet(const EvalContext *ctx, const FnCall *fp, const Rlist *args, Rval *rval_out);
+bool EvalContextFunctionCacheGet(EvalContext *ctx, const FnCall *fp, const Rlist *args, Rval *rval_out);
 void EvalContextFunctionCachePut(EvalContext *ctx, const FnCall *fp, const Rlist *args, const Rval *rval);
+long long EvalContextFunctionCacheMisses(const EvalContext *ctx);
+long long EvalContextFunctionCacheHits(const EvalContext *ctx);
+size_t EvalContextFunctionCacheSize(const EvalContext *ctx);
 
 const void  *EvalContextVariableControlCommonGet(const EvalContext *ctx, CommonControl lval);
 

--- a/libpromises/instrumentation.c
+++ b/libpromises/instrumentation.c
@@ -58,7 +58,7 @@ struct timespec BeginMeasure()
 
 /***************************************************************/
 
-void EndMeasurePromise(struct timespec start, const Promise *pp)
+void EndMeasurePromise(EvalContext *ctx, struct timespec start, const Promise *pp)
 {
     char id[CF_BUFSIZE], *mid = NULL;
 
@@ -89,6 +89,13 @@ void EndMeasurePromise(struct timespec start, const Promise *pp)
     if (TIMING)
     {
         Log(LOG_LEVEL_VERBOSE, "T: .........................................................");
+        if (ctx)
+        {
+            Log(LOG_LEVEL_VERBOSE, "T: function cache hits %lld misses %lld size %ld",
+                EvalContextFunctionCacheMisses(ctx),
+                EvalContextFunctionCacheHits(ctx),
+                EvalContextFunctionCacheSize(ctx));
+        }
     }
 }
 

--- a/libpromises/instrumentation.h
+++ b/libpromises/instrumentation.h
@@ -29,10 +29,11 @@
 
 #include <set.h>
 #include <class.h>
+#include <eval_context.h>
 
 struct timespec BeginMeasure(void);
 void EndMeasure(char *eventname, struct timespec start);
 int EndMeasureValueMs(struct timespec start);
-void EndMeasurePromise(struct timespec start, const Promise *pp);
+void EndMeasurePromise(EvalContext *ctx, struct timespec start, const Promise *pp);
 extern bool TIMING;
 #endif


### PR DESCRIPTION
@jimis this may be useful to measure function cache performance. It's a pretty trivial change.