### PR TITLE
Parsing an empty file should give empty list, not no list at all.

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -5906,7 +5906,7 @@ static FnCallResult ReadList(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const FnCal
 
     free(file_buffer);
 
-    if (newlist && noerrors)
+    if (noerrors)
     {
         return (FnCallResult) { FNCALL_SUCCESS, { newlist, RVAL_TYPE_LIST } };
     }


### PR DESCRIPTION
Changelog: Behavior change: When using readintlist(), readreallist()
or readstringlist(), parsing an empty file will no longer result in a
failed function call, but instead an empty list. Failure to open the
file will still result in a failed function call.