### PR TITLE
storage: Properly initialize the list of current mounts CFE-1803

### DIFF
--- a/cf-agent/verify_storage.c
+++ b/cf-agent/verify_storage.c
@@ -132,7 +132,7 @@ PromiseResult VerifyStoragePromise(EvalContext *ctx, char *path, const Promise *
     PromiseResult result = PROMISE_RESULT_NOOP;
 
 #ifndef __MINGW32__
-    if ((SeqLength(GetGlobalMountedFSList())) && (!LoadMountInfo(GetGlobalMountedFSList())))
+    if ((!SeqLength(GetGlobalMountedFSList())) && (!LoadMountInfo(GetGlobalMountedFSList())))
     {
         Log(LOG_LEVEL_ERR, "Couldn't obtain a list of mounted filesystems - aborting");
         YieldCurrentLock(thislock);


### PR DESCRIPTION
In commit 35523330, the sense of this check was inadvertently changed
from "If the list is empty, and LoadMountInfo fails, report an error" to
"If the list is non-empty, and LoadMountInfo fails, report an error".
This caused LoadMountInfo to never get called, so cf-agent assumed that
nothing was mounted and therefore that nothing needed to be unmounted.