### PR TITLE
ACL bug CFE-616

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -415,7 +415,7 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
 
 /* Phase 1 - */
 
-    if ((exists && ((a.haverename) || (a.haveperms) || (a.havechange) || (a.transformer))) ||
+    if ((exists && ((a.haverename) || (a.haveperms) || (a.havechange) || (a.transformer)) || (a.acl.acl_entries != NULL)) ||
         ((exists || link) && a.havedelete))
     {
         lstat(path, &oslb);     /* if doesn't exist have to stat again anyway */

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -694,7 +694,7 @@ PromiseResult ScheduleEditOperation(EvalContext *ctx, char *filename, Attributes
         {
             strcpy(edit_bundle_name, (char *) vp);
             args = NULL;
-        }             
+        }
         else
         {
             goto exit;
@@ -737,7 +737,7 @@ PromiseResult ScheduleEditOperation(EvalContext *ctx, char *filename, Attributes
         {
             goto exit;
         }
-        
+
         Log(LOG_LEVEL_VERBOSE, "Handling file edits in edit_xml bundle '%s'", edit_bundle_name);
 
         const Bundle *bp = EvalContextResolveBundleExpression(ctx, policy, edit_bundle_name, "edit_xml");
@@ -752,7 +752,7 @@ PromiseResult ScheduleEditOperation(EvalContext *ctx, char *filename, Attributes
         }
     }
 
-    
+
     if (a.edit_template)
     {
         Log(LOG_LEVEL_VERBOSE, "Rendering '%s' using template '%s' with method '%s'",

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -132,7 +132,7 @@ void VerifyFileLeaf(EvalContext *ctx, char *path, struct stat *sb, Attributes at
 
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promiser", path, CF_DATA_TYPE_STRING, "source=promise");        // Parameters may only be scalars
     Attributes org_attr = GetFilesAttributes(ctx, pp);
-    attr = GetExpandedAttributes(ctx, pp, &org_attr); 
+    attr = GetExpandedAttributes(ctx, pp, &org_attr);
 
     if (attr.transformer != NULL)
     {
@@ -975,7 +975,7 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
         {
             result = PromiseResultUpdate(result, VerifyCopy(ctx, newfrom, newto, attr, pp, inode_cache, conn));
         }
-        
+
         if (conn != NULL &&
             conn->conn_info->status != CONNECTIONINFO_STATUS_ESTABLISHED)
         {
@@ -2079,7 +2079,6 @@ PromiseResult VerifyFileAttributes(EvalContext *ctx, const char *file, struct st
     {
         newperm |= attr.perms.plus;
         newperm &= ~(attr.perms.minus);
-
         /* directories must have x set if r set, regardless  */
 
         if (S_ISDIR(dstat->st_mode))

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -2147,10 +2147,6 @@ PromiseResult VerifyFileAttributes(EvalContext *ctx, const char *file, struct st
     }
 #endif
 
-    if (attr.acl.acl_entries)
-    {
-        result = PromiseResultUpdate(result, VerifyACL(ctx, file, attr, pp));
-    }
 
 #ifndef __MINGW32__
     result = PromiseResultUpdate(result, VerifySetUidGid(ctx, file, dstat, dstat->st_mode, pp, attr));
@@ -2258,6 +2254,11 @@ PromiseResult VerifyFileAttributes(EvalContext *ctx, const char *file, struct st
     }
 # endif
 #endif
+
+    if (attr.acl.acl_entries)
+    {
+        result = PromiseResultUpdate(result, VerifyACL(ctx, file, attr, pp));
+    }
 
     if (attr.touch)
     {

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1305,7 +1305,7 @@ typedef struct
     char *package_version_equal_command;
 
     int package_noverify_returncode;
-    
+
     bool has_package_method;
     bool is_empty;
 } Packages;
@@ -1323,10 +1323,10 @@ typedef struct
 
 typedef struct
 {
-    Rlist *control_package_inventory; /* list of all inventory used package managers 
+    Rlist *control_package_inventory; /* list of all inventory used package managers
                                        * names taken from common control */
     char *control_package_module;    /* policy default package manager name */
-    Seq *package_modules_bodies; /* list of all discovered in policy PackageManagerBody 
+    Seq *package_modules_bodies; /* list of all discovered in policy PackageManagerBody
                                    * bodies taken from common control */
 } PackagePromiseContext;
 
@@ -1339,7 +1339,7 @@ typedef struct
     char *package_version;
     char *package_architecture;
     Rlist *package_options;
-    
+
     bool is_empty;
 } NewPackages;
 
@@ -1608,4 +1608,3 @@ extern const ConstraintSyntax CFEX_CONTROLBODY[];
 typedef struct ServerConnectionState_ ServerConnectionState;
 
 #endif
-

--- a/tests/acceptance/10_files/12_acl/acl.cf.sub
+++ b/tests/acceptance/10_files/12_acl/acl.cf.sub
@@ -118,8 +118,8 @@ bundle agent init
                          "add_perm_user",
                          "rm_perm",
                          "overwrite_add_remove",
-                         #"default",
-                         #"default_specify",
+                         "default",
+                         "default_specify",
                        } ;
 
     windows::


### PR DESCRIPTION
Fixes CFE-616. Added acl_entries to phase 1 of VerifyFilePromise to ensure acls are applied, and changed order of applying perms and acls. ACLs are now applied after regular perms and the test passes.