### PR TITLE
ENT-2739: Don't skip output filtering if old output log doesn't exist.

### DIFF
--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -384,9 +384,9 @@ static bool LineIsFiltered(const ExecConfig *config,
     return !included || excluded;
 }
 
-static bool CompareResultEqual(const ExecConfig *config,
-                               const char *filename,
-                               const char *prev_file)
+static bool CompareResultEqualOrFiltered(const ExecConfig *config,
+                                         const char *filename,
+                                         const char *prev_file)
 {
     Log(LOG_LEVEL_VERBOSE, "Comparing files  %s with %s", prev_file, filename);
 
@@ -599,7 +599,7 @@ static void MailResult(const ExecConfig *config, const char *file)
         snprintf(prev_file, CF_BUFSIZE, "%s/outputs/previous", GetWorkDir());
         MapName(prev_file);
 
-        if (CompareResultEqual(config, file, prev_file))
+        if (CompareResultEqualOrFiltered(config, file, prev_file))
         {
             Log(LOG_LEVEL_VERBOSE, "Mail report: previous output is the same as current so do not mail it");
             return;

--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -394,7 +394,7 @@ static bool CompareResultEqualOrFiltered(const ExecConfig *config,
 
     FILE *old_fp = safe_fopen(prev_file, "r");
     FILE *new_fp = safe_fopen(filename, "r");
-    if (old_fp && new_fp)
+    if (new_fp)
     {
         const char *errptr;
         int erroffset;
@@ -419,12 +419,15 @@ static bool CompareResultEqualOrFiltered(const ExecConfig *config,
         while (regex)
         {
             char *old_msg = NULL;
-            while (CfReadLine(&old_line, &old_line_size, old_fp) >= 0)
+            if (old_fp)
             {
-                if (!LineIsFiltered(config, old_line))
+                while (CfReadLine(&old_line, &old_line_size, old_fp) >= 0)
                 {
-                    old_msg = old_line;
-                    break;
+                    if (!LineIsFiltered(config, old_line))
+                    {
+                        old_msg = old_line;
+                        break;
+                    }
                 }
             }
 

--- a/tests/acceptance/25_cf-execd/mail_1st_run_empty_new_log.cf
+++ b/tests/acceptance/25_cf-execd/mail_1st_run_empty_new_log.cf
@@ -1,0 +1,37 @@
+# Tests that no mail is sent by cf-execd on the first run (hence the old log
+# doesn't exist) and if the new log is empty.
+
+body common control
+{
+    inputs => { "../default.cf.sub", "mailfilter_common.cf.sub" };
+    bundlesequence => { default($(this.promiser_filename)) };
+}
+
+bundle agent init
+{
+  vars:
+      "reports"  slist => {
+                          };
+
+      # No mail is expected at all, since everything is filtered.
+      "expected" slist => { };
+      "unexpected" slist => { ".+" };
+
+      "includes" slist => {
+                          };
+      "excludes" slist => {
+                          };
+
+  methods:
+      "any" usebundle => prepare_mailfilter_test(@(reports),
+                                                 @(includes),
+                                                 @(excludes));
+}
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => check_cf_execd_mail(@(init.expected),
+                                             @(init.unexpected),
+                                             $(this.promise_filename));
+}

--- a/tests/acceptance/25_cf-execd/mail_empty_old_and_new_log.cf
+++ b/tests/acceptance/25_cf-execd/mail_empty_old_and_new_log.cf
@@ -1,0 +1,42 @@
+# Tests that no mail is sent by cf-execd if the old and new logs are empty.
+
+body common control
+{
+    inputs => { "../default.cf.sub", "mailfilter_common.cf.sub" };
+    bundlesequence => { default($(this.promiser_filename)) };
+}
+
+bundle agent init
+{
+  vars:
+      "reports"  slist => {
+                          };
+
+      # No mail is expected at all, since everything is filtered.
+      "expected" slist => { };
+      "unexpected" slist => { ".+" };
+
+      "includes" slist => {
+                          };
+      "excludes" slist => {
+                          };
+
+  methods:
+      "any" usebundle => prepare_mailfilter_test(@(reports),
+                                                 @(includes),
+                                                 @(excludes));
+
+  files:
+      "$(sys.workdir)/outputs/old.log"
+        create => "true";
+      "$(sys.workdir)/outputs/previous"
+        link_from => linkfrom("$(sys.workdir)/outputs/old.log", "symlink");
+}
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => check_cf_execd_mail(@(init.expected),
+                                             @(init.unexpected),
+                                             $(this.promise_filename));
+}

--- a/tests/acceptance/25_cf-execd/mailfilter_1st_run_everything_filtered.cf
+++ b/tests/acceptance/25_cf-execd/mailfilter_1st_run_everything_filtered.cf
@@ -1,0 +1,41 @@
+# Tests that no mail is sent by cf-execd if everything is filtered on the first
+# run (hence the old log doesn't exist).
+
+body common control
+{
+    inputs => { "../default.cf.sub", "mailfilter_common.cf.sub" };
+    bundlesequence => { default($(this.promiser_filename)) };
+}
+
+bundle agent init
+{
+  vars:
+      "reports"  slist => {
+                            "WrongString1",
+                            "WrongString2",
+                            "WrongString3",
+                          };
+
+      # No mail is expected at all, since everything is filtered.
+      "expected" slist => { };
+      "unexpected" slist => { ".+" };
+
+      "includes" slist => {
+                          };
+      "excludes" slist => {
+                            ".*WrongString.*"
+                          };
+
+  methods:
+      "any" usebundle => prepare_mailfilter_test(@(reports),
+                                                 @(includes),
+                                                 @(excludes));
+}
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => check_cf_execd_mail(@(init.expected),
+                                             @(init.unexpected),
+                                             $(this.promise_filename));
+}

--- a/tests/acceptance/25_cf-execd/mailfilter_common.cf.sub
+++ b/tests/acceptance/25_cf-execd/mailfilter_common.cf.sub
@@ -95,6 +95,7 @@ QUIT\r(
       "$(G.testfile).wanted"
         edit_line => append_regex($(wanted_regex));
 
+    any::
       "$(G.testfile).unwanted"
         create => "true";
     unwanted_not_empty::

--- a/tests/acceptance/25_cf-execd/mailfilter_empty_old_log_everything_filtered.cf
+++ b/tests/acceptance/25_cf-execd/mailfilter_empty_old_log_everything_filtered.cf
@@ -1,0 +1,47 @@
+# Tests that no mail is sent by cf-execd if everything is filtered and the old
+# log is empty.
+
+body common control
+{
+    inputs => { "../default.cf.sub", "mailfilter_common.cf.sub" };
+    bundlesequence => { default($(this.promiser_filename)) };
+}
+
+bundle agent init
+{
+  vars:
+      "reports"  slist => {
+                            "WrongString1",
+                            "WrongString2",
+                            "WrongString3",
+                          };
+
+      # No mail is expected at all, since everything is filtered.
+      "expected" slist => { };
+      "unexpected" slist => { ".+" };
+
+      "includes" slist => {
+                          };
+      "excludes" slist => {
+                            ".*WrongString.*"
+                          };
+
+  methods:
+      "any" usebundle => prepare_mailfilter_test(@(reports),
+                                                 @(includes),
+                                                 @(excludes));
+
+  files:
+      "$(sys.workdir)/outputs/old.log"
+        create => "true";
+      "$(sys.workdir)/outputs/previous"
+        link_from => linkfrom("$(sys.workdir)/outputs/old.log", "symlink");
+}
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => check_cf_execd_mail(@(init.expected),
+                                             @(init.unexpected),
+                                             $(this.promise_filename));
+}


### PR DESCRIPTION
   
    It was assumed we could short circuit in this case, but we can't
    because we still don't know whether the filtered output of the new log
    will produce any lines or not. So go through it even if the old log
    cannot be opened, and treat it as if the old log is a 0-byte file.
    
    Changelog: Fix bug which caused empty emails to be sent from cf-execd
    if there was no previous output log and the new log was fully filtered
    by email filters.
