### PR TITLE
CFE-2225, CFE-2325: Fix for double logging of output_prefix, and log process name for cf-agent syslog messages

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -852,7 +852,7 @@ bool GenericAgentArePromisesValid(const GenericAgentConfig *config)
 #if !defined(__MINGW32__)
 static void OpenLog(int facility)
 {
-    openlog(VPREFIX, LOG_PID | LOG_NOWAIT | LOG_ODELAY, facility);
+    openlog(NULL, LOG_PID | LOG_NOWAIT | LOG_ODELAY, facility);
 }
 #endif
 


### PR DESCRIPTION
This is my proposed fix for 2225 and 2325. When output_prefix is not set, cf-agent syslog messages have an empty process name. When it is set, we use that instead of the process name, and also include it elsewhere in the log message, doubling the ocurrences. By passing NULL to openlog(), we tell it to log the process name, which is desirable, and only include output_prefix once in the log message.