### PR TITLE
Allow getvariablemetatags() and getclassmetatags() to get a specific tag key

### DIFF
--- a/tests/acceptance/01_vars/02_functions/gettags.cf
+++ b/tests/acceptance/01_vars/02_functions/gettags.cf
@@ -12,11 +12,15 @@ bundle common init
       "myclass" expression => "any", meta => { "mytag1" };
       "myotherclass" expression => "any", meta => { "mytag5", "mytag51" };
       "myplainclass" expression => "any";
+      "keyclass" expression => "any", meta => { "foo=1", "mytag51", "foo", "foo=2" };
+      "keyclass2" expression => "any", meta => { "foo" };
 
   vars:
       "tests" slist => { "1", "2", "3", "4", "5" };
       "myvar" string => "123", meta => { "mytag3" };
       "myothervar" string => "123";
+      "keyvar" int => "1", meta => { "foo=1", "mytag51", "foo", "foo=2" };
+      "keyvar2" real => "20", meta => { "foo" };
 }
 
 bundle agent test
@@ -27,30 +31,19 @@ bundle agent test
       "tags3" slist => getvariablemetatags("init.myvar");
       "tags4" slist => getvariablemetatags("init.myothervar");
       "tags5" slist => getclassmetatags("myotherclass");
-
-      "actual[$(init.tests)]" string => format('%S', "tags$(init.tests)");
+      "tags6" slist => getclassmetatags("nosuchclass");
+      "tags7" slist => getvariablemetatags("nosuchvariable");
+      "tags8" slist => getclassmetatags("keyclass", "foo");
+      "tags9" slist => getclassmetatags("keyclass2", "foo");
+      "tagsa" slist => getvariablemetatags("init.keyvar", "foo");
+      "tagsb" slist => getvariablemetatags("init.keyvar2", "foo");
 }
+
 
 bundle agent check
 {
-  vars:
-      "expected[1]" string => '{ "source=promise", "mytag1" }';
-      "expected[2]" string => '{ "source=promise" }';
-      "expected[3]" string => '{ "source=promise", "mytag3" }';
-      "expected[4]" string => '{ "source=promise" }';
-      "expected[5]" string => '{ "source=promise", "mytag5", "mytag51" }';
-
-  classes:
-      "ok_$(init.tests)" expression => strcmp("$(test.actual[$(init.tests)])", "$(expected[$(init.tests)])");
-
-      "ok" and => { ok_1, ok_2, ok_3, ok_4, ok_5,  };
-
-  reports:
-    DEBUG::
-      "Pass case $(init.tests)" ifvarclass => "ok_$(init.tests)";
-      "FAIL case $(init.tests): actual '$(test.actual[$(init.tests)])', expected '$(expected[$(init.tests)])'" ifvarclass => "!ok_$(init.tests)";
-    ok::
-      "$(this.promise_filename) Pass";
-    !ok::
-      "$(this.promise_filename) FAIL";
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
 }

--- a/tests/acceptance/01_vars/02_functions/gettags.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/gettags.cf.expected.json
@@ -1,0 +1,31 @@
+{
+  "tags1": [
+    "source=promise",
+    "mytag1"
+  ],
+  "tags2": [
+    "source=promise"
+  ],
+  "tags3": [
+    "source=promise",
+    "mytag3"
+  ],
+  "tags4": [
+    "source=promise"
+  ],
+  "tags5": [
+    "source=promise",
+    "mytag5",
+    "mytag51"
+  ],
+  "tags8": [
+    "1",
+    "2"
+  ],
+  "tags9": [],
+  "tagsa": [
+    "1",
+    "2"
+  ],
+  "tagsb": []
+}


### PR DESCRIPTION
Simple change, low risk. Acceptance test included.