### PR TITLE
CFE-2448: install binaries in bin instead of sbin

### DIFF
--- a/cf-agent/Makefile.am
+++ b/cf-agent/Makefile.am
@@ -121,7 +121,7 @@ endif
 endif
 
 if !BUILTIN_EXTENSIONS
-  sbin_PROGRAMS = cf-agent
+  bin_PROGRAMS = cf-agent
 
   # Workaround for automake madness (try removing it if you want to know why).
   cf_agent_CFLAGS = $(AM_CFLAGS)

--- a/cf-execd/Makefile.am
+++ b/cf-execd/Makefile.am
@@ -50,7 +50,7 @@ libcf_execd_test_la_LIBADD = $(libcf_execd_la_LIBADD)
 libcf_execd_test_la_CPPFLAGS = $(AM_CPPFLAGS) -DTEST_CF_EXECD
 
 if !BUILTIN_EXTENSIONS
- sbin_PROGRAMS = cf-execd
+ bin_PROGRAMS = cf-execd
  # Workaround for automake madness (try removing it if you want to know why).
  cf_execd_CFLAGS = $(AM_CFLAGS)
  cf_execd_LDADD = libcf-execd.la

--- a/cf-key/Makefile.am
+++ b/cf-key/Makefile.am
@@ -42,7 +42,7 @@ libcf_key_la_SOURCES = \
 libcf_key_la_LIBADD = ../libpromises/libpromises.la
 
 if !BUILTIN_EXTENSIONS
- sbin_PROGRAMS = cf-key
+ bin_PROGRAMS = cf-key
  cf_key_LDADD = libcf-key.la
  cf_key_SOURCES =
 endif

--- a/cf-monitord/Makefile.am
+++ b/cf-monitord/Makefile.am
@@ -54,7 +54,7 @@ libcf_monitord_la_SOURCES = \
         cf-monitord.c
 
 if !BUILTIN_EXTENSIONS
- sbin_PROGRAMS = cf-monitord
+ bin_PROGRAMS = cf-monitord
  # Workaround for automake madness (try removing it if you want to know why).
  cf_monitord_CFLAGS = $(AM_CFLAGS)
  cf_monitord_LDADD = libcf-monitord.la

--- a/cf-promises/Makefile.am
+++ b/cf-promises/Makefile.am
@@ -37,7 +37,7 @@ libcf_promises_la_LIBADD = ../libpromises/libpromises.la
 libcf_promises_la_SOURCES = cf-promises.c
 
 if !BUILTIN_EXTENSIONS
- sbin_PROGRAMS = cf-promises
+ bin_PROGRAMS = cf-promises
  cf_promises_LDADD = libcf-promises.la
  cf_promises_SOURCES =
 endif

--- a/cf-runagent/Makefile.am
+++ b/cf-runagent/Makefile.am
@@ -38,7 +38,7 @@ libcf_runagent_la_LIBADD = ../libpromises/libpromises.la
 libcf_runagent_la_SOURCES = cf-runagent.c
 
 if !BUILTIN_EXTENSIONS
- sbin_PROGRAMS = cf-runagent
+ bin_PROGRAMS = cf-runagent
  cf_runagent_LDADD = libcf-runagent.la
  cf_runagent_SOURCES =
 endif

--- a/cf-serverd/Makefile.am
+++ b/cf-serverd/Makefile.am
@@ -49,7 +49,7 @@ libcf_serverd_la_SOURCES = \
 	strlist.c strlist.h
 
 if !BUILTIN_EXTENSIONS
- sbin_PROGRAMS = cf-serverd
+ bin_PROGRAMS = cf-serverd
  # Workaround for automake madness (try removing it if you want to know why).
  cf_serverd_CFLAGS = $(AM_CFLAGS)
  cf_serverd_LDADD = libcf-serverd.la

--- a/cf-upgrade/Makefile.am
+++ b/cf-upgrade/Makefile.am
@@ -21,7 +21,7 @@
 # (COSL) may apply to this file if you as a licensee so wish it. See
 # included file COSL.txt.
 #
-sbin_PROGRAMS = cf-upgrade
+bin_PROGRAMS = cf-upgrade
 
 LIBS=				 # This tool should not link to anything
 AM_LDFLAGS=

--- a/configure.ac
+++ b/configure.ac
@@ -206,7 +206,7 @@ AS_IF([test x"$enable_fhs" = xyes], [
     STATEDIR="default"
   fi
 
-  sbindir='${exec_prefix}/bin' # /var/cfengine/bin despite being sbin_?
+  bindir='${exec_prefix}/bin'
   projlibdir='${exec_prefix}/lib'
   mandir='${exec_prefix}/share/man'
 ])

--- a/contrib/masterfiles/git-failsafe.cf
+++ b/contrib/masterfiles/git-failsafe.cf
@@ -249,9 +249,9 @@ bundle agent git_update
             action => u_immediate,
         ifvarclass => "hpux";
 
-   "/usr/local/sbin"
-           comment => "Ensure cfengine binaries were copied to /usr/local/sbin",
-            handle => "update_files_usr_local_sbin",
+   "/usr/local/bin"
+           comment => "Ensure cfengine binaries were copied to /usr/local/bin",
+            handle => "update_files_usr_local_bin",
              perms => u_m("755"),
          copy_from => u_cp_nobck("$(sys.workdir)/bin"),
        file_select => u_cf3_files,

--- a/examples/process_signalling.cf
+++ b/examples/process_signalling.cf
@@ -55,7 +55,7 @@ bundle agent example
 
     start_cfserv::
 
-      "/usr/local/sbin/cfservd";
+      "/usr/local/bin/cfservd";
 
 }
 

--- a/examples/symlink_children.cf
+++ b/examples/symlink_children.cf
@@ -33,9 +33,9 @@ bundle agent main
 
       # This will make symlinks to each file in /var/cfengine/bin
       # for example:
-      # '/usr/local/sbin/cf-agent' -> '/var/cfengine/bin/cf-agent'
-      # '/usr/local/sbin/cf-serverd' -> '/var/cfengine/bin/cf-serverd'
-      "/usr/local/sbin"
+      # '/usr/local/bin/cf-agent' -> '/var/cfengine/bin/cf-agent'
+      # '/usr/local/bin/cf-serverd' -> '/var/cfengine/bin/cf-serverd'
+      "/usr/local/bin"
         link_from => linkchildren("/var/cfengine/bin"),
 	comment => "We like for cfengine binaries to be available inside of the
                     common $PATH";

--- a/ext/Makefile.am
+++ b/ext/Makefile.am
@@ -21,7 +21,7 @@
 # (COSL) may apply to this file if you as a licensee so wish it. See
 # included file COSL.txt.
 #
-sbin_PROGRAMS = rpmvercmp
+bin_PROGRAMS = rpmvercmp
 
 LDADD = ../libcompat/libcompat.la
 


### PR DESCRIPTION
https://tracker.mender.io/browse/CFE-2448

Since CFEngine can be used by normal users (for example to verify a policy using cf-promises), its binaries should be installed in bin instead of sbin when using FHS layout.
