### PR TITLE
Buffer size checks

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -208,9 +208,9 @@ Bundle *MakeTemporaryBundleFromTemplate(EvalContext *ctx, Policy *policy, Attrib
             // Get Action operator
             if (strncmp(buffer, "[%CFEngine", strlen("[%CFEngine")) == 0)
             {
-                char op[CF_BUFSIZE], brack[CF_SMALLBUF];
+                char op[CF_BUFSIZE], brack[4];
 
-                sscanf(buffer+strlen("[%CFEngine"), "%1024s %s", op, brack);
+                sscanf(buffer+strlen("[%CFEngine"), "%1024s %3s", op, brack);
 
                 if (strcmp(brack, "%]") != 0)
                 {

--- a/cf-agent/files_operators.c
+++ b/cf-agent/files_operators.c
@@ -73,15 +73,15 @@ int MoveObstruction(EvalContext *ctx, char *from, Attributes attr, const Promise
             }
 
             saved[0] = '\0';
-            strcpy(saved, from);
+            strlcpy(saved, from, sizeof(saved));
 
             if (attr.copy.backup == BACKUP_OPTION_TIMESTAMP || attr.edits.backup == BACKUP_OPTION_TIMESTAMP)
             {
                 snprintf(stamp, CF_BUFSIZE, "_%jd_%s", (intmax_t) CFSTARTTIME, CanonifyName(ctime(&now_stamp)));
-                strcat(saved, stamp);
+                strlcat(saved, stamp, sizeof(saved));
             }
 
-            strcat(saved, CF_SAVED);
+            strlcat(saved, CF_SAVED, sizeof(saved));
 
             cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_CHANGE, pp, attr, "Moving file object '%s' to '%s'", from, saved);
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_CHANGE);
@@ -112,12 +112,12 @@ int MoveObstruction(EvalContext *ctx, char *from, Attributes attr, const Promise
             }
 
             saved[0] = '\0';
-            strcpy(saved, from);
+            strlcpy(saved, from, sizeof(saved));
 
             snprintf(stamp, CF_BUFSIZE, "_%jd_%s", (intmax_t) CFSTARTTIME, CanonifyName(ctime(&now_stamp)));
-            strcat(saved, stamp);
-            strcat(saved, CF_SAVED);
-            strcat(saved, ".dir");
+            strlcat(saved, stamp, sizeof(saved));
+            strlcat(saved, CF_SAVED, sizeof(saved));
+            strlcat(saved, ".dir", sizeof(saved));
 
             if (stat(saved, &sb) != -1)
             {

--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -382,7 +382,7 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a,
 
             if (a.module)
             {
-                ModuleProtocol(ctx, cmdline, line, !a.contain.nooutput, module_context, module_tags, &persistence);
+                ModuleProtocol(ctx, cmdline, line, !a.contain.nooutput, module_context, sizeof(module_context), module_tags, &persistence);
             }
             else if ((!a.contain.nooutput) && (!EmptyString(line)))
             {

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -1340,7 +1340,7 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
 
         strlcpy(new, dest, CF_BUFSIZE);
 
-        if (!JoinSuffix(new, CF_NEW))
+        if (!JoinSuffix(new, sizeof(new), CF_NEW))
         {
             Log(LOG_LEVEL_ERR, "Unable to construct filename for copy");
             return false;
@@ -1399,13 +1399,13 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
             stampnow = time((time_t *) NULL);
             snprintf(stamp, CF_BUFSIZE - 1, "_%lu_%s", CFSTARTTIME, CanonifyName(ctime(&stampnow)));
 
-            if (!JoinSuffix(backup, stamp))
+            if (!JoinSuffix(backup, sizeof(backup), stamp))
             {
                 return false;
             }
         }
 
-        if (!JoinSuffix(backup, CF_SAVED))
+        if (!JoinSuffix(backup, sizeof(backup), CF_SAVED))
         {
             return false;
         }
@@ -1825,14 +1825,14 @@ static PromiseResult VerifyName(EvalContext *ctx, char *path, struct stat *sb, A
 
             if (attr.rename.disable_suffix)
             {
-                if (!JoinSuffix(newname, attr.rename.disable_suffix))
+                if (!JoinSuffix(newname, sizeof(newname), attr.rename.disable_suffix))
                 {
                     return result;
                 }
             }
             else
             {
-                if (!JoinSuffix(newname, ".cfdisabled"))
+                if (!JoinSuffix(newname, sizeof(newname), ".cfdisabled"))
                 {
                     return result;
                 }

--- a/cf-key/cf-key-functions.c
+++ b/cf-key/cf-key-functions.c
@@ -283,7 +283,7 @@ int RemoveKeys(const char *input, bool must_be_coherent)
     char equivalent[CF_BUFSIZE];
     equivalent[0] = '\0';
 
-    res = RemoveKeysFromLastSeen(input, must_be_coherent, equivalent);
+    res = RemoveKeysFromLastSeen(input, must_be_coherent, equivalent, sizeof(equivalent));
     if (res!=0)
     {
         return res;

--- a/cf-serverd/server_classic.c
+++ b/cf-serverd/server_classic.c
@@ -1199,7 +1199,9 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
             return false;
         }
 
-        plainlen = DecryptString(conn->encryption_type, recvbuffer + CF_PROTO_OFFSET, buffer, conn->session_key, len);
+        plainlen = DecryptString(buffer, sizeof(buffer),
+                                 recvbuffer + CF_PROTO_OFFSET, len,
+                                 conn->encryption_type, conn->session_key);
 
         cfscanf(buffer, strlen("GET"), strlen("dummykey"), check, sendbuffer, filename);
 
@@ -1266,7 +1268,9 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
 
         memcpy(out, recvbuffer + CF_PROTO_OFFSET, len);
 
-        plainlen = DecryptString(conn->encryption_type, out, recvbuffer, conn->session_key, len);
+        plainlen = DecryptString(recvbuffer, sizeof(recvbuffer),
+                                 out, len,
+                                 conn->encryption_type, conn->session_key);
 
         if (strncmp(recvbuffer, "OPENDIR", 7) != 0)
         {
@@ -1337,7 +1341,9 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
 
         memcpy(out, recvbuffer + CF_PROTO_OFFSET, len);
 
-        plainlen = DecryptString(conn->encryption_type, out, recvbuffer, conn->session_key, len);
+        plainlen = DecryptString(recvbuffer, sizeof(recvbuffer),
+                                 out, len,
+                                 conn->encryption_type, conn->session_key);
 
         if (plainlen < 0)
         {
@@ -1419,7 +1425,9 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
         }
 
         memcpy(out, recvbuffer + CF_PROTO_OFFSET, len);
-        plainlen = DecryptString(conn->encryption_type, out, recvbuffer, conn->session_key, len);
+        plainlen = DecryptString(recvbuffer, sizeof(recvbuffer),
+                                 out, len,
+                                 conn->encryption_type, conn->session_key);
 
         if (strncmp(recvbuffer, "MD5", 3) != 0)
         {
@@ -1478,7 +1486,9 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
         }
 
         memcpy(out, recvbuffer + CF_PROTO_OFFSET, len);
-        plainlen = DecryptString(conn->encryption_type, out, recvbuffer, conn->session_key, len);
+        plainlen = DecryptString(recvbuffer, sizeof(recvbuffer),
+                                 out, len,
+                                 conn->encryption_type, conn->session_key);
         encrypted = true;
 
         if (strncmp(recvbuffer, "VAR", 3) != 0)
@@ -1512,7 +1522,9 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
         }
 
         memcpy(out, recvbuffer + CF_PROTO_OFFSET, len);
-        plainlen = DecryptString(conn->encryption_type, out, recvbuffer, conn->session_key, len);
+        plainlen = DecryptString(recvbuffer, sizeof(recvbuffer),
+                                 out, len,
+                                 conn->encryption_type, conn->session_key);
         encrypted = true;
 
         if (strncmp(recvbuffer, "CONTEXT", 7) != 0)
@@ -1546,7 +1558,9 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
         }
 
         memcpy(out, recvbuffer + CF_PROTO_OFFSET, len);
-        plainlen = DecryptString(conn->encryption_type, out, recvbuffer, conn->session_key, len);
+        plainlen = DecryptString(recvbuffer, sizeof(recvbuffer),
+                                 out, len,
+                                 conn->encryption_type, conn->session_key);
 
         if (strncmp(recvbuffer, "QUERY", 5) != 0)
         {
@@ -1579,7 +1593,9 @@ int BusyWithClassicConnection(EvalContext *ctx, ServerConnectionState *conn)
         }
 
         memcpy(out, recvbuffer + CF_PROTO_OFFSET, len);
-        plainlen = DecryptString(conn->encryption_type, out, recvbuffer, conn->session_key, len);
+        plainlen = DecryptString(recvbuffer, sizeof(recvbuffer),
+                                 out, len,
+                                 conn->encryption_type, conn->session_key);
 
         if (strncmp(recvbuffer, "CALL_ME_BACK collect_calls", strlen("CALL_ME_BACK collect_calls")) != 0)
         {

--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -891,7 +891,9 @@ void GetServerLiteral(EvalContext *ctx, ServerConnectionState *conn, char *sendb
 
     if (encrypted)
     {
-        cipherlen = EncryptString(out, sendbuffer, strlen(sendbuffer) + 1, conn->encryption_type, conn->session_key);
+        cipherlen = EncryptString(out, sizeof(out),
+                                  sendbuffer, strlen(sendbuffer) + 1,
+                                  conn->encryption_type, conn->session_key);
         SendTransaction(conn->conn_info, out, cipherlen, CF_DONE);
     }
     else
@@ -931,7 +933,8 @@ void ReplyServerContext(ServerConnectionState *conn, int encrypted, Item *classe
     if (encrypted)
     {
         char out[CF_BUFSIZE];
-        int cipherlen = EncryptString(out, sendbuffer, strlen(sendbuffer) + 1,
+        int cipherlen = EncryptString(out, sizeof(out),
+                                      sendbuffer, strlen(sendbuffer) + 1,
                                       conn->encryption_type, conn->session_key);
         SendTransaction(conn->conn_info, out, cipherlen, CF_DONE);
     }
@@ -1008,7 +1011,9 @@ int CfSecOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *dirn
     if (!IsAbsoluteFileName(dirname))
     {
         strcpy(sendbuffer, "BAD: request to access a non-absolute filename");
-        cipherlen = EncryptString(out, sendbuffer, strlen(sendbuffer) + 1, conn->encryption_type, conn->session_key);
+        cipherlen = EncryptString(out, sizeof(out),
+                                  sendbuffer, strlen(sendbuffer) + 1,
+                                  conn->encryption_type, conn->session_key);
         SendTransaction(conn->conn_info, out, cipherlen, CF_DONE);
         return -1;
     }
@@ -1017,7 +1022,9 @@ int CfSecOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *dirn
     {
         Log(LOG_LEVEL_VERBOSE, "Couldn't open dir %s", dirname);
         snprintf(sendbuffer, CF_BUFSIZE, "BAD: cfengine, couldn't open dir %s", dirname);
-        cipherlen = EncryptString(out, sendbuffer, strlen(sendbuffer) + 1, conn->encryption_type, conn->session_key);
+        cipherlen = EncryptString(out, sizeof(out),
+                                  sendbuffer, strlen(sendbuffer) + 1,
+                                  conn->encryption_type, conn->session_key);
         SendTransaction(conn->conn_info, out, cipherlen, CF_DONE);
         return -1;
     }
@@ -1032,7 +1039,9 @@ int CfSecOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *dirn
     {
         if (strlen(dirp->d_name) + 1 + offset >= CF_BUFSIZE - CF_MAXLINKSIZE)
         {
-            cipherlen = EncryptString(out, sendbuffer, offset + 1, conn->encryption_type, conn->session_key);
+            cipherlen = EncryptString(out, sizeof(out),
+                                      sendbuffer, offset + 1,
+                                      conn->encryption_type, conn->session_key);
             SendTransaction(conn->conn_info, out, cipherlen, CF_MORE);
             offset = 0;
             memset(sendbuffer, 0, CF_BUFSIZE);
@@ -1047,7 +1056,9 @@ int CfSecOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *dirn
     strcpy(sendbuffer + offset, CFD_TERMINATOR);
 
     cipherlen =
-        EncryptString(out, sendbuffer, offset + 2 + strlen(CFD_TERMINATOR), conn->encryption_type, conn->session_key);
+        EncryptString(out, sizeof(out),
+                      sendbuffer, offset + 2 + strlen(CFD_TERMINATOR),
+                      conn->encryption_type, conn->session_key);
     SendTransaction(conn->conn_info, out, cipherlen, CF_DONE);
     DirClose(dirh);
     return 0;

--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -891,7 +891,7 @@ void GetServerLiteral(EvalContext *ctx, ServerConnectionState *conn, char *sendb
 
     if (encrypted)
     {
-        cipherlen = EncryptString(conn->encryption_type, sendbuffer, out, conn->session_key, strlen(sendbuffer) + 1);
+        cipherlen = EncryptString(out, sendbuffer, strlen(sendbuffer) + 1, conn->encryption_type, conn->session_key);
         SendTransaction(conn->conn_info, out, cipherlen, CF_DONE);
     }
     else
@@ -931,8 +931,8 @@ void ReplyServerContext(ServerConnectionState *conn, int encrypted, Item *classe
     if (encrypted)
     {
         char out[CF_BUFSIZE];
-        int cipherlen = EncryptString(conn->encryption_type, sendbuffer, out,
-                                      conn->session_key, strlen(sendbuffer) + 1);
+        int cipherlen = EncryptString(out, sendbuffer, strlen(sendbuffer) + 1,
+                                      conn->encryption_type, conn->session_key);
         SendTransaction(conn->conn_info, out, cipherlen, CF_DONE);
     }
     else
@@ -1008,7 +1008,7 @@ int CfSecOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *dirn
     if (!IsAbsoluteFileName(dirname))
     {
         strcpy(sendbuffer, "BAD: request to access a non-absolute filename");
-        cipherlen = EncryptString(conn->encryption_type, sendbuffer, out, conn->session_key, strlen(sendbuffer) + 1);
+        cipherlen = EncryptString(out, sendbuffer, strlen(sendbuffer) + 1, conn->encryption_type, conn->session_key);
         SendTransaction(conn->conn_info, out, cipherlen, CF_DONE);
         return -1;
     }
@@ -1017,7 +1017,7 @@ int CfSecOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *dirn
     {
         Log(LOG_LEVEL_VERBOSE, "Couldn't open dir %s", dirname);
         snprintf(sendbuffer, CF_BUFSIZE, "BAD: cfengine, couldn't open dir %s", dirname);
-        cipherlen = EncryptString(conn->encryption_type, sendbuffer, out, conn->session_key, strlen(sendbuffer) + 1);
+        cipherlen = EncryptString(out, sendbuffer, strlen(sendbuffer) + 1, conn->encryption_type, conn->session_key);
         SendTransaction(conn->conn_info, out, cipherlen, CF_DONE);
         return -1;
     }
@@ -1032,7 +1032,7 @@ int CfSecOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *dirn
     {
         if (strlen(dirp->d_name) + 1 + offset >= CF_BUFSIZE - CF_MAXLINKSIZE)
         {
-            cipherlen = EncryptString(conn->encryption_type, sendbuffer, out, conn->session_key, offset + 1);
+            cipherlen = EncryptString(out, sendbuffer, offset + 1, conn->encryption_type, conn->session_key);
             SendTransaction(conn->conn_info, out, cipherlen, CF_MORE);
             offset = 0;
             memset(sendbuffer, 0, CF_BUFSIZE);
@@ -1047,7 +1047,7 @@ int CfSecOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *dirn
     strcpy(sendbuffer + offset, CFD_TERMINATOR);
 
     cipherlen =
-        EncryptString(conn->encryption_type, sendbuffer, out, conn->session_key, offset + 2 + strlen(CFD_TERMINATOR));
+        EncryptString(out, sendbuffer, offset + 2 + strlen(CFD_TERMINATOR), conn->encryption_type, conn->session_key);
     SendTransaction(conn->conn_info, out, cipherlen, CF_DONE);
     DirClose(dirh);
     return 0;

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -359,8 +359,8 @@ Item *RemoteDirList(const char *dirname, bool encrypt, AgentConnection *conn)
         if (encrypt)
         {
             memcpy(in, recvbuffer, nbytes);
-            DecryptString(conn->encryption_type, in, recvbuffer,
-                          conn->session_key, nbytes);
+            DecryptString(recvbuffer, sizeof(recvbuffer), in, nbytes,
+                          conn->encryption_type, conn->session_key);
         }
 
         if (recvbuffer[0] == '\0')

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -320,9 +320,17 @@ Item *RemoteDirList(const char *dirname, bool encrypt, AgentConnection *conn)
 
         snprintf(in, CF_BUFSIZE, "OPENDIR %s", dirname);
         cipherlen = EncryptString(out, sizeof(out), in, strlen(in) + 1, conn->encryption_type, conn->session_key);
+
+        tosend = cipherlen + CF_PROTO_OFFSET;
+
+        if(tosend > sizeof(sendbuffer))
+        {
+            ProgrammingError("RemoteDirList: tosend (%d) > sendbuffer (%ld)",
+                             tosend, sizeof(sendbuffer));
+        }
+
         snprintf(sendbuffer, CF_BUFSIZE - 1, "SOPENDIR %d", cipherlen);
         memcpy(sendbuffer + CF_PROTO_OFFSET, out, cipherlen);
-        tosend = cipherlen + CF_PROTO_OFFSET;
     }
     else
     {

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -444,9 +444,17 @@ int CompareHashNet(const char *file1, const char *file2, bool encrypt, AgentConn
             EncryptString(out, sizeof(out), in,
                           strlen(in) + CF_SMALL_OFFSET + CF_DEFAULT_DIGEST_LEN,
                           conn->encryption_type, conn->session_key);
+
+        tosend = cipherlen + CF_PROTO_OFFSET;
+
+        if(tosend > sizeof(sendbuffer))
+        {
+            ProgrammingError("CompareHashNet: tosend (%d) > sendbuffer (%ld)",
+                             tosend, sizeof(sendbuffer));
+        }
+
         snprintf(sendbuffer, CF_BUFSIZE, "SMD5 %d", cipherlen);
         memcpy(sendbuffer + CF_PROTO_OFFSET, out, cipherlen);
-        tosend = cipherlen + CF_PROTO_OFFSET;
     }
     else
     {

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -319,7 +319,7 @@ Item *RemoteDirList(const char *dirname, bool encrypt, AgentConnection *conn)
         }
 
         snprintf(in, CF_BUFSIZE, "OPENDIR %s", dirname);
-        cipherlen = EncryptString(out, in, strlen(in) + 1, conn->encryption_type, conn->session_key);
+        cipherlen = EncryptString(out, sizeof(out), in, strlen(in) + 1, conn->encryption_type, conn->session_key);
         snprintf(sendbuffer, CF_BUFSIZE - 1, "SOPENDIR %d", cipherlen);
         memcpy(sendbuffer + CF_PROTO_OFFSET, out, cipherlen);
         tosend = cipherlen + CF_PROTO_OFFSET;
@@ -441,7 +441,7 @@ int CompareHashNet(const char *file1, const char *file2, bool encrypt, AgentConn
         }
 
         cipherlen =
-            EncryptString(out, in,
+            EncryptString(out, sizeof(out), in,
                           strlen(in) + CF_SMALL_OFFSET + CF_DEFAULT_DIGEST_LEN,
                           conn->encryption_type, conn->session_key);
         snprintf(sendbuffer, CF_BUFSIZE, "SMD5 %d", cipherlen);
@@ -570,7 +570,7 @@ int EncryptCopyRegularFileNet(const char *source, const char *dest, off_t size, 
     EVP_CIPHER_CTX_init(&crypto_ctx);
 
     snprintf(in, CF_BUFSIZE - CF_PROTO_OFFSET, "GET dummykey %s", source);
-    cipherlen = EncryptString(out, in, strlen(in) + 1, conn->encryption_type, conn->session_key);
+    cipherlen = EncryptString(out, sizeof(out), in, strlen(in) + 1, conn->encryption_type, conn->session_key);
     snprintf(workbuf, CF_BUFSIZE, "SGET %4d %4d", cipherlen, blocksize);
     memcpy(workbuf + CF_PROTO_OFFSET, out, cipherlen);
     tosend = cipherlen + CF_PROTO_OFFSET;

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -587,9 +587,17 @@ int EncryptCopyRegularFileNet(const char *source, const char *dest, off_t size, 
 
     snprintf(in, CF_BUFSIZE - CF_PROTO_OFFSET, "GET dummykey %s", source);
     cipherlen = EncryptString(out, sizeof(out), in, strlen(in) + 1, conn->encryption_type, conn->session_key);
+
+    tosend = cipherlen + CF_PROTO_OFFSET;
+
+    if(tosend > sizeof(workbuf))
+    {
+        ProgrammingError("EncryptCopyRegularFileNet: tosend (%d) > workbuf (%ld)",
+                         tosend, sizeof(workbuf));
+    }
+
     snprintf(workbuf, CF_BUFSIZE, "SGET %4d %4d", cipherlen, blocksize);
     memcpy(workbuf + CF_PROTO_OFFSET, out, cipherlen);
-    tosend = cipherlen + CF_PROTO_OFFSET;
 
 /* Send proposition C0 - query */
 

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -319,7 +319,7 @@ Item *RemoteDirList(const char *dirname, bool encrypt, AgentConnection *conn)
         }
 
         snprintf(in, CF_BUFSIZE, "OPENDIR %s", dirname);
-        cipherlen = EncryptString(conn->encryption_type, in, out, conn->session_key, strlen(in) + 1);
+        cipherlen = EncryptString(out, in, strlen(in) + 1, conn->encryption_type, conn->session_key);
         snprintf(sendbuffer, CF_BUFSIZE - 1, "SOPENDIR %d", cipherlen);
         memcpy(sendbuffer + CF_PROTO_OFFSET, out, cipherlen);
         tosend = cipherlen + CF_PROTO_OFFSET;
@@ -441,8 +441,9 @@ int CompareHashNet(const char *file1, const char *file2, bool encrypt, AgentConn
         }
 
         cipherlen =
-            EncryptString(conn->encryption_type, in, out, conn->session_key,
-                          strlen(in) + CF_SMALL_OFFSET + CF_DEFAULT_DIGEST_LEN);
+            EncryptString(out, in,
+                          strlen(in) + CF_SMALL_OFFSET + CF_DEFAULT_DIGEST_LEN,
+                          conn->encryption_type, conn->session_key);
         snprintf(sendbuffer, CF_BUFSIZE, "SMD5 %d", cipherlen);
         memcpy(sendbuffer + CF_PROTO_OFFSET, out, cipherlen);
         tosend = cipherlen + CF_PROTO_OFFSET;
@@ -569,7 +570,7 @@ int EncryptCopyRegularFileNet(const char *source, const char *dest, off_t size, 
     EVP_CIPHER_CTX_init(&crypto_ctx);
 
     snprintf(in, CF_BUFSIZE - CF_PROTO_OFFSET, "GET dummykey %s", source);
-    cipherlen = EncryptString(conn->encryption_type, in, out, conn->session_key, strlen(in) + 1);
+    cipherlen = EncryptString(out, in, strlen(in) + 1, conn->encryption_type, conn->session_key);
     snprintf(workbuf, CF_BUFSIZE, "SGET %4d %4d", cipherlen, blocksize);
     memcpy(workbuf + CF_PROTO_OFFSET, out, cipherlen);
     tosend = cipherlen + CF_PROTO_OFFSET;

--- a/libcfnet/communication.c
+++ b/libcfnet/communication.c
@@ -237,34 +237,6 @@ int IPString2Hostname(char *dst, const char *ipaddr, size_t dst_size)
 
 /*****************************************************************************/
 
-int GetMyHostInfo(char nameBuf[MAXHOSTNAMELEN], char ipBuf[MAXIP4CHARLEN])
-{
-    char *ip;
-    struct hostent *hostinfo;
-
-    if (gethostname(nameBuf, MAXHOSTNAMELEN) == 0)
-    {
-        if ((hostinfo = gethostbyname(nameBuf)) != NULL)
-        {
-            ip = inet_ntoa(*(struct in_addr *) *hostinfo->h_addr_list);
-            strlcpy(ipBuf, ip, MAXIP4CHARLEN);
-            return true;
-        }
-        else
-        {
-            Log(LOG_LEVEL_ERR, "Could not get host entry for local host. (gethostbyname: %s)", GetErrorStr());
-        }
-    }
-    else
-    {
-        Log(LOG_LEVEL_ERR, "Could not get host name. (gethostname: %s)", GetErrorStr());
-    }
-
-    return false;
-}
-
-/*****************************************************************************/
-
 unsigned short SocketFamily(int sd)
 {
     struct sockaddr_storage ss = {0};

--- a/libcfnet/communication.h
+++ b/libcfnet/communication.h
@@ -42,7 +42,6 @@ int IsIPV6Address(char *name);
 int IsIPV4Address(char *name);
 int Hostname2IPString(char *dst, const char *hostname, size_t dst_size);
 int IPString2Hostname(char *dst, const char *ipaddr, size_t dst_size);
-int GetMyHostInfo(char nameBuf[MAXHOSTNAMELEN], char ipBuf[MAXIP4CHARLEN]);
 unsigned short SocketFamily(int sd);
 
 #endif

--- a/libcfnet/stat_cache.c
+++ b/libcfnet/stat_cache.c
@@ -145,8 +145,8 @@ int cf_remote_stat(AgentConnection *conn, bool encrypt, const char *file,
 
         snprintf(in, CF_BUFSIZE - 1, "SYNCH %jd STAT %s",
                  (intmax_t) tloc, file);
-        int cipherlen = EncryptString(conn->encryption_type, in, out,
-                                      conn->session_key, strlen(in) + 1);
+        int cipherlen = EncryptString(out, in, strlen(in) + 1,
+                                      conn->encryption_type, conn->session_key);
         snprintf(sendbuffer, CF_BUFSIZE - 1, "SSYNCH %d", cipherlen);
         memcpy(sendbuffer + CF_PROTO_OFFSET, out, cipherlen);
         tosend = cipherlen + CF_PROTO_OFFSET;

--- a/libcfnet/stat_cache.c
+++ b/libcfnet/stat_cache.c
@@ -145,7 +145,7 @@ int cf_remote_stat(AgentConnection *conn, bool encrypt, const char *file,
 
         snprintf(in, CF_BUFSIZE - 1, "SYNCH %jd STAT %s",
                  (intmax_t) tloc, file);
-        int cipherlen = EncryptString(out, in, strlen(in) + 1,
+        int cipherlen = EncryptString(out, sizeof(out), in, strlen(in) + 1,
                                       conn->encryption_type, conn->session_key);
         snprintf(sendbuffer, CF_BUFSIZE - 1, "SSYNCH %d", cipherlen);
         memcpy(sendbuffer + CF_PROTO_OFFSET, out, cipherlen);

--- a/libpromises/addr_lib.c
+++ b/libpromises/addr_lib.c
@@ -42,12 +42,6 @@ int FuzzySetMatch(const char *s1, const char *s2)
     short isCIDR = false, isrange = false, isv6 = false, isv4 = false;
     char address[CF_ADDRSIZE];
 
-    if (strlen(s1) >= CF_MAX_IP_LEN)
-    {
-        Log(LOG_LEVEL_ERR, "IP set string '%s' is too large to parse (>=%d)", s1, CF_MAX_IP_LEN);
-        return -1;
-    }
-
     if (strcmp(s1, s2) == 0)
     {
         return 0;

--- a/libpromises/addr_lib.c
+++ b/libpromises/addr_lib.c
@@ -157,7 +157,7 @@ int FuzzySetMatch(const char *s1, const char *s2)
         else
         {
             long i, from = -1, to = -1, cmp = -1;
-            char buffer1[CF_MAX_IP_LEN], buffer2[CF_MAX_IP_LEN];
+            char buffer1[64], buffer2[64];
 
             const char *sp1 = s1;
             const char *sp2 = s2;
@@ -165,7 +165,8 @@ int FuzzySetMatch(const char *s1, const char *s2)
             for (i = 0; i < 4; i++)
             {
                 buffer1[0] = '\0';
-                sscanf(sp1, "%[^.]", buffer1);
+                sscanf(sp1, "%63[^.]", buffer1);
+                buffer1[63] = '\0';
 
                 if (strlen(buffer1) == 0)
                 {
@@ -173,7 +174,10 @@ int FuzzySetMatch(const char *s1, const char *s2)
                 }
 
                 sp1 += strlen(buffer1) + 1;
-                sscanf(sp2, "%[^.]", buffer2);
+
+                sscanf(sp2, "%63[^.]", buffer2);
+                buffer2[63] = '\0';
+
                 sp2 += strlen(buffer2) + 1;
 
                 if (strstr(buffer1, "-"))
@@ -256,16 +260,21 @@ int FuzzySetMatch(const char *s1, const char *s2)
         else
         {
             long i, from = -1, to = -1, cmp = -1;
-            char buffer1[CF_MAX_IP_LEN], buffer2[CF_MAX_IP_LEN];
+            char buffer1[64], buffer2[64];
 
             const char *sp1 = s1;
             const char *sp2 = s2;
 
             for (i = 0; i < 8; i++)
             {
-                sscanf(sp1, "%[^:]", buffer1);
+                sscanf(sp1, "%63[^:]", buffer1);
+                buffer1[63] = '\0';
+
                 sp1 += strlen(buffer1) + 1;
-                sscanf(sp2, "%[^:]", buffer2);
+
+                sscanf(sp2, "%63[^:]", buffer2);
+                buffer2[63] = '\0';
+
                 sp2 += strlen(buffer2) + 1;
 
                 if (strstr(buffer1, "-"))

--- a/libpromises/addr_lib.c
+++ b/libpromises/addr_lib.c
@@ -42,6 +42,12 @@ int FuzzySetMatch(const char *s1, const char *s2)
     short isCIDR = false, isrange = false, isv6 = false, isv4 = false;
     char address[CF_ADDRSIZE];
 
+    if (strlen(s1) >= CF_MAX_IP_LEN)
+    {
+        Log(LOG_LEVEL_ERR, "IP set string '%s' is too large to parse (>=%d)", s1, CF_MAX_IP_LEN);
+        return -1;
+    }
+
     if (strcmp(s1, s2) == 0)
     {
         return 0;

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -499,7 +499,7 @@ bool DoubleFromString(const char *s, double *value_out)
     static const double NO_DOUBLE = -123.45;
 
     double a = NO_DOUBLE;
-    char remainder[CF_BUFSIZE];
+    char remainder[4096];
     char c = 'X';
 
     if (s == NULL)
@@ -509,7 +509,7 @@ bool DoubleFromString(const char *s, double *value_out)
 
     remainder[0] = '\0';
 
-    sscanf(s, "%lf%c%s", &a, &c, remainder);
+    sscanf(s, "%lf%c%4095s", &a, &c, remainder);
 
     if ((a == NO_DOUBLE) || (!IsSpace(remainder)))
     {

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -520,21 +520,18 @@ bool DoubleFromString(const char *s, double *value_out)
     static const double NO_DOUBLE = -123.45;
 
     double a = NO_DOUBLE;
-    char remainder[4096];
-    char c = 'X';
+    char c = 'X', remainder = '\0';
 
     if (s == NULL)
     {
         return false;
     }
 
-    remainder[0] = '\0';
+    sscanf(s, "%lf%c%c", &a, &c, &remainder);
 
-    sscanf(s, "%lf%c%4095s", &a, &c, remainder);
-
-    if ((a == NO_DOUBLE) || (!IsSpace(remainder)))
+    if ((a == NO_DOUBLE) || (!isspace(remainder)))
     {
-        Log(LOG_LEVEL_ERR, "Reading assumed real value '%s', anomalous remainder '%s'", s, remainder);
+        Log(LOG_LEVEL_ERR, "Reading assumed real value '%s', anomalous remainder '%c'", s, remainder);
         return false;
     }
     else

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -434,7 +434,7 @@ long IntFromString(const char *s)
 
 // Test whether remainder is space only
 
-    if ((a == CF_NOINT) || (remainder == ' '))
+    if ((a == CF_NOINT) || (!isspace(remainder)))
     {
         Log(LOG_LEVEL_INFO, "Error reading assumed integer value '%s' => 'non-value', found remainder '%c'",
               s, remainder);

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -389,8 +389,7 @@ bool BooleanFromString(const char *s)
 long IntFromString(const char *s)
 {
     long long a = CF_NOINT;
-    char c = 'X';
-    char remainder[CF_BUFSIZE];
+    char c = 'X', remainder = '\0';
 
     if (s == NULL)
     {
@@ -407,15 +406,14 @@ long IntFromString(const char *s)
         return (long) CFSTARTTIME;
     }
 
-    remainder[0] = '\0';
 
-    sscanf(s, "%lld%c%s", &a, &c, remainder);
+    sscanf(s, "%lld%c%c", &a, &c, &remainder);
 
 // Test whether remainder is space only
 
-    if ((a == CF_NOINT) || (!IsSpace(remainder)))
+    if ((a == CF_NOINT) || (remainder == ' '))
     {
-        Log(LOG_LEVEL_INFO, "Error reading assumed integer value '%s' => 'non-value', found remainder '%s'",
+        Log(LOG_LEVEL_INFO, "Error reading assumed integer value '%s' => 'non-value', found remainder '%c'",
               s, remainder);
         if (strchr(s, '$'))
         {

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -432,12 +432,12 @@ long IntFromString(const char *s)
 
     sscanf(s, "%lld%c%c", &a, &c, &remainder);
 
-// Test whether remainder is space only
-
-    if ((a == CF_NOINT) || (!isspace(remainder)))
+    if ((a == CF_NOINT) || ((!isspace(remainder)) && (remainder != '\0')))
     {
-        Log(LOG_LEVEL_INFO, "Error reading assumed integer value '%s' => 'non-value', found remainder '%c'",
-              s, remainder);
+        Log(LOG_LEVEL_ERR,
+            "IntFromString: Failed to parse assumed integer value '%s' (int=%lld, conversion=%c, remainder=%c)",
+            s, a, c, remainder);
+
         if (strchr(s, '$'))
         {
             Log(LOG_LEVEL_INFO, "The variable might not yet be expandable - not necessarily an error");
@@ -529,9 +529,11 @@ bool DoubleFromString(const char *s, double *value_out)
 
     sscanf(s, "%lf%c%c", &a, &c, &remainder);
 
-    if ((a == NO_DOUBLE) || (!isspace(remainder)))
+    if ((a == NO_DOUBLE) || ((!isspace(remainder)) && (remainder != '\0')))
     {
-        Log(LOG_LEVEL_ERR, "Reading assumed real value '%s', anomalous remainder '%c'", s, remainder);
+        Log(LOG_LEVEL_ERR,
+            "DoubleFromString: Failed to parse assumed real value '%s' (double=%lf, conversion=%c, remainder=%c)",
+            s, a, c, remainder);
         return false;
     }
     else

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -211,11 +211,11 @@ char *Rlist2String(Rlist *list, char *sep)
 
     for (rp = list; rp != NULL; rp = rp->next)
     {
-        strcat(line, RlistScalarValue(rp));
+        strlcat(line, RlistScalarValue(rp), sizeof(line));
 
         if (rp->next)
         {
-            strcat(line, sep);
+            strlcat(line, sep, sizeof(line));
         }
     }
 

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -208,14 +208,37 @@ char *Rlist2String(Rlist *list, char *sep)
     Rlist *rp;
 
     line[0] = '\0';
+    size_t sep_length = strlen(sep);
+    size_t line_chars_left = sizeof(line);
 
     for (rp = list; rp != NULL; rp = rp->next)
     {
-        strlcat(line, RlistScalarValue(rp), sizeof(line));
+        char *rlist_scalar = RlistScalarValue(rp);
+        size_t rlist_scalar_length = strlen(rlist_scalar);
+
+        if(rlist_scalar_length + 1 > line_chars_left)
+        {
+            Log(LOG_LEVEL_ERR,
+                "Rlist2String: Internal limit reached (line='%s', rlist_scalar='%s')",
+                line, rlist_scalar);
+            break;
+        }
+
+        strlcat(line, rlist_scalar, sizeof(line));
+        line_chars_left -= rlist_scalar_length;
 
         if (rp->next)
         {
+            if(sep_length + 1 > line_chars_left)
+            {
+                Log(LOG_LEVEL_ERR,
+                    "Rlist2String: Internal limit reached (line='%s', sep='%s')",
+                    line, sep);
+                break;
+            }
+
             strlcat(line, sep, sizeof(line));
+            line_chars_left -= sep_length;
         }
     }
 

--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -485,27 +485,38 @@ size_t CipherBlockSizeBytes(const EVP_CIPHER *cipher)
 
 size_t CipherTextSizeMax(const EVP_CIPHER* cipher, size_t plaintext_size)
 {
-    if(plaintext_size <= 0)
-    {
-        ProgrammingError("CipherTextSizeMax: plaintext_size is not positive (%ld)",
-                         plaintext_size);
-    }
+    // see man EVP_DecryptUpdate() and EVP_DecryptFinal_ex()
+    size_t padding_size = (CipherBlockSizeBytes(cipher) * 2) - 1;
 
     // check for potential integer overflow, leave some buffer
-    if(plaintext_size > INT_MAX - 1024)
+    if(plaintext_size > SIZE_MAX - padding_size)
     {
-        ProgrammingError("CipherTextSizeMax: plaintext_size is too large (%ld)",
+        ProgrammingError("CipherTextSizeMax: plaintext_size is too large (%zu)",
                          plaintext_size);
     }
 
-    // see man EVP_EncryptUpdate() and EVP_EncryptFinal_ex()
-    return plaintext_size + (CipherBlockSizeBytes(cipher) * 2) - 1;
+    return plaintext_size + padding_size;
 }
 
+size_t PlainTextSizeMax(const EVP_CIPHER* cipher, size_t ciphertext_size)
+{
+    // see man EVP_DecryptUpdate() and EVP_DecryptFinal_ex()
+    size_t padding_size = (CipherBlockSizeBytes(cipher) * 2);
+
+    // check for potential integer overflow, leave some buffer
+    if(ciphertext_size > SIZE_MAX - padding_size)
+    {
+        ProgrammingError("PlainTextSizeMax: ciphertext_size is too large (%zu)",
+                         ciphertext_size);
+    }
+
+    return ciphertext_size + padding_size;
+}
 
 /*********************************************************************/
 
-int DecryptString(char type, const char *in, char *out, unsigned char *key, int cipherlen)
+int DecryptString(char *out, size_t out_size, const char *in, int cipherlen,
+                  char type, unsigned char *key)
 {
     int plainlen = 0, tmplen;
     unsigned char iv[32] =
@@ -514,6 +525,14 @@ int DecryptString(char type, const char *in, char *out, unsigned char *key, int 
 
     if (key == NULL)
         ProgrammingError("DecryptString: session key == NULL");
+
+    size_t max_plaintext_size = PlainTextSizeMax(CfengineCipher(type), cipherlen);
+
+    if(max_plaintext_size > out_size)
+    {
+        ProgrammingError("DecryptString: output buffer too small: max_plaintext_size (%ld) > out_size (%ld)",
+                          max_plaintext_size, out_size);
+    }
 
     EVP_CIPHER_CTX_init(&ctx);
     EVP_DecryptInit_ex(&ctx, CfengineCipher(type), NULL, key, iv);
@@ -535,6 +554,12 @@ int DecryptString(char type, const char *in, char *out, unsigned char *key, int 
     }
 
     plainlen += tmplen;
+
+    if(plainlen > max_plaintext_size)
+    {
+        ProgrammingError("DecryptString: too large plaintext written: plainlen (%d) > max_plaintext_size (%ld)",
+                          plainlen, max_plaintext_size);
+    }
 
     EVP_CIPHER_CTX_cleanup(&ctx);
 

--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -432,7 +432,7 @@ bool SavePublicKey(const char *user, const char *digest, const RSA *key)
     return true;
 }
 
-int EncryptString(char type, const char *in, char *out, unsigned char *key, int plainlen)
+int EncryptString(char *out, const char *in, int plainlen, char type, unsigned char *key)
 {
     int cipherlen = 0, tmplen;
     unsigned char iv[32] =

--- a/libpromises/crypto.h
+++ b/libpromises/crypto.h
@@ -39,7 +39,7 @@ const char *CryptoLastErrorString(void);
 void DebugBinOut(char *buffer, int len, char *com);
 bool LoadSecretKeys(void);
 void PolicyHubUpdateKeys(const char *policy_server);
-int EncryptString(char type, const char *in, char *out, unsigned char *key, int len);
+int EncryptString(char *out, const char *in, int plainlen, char type, unsigned char *key);
 int DecryptString(char type, const char *in, char *out, unsigned char *key, int len);
 RSA *HavePublicKey(const char *username, const char *ipaddress, const char *digest);
 RSA *HavePublicKeyByIP(const char *username, const char *ipaddress);

--- a/libpromises/crypto.h
+++ b/libpromises/crypto.h
@@ -39,7 +39,10 @@ const char *CryptoLastErrorString(void);
 void DebugBinOut(char *buffer, int len, char *com);
 bool LoadSecretKeys(void);
 void PolicyHubUpdateKeys(const char *policy_server);
-int EncryptString(char *out, const char *in, int plainlen, char type, unsigned char *key);
+int EncryptString(char *out, size_t out_size, const char *in, int plainlen,
+                  char type, unsigned char *key);
+size_t CipherBlockSizeBytes(const EVP_CIPHER *cipher);
+size_t CipherTextSizeMax(const EVP_CIPHER* cipher, size_t plaintext_size);
 int DecryptString(char type, const char *in, char *out, unsigned char *key, int len);
 RSA *HavePublicKey(const char *username, const char *ipaddress, const char *digest);
 RSA *HavePublicKeyByIP(const char *username, const char *ipaddress);

--- a/libpromises/crypto.h
+++ b/libpromises/crypto.h
@@ -43,7 +43,9 @@ int EncryptString(char *out, size_t out_size, const char *in, int plainlen,
                   char type, unsigned char *key);
 size_t CipherBlockSizeBytes(const EVP_CIPHER *cipher);
 size_t CipherTextSizeMax(const EVP_CIPHER* cipher, size_t plaintext_size);
-int DecryptString(char type, const char *in, char *out, unsigned char *key, int len);
+size_t PlainTextSizeMax(const EVP_CIPHER* cipher, size_t ciphertext_size);
+int DecryptString(char *out, size_t out_size, const char *in, int cipherlen,
+                  char type, unsigned char *key);
 RSA *HavePublicKey(const char *username, const char *ipaddress, const char *digest);
 RSA *HavePublicKeyByIP(const char *username, const char *ipaddress);
 bool SavePublicKey(const char *username, const char *digest, const RSA *key);

--- a/libpromises/enterprise_stubs.c
+++ b/libpromises/enterprise_stubs.c
@@ -85,10 +85,6 @@ ENTERPRISE_FUNC_1ARG_DEFINE_STUB(const char *, PromiseID, ARG_UNUSED const Promi
 /* all agents: logging.c */
 
 
-ENTERPRISE_VOID_FUNC_4ARG_DEFINE_STUB(void, TrackValue, char *, date, double, kept, double, repaired, double, notkept)
-{
-}
-
 ENTERPRISE_VOID_FUNC_2ARG_DEFINE_STUB(void, LogTotalCompliance, const char *, version, int, background_tasks)
 {
     double total = (double) (PR_KEPT + PR_NOTKEPT + PR_REPAIRED) / 100.0;

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7335,7 +7335,7 @@ static int ExecModule(EvalContext *ctx, char *command)
             }
         }
 
-        ModuleProtocol(ctx, command, line, print, context, tags, &persistence);
+        ModuleProtocol(ctx, command, line, print, context, sizeof(context), tags, &persistence);
     }
     bool atend = feof(pp);
     cf_pclose(pp);
@@ -7351,7 +7351,7 @@ static int ExecModule(EvalContext *ctx, char *command)
     return true;
 }
 
-void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print, char* context, StringSet *tags, long *persistence)
+void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print, char* context, size_t context_size, StringSet *tags, long *persistence)
 {
     assert(tags);
 
@@ -7364,7 +7364,7 @@ void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print
 
         /* Canonicalize filename into acceptable namespace name */
         CanonifyNameInPlace(filename);
-        strcpy(context, filename);
+        strlcpy(context, filename, context_size);
         Log(LOG_LEVEL_VERBOSE, "Module context '%s'", context);
     }
 
@@ -7388,7 +7388,7 @@ void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print
             else if (StringMatchFullWithPrecompiledRegex(context_name_rx, content))
             {
                 Log(LOG_LEVEL_VERBOSE, "Module changed variable context from '%s' to '%s'", context, content);
-                strcpy(context, content);
+                strlcpy(context, content, context_size);
             }
             else
             {

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7355,6 +7355,13 @@ void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print
 {
     assert(tags);
 
+    // see the sscanf() limit below
+    if(context_size < 51)
+    {
+        ProgrammingError("ModuleProtocol: context_size too small (%zu)",
+                         context_size);
+    }
+
     if (*context == '\0')
     {
         /* Infer namespace from script name */

--- a/libpromises/evalfunction.h
+++ b/libpromises/evalfunction.h
@@ -34,7 +34,7 @@ FnCallResult FnCallHostInNetgroup(EvalContext *ctx, const Policy *policy, const 
 
 int FnNumArgs(const FnCallType *call_type);
 
-void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print, char* context, StringSet *tags, long *persistence);
+void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print, char* context, size_t context_size, StringSet *tags, long *persistence);
 
 /* Implemented in Nova for Win32 */
 FnCallResult FnCallGroupExists(EvalContext *ctx, const Policy *policy, const FnCall *fp, const Rlist *finalargs);

--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -149,14 +149,11 @@ Returns true if so, false otherwise.
 
 /*********************************************************************/
 
-/**
- * @TODO fix the dangerous path lengths
- */
-char *JoinSuffix(char *path, const char *leaf)
+char *JoinSuffix(char *path, size_t path_size, const char *leaf)
 {
     int len = strlen(leaf);
 
-    if (Chop(path, CF_EXPANDSIZE) == -1)
+    if (Chop(path, path_size) == -1)
     {
         Log(LOG_LEVEL_ERR, "Chop was called on a string that seemed to have no terminator");
     }
@@ -169,7 +166,7 @@ char *JoinSuffix(char *path, const char *leaf)
         return NULL;
     }
 
-    strcat(path, leaf);
+    strlcat(path, leaf, path_size);
     return path;
 }
 

--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -159,14 +159,14 @@ char *JoinSuffix(char *path, size_t path_size, const char *leaf)
     }
     DeleteSlash(path);
 
-    if ((strlen(path) + len) > (CF_BUFSIZE - CF_BUFFERMARGIN))
+    if (strlen(path) + len + 1 > path_size)
     {
-        Log(LOG_LEVEL_ERR, "Internal limit 2: Buffer ran out of space constructing string. Tried to add %s to %s",
+        Log(LOG_LEVEL_ERR, "JoinSuffix: Internal limit reached. Tried to add %s to %s",
               leaf, path);
         return NULL;
     }
 
-    strlcat(path, leaf, path_size);
+    strcat(path, leaf);
     return path;
 }
 

--- a/libpromises/files_names.h
+++ b/libpromises/files_names.h
@@ -39,7 +39,7 @@ FilePathType FilePathGetType(const char *file_path);
 int IsNewerFileTree(const char *dir, time_t reftime);
 int CompareCSVName(const char *s1, const char *s2);
 int IsDir(const char *path);
-char *JoinSuffix(char *path, const char *leaf);
+char *JoinSuffix(char *path, size_t path_size, const char *leaf);
 int IsAbsPath(const char *path);
 void AddSlash(char *str);
 char *GetParentDirectoryCopy(const char *path);

--- a/libpromises/item_lib.c
+++ b/libpromises/item_lib.c
@@ -637,33 +637,6 @@ Item *SplitStringAsItemList(const char *string, char sep)
 
 /*********************************************************************/
 
-/* NB: does not escape entries in list ! */
-char *ItemList2CSV(const Item *list)
-{
-    /* After each entry, we need space for either a ',' (before the
-     * next entry) or a final '\0'. */
-    int len = ItemListSize(list) + ListLen(list);
-    char *s = xmalloc(len);
-    *s = '\0';
-
-    /* No point cycle-checking; done while computing len. */
-    for (const Item *ip = list; ip != NULL; ip = ip->next)
-    {
-        if (ip->name)
-        {
-            strcat(s, ip->name);
-        }
-
-        if (ip->next)
-        {
-            strcat(s, ",");
-        }
-    }
-    assert(strlen(s) + 1 == len);
-
-    return s;
-}
-
 /**
  * Write all strings in list to buffer #buf, separating them with
  * #separator. Watch out, no escaping happens.

--- a/libpromises/item_lib.h
+++ b/libpromises/item_lib.h
@@ -90,7 +90,6 @@ void DeleteItemList(Item *item);
 void DeleteItem(Item **liststart, Item *item);
 void IncrementItemListCounter(Item *ptr, const char *string);
 void SetItemListCounter(Item *ptr, const char *string, int value);
-char *ItemList2CSV(const Item *list);
 size_t ItemList2CSV_bound(const Item *list, char *buf, size_t buf_size, char separator);
 int ItemListSize(const Item *list);
 

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -437,9 +437,10 @@ bool IsLastSeenCoherent(void)
  * @param[in]     ip : either in (SHA/MD5 format)
  * @param[in,out] digest: return corresponding digest of input host.
  *                        If NULL, return nothing
+ * @param[in] digest_size: size of digest parameter
  * @retval true if entry was deleted, false otherwise
  */
-bool DeleteIpFromLastSeen(const char *ip, char *digest)
+bool DeleteIpFromLastSeen(const char *ip, char *digest, size_t digest_size)
 {
     DBHandle *db;
     bool res = false;
@@ -472,7 +473,7 @@ bool DeleteIpFromLastSeen(const char *ip, char *digest)
         {
             if (digest != NULL)
             {
-                strlcpy(digest, bufkey + 1, CF_BUFSIZE);
+                strlcpy(digest, bufkey + 1, digest_size);
             }
             DeleteDB(db, bufkey);
             DeleteDB(db, bufhost);
@@ -714,7 +715,7 @@ int RemoveKeysFromLastSeen(const char *input, bool must_be_coherent,
     else
     {
         Log(LOG_LEVEL_VERBOSE, "Removing host '%s' from lastseen database\n", input);
-        if (DeleteIpFromLastSeen(input, equivalent) == false)
+        if (DeleteIpFromLastSeen(input, equivalent, equivalent_size) == false)
         {
             Log(LOG_LEVEL_ERR, "Unable to remove host from lastseen database.");
             return 253;

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -504,9 +504,10 @@ clean:
  * @param[in]     key : either in (SHA/MD5 format)
  * @param[in,out] ip  : return the key corresponding host.
  *                      If NULL, return nothing
+ * @param[in] ip_size : length of ip parameter
  * @retval true if entry was deleted, false otherwise
  */
-bool DeleteDigestFromLastSeen(const char *key, char *ip)
+bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size)
 {
     DBHandle *db;
     bool res = false;
@@ -538,7 +539,7 @@ bool DeleteDigestFromLastSeen(const char *key, char *ip)
         {
             if (ip != NULL)
             {
-                strcpy(ip, host);
+                strlcpy(ip, host, ip_size);
             }
             DeleteDB(db, bufhost);
             DeleteDB(db, bufkey);
@@ -684,7 +685,7 @@ int LastSeenHostKeyCount(void)
  * @retval 0 if entry was deleted, <>0 otherwise
  */
 int RemoveKeysFromLastSeen(const char *input, bool must_be_coherent,
-                           char *equivalent)
+                           char *equivalent, size_t equivalent_size)
 {
     bool is_coherent = false;
 
@@ -704,7 +705,7 @@ int RemoveKeysFromLastSeen(const char *input, bool must_be_coherent,
     if (is_digest == true)
     {
         Log(LOG_LEVEL_VERBOSE, "Removing digest '%s' from lastseen database\n", input);
-        if (DeleteDigestFromLastSeen(input, equivalent) == false)
+        if (DeleteDigestFromLastSeen(input, equivalent, equivalent_size) == false)
         {
             Log(LOG_LEVEL_ERR, "Unable to remove digest from lastseen database.");
             return 252;

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -154,7 +154,7 @@ void UpdateLastSawHost(const char *hostkey, const char *address,
 /*****************************************************************************/
 
 /* Lookup a reverse entry (IP->KeyHash) in lastseen database. */
-static bool Address2HostkeyInDB(DBHandle *db, const char *address, char *result)
+static bool Address2HostkeyInDB(DBHandle *db, const char *address, char *result, size_t result_size)
 {
     char address_key[CF_BUFSIZE];
     char hostkey[CF_BUFSIZE];
@@ -185,7 +185,7 @@ static bool Address2HostkeyInDB(DBHandle *db, const char *address, char *result)
     }
 #endif
 
-    strlcpy(result, hostkey, CF_BUFSIZE);
+    strlcpy(result, hostkey, result_size);
     return true;
 }
 
@@ -226,7 +226,7 @@ bool Address2Hostkey(char *dst, size_t dst_size, const char *address)
         DBHandle *db;
         if (OpenDB(&db, dbid_lastseen))
         {
-            retval = Address2HostkeyInDB(db, address, dst);
+            retval = Address2HostkeyInDB(db, address, dst, dst_size);
             CloseDB(db);
         }
     }

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -43,7 +43,7 @@ bool Address2Hostkey(char *dst, size_t dst_size, const char *address);
 void LastSaw1(const char *ipaddress, const char *hashstr, LastSeenRole role);
 void LastSaw(const char *ipaddress, const char *digest, LastSeenRole role);
 
-bool DeleteIpFromLastSeen(const char *ip, char *digest);
+bool DeleteIpFromLastSeen(const char *ip, char *digest, size_t digest_size);
 bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size);
 
 /*

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -44,7 +44,7 @@ void LastSaw1(const char *ipaddress, const char *hashstr, LastSeenRole role);
 void LastSaw(const char *ipaddress, const char *digest, LastSeenRole role);
 
 bool DeleteIpFromLastSeen(const char *ip, char *digest);
-bool DeleteDigestFromLastSeen(const char *key, char *ip);
+bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size);
 
 /*
  * Return false in order to stop iteration
@@ -57,6 +57,6 @@ bool ScanLastSeenQuality(LastSeenQualityCallback callback, void *ctx);
 int LastSeenHostKeyCount(void);
 bool IsLastSeenCoherent(void);
 int RemoveKeysFromLastSeen(const char *input, bool must_be_coherent,
-                           char *equivalent);
+                           char *equivalent, size_t equivalent_size);
 
 #endif

--- a/libpromises/prototypes3.h
+++ b/libpromises/prototypes3.h
@@ -76,7 +76,6 @@ ENTERPRISE_FUNC_8ARG_DECLARE(void *, CfRegLDAP, EvalContext *, ctx, char *, uri,
 ENTERPRISE_VOID_FUNC_3ARG_DECLARE(void, CacheUnreliableValue, char *, caller, char *, handle, char *, buffer);
 ENTERPRISE_FUNC_3ARG_DECLARE(int, RetrieveUnreliableValue, char *, caller, char *, handle, char *, buffer);
 ENTERPRISE_VOID_FUNC_2ARG_DECLARE(void, TranslatePath, char *, new, const char *, old);
-ENTERPRISE_VOID_FUNC_4ARG_DECLARE(void, TrackValue, char *, date, double, kept, double, repaired, double, notkept);
 ENTERPRISE_FUNC_4ARG_DECLARE(bool, ListHostsWithClass, EvalContext *, ctx, Rlist **, return_list, char *, class_name, char *, return_format);
 
 ENTERPRISE_VOID_FUNC_2ARG_DECLARE(void, ShowPromises, const Seq *, bundles, const Seq *, bodies);

--- a/tests/unit/conversion_test.c
+++ b/tests/unit/conversion_test.c
@@ -9,12 +9,29 @@ static void test_str_to_service_policy(void)
     assert_int_equal(ServicePolicyFromString("restart"), SERVICE_POLICY_RESTART);
 }
 
+static void test_int_from_string(void)
+{
+    assert_int_equal(IntFromString("0"), 0);
+
+    assert_int_equal(IntFromString("1"), 1);
+    assert_int_equal((int)IntFromString("-1"), -1);
+
+    assert_int_equal(IntFromString("1k"), 1000);
+    assert_int_equal((int)IntFromString("-1k"), -1000);
+}
+
 static void test_double_from_string(void)
 {
     {
         double val;
         assert_true(DoubleFromString("1.2k", &val));
         assert_double_close(1200.0, val);
+    }
+
+    {
+        double val;
+        assert_true(DoubleFromString("1.2976", &val));
+        assert_double_close(1.2976, val);
     }
 
     {
@@ -123,6 +140,7 @@ int main()
     const UnitTest tests[] =
     {
         unit_test(test_str_to_service_policy),
+        unit_test(test_int_from_string),
         unit_test(test_double_from_string),
         unit_test(test_CommandArg0_bound),
     };

--- a/tests/unit/crypto_symmetric_test.c
+++ b/tests/unit/crypto_symmetric_test.c
@@ -42,7 +42,7 @@ static void test_symmetric_encrypt(void)
     char ciphertext[CF_BUFSIZE];
     int plaintext_len = strlen(PLAINTEXT) + 1;
     
-    int ciphertext_len = EncryptString(CIPHER_TYPE_CFENGINE, PLAINTEXT, ciphertext, KEY, plaintext_len);
+    int ciphertext_len = EncryptString(ciphertext, PLAINTEXT, plaintext_len, CIPHER_TYPE_CFENGINE, KEY);
 
     assert_int_equal(ciphertext_len, ComputeCiphertextLen(plaintext_len, CIPHER_BLOCK_SIZE_BYTES));
 

--- a/tests/unit/crypto_symmetric_test.c
+++ b/tests/unit/crypto_symmetric_test.c
@@ -69,40 +69,30 @@ static void test_symmetric_decrypt(void)
 static void test_cipher_block_size(void)
 {
     assert_int_equal(CipherBlockSizeBytes(EVP_bf_cbc()), 8);
-    assert_int_equal(CipherBlockSizeBytes(CfengineCipher('c')), 8);
 
     assert_int_equal(CipherBlockSizeBytes(EVP_aes_256_cbc()), 16);
-    assert_int_equal(CipherBlockSizeBytes(CfengineCipher('N')), 16);
 }
 
 static void test_cipher_text_size_max(void)
 {
     assert_int_equal(CipherTextSizeMax(EVP_aes_256_cbc(), 1), 32);
-    assert_int_equal(CipherTextSizeMax(CfengineCipher('N'), 1), 32);
 
     assert_int_equal(CipherTextSizeMax(EVP_aes_256_cbc(), CF_BUFSIZE), 4127);
-    assert_int_equal(CipherTextSizeMax(CfengineCipher('N'), CF_BUFSIZE), 4127);
 
     assert_int_equal(CipherTextSizeMax(EVP_bf_cbc(), 1), 16);
-    assert_int_equal(CipherTextSizeMax(CfengineCipher('c'), 1), 16);
 
     assert_int_equal(CipherTextSizeMax(EVP_bf_cbc(), CF_BUFSIZE), 4111);
-    assert_int_equal(CipherTextSizeMax(CfengineCipher('c'), CF_BUFSIZE), 4111);
 }
 
 static void test_plain_text_size_max(void)
 {
     assert_int_equal(PlainTextSizeMax(EVP_aes_256_cbc(), 1), 33);
-    assert_int_equal(PlainTextSizeMax(CfengineCipher('N'), 1), 33);
 
     assert_int_equal(PlainTextSizeMax(EVP_aes_256_cbc(), CF_BUFSIZE), 4128);
-    assert_int_equal(PlainTextSizeMax(CfengineCipher('N'), CF_BUFSIZE), 4128);
 
     assert_int_equal(PlainTextSizeMax(EVP_bf_cbc(), 1), 17);
-    assert_int_equal(PlainTextSizeMax(CfengineCipher('c'), 1), 17);
 
     assert_int_equal(PlainTextSizeMax(EVP_bf_cbc(), CF_BUFSIZE), 4112);
-    assert_int_equal(PlainTextSizeMax(CfengineCipher('c'), CF_BUFSIZE), 4112);
 }
 
 int main()

--- a/tests/unit/crypto_symmetric_test.c
+++ b/tests/unit/crypto_symmetric_test.c
@@ -58,7 +58,8 @@ static void test_symmetric_decrypt(void)
     
     char plaintext_out[CF_BUFSIZE];
     
-    int plaintext_len = DecryptString(CIPHER_TYPE_CFENGINE, ciphertext, plaintext_out, KEY, ciphertext_len);
+    int plaintext_len = DecryptString(plaintext_out, sizeof(plaintext_out),
+                                      ciphertext, ciphertext_len, CIPHER_TYPE_CFENGINE, KEY);
 
     assert_int_equal(plaintext_len, strlen(PLAINTEXT) + 1);
 
@@ -89,6 +90,21 @@ static void test_cipher_text_size_max(void)
     assert_int_equal(CipherTextSizeMax(CfengineCipher('c'), CF_BUFSIZE), 4111);
 }
 
+static void test_plain_text_size_max(void)
+{
+    assert_int_equal(PlainTextSizeMax(EVP_aes_256_cbc(), 1), 33);
+    assert_int_equal(PlainTextSizeMax(CfengineCipher('N'), 1), 33);
+
+    assert_int_equal(PlainTextSizeMax(EVP_aes_256_cbc(), CF_BUFSIZE), 4128);
+    assert_int_equal(PlainTextSizeMax(CfengineCipher('N'), CF_BUFSIZE), 4128);
+
+    assert_int_equal(PlainTextSizeMax(EVP_bf_cbc(), 1), 17);
+    assert_int_equal(PlainTextSizeMax(CfengineCipher('c'), 1), 17);
+
+    assert_int_equal(PlainTextSizeMax(EVP_bf_cbc(), CF_BUFSIZE), 4112);
+    assert_int_equal(PlainTextSizeMax(CfengineCipher('c'), CF_BUFSIZE), 4112);
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -101,6 +117,7 @@ int main()
         unit_test(test_symmetric_decrypt),
         unit_test(test_cipher_block_size),
         unit_test(test_cipher_text_size_max),
+        unit_test(test_plain_text_size_max),
     };
     
     return run_tests(tests);

--- a/tests/unit/crypto_symmetric_test.c
+++ b/tests/unit/crypto_symmetric_test.c
@@ -42,7 +42,9 @@ static void test_symmetric_encrypt(void)
     char ciphertext[CF_BUFSIZE];
     int plaintext_len = strlen(PLAINTEXT) + 1;
     
-    int ciphertext_len = EncryptString(ciphertext, PLAINTEXT, plaintext_len, CIPHER_TYPE_CFENGINE, KEY);
+    int ciphertext_len = EncryptString(ciphertext, sizeof(ciphertext),
+                                       PLAINTEXT, plaintext_len,
+                                       CIPHER_TYPE_CFENGINE, KEY);
 
     assert_int_equal(ciphertext_len, ComputeCiphertextLen(plaintext_len, CIPHER_BLOCK_SIZE_BYTES));
 
@@ -63,6 +65,30 @@ static void test_symmetric_decrypt(void)
     assert_string_equal(plaintext_out, PLAINTEXT);
 }
 
+static void test_cipher_block_size(void)
+{
+    assert_int_equal(CipherBlockSizeBytes(EVP_bf_cbc()), 8);
+    assert_int_equal(CipherBlockSizeBytes(CfengineCipher('c')), 8);
+
+    assert_int_equal(CipherBlockSizeBytes(EVP_aes_256_cbc()), 16);
+    assert_int_equal(CipherBlockSizeBytes(CfengineCipher('N')), 16);
+}
+
+static void test_cipher_text_size_max(void)
+{
+    assert_int_equal(CipherTextSizeMax(EVP_aes_256_cbc(), 1), 32);
+    assert_int_equal(CipherTextSizeMax(CfengineCipher('N'), 1), 32);
+
+    assert_int_equal(CipherTextSizeMax(EVP_aes_256_cbc(), CF_BUFSIZE), 4127);
+    assert_int_equal(CipherTextSizeMax(CfengineCipher('N'), CF_BUFSIZE), 4127);
+
+    assert_int_equal(CipherTextSizeMax(EVP_bf_cbc(), 1), 16);
+    assert_int_equal(CipherTextSizeMax(CfengineCipher('c'), 1), 16);
+
+    assert_int_equal(CipherTextSizeMax(EVP_bf_cbc(), CF_BUFSIZE), 4111);
+    assert_int_equal(CipherTextSizeMax(CfengineCipher('c'), CF_BUFSIZE), 4111);
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -73,6 +99,8 @@ int main()
         unit_test(test_cipher_init),
         unit_test(test_symmetric_encrypt),
         unit_test(test_symmetric_decrypt),
+        unit_test(test_cipher_block_size),
+        unit_test(test_cipher_text_size_max),
     };
     
     return run_tests(tests);

--- a/tests/unit/lastseen_test.c
+++ b/tests/unit/lastseen_test.c
@@ -178,7 +178,7 @@ static void test_remove(void)
     UpdateLastSawHost("SHA-12345", "127.0.0.64", false, 556);
 
     //RemoveHostFromLastSeen("SHA-12345");
-    DeleteDigestFromLastSeen("SHA-12345", NULL);
+    DeleteDigestFromLastSeen("SHA-12345", NULL, 0);
 
     DBHandle *db;
     OpenDB(&db, dbid_lastseen);
@@ -199,7 +199,7 @@ static void test_remove_ip(void)
     UpdateLastSawHost("SHA-12345", "127.0.0.64", false, 556);
 
     char digest[CF_BUFSIZE];
-    DeleteIpFromLastSeen("127.0.0.64", digest);
+    DeleteIpFromLastSeen("127.0.0.64", digest, sizeof(digest));
 
     DBHandle *db;
     OpenDB(&db, dbid_lastseen);


### PR DESCRIPTION
For some functions that write to output buffers they take as parameters, add an output buffer size parameter as well and and check it. Also add some checks to ensure we are not writing past some buffers that potentially could create instability or security risks. Some unused functions were removed.

Please backport to 3.9 once merged.
