### PR TITLE
Fix: Use specifed output type with --list

### DIFF
--- a/contrib/enterprise/report.pl
+++ b/contrib/enterprise/report.pl
@@ -15,12 +15,13 @@ my %outputs = (
                html => sub { my $data = decode_json( shift ); print_html($data, shift) },
                list => sub { my $data = decode_json( shift ); print_hostlist($data, shift) },
                host => sub { my $data = decode_json( shift ); print_hostinfo($data, shift) },
+               ansible_emptyhostvars => sub { my $data = decode_json( shift ); print_ansible_emptyhostvars($data, shift) },
                json => sub { print @_ },
               );
 
 my %options = (
-               url => $ENV{CFENGINE_MP_URL} || 'http://admin:admin@localhost:80/',
-               output => 'csv',
+               url => $ENV{CFENGINE_MP_URL} || 'http://admin:admin@localhost:80',
+               output => 'list',
                limit => 100000,
                verbose => 0,
                list => 0,
@@ -42,12 +43,12 @@ my $query = shift;
 
 if ($options{list})
 {
-    $query = "SELECT Hosts.HostName, Contexts.ContextName FROM Hosts JOIN Contexts ON Hosts.Hostkey = Contexts.HostKey";
-    $options{output} = 'list';
+    $query = "SELECT Hosts.IPAddress, Contexts.ContextName FROM Hosts JOIN Contexts ON Hosts.Hostkey = Contexts.HostKey";
 }
+
 elsif (exists $options{host})
 {
-    $query = "SELECT Variables.Bundle, Variables.VariableName, Variables.VariableValue FROM Variables WHERE Variables.HostKey = (SELECT Hosts.Hostkey FROM Hosts WHERE Hosts.HostName = '$options{host}')";
+    $query = "SELECT Variables.Bundle, Variables.VariableName, Variables.VariableValue FROM Variables WHERE Variables.HostKey = (SELECT Hosts.Hostkey FROM Hosts WHERE Hosts.IPAddress = '$options{host}')";
     $options{output} = 'host';
 }
 
@@ -143,4 +144,23 @@ sub print_hostinfo
     }
 
     print encode_json(\%info), "\n";
+}
+
+sub print_ansible_emptyhostvars
+{
+    my $data = shift;
+    my %list;
+
+    foreach my $row (@{$data->{data}->[0]->{rows}})
+    {
+        push @{$list{$row->[1]}}, $row->[0];
+    }
+
+    # Insert empty _meta hostvars to speed ansible up when not using host
+    # variables. It would be nice to add another output option that combined the
+    # --host option for each host in the infrastructure to provide all the
+    # variables at once.
+    $list{'_meta'}->{'hostvars'} = {};
+
+    print encode_json(\%list), "\n";
 }


### PR DESCRIPTION
When using --list the output type was forced to list being an ansible
compatible seralized json string. However this made it impossible to
--list in any other output type.

This also adds an ansible_emptyhostvars output type which inserts a
_meta section defining that no host vars exist. This can speed up
working with ansible on a large scale env as it avoids making individual
executions to retrieve host data.