### PR TITLE
CFE-2260: allow ifelse(FALSE, $(x), "something else") to work

### DIFF
--- a/tests/acceptance/01_vars/02_functions/ifelse_isvariable.cf
+++ b/tests/acceptance/01_vars/02_functions/ifelse_isvariable.cf
@@ -16,12 +16,7 @@ bundle agent test
 {
   meta:
       "description"
-        string => "Test that ifelse can use the result of isvariable
-                   as a class identifer";
-
-      "test_soft_fail"
-        string => "any",
-        meta => { "redmine7878" };
+        string => "Test that ifelse can use the result of isvariable as a class identifer";
 
   vars:
       # Since init.passwd_file is defined, I expect the value to be
@@ -39,34 +34,8 @@ bundle agent test
 
 bundle agent check
 {
-  classes:
-      "ok_passwd_file"
-        expression => strcmp( "/tmp/custom_passwd", $(init.passwd_file) );
-
-      "ok_shadow_file"
-        expression => strcmp( "/etc/shadow", $(init.use_shadow_file) );
-
-      "ok" and => { "ok_passwd_file", "ok_shadow_file" };
-
-  reports:
-    DEBUG::
-      "Found test.use_passwd_file = $(test.use_passwd_file) to be as expected"
-        if => "ok_passwd_file";
-
-      "Found test.use_shadow_file = $(test.use_shadow_filee) to be as expected"
-         if => "ok_shadow_file";
-
-      "Found value for test.use_passwd_file to be INCORRECT
-       expected '/tmp/custom_passwd' got '$(test.use_passwd_file)'"
-        unless => "ok_passwd_file";
-
-      "Found value for test.use_shadow_file to be INCORRECT
-       expected '/etc/shadow' got '$(test.use_shadow_file)'"
-        unless => "ok_shadow_file";
-
-    ok::
-      "$(this.promise_filename) Pass";
-
-    !ok::
-      "$(this.promise_filename) FAIL";
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
 }

--- a/tests/acceptance/01_vars/02_functions/ifelse_isvariable.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/ifelse_isvariable.cf.expected.json
@@ -1,0 +1,4 @@
+{
+  "use_passwd_file": "/tmp/custom_passwd",
+  "use_shadow_file": "/etc/shadow"
+}


### PR DESCRIPTION
see https://tracker.mender.io/browse/CFE-2260

* fixes the acceptance test (it was a bit broken before)
* special-cases the FnCall `ifelse("!any", ANYTHING, "foo")` to be allowed to evaluate even though `ANYTHING` may be an unexpanded variable. This is only done if `ifelse()` is called with exactly 3 arguments, but could be generalized fairly easily.

Use case:

```
ifelse( isvariable("init.passwd_file"), $(init.passwd_file), "/etc/passwd")
```
