### PR TITLE
ARCHIVE-1619: allow maplist(), maparray(), and mapdata() to evaluate function calls during iteration

### DIFF
--- a/libpromises/fncall.h
+++ b/libpromises/fncall.h
@@ -66,7 +66,10 @@ typedef enum
     // Collecting functions take a variable reference OR can accept a
     // nested function call. Either way, those parameters are
     // collected into a data container.
-    FNCALL_OPTION_COLLECTING = 1 << 2
+    FNCALL_OPTION_COLLECTING = 1 << 2,
+    // Delayed-evaluation functions will evaluate their arguments directly,
+    // so they can do things like maplist(canonify($(this)), mylist)
+    FNCALL_OPTION_DELAYED_EVALUATION = 1 << 3
 } FnCallOption;
 
 typedef struct
@@ -98,6 +101,7 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
 const FnCallType *FnCallTypeGet(const char *name);
 
 FnCall *ExpandFnCall(EvalContext *ctx, const char *ns, const char *scope, const FnCall *f);
+Rlist *NewExpArgs(EvalContext *ctx, const Policy *policy, const FnCall *fp, const FnCallType *fp_type);
 
 // TODO: should probably demolish this eventually
 void FnCallShow(FILE *fout, const char *prefix, const FnCall *fp, const Rlist *args);

--- a/tests/acceptance/01_vars/02_functions/maparray.cf
+++ b/tests/acceptance/01_vars/02_functions/maparray.cf
@@ -46,6 +46,7 @@ bundle agent test
       "array[last]" string => "last";
 
       "mapped" slist => maparray("key=$(this.k) value=$(this.v)", "array");
+      "mapped2" slist => maparray(concat("key=$(this.k) value=$(this.v)"), "array");
 
   files:
       "$(G.testfile).actual"
@@ -61,9 +62,11 @@ bundle edit_line test_insert
 {
   vars:
       "mapped" slist => { @{test.mapped} };
+      "mapped2" slist => { @{test.mapped2} };
 
   insert_lines:
       "$(mapped)";
+      "$(mapped2)";
 }
 
 #######################################################

--- a/tests/acceptance/01_vars/02_functions/maparray_mapdata.cf
+++ b/tests/acceptance/01_vars/02_functions/maparray_mapdata.cf
@@ -58,6 +58,7 @@ bundle agent test
       "maparray_$(X)_$(Y)" slist => maparray("$(spec$(Y))", "load$(X)");
       "mapdata_none_$(X)_$(Y)" data => mapdata("none", "$(spec$(Y))", "load$(X)");
       "mapdata_canonify_$(X)_$(Y)" data => mapdata("canonify", "$(spec$(Y))", "load$(X)");
+      "mapdata_canonify_eval_$(X)_$(Y)" data => mapdata("canonify", concat("$(spec$(Y))"), "load$(X)");
       "mapdata_json_$(X)_$(Y)" data => mapdata("json", "$(jsonspec$(Y))", "load$(X)");
 
       "bad1" data => mapdata("json", "", missingvar);

--- a/tests/acceptance/01_vars/02_functions/maparray_mapdata.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/maparray_mapdata.cf.expected.json
@@ -230,6 +230,98 @@
   "mapdata_canonify_6_4": [
     "xvalue_should_be_avalue"
   ],
+  "mapdata_canonify_eval_1_1": [
+    "key___0",
+    "key___1",
+    "key___2"
+  ],
+  "mapdata_canonify_eval_1_2": [
+    "key___0__value___1",
+    "key___1__value___2",
+    "key___2__value___3"
+  ],
+  "mapdata_canonify_eval_1_3": [
+    "key___0__key2_____this_k_1____value___1",
+    "key___1__key2_____this_k_1____value___2",
+    "key___2__key2_____this_k_1____value___3"
+  ],
+  "mapdata_canonify_eval_1_4": [
+    "xvalue_should_be_0value",
+    "xvalue_should_be_1value",
+    "xvalue_should_be_2value"
+  ],
+  "mapdata_canonify_eval_2_1": [
+    "key___0",
+    "key___1",
+    "key___2"
+  ],
+  "mapdata_canonify_eval_2_2": [
+    "key___0__value___eleme_nt1",
+    "key___1__value___element2",
+    "key___2__value___element3"
+  ],
+  "mapdata_canonify_eval_2_3": [
+    "key___0__key2_____this_k_1____value___eleme_nt1",
+    "key___1__key2_____this_k_1____value___element2",
+    "key___2__key2_____this_k_1____value___element3"
+  ],
+  "mapdata_canonify_eval_2_4": [
+    "xvalue_should_be_0value",
+    "xvalue_should_be_1value",
+    "xvalue_should_be_2value"
+  ],
+  "mapdata_canonify_eval_3_1": [
+    "key___x_x"
+  ],
+  "mapdata_canonify_eval_3_2": [
+    "key___x_x__value___y_y"
+  ],
+  "mapdata_canonify_eval_3_3": [
+    "key___x_x__key2_____this_k_1____value___y_y"
+  ],
+  "mapdata_canonify_eval_3_4": [
+    "xvalue_should_be_xxvalue"
+  ],
+  "mapdata_canonify_eval_4_1": [],
+  "mapdata_canonify_eval_4_2": [],
+  "mapdata_canonify_eval_4_3": [],
+  "mapdata_canonify_eval_4_4": [],
+  "mapdata_canonify_eval_5_1": [
+    "key___mykey",
+    "key___anotherkey",
+    "key___lastkey_"
+  ],
+  "mapdata_canonify_eval_5_2": [
+    "key___mykey__value___myvalue",
+    "key___anotherkey__value___anothervalue",
+    "key___lastkey___value___o_ne",
+    "key___lastkey___value___two",
+    "key___lastkey___value___three"
+  ],
+  "mapdata_canonify_eval_5_3": [
+    "key___mykey__key2_____this_k_1____value___myvalue",
+    "key___anotherkey__key2_____this_k_1____value___anothervalue",
+    "key___lastkey___key2_____this_k_1____value___o_ne",
+    "key___lastkey___key2_____this_k_1____value___two",
+    "key___lastkey___key2_____this_k_1____value___three"
+  ],
+  "mapdata_canonify_eval_5_4": [
+    "xvalue_should_be_myvalue",
+    "xvalue_should_be_anothervalue",
+    "xvalue_should_be_lastvalue"
+  ],
+  "mapdata_canonify_eval_6_1": [
+    "key___a"
+  ],
+  "mapdata_canonify_eval_6_2": [
+    "key___a__value___c"
+  ],
+  "mapdata_canonify_eval_6_3": [
+    "key___a__key2___b__value___c"
+  ],
+  "mapdata_canonify_eval_6_4": [
+    "xvalue_should_be_avalue"
+  ],
   "mapdata_json_1_1": [],
   "mapdata_json_1_2": [
     {

--- a/tests/acceptance/01_vars/02_functions/maplist.cf
+++ b/tests/acceptance/01_vars/02_functions/maplist.cf
@@ -22,6 +22,9 @@ bundle agent test
       "mapped_testlist" slist => maplist("value=$(this)", "testlist");
       "mapped_empty" slist => maplist("value=$(this)", empty);
       "mapped_inline" slist => maplist("value=$(this)", '["a", "b", "c"]');
+      "mapped_function_empty" slist => maplist(canonify($(this)), empty);
+      "mapped_function1" slist => maplist(format("%10.10s", $(this)), testlist);
+      "mapped_function2" slist => maplist(canonify($(this)), '["a or b", "b and c", "c+d", "e"]');
 }
 
 #######################################################

--- a/tests/acceptance/01_vars/02_functions/maplist.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/maplist.cf.expected.json
@@ -1,6 +1,20 @@
 {
   "empty": [],
   "mapped_empty": [],
+  "mapped_function1": [
+    "      zero",
+    "       two",
+    "   three's",
+    "four-fore:",
+    "      last"
+  ],
+  "mapped_function2": [
+    "a_or_b",
+    "b_and_c",
+    "c_d",
+    "e"
+  ],
+  "mapped_function_empty": [],
   "mapped_inline": [
     "value=a",
     "value=b",


### PR DESCRIPTION
Briefly, this allows the user to do `maplist(function($(this)), mylist)` (delay evaluation of function calls inside some special iteration functions).

Also covers `maparray()` and `mapdata()`.

I added some tests.

If this is acceptable, I can add a ChangeLog entry and docs.

@nickanderson this is a long-standing feature request, and users definitely expect it to work this way.