### PR TITLE
Redmine #7961: Remove auto-loading of "inputs" mentioned in def.json.

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1649,6 +1649,9 @@ StringSet *EvalContextStackPromisees(const EvalContext *ctx)
     return promisees;
 }
 
+/*
+ * Copies value, so you need to free your own copy afterwards.
+ */
 bool EvalContextVariablePutSpecial(EvalContext *ctx, SpecialScope scope, const char *lval, const void *value, DataType type, const char *tags)
 {
     if (strchr(lval, '['))
@@ -1824,6 +1827,9 @@ static void VarRefStackQualify(const EvalContext *ctx, VarRef *ref)
     }
 }
 
+/*
+ * Copies value, so you need to free your own copy afterwards.
+ */
 bool EvalContextVariablePut(EvalContext *ctx,
                             const VarRef *ref, const void *value,
                             DataType type, const char *tags)

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -1030,7 +1030,7 @@ static void ResolveControlBody(EvalContext *ctx, GenericAgentConfig *config,
         VarRef *ref = VarRefParseFromScope(lval, scope);
         EvalContextVariableRemove(ctx, ref);
 
-        RvalType rval_proper_datatype =
+        DataType rval_proper_datatype =
             ConstraintSyntaxGetDataType(body_syntax, lval);
         if (evaluated_rval.type != DataTypeToRvalType(rval_proper_datatype))
         {

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -336,10 +336,12 @@ void LoadAugmentsData(EvalContext *ctx, const Buffer* filename_buffer, const Jso
                 {
                     Log(LOG_LEVEL_VERBOSE, "Installing augments def.augments_inputs from file '%s'",
                         BufferData(filename_buffer));
+                    Rlist *rlist = ContainerToRlist(inputs);
                     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_DEF,
-                                                  "augments_inputs", JsonCopy(inputs),
-                                                  CF_DATA_TYPE_CONTAINER,
+                                                  "augments_inputs", rlist,
+                                                  CF_DATA_TYPE_STRING_LIST,
                                                   "source=augments_file");
+                    RlistDestroy(rlist);
                 }
                 else
                 {

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -334,10 +334,10 @@ void LoadAugmentsData(EvalContext *ctx, const Buffer* filename_buffer, const Jso
                     JsonGetContainerType(inputs) == JSON_CONTAINER_TYPE_ARRAY &&
                     JsonArrayContainsOnlyPrimitives(inputs))
                 {
-                    Log(LOG_LEVEL_VERBOSE, "Installing augments def.augment_inputs from file '%s'",
+                    Log(LOG_LEVEL_VERBOSE, "Installing augments def.augments_inputs from file '%s'",
                         BufferData(filename_buffer));
                     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_DEF,
-                                                  "augment_inputs", JsonCopy(inputs),
+                                                  "augments_inputs", JsonCopy(inputs),
                                                   CF_DATA_TYPE_CONTAINER,
                                                   "source=augments_file");
                 }

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -311,35 +311,6 @@ static Policy *LoadPolicyFile(EvalContext *ctx, GenericAgentConfig *config, cons
 
     PolicyResolve(ctx, policy, config);
 
-    DataType def_inputs_type = CF_DATA_TYPE_NONE;
-    VarRef *inputs_ref = VarRefParse("def.augment_inputs");
-    const void *def_inputs = EvalContextVariableGet(ctx, inputs_ref, &def_inputs_type);
-    VarRefDestroy(inputs_ref);
-
-    if (RVAL_TYPE_CONTAINER == DataTypeToRvalType(def_inputs_type) && NULL != def_inputs)
-    {
-        const JsonElement *el;
-        JsonIterator iter = JsonIteratorInit((JsonElement*) def_inputs);
-        while ((el = JsonIteratorNextValueByType(&iter, JSON_ELEMENT_TYPE_PRIMITIVE, true)))
-        {
-            char *input = JsonPrimitiveToString(el);
-
-            Log(LOG_LEVEL_VERBOSE, "Loading augments from def.augment_inputs: %s", input);
-
-            Rlist* inputs_rlist = NULL;
-            RlistAppendScalar(&inputs_rlist, input);
-            Policy *aux_policy = LoadPolicyInputFiles(ctx, config, inputs_rlist,
-                                                      parsed_files_and_checksums, failed_files);
-            if (aux_policy)
-            {
-                policy = PolicyMerge(policy, aux_policy);
-            }
-
-            RlistDestroy(inputs_rlist);
-            free(input);
-        }
-    }
-
     Body *body_common_control = PolicyGetBody(policy, NULL, "common", "control");
     Body *body_file_control = PolicyGetBody(policy, NULL, "file", "control");
 

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -367,7 +367,6 @@ Rval RvalNewRewriter(const void *item, RvalType type, JsonElement *map)
                 char closing_brace = 0;
                 for (int c = 0; c < buffer_from[c]; c++)
                 {
-                    printf("In %s at %i: '%s'\n", __func__, __LINE__, buffer_from);
                     if (buffer_from[c] == '$')
                     {
                         if (buffer_from[c+1] == '(')

--- a/tests/acceptance/00_basics/def.json/json-inputs-not-array.cf
+++ b/tests/acceptance/00_basics/def.json/json-inputs-not-array.cf
@@ -1,4 +1,5 @@
-# basic test of the def.json facility: inputs
+# Test that a def.json inputs section that doesn't contain an array produces an
+# error message.
 body common control
 {
       inputs => { "../../default.cf.sub" };
@@ -17,13 +18,6 @@ body common control
     inputs => { @(def.augments_inputs) };
 }
 ');
-      "" usebundle => file_make("$(sys.inputdir)/secondary.cf", '
-bundle common x
-{
-  classes:
-    "test_class_9f606e44752ce34ef39ee7d4754c5c84890d2b14" expression => "any";
-}
-');
 
       "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
 }
@@ -33,8 +27,9 @@ bundle common x
 bundle agent check
 {
   vars:
-    "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf|$(G.grep) test_class";
+    "command" string => "$(sys.cf_promises) -f $(sys.inputdir)/promises.cf";
 
   methods:
-      "" usebundle => dcs_passif_output("test_class_9f606e44752ce34ef39ee7d4754c5c84890d2b14\s+source=promise", "", $(command), $(this.promise_filename));
+      "" usebundle => dcs_passif_output(".*Trying to augment inputs in [^\n]* but the value was not a list of strings.*",
+                                        "", $(command), $(this.promise_filename));
 }

--- a/tests/acceptance/00_basics/def.json/json-inputs-not-array.cf.json
+++ b/tests/acceptance/00_basics/def.json/json-inputs-not-array.cf.json
@@ -1,0 +1,3 @@
+{
+ "inputs": { "there-should-not-be-a-key-here": "nor-a-value" }
+}

--- a/tests/acceptance/00_basics/def.json/json-inputs-not-auto-applied.cf
+++ b/tests/acceptance/00_basics/def.json/json-inputs-not-auto-applied.cf
@@ -1,4 +1,4 @@
-# basic test of the def.json facility: inputs
+# Test that def.json:inputs is not auto loaded.
 body common control
 {
       inputs => { "../../default.cf.sub" };
@@ -14,14 +14,14 @@ bundle agent test
       "" usebundle => file_make("$(sys.inputdir)/promises.cf", '
 body common control
 {
-    inputs => { @(def.augments_inputs) };
+    inputs => {  };
 }
 ');
       "" usebundle => file_make("$(sys.inputdir)/secondary.cf", '
 bundle common x
 {
   classes:
-    "test_class_9f606e44752ce34ef39ee7d4754c5c84890d2b14" expression => "any";
+    "test_class_8f606e44752ce34ef39ee7d4754c5c84890d2b14" expression => "any";
 }
 ');
 
@@ -36,5 +36,5 @@ bundle agent check
     "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf|$(G.grep) test_class";
 
   methods:
-      "" usebundle => dcs_passif_output("test_class_9f606e44752ce34ef39ee7d4754c5c84890d2b14\s+source=promise", "", $(command), $(this.promise_filename));
+      "" usebundle => dcs_passif_output("", ".*test_class_8f606e44752ce34ef39ee7d4754c5c84890d2b14.*", $(command), $(this.promise_filename));
 }

--- a/tests/acceptance/00_basics/def.json/json-inputs-not-auto-applied.cf.json
+++ b/tests/acceptance/00_basics/def.json/json-inputs-not-auto-applied.cf.json
@@ -1,0 +1,3 @@
+{
+ "inputs": [ "$(sys.inputdir)/secondary.cf" ]
+}

--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -780,21 +780,21 @@ bundle agent dcs_passif_output(wanted, unwanted, command, test)
 
   reports:
     DEBUG::
-      "$(this.bundle): bad: $(wanted) was NOT found in the output of $(command)"
+      "$(this.bundle): bad: '$(wanted)' was NOT found in the output of '$(command)'"
       ifvarclass => "!__passif_output_wanted";
 
-      "$(this.bundle): bad: $(unwanted) WAS found in the output of $(command)"
+      "$(this.bundle): bad: '$(unwanted)' WAS found in the output of '$(command)'"
       ifvarclass => "__passif_output_unwanted";
 
     EXTRA::
-      "$(this.bundle): good: $(wanted) WAS found in the output of $(command)"
+      "$(this.bundle): good: '$(wanted)' WAS found in the output of '$(command)'"
       ifvarclass => "__passif_output_wanted";
 
-      "$(this.bundle): good: $(unwanted) was NOT found in the output of $(command)"
+      "$(this.bundle): good: '$(unwanted)' was NOT found in the output of '$(command)'"
       ifvarclass => "!__passif_output_unwanted";
 
     DEBUG::
-      "$(this.bundle): the output of command '$(command)' was: $(subout)";
+      "$(this.bundle): the output of command '$(command)' was: '$(subout)'";
 }
 
 bundle agent dcs_passif_output1(wanted, command, test)


### PR DESCRIPTION
This was done in order to solve the problem that def.json is applied
to all policy files, including failsafe.cf. If there is a syntax error
in any of those files, all policy files will stop working and the host
is unable to recover.

Now one has to use the "inputs" section by referring to it as the
$(def.augments_inputs) variable, which it will populate.

Changelog: Fix bug which could render host unable to recover from a
syntax error, even if failsafe.cf was utilized. This could happen if
the file containing the syntax error was specified in the def.json
special file.

Changelog: Change: Policy files specified in the "inputs" section of
def.json will no longer be auto-loaded. One has to refer to the
$(def.augments_inputs) variable in the policy (the standard
masterfiles policies include this by default). This only affects
installations which are not based on the standard masterfiles, and
which are using the "inputs" field inside def.json.