### PR TITLE
Reverse order of binary lookup in testall.

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -822,12 +822,12 @@ fi
 #   $core_objdir/../{enterprise,masterfiles}/tests/acceptance
 find_default_binary()
 {
-    [ -n "$BINDIR" -a -x "$BINDIR/$2" ] && eval $1=\""$BINDIR/$2"\"
-    [ -x "`pwd`/$2/$2" ] && eval $1=\""`pwd`/$2/$2"\"
-    [ -x "`pwd`/../../$2/$2" ] && eval $1=\""`pwd`/../../$2/$2"\"
-    [ -x "`pwd`/../../bin/$2" ] && eval $1=\""`pwd`/../../bin/$2"\"
-    [ -x "`pwd`/../../ext/$2" ] && eval $1=\""`pwd`/../../ext/$2"\"
     [ -x "`pwd`/../../../core/$2/$2" ] && eval $1=\""`pwd`/../../../core/$2/$2"\"
+    [ -x "`pwd`/../../ext/$2" ] && eval $1=\""`pwd`/../../ext/$2"\"
+    [ -x "`pwd`/../../bin/$2" ] && eval $1=\""`pwd`/../../bin/$2"\"
+    [ -x "`pwd`/../../$2/$2" ] && eval $1=\""`pwd`/../../$2/$2"\"
+    [ -x "`pwd`/$2/$2" ] && eval $1=\""`pwd`/$2/$2"\"
+    [ -n "$BINDIR" -a -x "$BINDIR/$2" ] && eval $1=\""$BINDIR/$2"\"
 }
 find_default_binary DEFAGENT cf-agent
 find_default_binary DEFCF_PROMISES cf-promises


### PR DESCRIPTION
It's actually the last path that ends up being used, not the first,
and it is this order of priority we want. This was motivated by trying
to run acceptance tests in a directory not named core, but core was
present next to it.