### PR TITLE
Add sys.user_data container for user starting agent.

### DIFF
--- a/examples/getuserinfo.cf
+++ b/examples/getuserinfo.cf
@@ -1,0 +1,43 @@
+#  Copyright (C) Cfengine AS
+
+#  This file is part of Cfengine 3 - written and maintained by Cfengine AS.
+
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License as published by the
+#  Free Software Foundation; version 3.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+# To the extent this program is licensed as part of the Enterprise
+# versions of Cfengine, the applicable Commercial Open Source License
+# (COSL) may apply to this file if you as a licensee so wish it. See
+# included file COSL.txt.
+
+#+begin_src cfengine3
+body common control
+{
+      bundlesequence => { "example" };
+}
+
+bundle agent example
+{
+    vars:
+      # note the results here will vary depending on your platform
+      "me" data => getuserinfo(); # the current user's info
+      "root" data => getuserinfo("root"); # the "root" user's info (usually UID 0)
+      "uid0" data => getuserinfo(0); # lookup user info for UID 0 (usually "root")
+
+      # sys.user_data has the information for the user that started the agent
+      "out" string => format("I am '%s', root shell is '%s', and the agent was started by %S", "$(me[description])", "$(root[shell])", "sys.user_data");
+
+  reports:
+      "$(out)";
+}
+#+end_src

--- a/libenv/sysinfo.h
+++ b/libenv/sysinfo.h
@@ -38,4 +38,6 @@ void GetInterfacesInfo(EvalContext *ctx);
 void GetNetworkingInfo(EvalContext *ctx);
 JsonElement* GetNetworkingConnections(EvalContext *ctx);
 
+JsonElement* GetUserInfo(const void *passwd);
+
 #endif

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -828,24 +828,12 @@ static FnCallResult FnCallGetUserInfo(ARG_UNUSED EvalContext *ctx, ARG_UNUSED co
         }
     }
 
-    if (pw == NULL)
+    JsonElement *result = GetUserInfo(pw);
+
+    if (result == NULL)
     {
         return FnFailure();
     }
-
-
-    JsonElement *result = JsonObjectCreate(10);
-    JsonObjectAppendString(result, "username", pw->pw_name);
-    JsonObjectAppendString(result, "description", pw->pw_gecos);
-    JsonObjectAppendString(result, "home_dir", pw->pw_dir);
-    JsonObjectAppendString(result, "shell", pw->pw_shell);
-    JsonObjectAppendInteger(result, "uid", pw->pw_uid);
-    JsonObjectAppendInteger(result, "gid", pw->pw_gid);
-    //JsonObjectAppendBool(result, "locked", IsAccountLocked(pw->pw_name, pw));
-    // TODO: password: { format: "hash", data: { ...GetPasswordHash()... } }
-    // TODO: group_primary: name of group
-    // TODO: groups_secondary: [ names of groups ]
-    // TODO: gids_secondary: [ gids of groups ]
 
     return (FnCallResult) { FNCALL_SUCCESS, (Rval) { result, RVAL_TYPE_CONTAINER } };
 }


### PR DESCRIPTION
@jimis @nickanderson @skreuzer as discussed in #2575 and #1413 

For the current execution's user info, you still have to `getuserinfo()` which implicitly looks at the current UID. Or you can use the current promise UID variable: `getuserinfo($(this.promiser_uid))`. That way, we avoid wasting time converting the passwd struct to a data container on every promise evaluation, since I think it will be needed very rarely in the context of general CFEngine execution.