### PR TITLE
Don't follow symbolic links when copying extended attributes.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1121,16 +1121,16 @@ dnl #######################################################################
 dnl Enable extended attributes. Used for SELinux and ACLs
 dnl #######################################################################
 
-AC_CHECK_FUNCS(listxattr, [AC_DEFINE(WITH_XATTR, 1, [Define if you have a libc that supports extended attributes])])
+AC_CHECK_FUNCS(llistxattr, [AC_DEFINE(WITH_XATTR, 1, [Define if you have a libc that supports extended attributes])])
 AC_CHECK_HEADERS([attr/xattr.h sys/xattr.h])
 
 AC_MSG_CHECKING([whether xattr functions have extra arguments])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <sys/types.h>
                                     #include <sys/xattr.h>],
-                                    [(void)listxattr("", 0, 0, 0);
-                                    (void)getxattr("", "", 0, 0, 0, 0);
-                                    (void)setxattr("", "", "", 0, 0, 0);
-                                    (void)removexattr("", "", 0);])],
+                                    [(void)llistxattr("", 0, 0, 0);
+                                    (void)lgetxattr("", "", 0, 0, 0, 0);
+                                    (void)lsetxattr("", "", "", 0, 0, 0);
+                                    (void)lremovexattr("", "", 0);])],
                   [AC_DEFINE(WITH_XATTR_EXTRA_ARGS, 1, [Define if your xattr implementation has extra arguments])]
                   [AC_MSG_RESULT([yes])],
                   [AC_MSG_RESULT([no])])

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -3415,13 +3415,13 @@ static FnCallResult FnCallFileStatDetails(ARG_UNUSED EvalContext *ctx,
 #if defined(WITH_XATTR)
         // Extended attributes include both POSIX ACLs and SELinux contexts.
         char attr_raw_names[CF_BUFSIZE];
-        ssize_t attr_raw_names_size = listxattr(path, attr_raw_names, sizeof(attr_raw_names));
+        ssize_t attr_raw_names_size = llistxattr(path, attr_raw_names, sizeof(attr_raw_names));
 
         if (attr_raw_names_size < 0)
         {
             if (errno != ENOTSUP && errno != ENODATA)
             {
-                Log(LOG_LEVEL_ERR, "Can't read extended attributes of '%s'. (listxattr: %s)",
+                Log(LOG_LEVEL_ERR, "Can't read extended attributes of '%s'. (llistxattr: %s)",
                     path, GetErrorStr());
             }
         }
@@ -3441,7 +3441,7 @@ static FnCallResult FnCallFileStatDetails(ARG_UNUSED EvalContext *ctx,
                 }
 
                 char data[CF_BUFSIZE];
-                int datasize = getxattr(path, current, data, sizeof(data));
+                int datasize = lgetxattr(path, current, data, sizeof(data));
                 if (datasize < 0)
                 {
                     if (errno == ENOTSUP)
@@ -3450,7 +3450,7 @@ static FnCallResult FnCallFileStatDetails(ARG_UNUSED EvalContext *ctx,
                     }
                     else
                     {
-                        Log(LOG_LEVEL_ERR, "Can't read extended attribute '%s' of '%s'. (getxattr: %s)",
+                        Log(LOG_LEVEL_ERR, "Can't read extended attribute '%s' of '%s'. (lgetxattr: %s)",
                             path, current, GetErrorStr());
                     }
                 }

--- a/libpromises/files_copy.c
+++ b/libpromises/files_copy.c
@@ -205,7 +205,7 @@ bool CopyFileExtendedAttributesDisk(const char *source, const char *destination)
     ssize_t attr_raw_names_size;
     char attr_raw_names[CF_BUFSIZE];
 
-    attr_raw_names_size = listxattr(source, attr_raw_names, sizeof(attr_raw_names));
+    attr_raw_names_size = llistxattr(source, attr_raw_names, sizeof(attr_raw_names));
     if (attr_raw_names_size < 0)
     {
         if (errno == ENOTSUP || errno == ENODATA)
@@ -214,7 +214,7 @@ bool CopyFileExtendedAttributesDisk(const char *source, const char *destination)
         }
         else
         {
-            Log(LOG_LEVEL_ERR, "Can't copy extended attributes from '%s' to '%s'. (listxattr: %s)",
+            Log(LOG_LEVEL_ERR, "Can't copy extended attributes from '%s' to '%s'. (llistxattr: %s)",
                 source, destination, GetErrorStr());
             return false;
         }
@@ -227,7 +227,7 @@ bool CopyFileExtendedAttributesDisk(const char *source, const char *destination)
         pos += strlen(current) + 1;
 
         char data[CF_BUFSIZE];
-        int datasize = getxattr(source, current, data, sizeof(data));
+        int datasize = lgetxattr(source, current, data, sizeof(data));
         if (datasize < 0)
         {
             if (errno == ENOTSUP)
@@ -236,13 +236,13 @@ bool CopyFileExtendedAttributesDisk(const char *source, const char *destination)
             }
             else
             {
-                Log(LOG_LEVEL_ERR, "Can't copy extended attributes from '%s' to '%s'. (getxattr: %s: %s)",
+                Log(LOG_LEVEL_ERR, "Can't copy extended attributes from '%s' to '%s'. (lgetxattr: %s: %s)",
                     source, destination, GetErrorStr(), current);
                 return false;
             }
         }
 
-        int ret = setxattr(destination, current, data, datasize, 0);
+        int ret = lsetxattr(destination, current, data, datasize, 0);
         if (ret < 0)
         {
             if (errno == ENOTSUP)
@@ -251,7 +251,7 @@ bool CopyFileExtendedAttributesDisk(const char *source, const char *destination)
             }
             else
             {
-                Log(LOG_LEVEL_ERR, "Can't copy extended attributes from '%s' to '%s'. (setxattr: %s: %s)",
+                Log(LOG_LEVEL_ERR, "Can't copy extended attributes from '%s' to '%s'. (lsetxattr: %s: %s)",
                     source, destination, GetErrorStr(), current);
                 return false;
             }

--- a/libpromises/files_copy.h
+++ b/libpromises/files_copy.h
@@ -28,12 +28,12 @@
 #include <cf3.defs.h>
 
 #ifdef WITH_XATTR_EXTRA_ARGS
-#define listxattr(__arg1, __arg2, __arg3) \
-    listxattr((__arg1), (__arg2), (__arg3), 0)
-#define getxattr(__arg1, __arg2, __arg3, __arg4) \
-    getxattr((__arg1), (__arg2), (__arg3), (__arg4), 0, 0)
-#define setxattr(__arg1, __arg2, __arg3, __arg4, __arg5) \
-    setxattr((__arg1), (__arg2), (__arg3), (__arg4), 0, (__arg5))
+#define llistxattr(__arg1, __arg2, __arg3) \
+    llistxattr((__arg1), (__arg2), (__arg3), 0)
+#define lgetxattr(__arg1, __arg2, __arg3, __arg4) \
+    lgetxattr((__arg1), (__arg2), (__arg3), (__arg4), 0, 0)
+#define lsetxattr(__arg1, __arg2, __arg3, __arg4, __arg5) \
+    lsetxattr((__arg1), (__arg2), (__arg3), (__arg4), 0, (__arg5))
 #endif
 
 bool CopyRegularFileDisk(const char *source, const char *destination);


### PR DESCRIPTION
We want to copy the attributes of the source link to the destination link.
Seen when using copy_from.preserve => "true".

Changelog: Title

Based on a patch by:
Eystein Måløy Stenberg <eystein.maloy.stenberg@cfengine.com>