### PR TITLE
ENT-2737: Fix failsafe.cf not populating modules directory.

### DIFF
--- a/libpromises/failsafe.cf
+++ b/libpromises/failsafe.cf
@@ -114,6 +114,14 @@ bundle agent failsafe_cfe_internal_update
         depth_search => failsafe_recurse("inf"),
         classes => failsafe_results("namespace", "inputdir_update");
 
+    !policy_server::
+
+      "$(sys.workdir)/modules"
+        handle => "failsafe_cfe_internal_bootstrap_update_files_sys_workdir_modules_shortcut",
+        copy_from => failsafe_scp("modules"),
+        depth_search => failsafe_recurse("inf"),
+        classes => failsafe_results("namespace", "modulesdir_update");
+
     !windows.inputdir_update_error::
 
       # When running on a *nix platform with homogeneous packages


### PR DESCRIPTION
This has become important after the switch to the new package promise
for inventory by default, since it will immediately start looking for
the package modules.