### PR TITLE
Actually check if postgres is running when checking status with init script

### DIFF
--- a/misc/init.d/cfengine3.in
+++ b/misc/init.d/cfengine3.in
@@ -451,6 +451,22 @@ cf_status_daemon()
     fi
 }
 
+cf_status_postgres_daemon() {
+     local data_directory="$1"
+     local pidfile="${data_directory}/postmaster.pid"
+     local pids="$(cf_get_matching_pids --ignore-user "postgres")"
+
+     if [ -n "$pids" -a -f $pidfile ]; then
+         pid_from_file=$(sed -n 1p $pidfile)
+         if [ -n "$(echo $pids | egrep -w $pid_from_file)" ]; then
+             echo "postgres is running..."
+             return
+         fi
+     fi
+
+     echo "postgres is not running..."
+ }
+
 cf_start_core_daemons()
 {
     # start cf-execd


### PR DESCRIPTION
The generic cf_status_daemon won't work for postgres for a number of reasons:

1) The postgres pid file is postmaster.pid, this code assumes it'll be the name of the directory passed to the function.
2) The postgres pid file doesn't follow the standard being checked in: cf_pidfile_pid()
3) The call to "cf_get_matching_pids()" only checks root processes, postgres is running as the postgres user, so an argument has to be passed.

The following commit adds a specific status check for the postgres service 