### PR TITLE
CFE-2397: Avoid JSON incompatible code path in getindices().

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -2247,6 +2247,8 @@ static FnCallResult FnCallGetIndicesClassic(EvalContext *ctx, ARG_UNUSED const P
 static FnCallResult FnCallGetIndices(EvalContext *ctx, ARG_UNUSED const Policy *policy, const FnCall *fp, const Rlist *finalargs)
 {
     const char *name_str = RlistScalarValueSafe(finalargs);
+    bool allocated = false;
+    JsonElement *json = NULL;
 
     // Protect against collected args (their rval type will be data
     // container). This is a special case to preserve legacy behavior
@@ -2256,19 +2258,49 @@ static FnCallResult FnCallGetIndices(EvalContext *ctx, ARG_UNUSED const Policy *
         VarRef *ref = ResolveAndQualifyVarName(fp, name_str);
         DataType type = CF_DATA_TYPE_NONE;
         EvalContextVariableGet(ctx, ref, &type);
-        VarRefDestroy(ref);
 
-        if (type != CF_DATA_TYPE_CONTAINER &&
-            StringMatchFull(".*[a-zA-Z0-9_](\\[[a-zA-Z0-9_]+\\])+$", name_str))
+        if (type != CF_DATA_TYPE_CONTAINER)
         {
-            return FnCallGetIndicesClassic(ctx, policy, fp, finalargs);
+            JsonParseError res = JsonParseWithLookup(ctx, &LookupVarRefToJson, &name_str, &json);
+            if (res == JSON_PARSE_OK)
+            {
+                if (JsonGetElementType(json) == JSON_ELEMENT_TYPE_PRIMITIVE)
+                {
+                    // VarNameOrInlineToJson() would now look up this primitive
+                    // in the variable table, returning a JSON container for
+                    // whatever type it is, but since we already know that it's
+                    // not a native container type (thanks to the
+                    // CF_DATA_TYPE_CONTAINER check above) we skip that, and
+                    // stick to the legacy data types.
+                    JsonDestroy(json);
+                    VarRefDestroy(ref);
+                    return FnCallGetIndicesClassic(ctx, policy, fp, finalargs);
+                }
+                else
+                {
+                    // Inline JSON of some sort.
+                    allocated = true;
+                }
+            }
+            else
+            {
+                // Invalid inline JSON. Same case as Classic case above.
+                VarRefDestroy(ref);
+                return FnCallGetIndicesClassic(ctx, policy, fp, finalargs);
+            }
         }
-    }
+        else
+        {
+            // A variable holding a container.
+            json = VarRefValueToJson(ctx, fp, ref, NULL, 0, true, &allocated);
+        }
 
-    // Try to load directly. This case will behave correctly whether
-    // finalrgs holds a scalar or not.
-    bool allocated = false;
-    JsonElement *json = VarNameOrInlineToJson(ctx, fp, finalargs, true, &allocated);
+        VarRefDestroy(ref);
+    }
+    else
+    {
+        json = VarNameOrInlineToJson(ctx, fp, finalargs, true, &allocated);
+    }
 
     // we failed to produce a valid JsonElement, so give up
     if (json == NULL)

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -334,8 +334,8 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
 
     Rlist *expargs = NewExpArgs(ctx, policy, fp);
 
-    Writer *fncall_writer;
-    const char *fncall_string;
+    Writer *fncall_writer = NULL;
+    const char *fncall_string = "";
     if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
     {
         fncall_writer = StringWriter();

--- a/libpromises/var_expressions.c
+++ b/libpromises/var_expressions.c
@@ -419,9 +419,7 @@ char *VarRefToString(const VarRef *ref, bool qualified)
         BufferAppend(buf, "]", sizeof(char));
     }
 
-    char *var_string = xstrdup(BufferData(buf));
-    BufferDestroy(buf);
-    return var_string;
+    return BufferClose(buf);
 }
 
 char *VarRefMangle(const VarRef *ref)

--- a/tests/acceptance/01_vars/02_functions/getindices.cf
+++ b/tests/acceptance/01_vars/02_functions/getindices.cf
@@ -13,6 +13,29 @@ body common control
 
 #######################################################
 
+# Do not change the name of this bundle or of variables inside this bundle. The
+# original bug CFE-2397 depended on a certain order in the variable table which
+# was triggered by these names.
+bundle common b
+{
+  vars:
+      "d[k]" string => "val1";
+      "d[f][f1]" string => "val2";
+      "d[s][s1]" string => "val3";
+
+      "d_keys" slist => getindices("d");
+      "d_keys_f" slist => getindices("d[f]");
+      "d_keys_s" slist => getindices("d[s]");
+
+      "c[$(d_keys)]" string => "$(d[$(d_keys)])";
+      "c[f][$(d_keys_f)]" string => "$(d[f][$(d_keys_f)])";
+      "c[s][$(d_keys_s)]" string => "$(d[s][$(d_keys_s)])";
+
+      "c_keys" slist => getindices("c");
+      "c_keys_f" slist => getindices("c[f]");
+      "c_keys_s" slist => getindices("c[s]");
+}
+
 bundle agent test
 {
   vars:
@@ -27,6 +50,10 @@ bundle agent test
       "userfields" slist => getindices("user[fullname]");
       "inline_fields" slist => getindices('{ "foo": 1, "bar": 2 }');
       "inline_numfields" slist => getindices('[ "foo", 1, "bar", 2 ]');
+      "inline_function" slist => getindices(parsejson('{ "a": "b", "c": "d" }'));
+      "c_keys"   slist => { @(b.c_keys) };
+      "c_keys_f"   slist => { @(b.c_keys_f) };
+      "c_keys_s"   slist => { @(b.c_keys_s) };
 }
 
 #######################################################

--- a/tests/acceptance/01_vars/02_functions/getindices.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/getindices.cf.expected.json
@@ -1,4 +1,15 @@
 {
+  "c_keys": [
+    "s",
+    "f",
+    "k"
+  ],
+  "c_keys_f": [
+    "f1"
+  ],
+  "c_keys_s": [
+    "s1"
+  ],
   "fields": [
     "dirs",
     "fullname",
@@ -7,6 +18,10 @@
   "inline_fields": [
     "foo",
     "bar"
+  ],
+  "inline_function": [
+    "a",
+    "c"
   ],
   "inline_numfields": [
     "0",


### PR DESCRIPTION
```
If we have two indexed CFEngine variables:

vars:
  "a[x]"    string => "one";
  "a[x][y]" string => "two";

this structure is impossible to turn into JSON because if we do, we
get:

{
  "a": {
    "x": "one",
    "x": {
      "y": "two"
    }
  }
}

which contains two identical "x" keys, and is therefore invalid JSON.

In this case the old code would crash in some cases, but it's order
dependent, so it didn't always happen.

It's not necessary to use JSON for getindices(), since it returns a
list, but this was nevertheless the path taken in the code. So fix it
by avoiding this code path and taking the legacy path which handles
this case. Some extra care is needed because there are several ways in
which the input can be JSON, either by being specified inline, or by
referring to a variable that holds JSON, and in this case we need to
take the JSON path.

Changelog: Fix occasional segfault when running getindices() on a
variable that has indices of multiple depths (e.g. both "a[x]" and
"a[x][y]").
Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>
```

A couple of cleanup commits as well.