### PR TITLE
Change: Log level for keeping verbatim JSON to DEBUG

### DIFF
--- a/libutils/json.c
+++ b/libutils/json.c
@@ -1673,7 +1673,7 @@ static JsonParseError JsonParseAsString(const char **data, char **str_out)
                  * \u{hex digits} - we have no way to represent the
                  * character they denote.  So keep them verbatim, for
                  * want of any other way to handle them; but warn. */
-                Log(LOG_LEVEL_WARNING,
+                Log(LOG_LEVEL_DEBUG,
                     "Keeping verbatim unrecognised JSON escape '%.6s'",
                     *data - 1); /* i.e. include the \ in the displayed escape */
                 WriterWriteChar(writer, '\\');


### PR DESCRIPTION
Manual backport of dd337dd04d6d95ad03931db8c329ecfdcfb67aa8
Jira #CFE-2141
Changelog: Title