### PR TITLE
CFE-2439: failsafe policy should not copy VCS files

### DIFF
--- a/libpromises/failsafe.cf
+++ b/libpromises/failsafe.cf
@@ -115,6 +115,7 @@ bundle agent failsafe_cfe_internal_update
         handle => "failsafe_cfe_internal_bootstrap_update_files_sys_workdir_inputs_shortcut",
         copy_from => failsafe_scp("$(masterfiles_dir_remote)"),
         depth_search => failsafe_recurse("inf"),
+        file_select => failsafe_exclude_vcs_files,
         classes => failsafe_results("namespace", "inputdir_update");
 
     !policy_server::
@@ -123,6 +124,7 @@ bundle agent failsafe_cfe_internal_update
         handle => "failsafe_cfe_internal_bootstrap_update_files_sys_workdir_modules_shortcut",
         copy_from => failsafe_scp("modules"),
         depth_search => failsafe_recurse("inf"),
+        file_select => failsafe_exclude_vcs_files,
         classes => failsafe_results("namespace", "modulesdir_update");
 
     !windows.inputdir_update_error::
@@ -136,6 +138,7 @@ bundle agent failsafe_cfe_internal_update
         handle => "failsafe_cfe_internal_bootstrap_update_files_sys_workdir_inputs_not_windows",
         copy_from => failsafe_scp("$(sys.masterdir)"),
         depth_search => failsafe_recurse("inf"),
+        file_select => failsafe_exclude_vcs_files,
         classes => failsafe_results("namespace", "inputdir_update"),
         comment => "If we failed to fetch policy we try again using
                     the legacy default in case we are fetching policy
@@ -150,6 +153,7 @@ bundle agent failsafe_cfe_internal_update
         handle => "failsafe_cfe_internal_bootstrap_update_files_sys_workdir_inputs_windows",
         copy_from => failsafe_scp("/var/cfengine/masterfiles"),
         depth_search => failsafe_recurse("inf"),
+        file_select => failsafe_exclude_vcs_files,
         classes => failsafe_results("namespace", "inputdir_update"),
         comment => "If we failed to fetch policy we try again using
                     the legacy default in case we are fetching policy
@@ -163,6 +167,7 @@ bundle agent failsafe_cfe_internal_update
         handle => "failsafe_cfe_internal_bootstrap_update_files_sys_workdir_bin_twin_windows",
         copy_from => failsafe_cp("$(sys.workdir)\\bin\\."),
         depth_search => failsafe_recurse("1"),
+        file_select => failsafe_exclude_vcs_files,
         comment => "Make sure we maintain a clone of the binaries and
                     libraries for updating";
 
@@ -387,6 +392,12 @@ body depth_search failsafe_recurse(d)
 {
       depth => "$(d)";
       exclude_dirs => { "\.svn", "\.git" };
+}
+############################################
+body file_select failsafe_exclude_vcs_files
+{
+      leaf_name => { "\.git.*", "\.mailmap" };
+      file_result => "!leaf_name";
 }
 ############################################
 body service_method failsafe_bootstart


### PR DESCRIPTION
Failsafe policy does some file copies to update policy and modules. When doing
these file copies, it should avoid copying VCS files (like .gitignore files).