### PR TITLE
Add "true" as a special expression that is always EVAL_EXPRESSION_TRUE

### DIFF
--- a/libpromises/logic_expressions.c
+++ b/libpromises/logic_expressions.c
@@ -250,8 +250,19 @@ ExpressionValue EvalExpression(const Expression *expr,
         {
             return EXPRESSION_VALUE_ERROR;
         }
+        else if (0 == strcmp("true", name))
+        {
+            ret =  EXPRESSION_VALUE_TRUE;
+        }
+        else if (0 == strcmp("false", name))
+        {
+            ret =  EXPRESSION_VALUE_FALSE;
+        }
+        else
+        {
+            ret = (*nameevalfn) (name, param);
+        }
 
-        ret = (*nameevalfn) (name, param);
         free(name);
         return ret;
     }

--- a/tests/acceptance/02_classes/01_basic/from_json_booleans.cf
+++ b/tests/acceptance/02_classes/01_basic/from_json_booleans.cf
@@ -1,0 +1,38 @@
+###########################################################
+#
+# Test expansion of JSON booleans
+#
+###########################################################
+
+body common control
+{
+    inputs => { "../../default.cf.sub" };
+    bundlesequence => { default($(this.promise_filename)) };
+    version => "1.0";
+}
+
+###########################################################
+
+bundle agent test
+{
+  classes:
+      "canary" expression => "any", meta => { "collect" }; # just a baseline test
+      "from_$(json)" expression => "$(json)", meta => { "collect" }; # iterates through non-nulls
+      "from_null" expression => "$(json[maybe])", meta => { "collect" };
+      "from_missing" expression => "$(json[nonesuch])", meta => { "collect" };
+
+  vars:
+      "json" data => '{ "yes": true, "no": false, "maybe": null }';
+      "var_$(json)" string => "$(json)";
+      "collected" slist => sort(classesmatching(".*", "collect"));
+}
+
+###########################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
+}

--- a/tests/acceptance/02_classes/01_basic/from_json_booleans.cf.expected.json
+++ b/tests/acceptance/02_classes/01_basic/from_json_booleans.cf.expected.json
@@ -1,0 +1,13 @@
+{
+  "collected": [
+    "canary",
+    "from_true"
+  ],
+  "json": {
+    "maybe": null,
+    "no": false,
+    "yes": true
+  },
+  "var_false": "false",
+  "var_true": "true"
+}


### PR DESCRIPTION
@jimis this is what we discussed on IRC. See the acceptance test: only `from_true` is defined, the others (`false`, `null`, and a missing value) are false.

All other acceptance tests pass.