### PR TITLE
Add support for Jira tickets in test suppression meta tags.

### DIFF
--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -261,13 +261,13 @@ bundle agent test_precheck
       "test_skip_needs_work" slist => variablesmatching(".*_meta\.test_skip_needs_work");
       "test_$(fail_types)_fail" slist => variablesmatching(".*_meta\.test_$(fail_types)_fail");
       "test_$(fail_types)_fail_metatags" slist => getvariablemetatags("$(test_$(fail_types)_fail)");
-      "test_$(fail_types)_fail_redmine" slist => filter("redmine.*", "test_$(fail_types)_fail_metatags", "true", "false", 1);
+      "test_$(fail_types)_fail_ticket" slist => filter("(redmine|CFE-|ENT-|ARCHIVE-|QA-).*", "test_$(fail_types)_fail_metatags", "true", "false", 1);
 
   classes:
       "test_skip_unsupported_set" expression => some(".*", "test_skip_unsupported");
       "test_skip_needs_work_set" expression => some(".*", "test_skip_needs_work");
       "test_$(fail_types)_fail_set" expression => some(".*", "test_$(fail_types)_fail");
-      "test_$(fail_types)_fail_redmine_set" expression => some(".*", "test_$(fail_types)_fail_redmine");
+      "test_$(fail_types)_fail_ticket_set" expression => some(".*", "test_$(fail_types)_fail_ticket");
 
       "test_skip_unsupported_match" and => { "test_skip_unsupported_set", "$($(test_skip_unsupported))" };
       "test_skip_needs_work_match" and => { "test_skip_needs_work_set", "$($(test_skip_needs_work))" };
@@ -282,14 +282,14 @@ bundle agent test_precheck
       "$(this.promise_filename) Skip/unsupported";
     test_skip_needs_work_match::
       "$(this.promise_filename) Skip/needs_work";
-    test_suppress_fail_match.test_suppress_fail_redmine_set::
-      "$(this.promise_filename) XFAIL/$(test_suppress_fail_redmine)";
-    test_suppress_fail_match.!test_suppress_fail_redmine_set::
-      "$(this.promise_filename) FAIL/no_redmine_number";
-    test_soft_fail_match.test_soft_fail_redmine_set::
-      "$(this.promise_filename) SFAIL/$(test_soft_fail_redmine)";
-    test_soft_fail_match.!test_soft_fail_redmine_set::
-      "$(this.promise_filename) FAIL/no_redmine_number";
+    test_suppress_fail_match.test_suppress_fail_ticket_set::
+      "$(this.promise_filename) XFAIL/$(test_suppress_fail_ticket)";
+    test_suppress_fail_match.!test_suppress_fail_ticket_set::
+      "$(this.promise_filename) FAIL/no_ticket_number";
+    test_soft_fail_match.test_soft_fail_ticket_set::
+      "$(this.promise_filename) SFAIL/$(test_soft_fail_ticket)";
+    test_soft_fail_match.!test_soft_fail_ticket_set::
+      "$(this.promise_filename) FAIL/no_ticket_number";
 }
 
 #######################################################

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -485,22 +485,22 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
                     RESULT=FAIL
                     RESULT_MSG="${COLOR_FAILURE}FAIL (Failure was expected, but the test had an unexpected test outcome, check test output, Pass/FAIL need to match exactly)${COLOR_NORMAL}"
                 else
-                    REDMINE="$(egrep "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE | sed -e "s,.*[XS]FAIL/redmine[^0-9]*\([0-9][0-9]*\).*,\1,")"
+                    TICKET="$(egrep "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE | sed -e "s,.*[XS]FAIL/\(.*\),\1,")"
                     RESULT="$(egrep "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE | sed -e "s,.*\([XS]FAIL\).*,\1,")"
                     if [ "$RESULT" = "XFAIL" ]
                     then
-                        RESULT_MSG="${COLOR_WARNING}FAIL (Suppressed, Redmine #$REDMINE)${COLOR_NORMAL}"
+                        RESULT_MSG="${COLOR_WARNING}FAIL (Suppressed, $TICKET)${COLOR_NORMAL}"
                     else
-                        RESULT_MSG="${COLOR_WARNING}Soft fail (Redmine #$REDMINE)${COLOR_NORMAL}"
+                        RESULT_MSG="${COLOR_WARNING}Soft fail ($TICKET)${COLOR_NORMAL}"
                     fi
                 fi
             elif [ $RETVAL -ne 0 ]
             then
                 RESULT=FAIL
-            elif egrep "R: .*$ESCAPED_TEST FAIL/no_redmine_number" $OUTFILE > /dev/null
+            elif egrep "R: .*$ESCAPED_TEST FAIL/no_ticket_number" $OUTFILE > /dev/null
             then
                 RESULT=FAIL
-                RESULT_MSG="${COLOR_FAILURE}FAIL (Tried to suppress failure, but no Redmine issue number is provided)${COLOR_NORMAL}"
+                RESULT_MSG="${COLOR_FAILURE}FAIL (Tried to suppress failure, but no issue number is provided)${COLOR_NORMAL}"
             elif egrep "R: .*$ESCAPED_TEST Wait/[0-9]+" $OUTFILE > /dev/null
             then
                 if [ -z "$NEXT_TIMEOUT_VAR" ]


### PR DESCRIPTION
Strings starting with "CFE-", "ENT-", "ARCHIVE-" and "QA-" are valid
ticket identifiers.

Redmine support is retained for existing tests.