### PR TITLE
ENT-2831: Fix bootstrap hanging on non-systemd platforms.

### DIFF
--- a/misc/systemd/cf-redis-server.service.in
+++ b/misc/systemd/cf-redis-server.service.in
@@ -9,8 +9,9 @@ Wants=cf-hub.service
 Before=cf-consumer.service
 
 [Service]
-Type=simple
+Type=forking
 ExecStart=@workdir@/bin/redis-server @workdir@/config/redis.conf
+PIDFile=@workdir@/redis-server.pid
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
redis-server needs to daemonize, otherwise non-systemd platforms will
hang when trying to launch it.

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>