### PR TITLE
Check entire group string to see if it is a gid or a group name in groupexists.

### DIFF
--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -1176,7 +1176,11 @@ gid_t Str2Gid(const char *gidbuff, char *groupcopy, const Promise *pp)
         else
         {
             gid = gr->gr_gid;
-            strcpy(groupcopy, gidbuff);
+
+            if (groupcopy != NULL)
+            {
+                strcpy(groupcopy, gidbuff);
+            }
         }
     }
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -6972,7 +6972,7 @@ FnCallResult FnCallGroupExists(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const Pol
 {
     char *arg = RlistScalarValue(finalargs);
 
-    if (isdigit((int) *arg))
+    if (StringIsNumeric(arg))
     {
         gid_t gid = Str2Gid(arg, NULL, NULL);
         if (gid == CF_SAME_GROUP || gid == CF_UNKNOWN_GROUP)


### PR DESCRIPTION
Also fix a possible segfault when calling `Str2Gid` with a group name and a `NULL` `groupcopy`.