### PR TITLE
Cleanup signal handling for agents and enable them earlier.

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -217,6 +217,7 @@ static const char *const HINTS[] =
 
 int main(int argc, char *argv[])
 {
+    SetupSignalsForAgent();
 #ifdef HAVE_LIBXML2
         xmlInitParser();
 #endif
@@ -661,13 +662,6 @@ static void ThisAgentInit(void)
 #ifdef HAVE_SETSID
     setsid();
 #endif
-
-    signal(SIGINT, HandleSignalsForAgent);
-    signal(SIGTERM, HandleSignalsForAgent);
-    signal(SIGHUP, SIG_IGN);
-    signal(SIGPIPE, SIG_IGN);
-    signal(SIGUSR1, HandleSignalsForAgent);
-    signal(SIGUSR2, HandleSignalsForAgent);
 
     CFA_MAXTHREADS = 30;
     EDITFILESIZE = 100000;

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -114,7 +114,7 @@ static void handleShowKeysSignal(int signum)
     signal(signum, handleShowKeysSignal);
 }
 
-static void ThisAgentInit(CfKeySigHandler sighandler)
+static void SetupSignalsForCfKey(CfKeySigHandler sighandler)
 {
     signal(SIGINT, sighandler);
     signal(SIGTERM, sighandler);
@@ -126,6 +126,8 @@ static void ThisAgentInit(CfKeySigHandler sighandler)
 
 int main(int argc, char *argv[])
 {
+    SetupSignalsForCfKey(HandleSignalsForAgent);
+
     GenericAgentConfig *config = CheckOpts(argc, argv);
     EvalContext *ctx = EvalContextNew();
     GenericAgentConfigApply(ctx, config);
@@ -134,7 +136,7 @@ int main(int argc, char *argv[])
 
     if (SHOWHOSTS)
     {
-        ThisAgentInit(handleShowKeysSignal);
+        SetupSignalsForCfKey(handleShowKeysSignal);
         ShowLastSeenHosts();
         return 0;
     }
@@ -145,7 +147,6 @@ int main(int argc, char *argv[])
     }
 
     GenericAgentPostLoadInit(ctx);
-    ThisAgentInit(HandleSignalsForAgent);
 
     if (REMOVEKEYS)
     {

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -124,6 +124,8 @@ static const char *const HINTS[] =
 
 int main(int argc, char *argv[])
 {
+    SetupSignalsForAgent();
+
     GenericAgentConfig *config = CheckOpts(argc, argv);
     enum generic_agent_config_common_policy_output_format format = config->agent_specific.common.policy_output_format;
 

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -64,6 +64,7 @@
 #include <cf-windows-functions.h>
 #include <loading.h>
 #include <iteration.h>
+#include <signals.h>
 
 static pthread_once_t pid_cleanup_once = PTHREAD_ONCE_INIT; /* GLOBAL_T */
 
@@ -1965,4 +1966,14 @@ bool GenericAgentPostLoadInit(const EvalContext *ctx)
         EvalContextVariableControlCommonGet(ctx, COMMON_CONTROL_TLS_MIN_VERSION);
 
     return cfnet_init(tls_min_version, tls_ciphers);
+}
+
+void SetupSignalsForAgent(void)
+{
+    signal(SIGINT, HandleSignalsForAgent);
+    signal(SIGTERM, HandleSignalsForAgent);
+    signal(SIGHUP, SIG_IGN);
+    signal(SIGPIPE, SIG_IGN);
+    signal(SIGUSR1, HandleSignalsForAgent);
+    signal(SIGUSR2, HandleSignalsForAgent);
 }

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -139,5 +139,6 @@ void GetReleaseIdFile(const char *base_path, char *filename, size_t max_size);
 
 bool GenericAgentPostLoadInit(const EvalContext *ctx);
 
+void SetupSignalsForAgent(void);
 
 #endif


### PR DESCRIPTION
The motivation for this is that during policy loading, certain
functions may be evaluated that open pipes, and if these pipes at any
point become disconnected, we get an EPIPE signal. This is ignored
once we get to the evaluation stage, but during loading the signal
handlers have not been enabled yet.

This was originally seen during introduction of the mapdata()
function, which opens a pipe to an external process. In the test for
this function, `cat` was used to output a prerendered response, but
`cat` was also expected to consume the data input. Depending on
timing, if the data was written to `cat` before it terminated,
everything would be fine, but if `cat` terminated before data could be
written (because it was catting a file, not from stdin), cf-promises
would get an EPIPE signal and terminate abnormally.

Upon inspection of our signal handling, it appears this can happen in
cf-agent as well, and is as such "a ticking time bomb". Therefore this
commit cleans up the signal handling a bit, consolidates it where
possible, and moves all signal handler initialization to the beginning
of each agent main().

Daemons have other signal handler requirements and were left alone for
now.