### PR TITLE
CFE-2161: Fix missing ps fields causing segfaults on Solaris.

### DIFF
--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -118,7 +118,8 @@ static bool SelectProcess(const char *procentry,
 
     if (!SplitProcLine(procentry, pstime, names, start, end, column))
     {
-        return false;
+        result = false;
+        goto cleanup;
     }
 
     ApplyPlatformExtraTable(names, column);
@@ -893,7 +894,7 @@ bool IsProcessNameRunning(char *procNameRegex)
         if (!SplitProcLine(ip->name, pstime, colHeaders, start, end, lineSplit))
         {
             Log(LOG_LEVEL_ERR, "IsProcessNameRunning: Could not split process line '%s'", ip->name);
-            continue;
+            goto loop_cleanup;
         }
 
         ApplyPlatformExtraTable(colHeaders, lineSplit);
@@ -903,6 +904,7 @@ bool IsProcessNameRunning(char *procNameRegex)
             matched = true;
         }
 
+   loop_cleanup:
         for (i = 0; lineSplit[i] != NULL; i++)
         {
             free(lineSplit[i]);

--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -54,48 +54,84 @@
 #endif
 TABLE_STORAGE Item *PROCESSTABLE = NULL;
 
+typedef enum
+{
+    /*
+     * In this mode, all columns must be present by the occurrence of at least
+     * one non-whitespace character.
+     */
+    PCA_AllColumnsPresent,
+    /*
+     * In this mode, if a process is a zombie, and if there is nothing but
+     * whitespace in the byte columns directly below a header, that column is
+     * skipped.
+     *
+     * This means that very little text shifting will be tolerated, preferably
+     * none, or small enough that all column entries still remain under their
+     * own header. It also means that a zombie process must be detectable by
+     * reading the 'Z' state directly below the 'S' or 'ST' header.
+     */
+    PCA_ZombieSkipEmptyColumns,
+} PsColumnAlgorithm;
+
+/*
+  Ideally this should be autoconf-tested, but it's really hard to do so. See
+  SplitProcLine() to see the exact effects this has.
+*/
+static const PsColumnAlgorithm PS_COLUMN_ALGORITHM[] =
+{
+    [PLATFORM_CONTEXT_UNKNOWN] = PCA_AllColumnsPresent,
+    [PLATFORM_CONTEXT_OPENVZ] = PCA_AllColumnsPresent,      /* virt_host_vz_vzps */
+    [PLATFORM_CONTEXT_HP] = PCA_AllColumnsPresent,          /* hpux */
+    [PLATFORM_CONTEXT_AIX] = PCA_ZombieSkipEmptyColumns,    /* aix */
+    [PLATFORM_CONTEXT_LINUX] = PCA_AllColumnsPresent,       /* linux */
+    [PLATFORM_CONTEXT_BUSYBOX] = PCA_AllColumnsPresent,     /* linux */
+    [PLATFORM_CONTEXT_SOLARIS] = PCA_AllColumnsPresent,     /* solaris >= 11 */
+    [PLATFORM_CONTEXT_SUN_SOLARIS] = PCA_AllColumnsPresent, /* solaris  < 11 */
+    [PLATFORM_CONTEXT_FREEBSD] = PCA_AllColumnsPresent,     /* freebsd */
+    [PLATFORM_CONTEXT_NETBSD] = PCA_AllColumnsPresent,      /* netbsd */
+    [PLATFORM_CONTEXT_CRAYOS] = PCA_AllColumnsPresent,      /* cray */
+    [PLATFORM_CONTEXT_WINDOWS_NT] = PCA_AllColumnsPresent,  /* NT - cygnus */
+    [PLATFORM_CONTEXT_SYSTEMV] = PCA_AllColumnsPresent,     /* unixware */
+    [PLATFORM_CONTEXT_OPENBSD] = PCA_AllColumnsPresent,     /* openbsd */
+    [PLATFORM_CONTEXT_CFSCO] = PCA_AllColumnsPresent,       /* sco */
+    [PLATFORM_CONTEXT_DARWIN] = PCA_AllColumnsPresent,      /* darwin */
+    [PLATFORM_CONTEXT_QNX] = PCA_AllColumnsPresent,         /* qnx  */
+    [PLATFORM_CONTEXT_DRAGONFLY] = PCA_AllColumnsPresent,   /* dragonfly */
+    [PLATFORM_CONTEXT_MINGW] = PCA_AllColumnsPresent,       /* mingw */
+    [PLATFORM_CONTEXT_VMWARE] = PCA_AllColumnsPresent,      /* vmware */
+    [PLATFORM_CONTEXT_ANDROID] = PCA_AllColumnsPresent,     /* android */
+};
+
 #if defined(__sun) || defined(TEST_UNIT_TEST)
 static StringMap *UCB_PS_MAP = NULL;
 // These will be tried in order.
-const char *SOLARIS_UCB_STYLE_PS[] = {
+static const char *UCB_STYLE_PS[] = {
     "/usr/ucb/ps",
     "/bin/ps",
     NULL
 };
-const char *SOLARIS_UCB_STYLE_PS_ARGS = "axwww";
+static const char *UCB_STYLE_PS_ARGS = "axwww";
+static const PsColumnAlgorithm UCB_STYLE_PS_COLUMN_ALGORITHM = PCA_ZombieSkipEmptyColumns;
 #endif
 
 static int SelectProcRangeMatch(char *name1, char *name2, int min, int max, char **names, char **line);
 static bool SelectProcRegexMatch(const char *name1, const char *name2, const char *regex, bool anchored, char **colNames, char **line);
-static bool SplitProcLine(const char *proc, time_t pstime, char **names, int *start, int *end, char **line);
+static bool SplitProcLine(const char *proc,
+                          time_t pstime,
+                          char **names,
+                          int *start,
+                          int *end,
+                          PsColumnAlgorithm pca,
+                          char **line);
 static int SelectProcTimeCounterRangeMatch(char *name1, char *name2, time_t min, time_t max, char **names, char **line);
 static int SelectProcTimeAbsRangeMatch(char *name1, char *name2, time_t min, time_t max, char **names, char **line);
 static int GetProcColumnIndex(const char *name1, const char *name2, char **names);
 static void GetProcessColumnNames(const char *proc, char **names, int *start, int *end);
 static int ExtractPid(char *psentry, char **names, int *end);
 static void ApplyPlatformExtraTable(char **names, char **columns);
-static bool ZombiesCanHaveEmptyColumns(void);
 
 /***************************************************************************/
-
-// For unit testing
-#ifndef TEST_UNIT_TEST
-
-static bool ZombiesCanHaveEmptyColumns(void)
-{
-#ifdef _AIX
-    /*
-      Ideally this should be autoconf-tested, but it's really hard to do so. ATM
-      AIX is the only platform known to produce empty columns in ps output. See
-      SplitProcLine() to see the exact effects this has.
-    */
-    return true;
-#else
-    return false;
-#endif
-}
-
-#endif // TEST_UNIT_TEST
 
 static bool SelectProcess(const char *procentry,
                           time_t pstime,
@@ -116,7 +152,8 @@ static bool SelectProcess(const char *procentry,
 
     memset(column, 0, sizeof(column));
 
-    if (!SplitProcLine(procentry, pstime, names, start, end, column))
+    if (!SplitProcLine(procentry, pstime, names, start, end,
+                       PS_COLUMN_ALGORITHM[VPSHARDCLASS], column))
     {
         result = false;
         goto cleanup;
@@ -621,6 +658,7 @@ static bool SplitProcLine(const char *line,
                           char **names,
                           int *start,
                           int *end,
+                          PsColumnAlgorithm pca,
                           char **fields)
 {
     if (line == NULL || line[0] == '\0')
@@ -688,42 +726,55 @@ Solaris 9:
 
     bool zombie = false;
 
-    if (ZombiesCanHaveEmptyColumns())
+    if (pca == PCA_ZombieSkipEmptyColumns)
     {
-        // Find out if the process is a zombie. This check is known to work on
-        // AIX, other platforms have not been checked.
+        // Find out if the process is a zombie.
         for (int field = 0; names[field]; field++)
         {
-            if (strcmp(names[field], "ST") == 0)
+            if (strcmp(names[field], "S") == 0 ||
+                strcmp(names[field], "ST") == 0)
             {
                 // Check for zombie state.
-                if (start[field] < linelen)
+                for (int pos = start[field]; pos <= end[field] && pos < linelen; pos++)
                 {
                     // 'Z' letter with word boundary on each side.
-                    if (isspace(line[start[field] - 1])
-                        && line[start[field]] == 'Z'
-                        && (isspace(line[start[field] + 1])
-                            || line[start[field] + 1] == '\0'))
+                    if (isspace(line[pos - 1])
+                        && line[pos] == 'Z'
+                        && (isspace(line[pos + 1])
+                            || line[pos + 1] == '\0'))
                     {
                         Log(LOG_LEVEL_DEBUG, "Detected zombie process, "
                             "skipping parsing of empty ps fields.");
                         zombie = true;
                     }
                 }
+                break;
             }
         }
     }
 
     int field = 0;
     int pos = 0;
-    while (names[field] && pos <= linelen)
+    while (names[field])
     {
         // Some sanity checks.
-        if (start[field] >= linelen)
+        if (pos >= linelen)
         {
-            Log(LOG_LEVEL_ERR, "ps output line '%s' is shorter than its "
-                "associated header.", line);
-            return false;
+            if (pca == PCA_ZombieSkipEmptyColumns && zombie)
+            {
+                Log(LOG_LEVEL_DEBUG, "Assuming '%s' field is empty, "
+                    "since ps line '%s' is not long enough to reach under its "
+                    "header.", names[field], line);
+                fields[field] = xstrdup("");
+                field++;
+                continue;
+            }
+            else
+            {
+                Log(LOG_LEVEL_ERR, "ps output line '%s' is shorter than its "
+                    "associated header.", line);
+                return false;
+            }
         }
 
         bool cmd = (strcmp(names[field], "CMD") == 0 ||
@@ -742,7 +793,7 @@ Solaris 9:
         }
 
         // If zombie, check if field is empty.
-        if (ZombiesCanHaveEmptyColumns() && zombie)
+        if (pca == PCA_ZombieSkipEmptyColumns && zombie)
         {
             int empty_pos = start[field];
             bool empty = true;
@@ -891,7 +942,8 @@ bool IsProcessNameRunning(char *procNameRegex)
             continue;
         }
 
-        if (!SplitProcLine(ip->name, pstime, colHeaders, start, end, lineSplit))
+        if (!SplitProcLine(ip->name, pstime, colHeaders, start, end,
+                           PS_COLUMN_ALGORITHM[VPSHARDCLASS], lineSplit))
         {
             Log(LOG_LEVEL_ERR, "IsProcessNameRunning: Could not split process line '%s'", ip->name);
             goto loop_cleanup;
@@ -1242,27 +1294,27 @@ const char *GetProcessTableLegend(void)
 #if defined(__sun) || defined(TEST_UNIT_TEST)
 static FILE *OpenUcbPsPipe(void)
 {
-    for (int i = 0; SOLARIS_UCB_STYLE_PS[i]; i++)
+    for (int i = 0; UCB_STYLE_PS[i]; i++)
     {
         struct stat statbuf;
-        if (stat(SOLARIS_UCB_STYLE_PS[i], &statbuf) < 0)
+        if (stat(UCB_STYLE_PS[i], &statbuf) < 0)
         {
             Log(LOG_LEVEL_VERBOSE,
                 "%s not found, cannot be used for extra process information",
-                SOLARIS_UCB_STYLE_PS[i]);
+                UCB_STYLE_PS[i]);
             continue;
         }
         if (!(statbuf.st_mode & 0111))
         {
             Log(LOG_LEVEL_VERBOSE,
                 "%s not executable, cannot be used for extra process information",
-                SOLARIS_UCB_STYLE_PS[i]);
+                UCB_STYLE_PS[i]);
             continue;
         }
 
         char *ps_cmd;
-        xasprintf(&ps_cmd, "%s %s", SOLARIS_UCB_STYLE_PS[i],
-                  SOLARIS_UCB_STYLE_PS_ARGS);
+        xasprintf(&ps_cmd, "%s %s", UCB_STYLE_PS[i],
+                  UCB_STYLE_PS_ARGS);
 
         FILE *cmd = cf_popen(ps_cmd, "rt", false);
         if (!cmd)
@@ -1330,7 +1382,8 @@ static void ReadFromUcbPsPipe(FILE *cmd)
 
         char *columns[CF_PROCCOLS];
         memset(columns, 0, sizeof(columns));
-        if (!SplitProcLine(line, pstime, names, start, end, columns))
+        if (!SplitProcLine(line, pstime, names, start, end,
+                           UCB_STYLE_PS_COLUMN_ALGORITHM, columns))
         {
             Log(LOG_LEVEL_WARNING,
                 "Not able to parse ps output: \"%s\"", line);

--- a/tests/unit/split_process_line_test.c
+++ b/tests/unit/split_process_line_test.c
@@ -4,12 +4,6 @@
 
 #include <processes_select.c>
 
-bool EMPTY_COLUMNS = false;
-static bool ZombiesCanHaveEmptyColumns(void)
-{
-    return EMPTY_COLUMNS;
-}
-
 /* Actual ps output witnessed. */
 static void test_split_line_challenges(void)
 {
@@ -32,7 +26,7 @@ static void test_split_line_challenges(void)
     assert_string_equal(name[user], "USER");
     assert_string_equal(name[nlwp], "NLWP");
 
-    assert_true(SplitProcLine(lines[1], 1, name, start, end, field));
+    assert_true(SplitProcLine(lines[1], 1, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "operatic");
     assert_string_equal(field[nlwp], "9");
 
@@ -68,12 +62,12 @@ static void test_split_line_elapsed(void)
     assert_string_equal(name[user], "USER");
     assert_string_equal(name[stime], "STIME");
 
-    assert_true(SplitProcLine(lines[2], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[2], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "block");
     /* Copes when STIME is a date with a space in it. */
     assert_string_equal(field[stime], began);
 
-    assert_true(SplitProcLine(lines[1], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[1], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "space");
     /* Copes when STIME is a date with a space in it. */
     assert_string_equal(field[stime], began);
@@ -105,12 +99,12 @@ static void test_split_line_noelapsed(void)
     assert_string_equal(name[user], "USER");
     assert_string_equal(name[stime], "STIME");
 
-    assert_true(SplitProcLine(lines[2], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[2], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "block");
     /* Copes when STIME is a date with a space in it. */
     assert_string_equal(field[stime], "Jul02");
 
-    assert_true(SplitProcLine(lines[1], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[1], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "space");
     /* Copes when STIME is a date with a space in it. */
     assert_string_equal(field[stime], "Jul 02");
@@ -201,7 +195,7 @@ static void test_split_line_longcmd(void)
     assert_string_equal(name[user], "USER");
     assert_string_equal(name[command], "COMMAND");
 
-    assert_true(SplitProcLine(lines[1], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[1], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "longcmd");
     /* Does not truncate the command. */
     assert_string_equal(field[command], lines[1] + start[command]);
@@ -259,10 +253,10 @@ static void test_split_line(void)
 
     size_t line = sizeof(lines) / sizeof(const char *);
     /* Higher indexed tests first; test lines[line] then decrement line. */
-    assert_false(SplitProcLine(lines[--line], pstime, name, start, end, field)); /* NULL */
-    assert_false(SplitProcLine(lines[--line], pstime, name, start, end, field)); /* empty */
+    assert_false(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field)); /* NULL */
+    assert_false(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field)); /* empty */
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field)); /* basic */
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field)); /* basic */
     {
         /* Each field is as expected: */
         const char *each[] = {
@@ -282,36 +276,36 @@ static void test_split_line(void)
     }
     /* See field[user] checks for names of remaining tests. */
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "spacey");
     /* Discards leading and dangling space in command. */
     assert_string_equal(field[command], "echo");
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "inspace");
     /* Preserves spaces within a text field. */
     assert_string_equal(field[command], lines[line] + start[command]);
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field));
     /* Handle a text field overflowing to the right. */
     assert_string_equal(field[user], "wordright");
     /* Shouldn't pollute PID: */
     assert_string_equal(field[user + 1], "4");
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field));
     /* Handle a text field overflowing under next header. */
     assert_string_equal(field[user], "wordytoright");
     /* Shouldn't pollute PID: */
     assert_string_equal(field[user + 1], "4");
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "numleft");
     /* Handle numeric field overflowing under previous header. */
     assert_string_equal(field[vsz], "123432536");
     /* Shouldn't pollute STAT: */
     assert_string_equal(field[vsz - 1], "S");
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "numboth");
     /* Handle numeric field overflowing under previous header. */
     assert_string_equal(field[rss], "12784321");
@@ -319,7 +313,7 @@ static void test_split_line(void)
     assert_string_equal(field[rss - 1], "0");
     assert_string_equal(field[rss + 1], "1");
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "timeleft");
     /* Handle time fields overflowing almost under previous header. */
     assert_string_equal(field[stime + 1], "271-00:07:43");
@@ -327,7 +321,7 @@ static void test_split_line(void)
     /* Shouldn't pollute NLWP: */
     assert_string_equal(field[stime - 1], "1");
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "timesleft");
     /* Handle time fields overflowing under previous header. */
     assert_string_equal(field[stime + 1], "1271-00:07:43");
@@ -335,7 +329,7 @@ static void test_split_line(void)
     /* Shouldn't pollute NLWP: */
     assert_string_equal(field[stime - 1], "1");
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "timeright");
     /* Handle time field overflowing under next header. */
     assert_string_equal(field[command - 1], "1-02:07:14");
@@ -343,7 +337,7 @@ static void test_split_line(void)
     assert_string_equal(field[stime + 1], "92-21:17:55");
     assert_string_equal(field[command], "true");
 
-    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[--line], pstime, name, start, end, PCA_AllColumnsPresent, field));
     assert_string_equal(field[user], "timeboth");
     assert_int_equal(command, stime + 3); /* with elapsed and time between */
     /* Handle a time field overflowing almost under previous header
@@ -398,7 +392,7 @@ static void test_split_line_serious_overspill(void)
 
     // Test content
     {
-        assert_true(SplitProcLine(lines[1], pstime, name, start, end, field));
+        assert_true(SplitProcLine(lines[1], pstime, name, start, end, PCA_AllColumnsPresent, field));
         assert_string_equal(field[user], "johndoe");
         assert_string_equal(field[pid], "8263");
         assert_string_equal(field[sz], "19890");
@@ -407,7 +401,7 @@ static void test_split_line_serious_overspill(void)
     }
 
     {
-        assert_true(SplitProcLine(lines[2], pstime, name, start, end, field));
+        assert_true(SplitProcLine(lines[2], pstime, name, start, end, PCA_AllColumnsPresent, field));
         assert_string_equal(field[user], "noaccess");
         assert_string_equal(field[pid], "8264");
         assert_string_equal(field[sz], "19890");
@@ -416,7 +410,7 @@ static void test_split_line_serious_overspill(void)
     }
 
     {
-        assert_true(SplitProcLine(lines[3], pstime, name, start, end, field));
+        assert_true(SplitProcLine(lines[3], pstime, name, start, end, PCA_AllColumnsPresent, field));
         assert_string_equal(field[user], "noaccess");
         assert_string_equal(field[pid], "8265");
         assert_string_equal(field[sz], "19890");
@@ -431,7 +425,6 @@ typedef struct
     const char **lines;
 } LWData;
 
-#ifdef __sun
 static void *ListWriter(void *arg)
 {
     LWData *data = (LWData *)arg;
@@ -443,27 +436,29 @@ static void *ListWriter(void *arg)
 
     return NULL;
 }
-#endif
 
 static void test_platform_extra_table(void)
 {
-#ifndef __sun
-    return;
-
-#else // __sun
     static const char *lines[] = {
         "    USER   PID %CPU %MEM   SZ  RSS TT      S    STIME        TIME COMMAND",
         " johndoe  8263  0.0  0.2 19890 116241 ?       S   Jan_16    08:41:40 /usr/java/bin/java -server -Xmx128m -XX:+UseParallelGC -XX:ParallelGCThreads=4",
         "noaccess  8264  0.0  0.2 19890 116242 ?       S   Jan_16    08:41:40 /usr/java/bin/java -server -Xmx128m -XX:+UseParallelGC -XX:ParallelGCThreads=4",
         "noaccess  8265  0.0  0.2 19890 116243 ?       S   Jan_16    08:41:40 /usr/java/bin/java -server -Xmx128m -XX:+UseParallelGC -XX:ParallelGCThreads=4",
+        " jenkins 22306    -    -    0    0 ?       Z        -       00:00 <defunct>",
+        " jenkins 22307    -    -    0    0 ?       Z        -       00:00 <defunct>",
+        " jenkins 22308    -    -    0    0 ?       Z        -       00:00 <defunct>",
         NULL
     };
     static const char *ucb_lines[] = {
-        // Takes from Solaris 10. Yep, the line really is that long.
         "   PID TT       S  TIME COMMAND",
         "  8263 ?        S 521:40 /usr/java/bin/java blahblah",
+        // Takes from Solaris 10. Yep, the line really is that long.
         "  8264 ?        S 521:40 /usr/java/bin/java -server -Xmx128m -XX:+UseParallelGC -XX:ParallelGCThreads=4 -classpath /usr/share/webconsole/private/container/bin/bootstrap.jar:/usr/share/webconsole/private/container/bin/commons-logging.jar:/usr/share/webconsole/private/container/bin/log4j.jar:/usr/java/lib/tools.jar:/usr/java/jre/lib/jsse.jar -Djava.security.manager -Djava.security.policy==/var/webconsole/domains/console/conf/console.policy -Djavax.net.ssl.trustStore=/var/webconsole/domains/console/conf/keystore.jks -Djava.security.auth.login.config=/var/webconsole/domains/console/conf/consolelogin.conf -Dcatalina.home=/usr/share/webconsole/private/container -Dcatalina.base=/var/webconsole/domains/console -Dcom.sun.web.console.home=/usr/share/webconsole -Dcom.sun.web.console.conf=/etc/webconsole/console -Dcom.sun.web.console.base=/var/webconsole/domains/console -Dcom.sun.web.console.logdir=/var/log/webconsole/console -Dcom.sun.web.console.native=/usr/lib/webconsole -Dcom.sun.web.console.appbase=/var/webconsole/domains/console/webapps -Dcom.sun.web.console.secureport=6789 -Dcom.sun.web.console.unsecureport=6788 -Dcom.sun.web.console.unsecurehost=127.0.0.1 -Dwebconsole.default.file=/etc/webconsole/console/default.properties -Dwebconsole.config.file=/etc/webconsole/console/service.properties -Dcom.sun.web.console.startfile=/var/webconsole/tmp/console_start.tmp -Djava.awt.headless=true -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog org.apache.catalina.startup.Bootstrap start",
         "  8265 ?        S 521:40 /usr/java/bin/java blahblah",
+        // Taken from Solaris 10, notice the missing fields.
+        " 22306          Z  0:00  <defunct>",
+        " 22307          Z  0:00 ",
+        " 22308          Z  0:00",
         NULL
     };
     char *name[CF_PROCCOLS]; /* Headers */
@@ -505,12 +500,11 @@ static void test_platform_extra_table(void)
 
     // Test content
     {
-        assert_true(SplitProcLine(lines[1], pstime, name, start, end, field));
+        assert_true(SplitProcLine(lines[1], pstime, name, start, end, PCA_AllColumnsPresent, field));
         assert_string_equal(field[user], "johndoe");
         assert_string_equal(field[pid], "8263");
         assert_string_equal(field[sz], "19890");
-        // TODO: This is currently incorrectly parsed as "1162".
-        //assert_string_equal(field[rss], "116241");
+        assert_string_equal(field[rss], "116241");
         assert_string_equal(field[command], lines[1] + 69);
 
         ApplyPlatformExtraTable(name, field);
@@ -518,18 +512,16 @@ static void test_platform_extra_table(void)
         assert_string_equal(field[user], "johndoe");
         assert_string_equal(field[pid], "8263");
         assert_string_equal(field[sz], "19890");
-        // TODO: This is currently incorrectly parsed as "1162".
-        //assert_string_equal(field[rss], "116241");
+        assert_string_equal(field[rss], "116241");
         assert_string_equal(field[command], ucb_lines[1] + 25);
     }
 
     {
-        assert_true(SplitProcLine(lines[2], pstime, name, start, end, field));
+        assert_true(SplitProcLine(lines[2], pstime, name, start, end, PCA_AllColumnsPresent, field));
         assert_string_equal(field[user], "noaccess");
         assert_string_equal(field[pid], "8264");
         assert_string_equal(field[sz], "19890");
-        // TODO: This is currently incorrectly parsed as "1162".
-        //assert_string_equal(field[rss], "116242");
+        assert_string_equal(field[rss], "116242");
         assert_string_equal(field[command], lines[2] + 69);
 
         ApplyPlatformExtraTable(name, field);
@@ -537,18 +529,16 @@ static void test_platform_extra_table(void)
         assert_string_equal(field[user], "noaccess");
         assert_string_equal(field[pid], "8264");
         assert_string_equal(field[sz], "19890");
-        // TODO: This is currently incorrectly parsed as "1162".
-        //assert_string_equal(field[rss], "116242");
+        assert_string_equal(field[rss], "116242");
         assert_string_equal(field[command], ucb_lines[2] + 25);
     }
 
     {
-        assert_true(SplitProcLine(lines[3], pstime, name, start, end, field));
+        assert_true(SplitProcLine(lines[3], pstime, name, start, end, PCA_AllColumnsPresent, field));
         assert_string_equal(field[user], "noaccess");
         assert_string_equal(field[pid], "8265");
         assert_string_equal(field[sz], "19890");
-        // TODO: This is currently incorrectly parsed as "1162".
-        //assert_string_equal(field[rss], "116243");
+        assert_string_equal(field[rss], "116243");
         assert_string_equal(field[command], lines[3] + 69);
 
         ApplyPlatformExtraTable(name, field);
@@ -556,13 +546,62 @@ static void test_platform_extra_table(void)
         assert_string_equal(field[user], "noaccess");
         assert_string_equal(field[pid], "8265");
         assert_string_equal(field[sz], "19890");
-        // TODO: This is currently incorrectly parsed as "1162".
-        //assert_string_equal(field[rss], "116243");
+        assert_string_equal(field[rss], "116243");
         assert_string_equal(field[command], ucb_lines[3] + 25);
     }
 
+    {
+        assert_true(SplitProcLine(lines[4], pstime, name, start, end, PCA_AllColumnsPresent, field));
+        assert_string_equal(field[user], "jenkins");
+        assert_string_equal(field[pid], "22306");
+        assert_string_equal(field[sz], "0");
+        assert_string_equal(field[rss], "0");
+        assert_string_equal(field[command], lines[4] + 66);
+
+        ApplyPlatformExtraTable(name, field);
+        // Now check new and corrected values.
+        assert_string_equal(field[user], "jenkins");
+        assert_string_equal(field[pid], "22306");
+        assert_string_equal(field[sz], "0");
+        assert_string_equal(field[rss], "0");
+        assert_string_equal(field[command], "<defunct>");
+    }
+
+    {
+        assert_true(SplitProcLine(lines[5], pstime, name, start, end, PCA_AllColumnsPresent, field));
+        assert_string_equal(field[user], "jenkins");
+        assert_string_equal(field[pid], "22307");
+        assert_string_equal(field[sz], "0");
+        assert_string_equal(field[rss], "0");
+        assert_string_equal(field[command], lines[5] + 66);
+
+        ApplyPlatformExtraTable(name, field);
+        // Now check new and corrected values.
+        assert_string_equal(field[user], "jenkins");
+        assert_string_equal(field[pid], "22307");
+        assert_string_equal(field[sz], "0");
+        assert_string_equal(field[rss], "0");
+        assert_string_equal(field[command], "");
+    }
+
+    {
+        assert_true(SplitProcLine(lines[6], pstime, name, start, end, PCA_AllColumnsPresent, field));
+        assert_string_equal(field[user], "jenkins");
+        assert_string_equal(field[pid], "22308");
+        assert_string_equal(field[sz], "0");
+        assert_string_equal(field[rss], "0");
+        assert_string_equal(field[command], lines[6] + 66);
+
+        ApplyPlatformExtraTable(name, field);
+        // Now check new and corrected values.
+        assert_string_equal(field[user], "jenkins");
+        assert_string_equal(field[pid], "22308");
+        assert_string_equal(field[sz], "0");
+        assert_string_equal(field[rss], "0");
+        assert_string_equal(field[command], "");
+    }
+
     fclose(cmd_output);
-#endif // __sun
 }
 
 static void test_platform_specific_ps_examples(void)
@@ -605,6 +644,11 @@ static void test_platform_specific_ps_examples(void)
             "       -  <    >  <    >  <    >     -     -     - <> X         -    <      > <       >",
             " jenkins  205218       1  205218   0.0   7.0 125384 20 A    Mar 16    00:36:46 /usr/java6_64/bin/java -jar slave.jar -jnlpUrl http://jenkins.usdc.cfengine.com/computer/buildslave-aix-5.3-ppc64/slave-agent.jnlp",
             " <     >  <    >       X  <    >   < >   < > <    > <> X    <    >    <      > <                                                                                                                                >",
+            // Extreme case, a lot of fields missing. This only works when the
+            // process is a zombie and the platform uses the
+            // PCA_ZombieSkipEmptyColumns algorithm (which AIX does).
+            "          205218       1  205218                   20 Z",
+            "       -  <    >       X  <    >     -     -     - <> X        -           - -",
             NULL
         }, {
             // HPUX
@@ -717,13 +761,14 @@ static void test_platform_specific_ps_examples(void)
 
     for (int platform = 0; platform < NUM_OF_PLATFORMS; platform++)
     {
+        PsColumnAlgorithm pca;
         if (platform == TEST_AIX)
         {
-            EMPTY_COLUMNS = true;
+            pca = PCA_ZombieSkipEmptyColumns;
         }
         else
         {
-            EMPTY_COLUMNS = false;
+            pca = PCA_AllColumnsPresent;
         }
 
         for (int linenum = 0; pslines[platform][linenum]; linenum += 2)
@@ -736,7 +781,7 @@ static void test_platform_specific_ps_examples(void)
             }
             else
             {
-                assert_true(SplitProcLine(pslines[platform][linenum], 1460118341, names, start, end, fields));
+                assert_true(SplitProcLine(pslines[platform][linenum], 1460118341, names, start, end, pca, fields));
                 fields_to_check = fields;
             }
 

--- a/tests/unit/split_process_line_test.c
+++ b/tests/unit/split_process_line_test.c
@@ -10,16 +10,13 @@ static bool ZombiesCanHaveEmptyColumns(void)
     return EMPTY_COLUMNS;
 }
 
-/* Actual ps output witnessed, that we probably can't hope to robustly
- * parse. */
+/* Actual ps output witnessed. */
 static void test_split_line_challenges(void)
 {
-#if 0 /* Enable to see how many we actually get right ! */
     /* Collect all test data in one array to make alignments visible: */
     static const char *lines[] = {
         "USER       PID    SZ    VSZ   RSS NLWP STIME     ELAPSED     TIME COMMAND",
         "operatic 14338 1042534 4170136 2122012 9 Sep15 4-06:11:34 2-09:27:49 /usr/lib/opera/opera"
-        /* It's unlikely we'll realise NLWP is 9 ! */
     };
     char *name[CF_PROCCOLS]; /* Headers */
     char *field[CF_PROCCOLS]; /* Content */
@@ -27,21 +24,27 @@ static void test_split_line_challenges(void)
     int end[CF_PROCCOLS] = { 0 };
     int i, user = 0, nlwp = 5;
 
+    memset(name, 0, sizeof(name));
+    memset(field, 0, sizeof(field));
+
     /* Prepare data needed by tests and assert things tests can then assume: */
     GetProcessColumnNames(lines[0], name, start, end);
     assert_string_equal(name[user], "USER");
     assert_string_equal(name[nlwp], "NLWP");
 
-    assert_true(SplitProcLine(lines[1], pstime, name, start, end, field));
+    assert_true(SplitProcLine(lines[1], 1, name, start, end, field));
     assert_string_equal(field[user], "operatic");
     assert_string_equal(field[nlwp], "9");
 
-    /* Finally, tidy away headers: */
+    /* Finally, tidy away fields and headers: */
+    for (i = 0; field[i] != NULL; i++)
+    {
+        free(field[i]);
+    }
     for (i = 0; name[i] != NULL; i++)
     {
         free(name[i]);
     }
-#endif
 }
 
 static void test_split_line_elapsed(void)


### PR DESCRIPTION
The problem is that the ucb style ps can return empty fields, so we
need to account for that:
- Abstract the choice of parsing algorithm so it can be easily
  specified when running SplitProcLine().
- Make ucb ps use the "empty fields" algorithm.
- When dealing with lines that can have empty fields, never leave a
  field NULL, even if the ps line is too short to cover all the
  headers. This fixes the segfault, since in the ucb parsing case, the
  return value of SplitProcLine() would not be used, and hence we
  would try to read the string afterwards.

Also enable some tests on all platforms that should now pass
everywhere.