### PR TITLE
Fix: Test was incorrectly being skipped for *not* windows

### DIFF
--- a/tests/acceptance/10_files/can_set_sticky_bits_without_root_owning_directory.cf
+++ b/tests/acceptance/10_files/can_set_sticky_bits_without_root_owning_directory.cf
@@ -27,7 +27,7 @@ bundle agent test
                    own.";
 
       "test_skip_unsupported"
-        string => "!windows";
+        string => "windows";
 
   vars:
     !windows::


### PR DESCRIPTION
This is a *nix test, and is unsupported on *windows* platforms.