### PR TITLE
ENT-7949: add example for isipinsubnet()

### DIFF
--- a/examples/isipinsubnet.cf
+++ b/examples/isipinsubnet.cf
@@ -1,0 +1,47 @@
+#  Copyright (C) Cfengine AS
+
+#  This file is part of Cfengine 3 - written and maintained by Cfengine AS.
+
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License as published by the
+#  Free Software Foundation; version 3.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+# To the extent this program is licensed as part of the Enterprise
+# versions of Cfengine, the applicable Commercial Open Source License
+# (COSL) may apply to this file if you as a licensee so wish it. See
+# included file COSL.txt.
+
+###############################################################################
+#+begin_src cfengine3
+bundle agent main
+{
+  classes:
+
+      "in_192" expression => isipinsubnet("192.0.0.0/8", "192.1.2.3");
+      "in_192_2_2_2" expression => isipinsubnet("192.2.2.0/24", "192.1.2.3");
+
+  reports:
+
+    in_192::
+      "The address 192.1.2.3 is in the 192/8 subnet";
+    !in_192_2_2_2::
+      "The address 192.1.2.3 is not in the 192.2.2/24 subnet";
+}
+
+#+end_src
+###############################################################################
+#+begin_src example_output
+#@ ```
+#@ R: The address 192.1.2.3 is in the 192/8 subnet
+#@ R: The address 192.1.2.3 is not in the 192.2.2/24 subnet
+#@ ```
+#+end_src


### PR DESCRIPTION
This will be used in https://github.com/cfengine/documentation/pull/1553 instead of the current inline example.