### PR TITLE
CFE-2345: Rlists and thread-safety

### DIFF
--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -930,9 +930,7 @@ void RvalDestroy(Rval rval)
     switch (rval.type)
     {
     case RVAL_TYPE_SCALAR:
-        ThreadLock(cft_lock);
         free(RvalScalarValue(rval));
-        ThreadUnlock(cft_lock);
         return;
 
     case RVAL_TYPE_LIST:

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -32,7 +32,6 @@
 #include <fncall.h>
 #include <string_lib.h>                                       /* StringHash */
 #include <regex.h>          /* StringMatchWithPrecompiledRegex,CompileRegex */
-#include <mutex.h>
 #include <misc_lib.h>
 #include <assoc.h>
 #include <eval_context.h>
@@ -609,9 +608,9 @@ static Rlist *RlistPrependRval(Rlist **start, Rval rval)
 
     rp->next = *start;
     rp->val = rval;
-    ThreadLock(cft_lock);
+
     *start = rp;
-    ThreadUnlock(cft_lock);
+
     return rp;
 }
 

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -316,6 +316,9 @@ Rlist *RlistAppendRval(Rlist **start, Rval rval)
 {
     Rlist *rp = xmalloc(sizeof(Rlist));
 
+    rp->val  = rval;
+    rp->next = NULL;
+
     if (*start == NULL)
     {
         *start = rp;
@@ -330,14 +333,6 @@ Rlist *RlistAppendRval(Rlist **start, Rval rval)
 
         lp->next = rp;
     }
-
-    rp->val = rval;
-
-    ThreadLock(cft_lock);
-
-    rp->next = NULL;
-
-    ThreadUnlock(cft_lock);
 
     return rp;
 }

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -582,6 +582,9 @@ Rlist *RlistAppendAllTypes(Rlist **start, const void *item, RvalType type, bool 
 
     Rlist *rp = xmalloc(sizeof(Rlist));
 
+    rp->val  = RvalCopy((Rval) {(void *) item, type});
+    rp->next = NULL;
+
     if (*start == NULL)
     {
         *start = rp;
@@ -594,14 +597,6 @@ Rlist *RlistAppendAllTypes(Rlist **start, const void *item, RvalType type, bool 
 
         lp->next = rp;
     }
-
-    rp->val = RvalCopy((Rval) {(void *) item, type});
-
-    ThreadLock(cft_lock);
-
-    rp->next = NULL;
-
-    ThreadUnlock(cft_lock);
 
     return rp;
 }

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -582,7 +582,7 @@ Rlist *RlistAppendAllTypes(Rlist **start, const void *item, RvalType type, bool 
 
     Rlist *rp = xmalloc(sizeof(Rlist));
 
-    rp->val  = RvalCopy((Rval) {(void *) item, type});
+    rp->val  = RvalNew(item, type);
     rp->next = NULL;
 
     if (*start == NULL)

--- a/tests/unit/rlist_test.c
+++ b/tests/unit/rlist_test.c
@@ -720,12 +720,12 @@ const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *lval, D
 }
 
 pthread_mutex_t *cft_lock;
-int ThreadLock(pthread_mutex_t *name)
+int __ThreadLock(pthread_mutex_t *name)
 {
     return true;
 }
 
-int ThreadUnlock(pthread_mutex_t *name)
+int __ThreadUnlock(pthread_mutex_t *name)
 {
     return true;
 }


### PR DESCRIPTION
It all started from a segfault in rlist_test.c but reviewing the locking code in rlist.c indicated that most of it was bogus. In the end all thread-safety got removed, since it's only used in single-threaded contexts.
