### PR TITLE
Jira #2337: The lexer can go wrong with @if minimum_version macro

### DIFF
--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -87,7 +87,7 @@ comment    #[^\n]*
 macro_if_version    ^@if\ minimum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
 macro_if_feature    ^@if\ feature\([a-zA-Z0-9_]+\)
 macro_endif ^@endif
-macro_line ^[^@].*$
+macro_line ^[^@\n\xd\xa].*$
 
 promises   bundle
 
@@ -246,7 +246,7 @@ promise_type   [a-zA-Z_]+:
 
 
 <if_ignore_state>{macro_line}  {
-                                  ParserDebug("\tL:inside macro @if, ignoring text:%s\n", yytext);
+                                  ParserDebug("\tL:inside macro @if, ignoring line text:"%s"\n", yytext);
                                }
 
 <if_ignore_state>{macro_endif} {
@@ -258,10 +258,14 @@ promise_type   [a-zA-Z_]+:
                                    return 0;
                                  }
                                  P.if_depth--;
-                               }\
+                               }
+
+<if_ignore_state>{newline} {
+                           }
+
 <if_ignore_state>.    {
                           /* eat up al unknown chars when line starts with @*/
-                          ParserDebug("\tL:inside macro @if, ignoring text:%s\n", yytext);
+                          ParserDebug("\tL:inside macro @if, ignoring char text:"%s"\n", yytext);
                       }
 
 {promises}            {

--- a/tests/acceptance/00_basics/macros/if_ignore_newline_before_endif.cf
+++ b/tests/acceptance/00_basics/macros/if_ignore_newline_before_endif.cf
@@ -1,0 +1,30 @@
+######################################################
+#
+#  Test that @if works for greater versions
+#
+#####################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle common test
+{
+@if minimum_version(300.600)
+      Some new function here...
+      more text...
+
+
+@endif
+}
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_passif_expected("cfengine",
+                                         "",
+                                         $(this.promise_filename));
+}


### PR DESCRIPTION
The lexer could not handle empty newline(s) before a ```@endif```.