### PR TITLE
When no file is provided when calling cf-promises with cf or json out…

### DIFF
--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -132,10 +132,13 @@ int main(int argc, char *argv[])
     if (format == GENERIC_AGENT_CONFIG_COMMON_POLICY_OUTPUT_FORMAT_CF ||
         format == GENERIC_AGENT_CONFIG_COMMON_POLICY_OUTPUT_FORMAT_JSON)
     {
+        // If no file was provided, use 'promises.cf' by default
+        if (config->input_file == NULL) {
+            GenericAgentConfigSetInputFile(config, GetInputDir(), "promises.cf");
+        }
+
         // Just parse and write content to output
-        Policy *output_policy = ParserParseFile(AGENT_TYPE_COMMON, config->input_file,
-                                                config->agent_specific.common.parser_warnings,
-                                                config->agent_specific.common.parser_warnings_error);
+        Policy *output_policy = Cf3ParseFile(config, config->input_file);
         Writer *writer = FileWriter(stdout);
         if (format == GENERIC_AGENT_CONFIG_COMMON_POLICY_OUTPUT_FORMAT_CF)
         {

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -51,7 +51,7 @@ static Policy *LoadPolicyFile(EvalContext *ctx, GenericAgentConfig *config, cons
  * The difference between filename and input_input file is that the latter is the file specified by -f or
  * equivalently the file containing body common control. This will hopefully be squashed in later refactoring.
  */
-static Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_path)
+Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_path)
 {
     struct stat statbuf;
 

--- a/libpromises/loading.h
+++ b/libpromises/loading.h
@@ -29,5 +29,6 @@
 #include <generic_agent.h>
 
 Policy *LoadPolicy(EvalContext *ctx, GenericAgentConfig *config);
+Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_path);
 
 #endif


### PR DESCRIPTION
…put,

use promises.cf by default.

When parsing complete promises, libpromises uses promises.cf by default.
As the cf and json output options do not load the complete policy, we
provide the default filename in cf-promises.
Also use Cf3ParseFile to allow parsing JSON promises.

This restores the previous behavior.