### PR TITLE
Add: Test that expireafter works with methods

### DIFF
--- a/tests/acceptance/21_methods/action_ifelapsed_respected.cf
+++ b/tests/acceptance/21_methods/action_ifelapsed_respected.cf
@@ -1,0 +1,24 @@
+body common control
+{
+      inputs => { "../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+    "description" string => "Test that methods are terminated as expected when ifelapsed is set";
+
+    # The subtest uses /bin/sleep so the test needs work on windows.
+    "test_soft_fail"
+      string => "any",
+      meta => { "CFE-2444" };
+}
+
+bundle agent check
+{
+  methods:
+    "" usebundle => dcs_passif_output(".*", ".*DID NOT TIMEOUT.*", "$(sys.cf_agent) -Kf $(this.promise_filename).sub", $(this.promise_filename));
+}
+

--- a/tests/acceptance/21_methods/action_ifelapsed_respected.cf.sub
+++ b/tests/acceptance/21_methods/action_ifelapsed_respected.cf.sub
@@ -1,0 +1,23 @@
+bundle agent main
+{
+  methods:
+    "test"
+      action => expireafter_ten_sec;
+}
+
+body action expireafter_ten_sec
+{
+  expireafter => "10";
+}
+
+bundle agent test
+{
+  commands:
+    "/bin/sleep 30"
+      handle => "sleep";
+
+  reports:
+    "DID NOT TIMEOUT"
+      depends_on => { "sleep" };
+}
+


### PR DESCRIPTION
Jira #CFE-2444

Note this test currently fails on 3.9.0.

cf-agent -Kf ./action_ifelapsed_respected.cf -DAUTO
R: test description: Test that methods are terminated as expected when ifelapsed is set
R: /home/nickanderson/CFEngine/core/tests/acceptance/21_methods/./../dcs.cf.sub SFAIL/CFE-2444
R: /home/nickanderson/CFEngine/core/tests/acceptance/21_methods/./action_ifelapsed_respected.cf FAIL
