### PR TITLE
Fixups after discussion in #7137.

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1501,6 +1501,7 @@ static void LogVariableValue(const EvalContext *ctx, const Promise *pp)
 
     Log(LOG_LEVEL_VERBOSE, "V: '%s' => '%s'", pp->promiser, out);
     free(out);
+    VarRefDestroy(ref);
 }
 
 static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_UNUSED void *param)

--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1499,7 +1499,7 @@ static void LogVariableValue(const EvalContext *ctx, const Promise *pp)
             break;
     }
 
-    Log(LOG_LEVEL_VERBOSE, "V: '%s' => '%s'", pp->promiser, out);
+    Log(LOG_LEVEL_DEBUG, "V: '%s' => '%s'", pp->promiser, out);
     free(out);
     VarRefDestroy(ref);
 }
@@ -1514,10 +1514,13 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         strcmp("vars", pp->parent_promise_type->name) == 0)
     {
         result = VerifyVarPromise(ctx, pp, true);
-        if (result != PROMISE_RESULT_FAIL &&
-            LogGetGlobalLevel() >= LOG_LEVEL_VERBOSE)
+        if (result != PROMISE_RESULT_FAIL)
         {
-            LogVariableValue(ctx, pp);
+            Log(LOG_LEVEL_VERBOSE, "V:     Computing value of \"%s\"", pp->promiser);
+            if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
+            {
+                LogVariableValue(ctx, pp);
+            }
         }
     }
     else if (strcmp("defaults", pp->parent_promise_type->name) == 0)


### PR DESCRIPTION
https://dev.cfengine.com/issues/7137

```
commit b2ddcccb3867ad8dcd55d25047654f657b59b8c0
Author: Kristian Amlie <kristian.amlie@cfengine.com>
Date:   Mon Mar 14 11:13:42 2016

    Redmine #7137: Change verbosity of variable logging to debug.
    
    This was done because of discussions in named tickets, relating to
    potential length of variable strings as well as security concerns with
    variables containing sensitive data.
    
    Cancel-changelog: 34be1225eabdc845c573e7e7b2ce127e7149537e
    
    Changelog: Log variable definitions in debug output.

commit 80a30d425fcb6b186a5f936edb588fdf3ba113a5
Author: Kristian Amlie <kristian.amlie@cfengine.com>
Date:   Mon Mar 14 11:13:17 2016

    Add missing VarRefDestroy() in LogVariableValue().
```