### PR TITLE
INF-339: Alleviate network issues when testing on the Cloud.

### DIFF
--- a/tests/acceptance/16_cf-serverd/serial/network/004.cf
+++ b/tests/acceptance/16_cf-serverd/serial/network/004.cf
@@ -1,7 +1,7 @@
 #
 body common control
 {
-      inputs => { "../../default.cf.sub", "../../run_with_server.cf.sub" };
+      inputs => { "../../../default.cf.sub", "../../../run_with_server.cf.sub" };
       bundlesequence => { default("$(this.promise_filename)") };
       version => "1.0";
 }

--- a/tests/acceptance/16_cf-serverd/serial/network/004.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/network/004.cf.sub
@@ -6,7 +6,7 @@
 
 body common control
 {
-      inputs => { "../../default.cf.sub" };
+      inputs => { "../../../default.cf.sub" };
       bundlesequence  => { default("$(this.promise_filename)") };
       version => "1.0";
 }

--- a/tests/acceptance/16_cf-serverd/serial/network/lan_open.srv
+++ b/tests/acceptance/16_cf-serverd/serial/network/lan_open.srv
@@ -3,7 +3,7 @@
 body common control
 {
       bundlesequence => { "access_rules" };
-      inputs => { "../../default.cf.sub" };
+      inputs => { "../../../default.cf.sub" };
 
 }
 


### PR DESCRIPTION
This cf-serverd test (004.cf) uses the public interface, and as other
network tests have shown, fail on the cloud with "temporary name
resolution". So move it under "network" subdirectory, in order to be
skipped together with the rest of the network tests.