### PR TITLE
Make sure that no_output option can be used together with module.

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -384,7 +384,8 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a,
             {
                 ModuleProtocol(ctx, cmdline, line, !a.contain.nooutput, module_context, module_tags, &persistence);
             }
-            else if ((!a.contain.nooutput) && (!EmptyString(line)))
+
+            if (!a.contain.nooutput && !EmptyString(line))
             {
                 lineOutLen = strlen(comm) + strlen(line) + 12;
 

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -364,7 +364,14 @@ ExecContain GetExecContainConstraints(const EvalContext *ctx, const Promise *pp)
     e.owner = PromiseGetConstraintAsUid(ctx, "exec_owner", pp);
     e.group = PromiseGetConstraintAsGid(ctx, "exec_group", pp);
     e.preview = PromiseGetConstraintAsBoolean(ctx, "preview", pp);
-    e.nooutput = PromiseGetConstraintAsBoolean(ctx, "no_output", pp);
+    if (PromiseBundleOrBodyConstraintExists(ctx, "no_output", pp))
+    {
+        e.nooutput = PromiseGetConstraintAsBoolean(ctx, "no_output", pp);
+    }
+    else
+    {
+        e.nooutput = PromiseGetConstraintAsBoolean(ctx, "module", pp);
+    }
     e.timeout = PromiseGetConstraintAsInt(ctx, "exec_timeout", pp);
     e.chroot = PromiseGetConstraintAsRval(pp, "chroot", RVAL_TYPE_SCALAR);
     e.chdir = PromiseGetConstraintAsRval(pp, "chdir", RVAL_TYPE_SCALAR);

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1098,7 +1098,7 @@ typedef struct
     char *chdir;
     char *chroot;
     int preview;
-    int nooutput;
+    bool nooutput;
     int timeout;
 } ExecContain;
 

--- a/tests/acceptance/08_commands/01_modules/module_with_no_output.cf
+++ b/tests/acceptance/08_commands/01_modules/module_with_no_output.cf
@@ -1,0 +1,36 @@
+body common control
+{
+    inputs => { "../../default.cf.sub" };
+    bundlesequence => { default($(this.promise_filename)) };
+}
+
+bundle agent init
+{
+  methods:
+      "init" usebundle => file_make("$(G.testdir)/module.output.txt",
+                                    "=myvar=good_output_1");
+
+      "init" usebundle => file_make("$(G.testdir)/module.no_output.txt",
+                                    "=myvar=bad_output");
+
+      "init" usebundle => file_make("$(G.testdir)/module.default.txt",
+                                    "=myvar=bad_output");
+
+      "init" usebundle => file_make("$(G.testdir)/no_module.output.txt",
+                                    "=myvar=good_output_2");
+
+      "init" usebundle => file_make("$(G.testdir)/no_module.no_output.txt",
+                                    "=myvar=bad_output");
+
+      "init" usebundle => file_make("$(G.testdir)/no_module.default.txt",
+                                    "=myvar=good_output_3");
+}
+
+bundle agent check
+{
+  methods:
+      "check" usebundle => dcs_passif_output(".*good_output_1.*good_output_2.*good_output_3.*",
+                                             ".*bad_output.*",
+                                             "$(sys.cf_agent) -D AUTO -Kf $(this.promise_filename).sub",
+                                             $(this.promise_filename));
+}

--- a/tests/acceptance/08_commands/01_modules/module_with_no_output.cf.sub
+++ b/tests/acceptance/08_commands/01_modules/module_with_no_output.cf.sub
@@ -1,0 +1,33 @@
+body common control
+{
+    inputs => { "../../default.cf.sub" };
+    bundlesequence => { default($(this.promise_filename)) };
+}
+
+bundle agent test
+{
+  commands:
+      "$(G.cat) $(G.testdir)/module.output.txt"
+        module => "true",
+        contain => test_contain("false");
+
+      "$(G.cat) $(G.testdir)/module.no_output.txt"
+        module => "true",
+        contain => test_contain("true");
+
+      "$(G.cat) $(G.testdir)/module.default.txt"
+        module => "true";
+
+      "$(G.cat) $(G.testdir)/no_module.output.txt"
+        contain => test_contain("false");
+
+      "$(G.cat) $(G.testdir)/no_module.no_output.txt"
+        contain => test_contain("true");
+
+      "$(G.cat) $(G.testdir)/no_module.default.txt";
+}
+
+body contain test_contain(no_output)
+{
+    no_output => "$(no_output)";
+}


### PR DESCRIPTION
Currently, when commands promise is used there is no option
to override default 'no_output' behavior which is true.
This will allow overwriting the default 'no_output' value.

Changelog: Fix 'contain' attribute 'no_output' having no effect when
the 'commands' promise is using 'module => "true"'.

Based on a patch by Marcin Pasinski <marcin.pasinski@cfengine.com>.

CFE-2412

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>