### PR TITLE
CFE-2388: resolve body parameters repeatedly

### DIFF
--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -45,6 +45,25 @@
 
 #define CF_MAPPEDLIST '#'
 
+static StringSet *expand_exceptions = NULL;
+void ExpandExceptionAdd(const char *name)
+{
+    if (expand_exceptions == NULL)
+    {
+        expand_exceptions = StringSetNew();
+    }
+
+    StringSetAdd(expand_exceptions, xstrdup(name));
+}
+
+void ExpandExceptionRemove(const char *name)
+{
+    if (expand_exceptions != NULL)
+    {
+        StringSetRemove(expand_exceptions, name);
+    }
+}
+
 static PromiseResult ExpandPromiseAndDo(EvalContext *ctx, const Promise *pp,
                                         Rlist *lists, Rlist *containers,
                                         PromiseActuator *ActOnPromise, void *param);
@@ -687,6 +706,7 @@ bool ExpandScalar(const EvalContext *ctx,
         {
             DataType type = CF_DATA_TYPE_NONE;
             const void *value = NULL;
+            if (expand_exceptions == NULL || !StringSetContains(expand_exceptions, BufferData(current_item)))
             {
                 VarRef *ref = VarRefParseFromNamespaceAndScope(BufferData(current_item), ns, scope, CF_NS, '.');
                 value = EvalContextVariableGet(ctx, ref, &type);
@@ -698,8 +718,9 @@ bool ExpandScalar(const EvalContext *ctx,
             case RVAL_TYPE_SCALAR:
                 if (value)
                 {
-                     BufferAppendString(out, value);
-                     continue;
+                    //Log(LOG_LEVEL_DEBUG, "ExpandScalar: expanded %s to %s", BufferData(current_item), value);
+                    BufferAppendString(out, value);
+                    continue;
                 }
                 break;
 

--- a/libpromises/expand.h
+++ b/libpromises/expand.h
@@ -38,6 +38,9 @@ void MapIteratorsFromRval(EvalContext *ctx, const Bundle *bundle, Rval rval, Rli
 
 bool IsExpandable(const char *str);
 
+void ExpandExceptionAdd(const char *name);
+void ExpandExceptionRemove(const char *name);
+
 bool ExpandScalar(const EvalContext *ctx, const char *ns, const char *scope, const char *string, Buffer *out);
 Rval ExpandBundleReference(EvalContext *ctx, const char *ns, const char *scope, Rval rval);
 Rval ExpandPrivateRval(EvalContext *ctx, const char *ns, const char *scope, const void *rval_item, RvalType rval_type);

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -161,11 +161,18 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
                        (Rval) {xstrdup("true"), RVAL_TYPE_SCALAR }, false);
             }
 
-            if (bp->args)
+            if (!bp->args && args)
             {
-                /* There are arguments to insert */
-
-                if (!args)
+                Log(LOG_LEVEL_ERR,
+                    "Apparent body '%s' was undeclared or could "
+                    "have incorrect args, but used in a promise near "
+                    "line %zu of %s (possible unquoted literal value)",
+                    RvalScalarValue(cp->rval), pp->offset.line,
+                    PromiseGetBundle(pp)->source_path);
+            }
+            else
+            {
+                if (bp->args && !args)
                 {
                     Log(LOG_LEVEL_ERR,
                         "Argument mismatch for body reference '%s' in promise "
@@ -174,13 +181,14 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
                         PromiseGetBundle(pp)->source_path);
                 }
 
+                Seq *constraints_to_expand = SeqNew(10, NULL);
+                JsonElement *arg_rewrite = JsonObjectCreate(2);
                 for (size_t body_index = 0; body_index < SeqLength(bodies_and_args); body_index+=2)
                 {
                     // remember we reversed the Seq from what
                     // EvalContextResolveBodyExpression() created
                     Rval *called_rval = SeqAt(bodies_and_args, body_index);
                     const Body *current_body = SeqAt(bodies_and_args, body_index+1);
-                    JsonElement *arg_rewrite = JsonObjectCreate(2);
                     bool in_inheritance_chain = (SeqLength(bodies_and_args) - body_index > 2);
                     int given_args = 0;
 
@@ -228,6 +236,7 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
                             PromiseGetBundle(pp)->source_path);
                     }
 
+
                     for (size_t k = 0; k < SeqLength(current_body->conlist); k++)
                     {
                         Constraint *scp = SeqAt(current_body->conlist, k);
@@ -240,11 +249,31 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
 
                         if (IsDefinedClass(ctx, scp->classes))
                         {
+                            SeqAppend(constraints_to_expand, scp);
+                        }
+                    }
+
+                    // Only do the copy expansion if we copied something while inheriting
+                    // note that r < 0 can't be true because size_t is unsigned
+                    for (size_t r = SeqLength(constraints_to_expand); r != 0; r--)
+                    {
+                        Constraint *scp = SeqAt(constraints_to_expand, r-1);
+
+                        if (IsDefinedClass(ctx, scp->classes))
+                        {
                             Rval returnval = RvalNew(scp->rval.item, scp->rval.type);
 
                             // First we rewrite the Rval with the rewrite map
                             Rval rewrite = RvalCopyRewriter(returnval, arg_rewrite);
                             RvalDestroy(returnval);
+
+                            // TODO: this was only in the case of body call with no args, should it always happen?
+                            if (rewrite.type == RVAL_TYPE_LIST)
+                            {
+                                Rlist *new_list = RvalRlistValue(rewrite);
+                                RlistFlatten(ctx, &new_list);
+                                rewrite.item = new_list;
+                            }
 
                             // Second we expand body vars; note it has to happen ONLY ONCE
                             returnval = ExpandPrivateRval(ctx, NULL, "body", rewrite.item, rewrite.type);
@@ -262,118 +291,22 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
                             // leaving it commented out
 
                             // Writer *w = StringWriter();
-                            // RvalWrite(w, scp->rval);
+                            // RvalWrite(w, returnval);
                             // WriterWrite(w, " -> copied rval ");
                             // RvalWrite(w, scp_copy->rval);
+                            // WriterWrite(w, "; rewrite map ");
+                            // JsonWrite(w, arg_rewrite, 0);
 
-                            // Log(LOG_LEVEL_DEBUG, "DeRefCopyPromise: processing body %s: at index %ld, current body %s, copying constraint %s with rval %s", body_reference, body_index, current_body->name, scp->lval, StringWriterData(w));
+                            // Log(LOG_LEVEL_DEBUG, "DeRefCopyPromise: processing body %s: expanding constraint %s with rval %s",
+                            //     body_reference, scp->lval, StringWriterData(w));
                             // WriterClose(w);
                         }
                     }
 
-                    JsonDestroy(arg_rewrite);
                 }
-            }
-            else
-            {
-                /* No arguments to deal with or body undeclared */
+                JsonDestroy(arg_rewrite);
+                SeqDestroy(constraints_to_expand);
 
-                if (args)
-                {
-                    Log(LOG_LEVEL_ERR,
-                        "Apparent body '%s' was undeclared or could "
-                        "have incorrect args, but used in a promise near "
-                        "line %zu of %s (possible unquoted literal value)",
-                        RvalScalarValue(cp->rval), pp->offset.line,
-                        PromiseGetBundle(pp)->source_path);
-                }
-                else
-                {
-
-                    for (size_t body_index = 0; body_index < SeqLength(bodies_and_args); body_index+=2)
-                    {
-                        // remember we reversed the Seq from what
-                        // EvalContextResolveBodyExpression() created
-                        Rval *called_rval = SeqAt(bodies_and_args, body_index);
-                        const Body *current_body = SeqAt(bodies_and_args, body_index+1);
-                        JsonElement *arg_rewrite = JsonObjectCreate(2);
-                        bool in_inheritance_chain = (SeqLength(bodies_and_args) - body_index > 2);
-                        int given_args = 0;
-
-                        if (NULL == called_rval)
-                        {
-                            // nothing needed, this is not an inherit_from rval
-                        }
-                        else if (RVAL_TYPE_SCALAR == called_rval->type)
-                        {
-                            // We leave the parameters as they were.
-
-                            // Unless the current body matches the
-                            // parameters of the inherited body, there
-                            // will be unexpanded variables. But the
-                            // alternative is to match up body and fncall
-                            // arguments, which is not trivial.
-
-                            given_args = 0;
-                        }
-                        else if (RVAL_TYPE_FNCALL == called_rval->type)
-                        {
-                            const Rlist *call_args = RvalFnCallValue(*called_rval)->args;
-                            const Rlist *body_args = current_body->args;
-
-                            given_args = RlistLen(call_args);
-                            // step through the body and call args
-                            for (;
-                                 call_args && body_args;
-                                 call_args = call_args->next, body_args = body_args->next)
-                            {
-                                JsonObjectAppendString(arg_rewrite, RlistScalarValue(body_args), RlistScalarValue(call_args));
-                            }
-                        }
-
-                        int required_args = RlistLen(current_body->args);
-                        // only check arguments for inherited bodies
-                        if (in_inheritance_chain && required_args != given_args)
-                        {
-                            FatalError(ctx,
-                                "Argument count mismatch for body reference '%s' (gave %d arguments) vs. inherited body '%s:%s' (requires %d arguments) in promise "
-                                "at line %zu of file '%s'",
-                                body_reference, given_args,
-                                current_body->ns, current_body->name, required_args,
-                                pp->offset.line,
-                                PromiseGetBundle(pp)->source_path);
-                        }
-
-                        for (size_t k = 0; k < SeqLength(current_body->conlist); k++)
-                        {
-                            Constraint *scp = SeqAt(current_body->conlist, k);
-
-                            // we don't copy the inherit_from attribute or associated call
-                            if (strcmp("inherit_from", scp->lval) == 0)
-                            {
-                                continue;
-                            }
-
-                            if (IsDefinedClass(ctx, scp->classes))
-                            {
-                                Rval newrv = RvalCopyRewriter(scp->rval, arg_rewrite);
-                                if (newrv.type == RVAL_TYPE_LIST)
-                                {
-                                    Rlist *new_list = RvalRlistValue(newrv);
-                                    RlistFlatten(ctx, &new_list);
-                                    newrv.item = new_list;
-                                }
-
-                                // note that PromiseAppendConstraint() will overwrite existing constraints!
-                                // thus inheritance works, we just overwrite parents' constraints
-                                Constraint *scp_copy = PromiseAppendConstraint(pcopy, scp->lval, newrv, false);
-                                scp_copy->offset = scp->offset;
-                            }
-                        }
-
-                        JsonDestroy(arg_rewrite);
-                    }
-                }
             }
 
             EvalContextStackPopFrame(ctx);

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -252,10 +252,9 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
                     }
 
                     // Only do the copy expansion if we copied something while inheriting
-                    // note that r < 0 can't be true because size_t is unsigned
-                    for (size_t r = SeqLength(constraints_to_expand); r != 0; r--)
+                    for (size_t r = 0; r < SeqLength(constraints_to_expand); r++)
                     {
-                        Constraint *scp = SeqAt(constraints_to_expand, r-1);
+                        Constraint *scp = SeqAt(constraints_to_expand, r);
 
                         if (IsDefinedClass(ctx, scp->classes))
                         {
@@ -301,7 +300,7 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
                             // WriterWrite(w, "' -> expanded+rewritten rval '");
                             // RvalWrite(w, scp_copy->rval);
                             // WriterWrite(w, "'; rewrite map ");
-                            // JsonWrite(w, arg_rewrite, 0);
+                            // JsonWriteCompact(w, arg_rewrite);
 
                             // Log(LOG_LEVEL_DEBUG, "DeRefCopyPromise: in promise %s, processing body %s: expanding constraint %s with rval %s",
                             //     pcopy->promiser, body_reference, scp->lval, StringWriterData(w));

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -291,10 +291,11 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
                             // leaving it commented out
 
                             // Writer *w = StringWriter();
+                            // WriterWrite(w, "'");
                             // RvalWrite(w, returnval);
-                            // WriterWrite(w, " -> copied rval ");
+                            // WriterWrite(w, "' -> expanded+rewritten rval '");
                             // RvalWrite(w, scp_copy->rval);
-                            // WriterWrite(w, "; rewrite map ");
+                            // WriterWrite(w, "'; rewrite map ");
                             // JsonWrite(w, arg_rewrite, 0);
 
                             // Log(LOG_LEVEL_DEBUG, "DeRefCopyPromise: processing body %s: expanding constraint %s with rval %s",

--- a/tests/acceptance/00_basics/03_bodies/inherit_from_cfe_2388.cf
+++ b/tests/acceptance/00_basics/03_bodies/inherit_from_cfe_2388.cf
@@ -1,0 +1,60 @@
+#######################################################
+#
+# CFE-2388: test body inheritance with parameters
+#
+#######################################################
+
+body common control
+{
+        inputs => { "../../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+body copy_from from_ref(path1)
+{
+        source  => "$(init.referential_root_dir)/$(path1)";
+}
+
+body copy_from ref_for_level(level, path2)
+{
+        inherit_from => from_ref("$(level)/$(path2)");
+}
+
+body copy_from ref_common(path3)
+{
+      # inherit_from => from_ref("common/$(path3)");
+        inherit_from => ref_for_level("common", $(path3));
+}
+
+
+
+bundle agent init
+{
+  vars:
+      "referential_root_dir" string => "$(G.testdir)/ref";
+      "target_filepath" string => "$(referential_root_dir)/testtarget";
+      "source_filepath" string => "service_x/tmp/fic1";
+
+  methods:
+      "" usebundle => file_make_mog("$(referential_root_dir)/common/$(source_filepath)", "",
+                                   "644", $(this.promiser_uid), $(this.promiser_gid));
+
+      "" usebundle => file_tidy($(target_filepath));
+}
+
+
+bundle agent test
+{
+  files:
+      "$(init.target_filepath)"
+        copy_from => ref_common($(init.source_filepath)),
+        perms => mog("644", $(this.promiser_uid), $(this.promiser_gid));
+}
+
+bundle agent check
+{
+  methods:
+      "any"  usebundle => dcs_passif_fileexists($(init.target_filepath),
+                                               $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/03_bodies/inherit_from_cfe_2388.cf
+++ b/tests/acceptance/00_basics/03_bodies/inherit_from_cfe_2388.cf
@@ -23,8 +23,24 @@ body copy_from ref_for_level(level, path2)
 
 body copy_from ref_common(path3)
 {
-      # inherit_from => from_ref("common/$(path3)");
         inherit_from => ref_for_level("common", $(path3));
+}
+
+body copy_from from_ref_override_parameters(path1)
+{
+        servers => { "foo" };
+        source  => "$(init.referential_root_dir)/$(path1)";
+}
+
+body copy_from ref_for_level_override_parameters(level, path2)
+{
+        servers => { "localhost" };
+        inherit_from => from_ref_override_parameters("$(level)/$(path2)");
+}
+
+body copy_from ref_common_override_parameters(path3)
+{
+        inherit_from => ref_for_level_override_parameters("common", $(path3));
 }
 
 
@@ -34,13 +50,17 @@ bundle agent init
   vars:
       "referential_root_dir" string => "$(G.testdir)/ref";
       "target_filepath" string => "$(referential_root_dir)/testtarget";
+      "target_filepath_override_parameters" string => "$(referential_root_dir)/testtarget_override_parameters";
+
+      "targets" data => '[ target_filepath, target_filepath_override_parameters ]';
+
       "source_filepath" string => "service_x/tmp/fic1";
 
   methods:
       "" usebundle => file_make_mog("$(referential_root_dir)/common/$(source_filepath)", "",
                                    "644", $(this.promiser_uid), $(this.promiser_gid));
 
-      "" usebundle => file_tidy($(target_filepath));
+      "" usebundle => file_tidy($(targets));
 }
 
 
@@ -50,11 +70,15 @@ bundle agent test
       "$(init.target_filepath)"
         copy_from => ref_common($(init.source_filepath)),
         perms => mog("644", $(this.promiser_uid), $(this.promiser_gid));
+
+      "$(init.target_filepath_override_parameters)"
+        copy_from => ref_common_override_parameters($(init.source_filepath)),
+        perms => mog("644", $(this.promiser_uid), $(this.promiser_gid));
 }
 
 bundle agent check
 {
   methods:
-      "any"  usebundle => dcs_passif_fileexists($(init.target_filepath),
+      "any"  usebundle => dcs_passif_filesexist(@(init.targets),
                                                $(this.promise_filename));
 }

--- a/tests/acceptance/00_basics/03_bodies/inherit_from_cfe_2388_same_parameters.cf
+++ b/tests/acceptance/00_basics/03_bodies/inherit_from_cfe_2388_same_parameters.cf
@@ -1,0 +1,68 @@
+#######################################################
+#
+# CFE-2388: test body inheritance with same-named parameters
+#
+#######################################################
+
+body common control
+{
+        inputs => { "../../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+body copy_from from_ref_same_parameters(path_same)
+{
+        source  => "$(init.referential_root_dir)/$(path_same)";
+}
+
+body copy_from ref_for_level_same_parameters(level, path_same)
+{
+        inherit_from => from_ref_same_parameters("$(level)/$(path_same)");
+}
+
+body copy_from ref_common_same_parameters(path_same)
+{
+        inherit_from => ref_for_level_same_parameters("common", $(path_same));
+}
+
+bundle agent init
+{
+  vars:
+      "referential_root_dir" string => "$(G.testdir)/ref";
+      "target_filepath_same_parameters" string => "$(referential_root_dir)/testtarget_same_parameters";
+
+      "targets" data => '[ target_filepath_same_parameters ]';
+
+      "source_filepath" string => "service_x/tmp/fic1";
+
+  methods:
+      "" usebundle => file_make_mog("$(referential_root_dir)/common/$(source_filepath)", "",
+                                   "644", $(this.promiser_uid), $(this.promiser_gid));
+
+      "" usebundle => file_tidy($(targets));
+}
+
+
+bundle agent test
+{
+  meta:
+    "description"
+      string => "Test that body inheritance works with repeated parameter names.";
+
+    "test_soft_fail"
+      string => "any",
+      meta => { "CFE-2388" };
+
+  files:
+      "$(init.target_filepath_same_parameters)"
+        copy_from => ref_common_same_parameters($(init.source_filepath)),
+        perms => mog("644", $(this.promiser_uid), $(this.promiser_gid));
+}
+
+bundle agent check
+{
+  methods:
+      "any"  usebundle => dcs_passif_filesexist(@(init.targets),
+                                               $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/03_bodies/inherit_from_parameters.cf
+++ b/tests/acceptance/00_basics/03_bodies/inherit_from_parameters.cf
@@ -20,7 +20,10 @@ bundle common test
   reports:
       "test_inherit1" classes => scoped_classes_generic_inherit("namespace", "test_inherit");
       "test_inherit2" classes => scoped_classes_generic_some_inherit("test_inherit_some");
+      "test_inherit2_again" classes => scoped_classes_generic_some_inherit_again("test_inherit_some_again");
+      "test_inherit2_again2_noparams" classes => scoped_classes_generic_some_inherit_again2_noparams;
       "test_inherit3" classes => scoped_classes_generic_none_inherit;
+      "test_inherit_xyz_abc" classes => scoped_classes_generic_inherit_abc_xyz("test_inherit_def");
 }
 
 body classes scoped_classes_generic_inherit(myscope, myx)
@@ -33,15 +36,44 @@ body classes scoped_classes_generic_some_inherit(somex)
       inherit_from => scoped_classes_generic("namespace", $(somex));
 }
 
+# 3 levels of inheritance: scoped_classes_generic -> scoped_classes_generic_some_inherit -> scoped_classes_generic_some_inherit_again
+body classes scoped_classes_generic_some_inherit_again(somex2)
+{
+      inherit_from => scoped_classes_generic_some_inherit($(somex2));
+}
+
+# 5 levels of inheritance: scoped_classes_generic -> scoped_classes_generic_some_inherit -> scoped_classes_generic_some_inherit_again -> scoped_classes_generic_some_inherit_again2 -> scoped_classes_generic_some_inherit_again2_noparams
+body classes scoped_classes_generic_some_inherit_again2_noparams
+{
+      inherit_from => scoped_classes_generic_some_inherit_again2;
+}
+
+body classes scoped_classes_generic_some_inherit_again2
+{
+      inherit_from => scoped_classes_generic_some_inherit_again("test_inherit_some_again2");
+}
+
 body classes scoped_classes_generic_none_inherit
 {
       inherit_from => scoped_classes_generic("namespace", "test_inherit_none");
 }
 
+body classes scoped_classes_generic_inherit_xyz(xyz)
+{
+      inherit_from => scoped_classes_generic("namespace", $(xyz));
+}
+
+# we override xyz to something else, to test that the innermost xyz gets used
+# (as expected by scoping rules)
+body classes scoped_classes_generic_inherit_abc_xyz(xyz)
+{
+      inherit_from => scoped_classes_generic("namespace", "test_inherit_abc");
+}
+
 bundle agent check
 {
   methods:
-      "" usebundle => dcs_passif_expected("test_inherit_ok,test_inherit_some_ok,test_inherit_none_ok",
+      "" usebundle => dcs_passif_expected("test_inherit_ok,test_inherit_some_ok,test_inherit_some_again_ok,test_inherit_none_ok,test_inherit_abc_ok,test_inherit_some_again2_ok",
                                           "",
                                           $(this.promise_filename)),
       inherit => "true";

--- a/tests/acceptance/10_files/this_promiser.cf
+++ b/tests/acceptance/10_files/this_promiser.cf
@@ -1,13 +1,13 @@
 #######################################################
 #
-# Test this.promiser on files promises 
+# Test this.promiser on files promises
 #
 #######################################################
 
 body common control
 {
       inputs => { "../default.cf.sub" };
-      bundlesequence  => { default("$(this.promise_filename)") };   
+      bundlesequence  => { default("$(this.promise_filename)") };
       version => "1.0";
 }
 
@@ -58,6 +58,7 @@ bundle agent test
   commands:
     "$(G.true)"
       classes => promiser0_generic;
+
   files:
     # 6 promisers
     "$(G.testdir)/$(init.files)"
@@ -132,7 +133,7 @@ bundle agent template_test
 body file_select mustache_files
 {
      leaf_name => { "@(template_test.mustache_files)" };
-     file_result => "leaf_name";   
+     file_result => "leaf_name";
 }
 
 body delete tidyfiles
@@ -164,41 +165,33 @@ body depth_search test_recurse
 
 #######################################################
 
+bundle agent collect
+{
+  vars:
+      "todo" slist =>  expandrange("[0-4]", 1);
+      "ok_$(todo)_count" int => countclassesmatching(".*_$(todo)_ok");
+      "found_copy_me" int => length(findfiles("$(G.testdir)/copy_me"));
+
+      "bad_count" int => countclassesmatching("__this_promiser_[0-9]_ok");
+}
+
+#######################################################
+
 bundle agent check
 {
   vars:
-      "ok_promisers" slist => classesmatching(".*_ok");
-      "ok_0_count" int => countclassesmatching(".*_0_ok");
-      "ok_1_count" int => countclassesmatching(".*_1_ok");
-      "ok_2_count" int => countclassesmatching(".*_2_ok");
-      "ok_3_count" int => countclassesmatching(".*_3_ok");
-      "ok_4_count" int => countclassesmatching(".*_4_ok");
+      "ok_$(collect.todo)_classes" slist => classesmatching(".*_$(collect.todo)_ok");
 
-  classes:
-      "ok_expand" expression => none("__this_promiser_[0,1,2,3]_ok", ok_promisers);
-      "ok0" expression => strcmp("$(ok_0_count)", 1);
-      "ok1" expression => strcmp("$(ok_1_count)", 6);
-      "ok2" expression => strcmp("$(ok_2_count)", 4);
-      "ok3" expression => strcmp("$(ok_3_count)", 6);
-      "ok4" expression => strcmp("$(ok_4_count)", 4);
-      "ok5" expression => fileexists("$(G.testdir)/copy_me");
-
-      "ok" and => { "ok_expand", "ok0", "ok1", "ok2", "ok3", "ok4", "ok5" };
+  methods:
+      "collect";
+      "check"  usebundle => dcs_check_state(collect,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
   reports:
     DEBUG::
-      "$(ok_promisers)";
-      "0: $(ok_0_count)";
-      "1: $(ok_1_count)";
-      "2: $(ok_2_count)";
-      "3: $(ok_3_count)";
-      "4: $(ok_4_count)";
-    DEBUG.!ok5::
-      "5: file not copied";
-
-    ok::
-      "$(this.promise_filename) Pass";
-    !ok::
-      "$(this.promise_filename) FAIL";
+      "$(collect.todo): count=$(collect.ok_$(collect.todo)_count)";
+      "$(collect.todo): class = $(ok_$(collect.todo)_classes)";
 }
+
 ### PROJECT_ID: core
 ### CATEGORY_ID: 27

--- a/tests/acceptance/10_files/this_promiser.cf.expected.json
+++ b/tests/acceptance/10_files/this_promiser.cf.expected.json
@@ -1,0 +1,16 @@
+{
+  "bad_count": "0",
+  "found_copy_me": "1",
+  "ok_0_count": "1",
+  "ok_1_count": "6",
+  "ok_2_count": "4",
+  "ok_3_count": "6",
+  "ok_4_count": "4",
+  "todo": [
+    "0",
+    "1",
+    "2",
+    "3",
+    "4"
+  ]
+}

--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -717,6 +717,32 @@ bundle agent dcs_passif_fileexists(file, test)
       "$(this.bundle): $(file) exists.";
 }
 
+bundle agent dcs_passif_filesexist(files, test)
+{
+  vars:
+      "indices" slist => getindices(files);
+      "files_slist" slist => getvalues(files);
+      "files_str" string => format("%S", files);
+
+  classes:
+      "__passif" expression => filesexist(@(files_slist));
+      "$(indices)__passif" expression => fileexists("$(files[$(indices)])");
+
+  methods:
+      "" usebundle => dcs_passif("__passif", $(test)), inherit => "true";
+
+  reports:
+    "DEBUG.!$(indices)__passif"::
+      "$(this.bundle): file MISSING: $(files[$(indices)])";
+
+    "EXTRA.$(indices)__passif"::
+      "$(this.bundle): file OK: $(files[$(indices)])";
+    DEBUG.!__passif::
+      "$(this.bundle): MISSING: some of the files $(files_str)";
+    EXTRA.__passif::
+      "$(this.bundle): OK, all the files $(files_str) exist.";
+}
+
 bundle agent dcs_passif_file_absent(file, test)
 {
   classes:


### PR DESCRIPTION
See https://tracker.mender.io/browse/CFE-2388?focusedCommentId=73272

This fixes body inheritance with multiple levels by:
- accumulating the rewrite map across several inheritance steps
- expanding and rewriting **all** the body parameters on every inheritance step instead of just the specified ones

Acceptance test change included.
