### PR TITLE
CFE-2339 Don't accept old protocol by default.

### DIFF
--- a/cf-serverd/server.c
+++ b/cf-serverd/server.c
@@ -361,9 +361,9 @@ static void *HandleConnection(void *c)
     else if (protocol_version < CF_PROTOCOL_LATEST &&
              protocol_version > CF_PROTOCOL_UNDEFINED)
     {
-        /* This connection is legacy protocol. Do we allow it? */
-        if (SV.allowlegacyconnects != NULL &&           /* By default we do */
-            !IsMatchItemIn(SV.allowlegacyconnects, conn->ipaddr))
+        /* This connection is legacy protocol.
+         * We are not allowing it by default. */
+        if (!IsMatchItemIn(SV.allowlegacyconnects, conn->ipaddr))
         {
             Log(LOG_LEVEL_INFO,
                 "Connection is not using latest protocol, denying");

--- a/tests/acceptance/16_cf-serverd/serial/001.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/001.cf.sub
@@ -34,7 +34,6 @@ body copy_from copy_src_file(protocol_version)
       servers     => { "127.0.0.1" };
       compare     => "mtime";
       copy_backup => "false";
-      protocol_version => "$(protocol_version)";
 
       portnumber => "9876"; # localhost_open
 

--- a/tests/acceptance/16_cf-serverd/serial/004.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/004.cf.sub
@@ -35,8 +35,6 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
-      protocol_version => "$(protocol_version)";
-
       source      => "$(G.testdir)/source_file";
 
       # localhost comes first but will be denied

--- a/tests/acceptance/16_cf-serverd/serial/007.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/007.cf.sub
@@ -36,8 +36,6 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
-      protocol_version => "$(protocol_version)";
-
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       compare     => "digest";

--- a/tests/acceptance/16_cf-serverd/serial/008.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/008.cf.sub
@@ -35,8 +35,6 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
-      protocol_version => "$(protocol_version)";
-
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       compare     => "mtime";

--- a/tests/acceptance/16_cf-serverd/serial/010.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/010.cf.sub
@@ -34,8 +34,6 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
-      protocol_version => "$(protocol_version)";
-
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       copy_backup => "false";

--- a/tests/acceptance/16_cf-serverd/serial/011.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/011.cf.sub
@@ -34,8 +34,6 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
-      protocol_version => "$(protocol_version)";
-
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       copy_backup => "false";

--- a/tests/acceptance/16_cf-serverd/serial/allow_path1_then_deny_path2_a.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/allow_path1_then_deny_path2_a.cf.sub
@@ -20,7 +20,6 @@ body copy_from copy_from_port(port, protocol_version)
 
 {
       portnumber       => "$(port)";
-      protocol_version => "$(protocol_version)";
 
       # testroot dir is admitted on the server, while G.testdir is denied
       source      => "$(G.testroot)/source_file";

--- a/tests/acceptance/16_cf-serverd/serial/allowlegacyconnects_present.srv
+++ b/tests/acceptance/16_cf-serverd/serial/allowlegacyconnects_present.srv
@@ -12,15 +12,13 @@ body common control
 body server control
 
 {
-      port => "9891";
+      port => "9876";
 
       allowconnects         => { "127.0.0.1" , "::1" };
       allowallconnects      => { "127.0.0.1" , "::1" };
       trustkeysfrom         => { "127.0.0.1" , "::1" };
 
-      # Absence of this option *denies* access
-      # to classic protocol connections
-      #allowlegacyconnects   => { ... };
+      allowlegacyconnects   => { "127.0.0.1" , "::1" };
 }
 
 #########################################################

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_classic_protocol_success.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_classic_protocol_success.cf.sub
@@ -45,6 +45,6 @@ bundle agent check
 
   reports:
 
-    (copy1_repaired.copy2_repaired).(exists1.exists2).(!copy1_failed.!copy2_failed)::
+    (copy1_repaired.!copy2_repaired).(exists1.!exists2).(!copy1_failed.copy2_failed)::
       "$(fn[1]) Pass";
 }

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_digest_different.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_digest_different.cf.sub
@@ -34,8 +34,6 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
-      protocol_version => "$(protocol_version)";
-
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       compare     => "digest";

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_digest_different_expand_shortcut.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_digest_different_expand_shortcut.cf.sub
@@ -35,8 +35,6 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
-      protocol_version => "$(protocol_version)";
-
       # server-side expansion of shortcut
       source      => "simple_source";
 

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_encrypted_md5_zero_length_file.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_encrypted_md5_zero_length_file.cf.sub
@@ -32,8 +32,6 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
-      protocol_version => "$(protocol_version)";
-
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       copy_backup => "false";

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_md5_zero_length_file.cf
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_md5_zero_length_file.cf
@@ -16,9 +16,9 @@ bundle agent test
       "any" usebundle => dcs_fini("$(G.testdir)/destfile_latest");
 
       "any" usebundle => generate_key;
-      "any" usebundle => start_server("$(this.promise_dirname)/localhost_open.srv");
+      "any" usebundle => start_server("$(this.promise_dirname)/allowlegacyconnects_present.srv");
 
       "any" usebundle => run_test("$(this.promise_filename).sub");
 
-      "any" usebundle => stop_server("$(this.promise_dirname)/localhost_open.srv");
+      "any" usebundle => stop_server("$(this.promise_dirname)/allowlegacyconnects_present.srv");
 }

--- a/tests/acceptance/16_cf-serverd/serial/simple_copy_from_admit_localhost.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/simple_copy_from_admit_localhost.cf.sub
@@ -41,8 +41,6 @@ body copy_from copy_file(port, protocol_version)
       copy_backup => "false";
 
       portnumber       => "$(port)";
-      protocol_version => "$(protocol_version)";
-
       #encrypt     => "true";
       #verify      => "true";
       #purge       => "false";


### PR DESCRIPTION
Stop accepting clients using non TLS connections by default.

Changelog: Clients connections using non TLS protocol are rejected
by default. (CFE-2339).