### PR TITLE
Add getuserinfo() function

### DIFF
--- a/cf-agent/verify_users.h
+++ b/cf-agent/verify_users.h
@@ -31,5 +31,4 @@ PromiseResult VerifyUsersPromise(EvalContext *ctx, const Promise *pp);
 
 void VerifyOneUsersPromise (const char *puser, User u, PromiseResult *result, enum cfopaction action,
                             EvalContext *ctx, const Attributes *a, const Promise *pp);
-
 #endif

--- a/cf-agent/verify_users_stub.c
+++ b/cf-agent/verify_users_stub.c
@@ -33,3 +33,13 @@ void VerifyOneUsersPromise (ARG_UNUSED const char *puser, ARG_UNUSED User u,
 {
     Log(LOG_LEVEL_ERR, "Users promise type is not supported on this OS");
 }
+
+bool IsAccountLocked(const char *puser, const void *passwd_info)
+{
+    return false;
+}
+
+bool GetPasswordHash(const char *puser, const void *passwd_info, const char **result)
+{
+    return false;
+}

--- a/tests/acceptance/01_vars/02_functions/getuserinfo.cf
+++ b/tests/acceptance/01_vars/02_functions/getuserinfo.cf
@@ -1,0 +1,28 @@
+#######################################################
+#
+# Test 'getuserinfo' function
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  vars:
+      # this is pretty much all we can test across platforms
+      "info_root" string => nth(getuserinfo("root"), "username");
+      "info_0" string => nth(getuserinfo(0), "uid");
+}
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
+}

--- a/tests/acceptance/01_vars/02_functions/getuserinfo.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/getuserinfo.cf.expected.json
@@ -1,0 +1,4 @@
+{
+  "info_0": "0",
+  "info_root": "root"
+}


### PR DESCRIPTION
This is a first rough cut of the function `getuserinfo()` I proposed in #1413 

Returns:

```json
{
    "description": "root",
    "gid": 0,
    "home_dir": "/root",
    "shell": "/bin/bash",
    "uid": 0,
    "username": "root"
}
```

Still TODO: `locked` boolean, primary group name, list of secondary group names, list of secondary GIDs, and password data.