### PR TITLE
tar_portability_test.sh failing because of long paths.

### DIFF
--- a/tests/unit/tar_portability_test.sh
+++ b/tests/unit/tar_portability_test.sh
@@ -8,5 +8,6 @@ fi
 
 cd "$(dirname $0)/../.."
 
-tar --format=ustar -cf /dev/null *
+tar --exclude="tests/acceptance/workdir" --format=ustar -cf /dev/null *
+
 exit $?


### PR DESCRIPTION
Fixed by removing workdir in the shell script before running the test.