### PR TITLE
Change: Switch processes restart_class logging to verbose

### DIFF
--- a/cf-agent/verify_processes.c
+++ b/cf-agent/verify_processes.c
@@ -246,8 +246,8 @@ static PromiseResult VerifyProcessOp(EvalContext *ctx, Attributes a, const Promi
         else
         {
             PromiseResult status = killed ? PROMISE_RESULT_CHANGE : PROMISE_RESULT_NOOP;
-            cfPS(ctx, LOG_LEVEL_INFO, status, pp, a,
-                 "Setting restart class '%s' for promise '%s'", a.restart_class, pp->promiser);
+            cfPS(ctx, LOG_LEVEL_VERBOSE, status, pp, a,
+                 "C:     +  Global class: %s ", a.restart_class);
             result = PromiseResultUpdate(result, status);
             EvalContextClassPutSoft(ctx, a.restart_class, CONTEXT_SCOPE_NAMESPACE, "source=promise");
         }


### PR DESCRIPTION
This moves the logging of a class definition as the result of a
restart_class attached to a processes promise from info to verbose. No
other class definition logging happens in info.

Changelog: Title