### PR TITLE
CFE-2263 Fix select_end EOF matching.

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -387,7 +387,7 @@ static PromiseResult VerifyLineDeletions(EvalContext *ctx, const Promise *pp, Ed
         result = PromiseResultUpdate(result, PROMISE_RESULT_INTERRUPTED);
         return result;
     }
-    if (!end_ptr && a.region.select_end)
+    if (!end_ptr && a.region.select_end && !a.region.select_end_match_eof)
     {
         cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_INTERRUPTED, pp, a,
             "The promised end pattern '%s' was not found when selecting region to delete in '%s'",

--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -683,6 +683,15 @@ static PromiseResult VerifyLineInsertions(EvalContext *ctx, const Promise *pp, E
         result = PromiseResultUpdate(result, PROMISE_RESULT_INTERRUPTED);
         return result;
     }
+    
+    if (!end_ptr && a.region.select_end && !a.region.select_end_match_eof)
+    {
+        cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_INTERRUPTED, pp, a,
+            "The promised end pattern '%s' was not found when selecting region to insert in '%s'",
+             a.region.select_end, edcontext->filename);
+        result = PromiseResultUpdate(result, PROMISE_RESULT_INTERRUPTED);
+        return false;
+    }
 
     if (allow_multi_lines)
     {

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -1489,6 +1489,8 @@ EditRegion GetRegionConstraints(const EvalContext *ctx, const Promise *pp)
     e.select_end = PromiseGetConstraintAsRval(pp, "select_end", RVAL_TYPE_SCALAR);
     e.include_start = PromiseGetConstraintAsBoolean(ctx, "include_start_delimiter", pp);
     e.include_end = PromiseGetConstraintAsBoolean(ctx, "include_end_delimiter", pp);
+    e.select_end_match_eof = PromiseGetConstraintAsBoolean(ctx, "select_end_match_eof", pp);
+    
     return e;
 }
 

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1197,6 +1197,7 @@ typedef struct
     char *select_end;
     int include_start;
     int include_end;
+    bool select_end_match_eof;
 } EditRegion;
 
 typedef struct

--- a/libpromises/mod_files.c
+++ b/libpromises/mod_files.c
@@ -71,6 +71,7 @@ static const ConstraintSyntax select_region_constraints[] =
     ConstraintSyntaxNewBool("include_end_delimiter", "Whether to include the section delimiter. Default value: false", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("select_start", CF_ANYSTRING, "Regular expression matching start of edit region", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("select_end", CF_ANYSTRING, "Regular expression matches end of edit region from start", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewBool("select_end_match_eof", "Whether to include EOF as end of the region. Default value: false", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewNull()
 };
 

--- a/tests/acceptance/10_files/07_delete_lines/select_end_match_eof_true.cf
+++ b/tests/acceptance/10_files/07_delete_lines/select_end_match_eof_true.cf
@@ -1,0 +1,86 @@
+#######################################################
+#
+# Try to delete a region where select_end does not match 
+# end region and 'select_end_match_eof' is set to false.
+# CFE-2263
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };   
+      version => "1.0";
+}
+
+bundle agent init
+{
+  vars:
+      "states" slist => { "actual", "expected" };
+
+      "actual" string =>
+"header
+BEGIN
+    One potato
+    Two potato
+    Three potatoe
+    Four
+  END
+trailer";
+      "expected" string =>
+"header
+BEGIN";
+ 
+  files:
+      "$(G.testfile).$(states)"
+      create => "true",
+      edit_line => init_insert("$(init.$(states))"),
+      edit_defaults => init_empty;
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+body edit_defaults init_empty
+{
+      empty_file_before_editing => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+  files:
+      "$(G.testfile).actual"
+      edit_line => test_delete(".*");
+}
+
+bundle edit_line test_delete(str)
+{
+  delete_lines:
+      "$(str)"
+      select_region => test_select;
+}
+
+body select_region test_select
+{
+      select_start => "BEGIN";
+      select_end => "END"; # anchored regex doesn't match due to whitespace, but 
+                           # 'select_end_match_eof' is true.
+      select_end_match_eof => "true";
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => dcs_check_diff("$(G.testfile).actual",
+					    "$(G.testfile).expected",
+					    "$(this.promise_filename)");
+}
+### PROJECT_ID: core
+### CATEGORY_ID: 27

--- a/tests/acceptance/10_files/09_insert_lines/insert_line_end_match_eof.cf
+++ b/tests/acceptance/10_files/09_insert_lines/insert_line_end_match_eof.cf
@@ -1,7 +1,7 @@
 #######################################################
 #
-# Test non matching end selector in region.
-# This will cause content won't be added to file. 
+# Test matching EOF in file where end selector in region don't matches
+# anything
 #
 #######################################################
 
@@ -23,6 +23,7 @@ bar
 
       "expected" string => "[quux]
 bar
+foo
 ";
 
       "files" slist => { "actual", "expected" };
@@ -66,6 +67,7 @@ body select_region example_select
 {
       select_start => "\[quux\]";
       select_end => "\[.*\]";
+      select_end_match_eof => "true";
 }
 
 body location example_location


### PR DESCRIPTION
Make sure that if select_end is not matched in file, EOF is used as
and of region by default.
To change default behavior, 'select_end_match_eof' was introduced.
The default value is true, so EOF is threated as end of region by default.

Changelog: EOF is implicitly matched as an end of the region in edit_line
promises. To change default behavior 'select_end_match_eof' parameter
was introduced. (CFE-2263)