### PR TITLE
CFE-2455: Fix ghost cf-serverd process remnants started in the chroot

### DIFF
--- a/tests/acceptance/19_security/other_writeable/group_write.cf
+++ b/tests/acceptance/19_security/other_writeable/group_write.cf
@@ -50,7 +50,8 @@ bundle agent test
 {
 
   vars:
-    "agent_output" string => execresult("$(sys.cf_agent) -f $(G.testfile)", "noshell");
+    "agent_output" string => execresult("$(sys.cf_agent) -f $(G.testfile)", "noshell"),
+      if => fileexists("$(G.testfile)");
 
   classes:
     "security_exception"

--- a/tests/acceptance/19_security/other_writeable/other_write.cf
+++ b/tests/acceptance/19_security/other_writeable/other_write.cf
@@ -49,7 +49,9 @@ bundle agent test
 {
 
   vars:
-    "agent_output" string => execresult("$(sys.cf_agent) -f $(G.testfile)", "noshell");
+    "agent_output" string => execresult("$(sys.cf_agent) -f $(G.testfile)", "noshell"),
+      if => fileexists("$(G.testfile)");
+
 
   classes:
     "security_exception"


### PR DESCRIPTION
This execresult() is being executed 4-5 because of the different
evaluation passes. The first times, the .cf file doesn't even exist. As
a result, failsafe.cf is created and executed, which launches
cf-serverd.

The fix here is necessary after the CFE-2162 changes were introduced, to
avoid running the command before populating the variable.