### PR TITLE
ENT-2376 Prevent cf-serverd from being started without promises.cf on systemd hosts

### DIFF
--- a/misc/systemd/cf-execd.service.in
+++ b/misc/systemd/cf-execd.service.in
@@ -2,6 +2,7 @@
 Description=CFEngine Enterprise Execution Scheduler
 After=syslog.target
 ConditionPathExists=@workdir@/bin/cf-execd
+ConditionPathExists=@workdir@/inputs/promises.cf
 PartOf=cfengine3.service
 
 [Service]

--- a/misc/systemd/cf-serverd.service.in
+++ b/misc/systemd/cf-serverd.service.in
@@ -3,6 +3,8 @@ Description=CFEngine Enterprise file server
 After=syslog.target
 After=network.target
 ConditionPathExists=@workdir@/bin/cf-serverd
+ConditionPathExists=@workdir@/policy_server.dat
+ConditionPathExists=@workdir@/inputs/promises.cf
 PartOf=cfengine3.service
 
 [Service]


### PR DESCRIPTION
When the package is initially installed, the cf-serverd service unit is
enabled and started. This is before bootstrap happens, and thus before
there is a promises.cf in $(sys.inputdir). cf-serverd ends up running
from failsafe.cf and will never reload its config from promises.cf after
it appears in inputs. This change prevents cf-serverd from starting
until the host has been bootstrapped.