### PR TITLE
CFE-2474: Ensure that running failsafe many times in a row acts the sam

### DIFF
--- a/libpromises/failsafe.cf
+++ b/libpromises/failsafe.cf
@@ -34,6 +34,9 @@ body agent control
 {
       # Bootstrapping can't continue without keys
       abortclasses => { "no_ppkeys_ABORT_kept" };
+      # Make sure that running failsafe many times in a row does not
+      # change functionality
+      ifelapsed => "0";
 }
 
 ################################################################################


### PR DESCRIPTION
Previously the results were changing because of ifelapsed promise locking.