### PR TITLE
Fix "No such file or directory" LMDB error on heavily loaded hosts.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1039,6 +1039,9 @@ AC_REPLACE_FUNCS(pthread_attr_setstacksize)
 AC_CHECK_DECLS(pthread_sigmask, [], [], [[#include <signal.h>]])
 AC_REPLACE_FUNCS(pthread_sigmask)
 
+AC_CHECK_DECLS(sched_yield, [], [], [[#include <sched.h>]])
+AC_CHECK_FUNCS(sched_yield)
+
 AC_CHECK_DECLS([openat], [], [], [[#define _GNU_SOURCE 1
                                    #include <fcntl.h>]])
 AC_CHECK_DECLS([fstatat], [], [], [[#define _GNU_SOURCE 1


### PR DESCRIPTION
There is a race condition in LMDB that will fail to open the database
environment if another process is opening it at the exact same
time. This condition is signaled by returning ENOENT, which we should
never get otherwise. This can lead to error messages on a heavily
loaded machine, so try to open it again after allowing other threads
to finish their opening process.

Ref: CFE-2300

Changelog: Title