### PR TITLE
updated the bundle name in compare.cf

### DIFF
--- a/examples/compare.cf
+++ b/examples/compare.cf
@@ -34,7 +34,7 @@ body common control
 
 ###########################################################
 
-bundle agent example
+bundle agent test
 
 {     
   classes:


### PR DESCRIPTION
There was a _bundle name_ mismatch under `example/compare.cf`. Hence corrected it.