### PR TITLE
Revert removed tests for both classing and TLS protocol.

### DIFF
--- a/tests/acceptance/16_cf-serverd/serial/001.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/001.cf.sub
@@ -34,6 +34,7 @@ body copy_from copy_src_file(protocol_version)
       servers     => { "127.0.0.1" };
       compare     => "mtime";
       copy_backup => "false";
+      protocol_version => "$(protocol_version)";
 
       portnumber => "9876"; # localhost_open
 

--- a/tests/acceptance/16_cf-serverd/serial/004.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/004.cf.sub
@@ -35,6 +35,8 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
+      protocol_version => "$(protocol_version)";
+
       source      => "$(G.testdir)/source_file";
 
       # localhost comes first but will be denied

--- a/tests/acceptance/16_cf-serverd/serial/007.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/007.cf.sub
@@ -36,6 +36,8 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
+      protocol_version => "$(protocol_version)";
+
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       compare     => "digest";

--- a/tests/acceptance/16_cf-serverd/serial/008.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/008.cf.sub
@@ -35,6 +35,8 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
+      protocol_version => "$(protocol_version)";
+
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       compare     => "mtime";

--- a/tests/acceptance/16_cf-serverd/serial/010.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/010.cf.sub
@@ -34,6 +34,8 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
+      protocol_version => "$(protocol_version)";
+
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       copy_backup => "false";

--- a/tests/acceptance/16_cf-serverd/serial/011.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/011.cf.sub
@@ -34,6 +34,8 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
+      protocol_version => "$(protocol_version)";
+
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       copy_backup => "false";

--- a/tests/acceptance/16_cf-serverd/serial/allow_path1_then_deny_path2_a.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/allow_path1_then_deny_path2_a.cf.sub
@@ -20,6 +20,7 @@ body copy_from copy_from_port(port, protocol_version)
 
 {
       portnumber       => "$(port)";
+      protocol_version => "$(protocol_version)";
 
       # testroot dir is admitted on the server, while G.testdir is denied
       source      => "$(G.testroot)/source_file";

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_digest_different.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_digest_different.cf.sub
@@ -34,6 +34,8 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
+      protocol_version => "$(protocol_version)";
+
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       compare     => "digest";

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_digest_different_expand_shortcut.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_digest_different_expand_shortcut.cf.sub
@@ -35,6 +35,8 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
+      protocol_version => "$(protocol_version)";
+
       # server-side expansion of shortcut
       source      => "simple_source";
 

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_encrypted_md5_zero_length_file.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_encrypted_md5_zero_length_file.cf.sub
@@ -32,6 +32,8 @@ bundle agent test
 
 body copy_from copy_src_file(protocol_version)
 {
+      protocol_version => "$(protocol_version)";
+
       source      => "$(G.testdir)/source_file";
       servers     => { "127.0.0.1" };
       copy_backup => "false";

--- a/tests/acceptance/16_cf-serverd/serial/lan_open.srv
+++ b/tests/acceptance/16_cf-serverd/serial/lan_open.srv
@@ -25,6 +25,7 @@ body server control
       allowconnects         => { @(sys.ip_addresses) };
       allowallconnects      => { @(sys.ip_addresses) };
       trustkeysfrom         => { @(sys.ip_addresses) };
+      allowlegacyconnects   => { @(sys.ip_addresses) };
 }
 
 #########################################################

--- a/tests/acceptance/16_cf-serverd/serial/localhost_deny_one_directory.srv
+++ b/tests/acceptance/16_cf-serverd/serial/localhost_deny_one_directory.srv
@@ -15,6 +15,7 @@ body server control
       allowconnects         => { "127.0.0.1" , "::1" };
       allowallconnects      => { "127.0.0.1" , "::1" };
       trustkeysfrom         => { "127.0.0.1" , "::1" };
+      allowlegacyconnects   => { "127.0.0.1" , "::1" };
 }
 
 #########################################################

--- a/tests/acceptance/16_cf-serverd/serial/localhost_deny_one_directory_with_regex.srv
+++ b/tests/acceptance/16_cf-serverd/serial/localhost_deny_one_directory_with_regex.srv
@@ -15,6 +15,7 @@ body server control
       allowconnects         => { "127.0.0.1" , "::1" };
       allowallconnects      => { "127.0.0.1" , "::1" };
       trustkeysfrom         => { "127.0.0.1" , "::1" };
+      allowlegacyconnects   => { "127.0.0.1" , "::1" };
 }
 
 #########################################################

--- a/tests/acceptance/16_cf-serverd/serial/localhost_open.srv
+++ b/tests/acceptance/16_cf-serverd/serial/localhost_open.srv
@@ -17,6 +17,7 @@ body server control
       allowconnects         => { "127.0.0.1" , "::1" };
       allowallconnects      => { "127.0.0.1" , "::1" };
       trustkeysfrom         => { "127.0.0.1" , "::1" };
+      allowlegacyconnects   => { "127.0.0.1" , "::1" };
 }
 
 #########################################################

--- a/tests/acceptance/16_cf-serverd/serial/localhost_open_admit_hostnames.srv
+++ b/tests/acceptance/16_cf-serverd/serial/localhost_open_admit_hostnames.srv
@@ -19,6 +19,7 @@ body server control
       allowconnects         => { "127.0.0.1" , "::1" };
       allowallconnects      => { "127.0.0.1" , "::1" };
       trustkeysfrom         => { "127.0.0.1" , "::1" };
+      allowlegacyconnects   => { "127.0.0.1" , "::1" };
 }
 
 #########################################################

--- a/tests/acceptance/16_cf-serverd/serial/localhost_open_hostname.srv
+++ b/tests/acceptance/16_cf-serverd/serial/localhost_open_hostname.srv
@@ -19,6 +19,7 @@ body server control
       allowconnects         => { "127.0.0.1" , "::1" };
       allowallconnects      => { "127.0.0.1" , "::1" };
       trustkeysfrom         => { "127.0.0.1" , "::1" };
+      allowlegacyconnects   => { "127.0.0.1" , "::1" };
 }
 
 #########################################################

--- a/tests/acceptance/16_cf-serverd/serial/simple_copy_from_admit_localhost.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/simple_copy_from_admit_localhost.cf.sub
@@ -41,6 +41,8 @@ body copy_from copy_file(port, protocol_version)
       copy_backup => "false";
 
       portnumber       => "$(port)";
+      protocol_version => "$(protocol_version)";
+
       #encrypt     => "true";
       #verify      => "true";
       #purge       => "false";


### PR DESCRIPTION
After removing "protocol_version" all the tests were run with
classic protocol only. This is bringing back testing using both
classic and TLS protocols.