### PR TITLE
Make sure that no_output option can be used together with module.

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -384,7 +384,8 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a,
             {
                 ModuleProtocol(ctx, cmdline, line, !a.contain.nooutput, module_context, module_tags, &persistence);
             }
-            else if ((!a.contain.nooutput) && (!EmptyString(line)))
+            
+            if ((!a.contain.nooutput) && (!EmptyString(line)))
             {
                 lineOutLen = strlen(comm) + strlen(line) + 12;
 


### PR DESCRIPTION
Currently, when commands promise is used there is no option
to override default 'no_output' behavior which is true.
This will allow overwriting the default 'no_output' value.