### PR TITLE
Remove: Markup from function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,7 +25,7 @@
 	- Fix cf-serverd error messages with classic protocol clients
 	  (Redmine #7818)
 	- Change: Suppress standard services noise on SUSE (Redmine #6968)
-	- The `isvariable()` function call now correctly accepts all
+	- The isvariable() function call now correctly accepts all
 	  array variables when specified inline. Previously it would not accept
 	  certain special characters, even though they could be specified
 	  indirectly by using a variable to hold it. (Redmine #7088)


### PR DESCRIPTION
This is causing the doc build to fail with an unresolved link.
(cherry-picked from commit 6783639)