### PR TITLE
GenericAgentWriteHelp renamed and moved out of libpromises

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -469,7 +469,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 'h':
             {
                 Writer *w = FileWriter(stdout);
-                GenericAgentWriteHelp(w, "cf-agent", OPTIONS, HINTS, true);
+                WriterWriteHelp(w, "cf-agent", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
             exit(EXIT_SUCCESS);
@@ -550,7 +550,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         default:
             {
                 Writer *w = FileWriter(stdout);
-                GenericAgentWriteHelp(w, "cf-agent", OPTIONS, HINTS, true);
+                WriterWriteHelp(w, "cf-agent", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
             exit(EXIT_FAILURE);

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -268,7 +268,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 'h':
         {
             Writer *w = FileWriter(stdout);
-            GenericAgentWriteHelp(w, "cf-execd", OPTIONS, HINTS, true);
+            WriterWriteHelp(w, "cf-execd", OPTIONS, HINTS, true);
             FileWriterDetach(w);
         }
         exit(EXIT_SUCCESS);
@@ -303,7 +303,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         default:
         {
             Writer *w = FileWriter(stdout);
-            GenericAgentWriteHelp(w, "cf-execd", OPTIONS, HINTS, true);
+            WriterWriteHelp(w, "cf-execd", OPTIONS, HINTS, true);
             FileWriterDetach(w);
         }
         exit(EXIT_FAILURE);

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -291,7 +291,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 'h':
             {
                 Writer *w = FileWriter(stdout);
-                GenericAgentWriteHelp(w, "cf-key", OPTIONS, HINTS, false);
+                WriterWriteHelp(w, "cf-key", OPTIONS, HINTS, false);
                 FileWriterDetach(w);
             }
             exit(EXIT_SUCCESS);
@@ -326,7 +326,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         default:
             {
                 Writer *w = FileWriter(stdout);
-                GenericAgentWriteHelp(w, "cf-key", OPTIONS, HINTS, false);
+                WriterWriteHelp(w, "cf-key", OPTIONS, HINTS, false);
                 FileWriterDetach(w);
             }
             exit(EXIT_FAILURE);

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -190,7 +190,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 'h':
         {
             Writer *w = FileWriter(stdout);
-            GenericAgentWriteHelp(w, "cf-monitord", OPTIONS, HINTS, true);
+            WriterWriteHelp(w, "cf-monitord", OPTIONS, HINTS, true);
             FileWriterDetach(w);
         }
         exit(EXIT_SUCCESS);
@@ -225,7 +225,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         default:
         {
             Writer *w = FileWriter(stdout);
-            GenericAgentWriteHelp(w, "cf-monitord", OPTIONS, HINTS, true);
+            WriterWriteHelp(w, "cf-monitord", OPTIONS, HINTS, true);
             FileWriterDetach(w);
         }
         exit(EXIT_FAILURE);

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -393,7 +393,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 'h':
         {
             Writer *w = FileWriter(stdout);
-            GenericAgentWriteHelp(w, "cf-promises", OPTIONS, HINTS, true);
+            WriterWriteHelp(w, "cf-promises", OPTIONS, HINTS, true);
             FileWriterDetach(w);
         }
         exit(EXIT_SUCCESS);
@@ -460,7 +460,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
         default:
         {
             Writer *w = FileWriter(stdout);
-            GenericAgentWriteHelp(w, "cf-promises", OPTIONS, HINTS, true);
+            WriterWriteHelp(w, "cf-promises", OPTIONS, HINTS, true);
             FileWriterDetach(w);
         }
         exit(EXIT_FAILURE);

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -354,7 +354,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 'h':
         {
             Writer *w = FileWriter(stdout);
-            GenericAgentWriteHelp(w, "cf-runagent", OPTIONS, HINTS, true);
+            WriterWriteHelp(w, "cf-runagent", OPTIONS, HINTS, true);
             FileWriterDetach(w);
         }
         exit(EXIT_SUCCESS);
@@ -413,7 +413,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         default:
         {
             Writer *w = FileWriter(stdout);
-            GenericAgentWriteHelp(w, "cf-runagent", OPTIONS, HINTS, true);
+            WriterWriteHelp(w, "cf-runagent", OPTIONS, HINTS, true);
             FileWriterDetach(w);
         }
         exit(EXIT_FAILURE);

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -226,7 +226,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 'h':
             {
                 Writer *w = FileWriter(stdout);
-                GenericAgentWriteHelp(w, "cf-serverd", OPTIONS, HINTS, true);
+                WriterWriteHelp(w, "cf-serverd", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
             exit(EXIT_SUCCESS);
@@ -275,7 +275,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
         default:
             {
                 Writer *w = FileWriter(stdout);
-                GenericAgentWriteHelp(w, "cf-serverd", OPTIONS, HINTS, true);
+                WriterWriteHelp(w, "cf-serverd", OPTIONS, HINTS, true);
                 FileWriterDetach(w);
             }
             exit(EXIT_FAILURE);

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1597,39 +1597,6 @@ const char *GenericAgentResolveInputPath(const GenericAgentConfig *config, const
     return MapName(input_path);
 }
 
-void GenericAgentWriteHelp(Writer *w, const char *component, const struct option options[], const char *const hints[], bool accepts_file_argument)
-{
-    WriterWriteF(w, "Usage: %s [OPTION]...%s\n", component, accepts_file_argument ? " [FILE]" : "");
-
-    WriterWriteF(w, "\nOptions:\n");
-
-    for (int i = 0; options[i].name != NULL; i++)
-    {
-        char short_option[] = ", -*";
-        if (options[i].val < 128)
-        {
-            // Within ASCII range, means there is a short option.
-            short_option[3] = options[i].val;
-        }
-        else
-        {
-            // No short option.
-            short_option[0] = '\0';
-        }
-        if (options[i].has_arg)
-        {
-            WriterWriteF(w, "  --%-12s%s value - %s\n", options[i].name, short_option, hints[i]);
-        }
-        else
-        {
-            WriterWriteF(w, "  --%-12s%-10s - %s\n", options[i].name, short_option, hints[i]);
-        }
-    }
-
-    WriterWriteF(w, "\nWebsite: http://www.cfengine.com\n");
-    WriterWriteF(w, "This software is Copyright (C) 2008,2010-present CFEngine AS.\n");
-}
-
 ENTERPRISE_VOID_FUNC_1ARG_DEFINE_STUB(void, GenericAgentWriteVersion, Writer *, w)
 {
     WriterWriteF(w, "%s\n", NameVersion());

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -110,7 +110,6 @@ ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, GenericAgentAddEditionClasses, EvalConte
 void GenericAgentInitialize(EvalContext *ctx, GenericAgentConfig *config);
 void GenericAgentFinalize(EvalContext *ctx, GenericAgentConfig *config);
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, GenericAgentWriteVersion, Writer *, w);
-void GenericAgentWriteHelp(Writer *w, const char *comp, const struct option options[], const char *const hints[], bool accepts_file_argument);
 bool GenericAgentArePromisesValid(const GenericAgentConfig *config);
 time_t ReadTimestampFromPolicyValidatedFile(const GenericAgentConfig *config, const char *maybe_dirname);
 

--- a/libutils/writer.c
+++ b/libutils/writer.c
@@ -270,3 +270,36 @@ FILE *FileWriterDetach(Writer *writer)
     free(writer);
     return file;
 }
+
+void WriterWriteHelp(Writer *w, const char *component, const struct option options[], const char *const hints[], bool accepts_file_argument)
+{
+    WriterWriteF(w, "Usage: %s [OPTION]...%s\n", component, accepts_file_argument ? " [FILE]" : "");
+
+    WriterWriteF(w, "\nOptions:\n");
+
+    for (int i = 0; options[i].name != NULL; i++)
+    {
+        char short_option[] = ", -*";
+        if (options[i].val < 128)
+        {
+            // Within ASCII range, means there is a short option.
+            short_option[3] = options[i].val;
+        }
+        else
+        {
+            // No short option.
+            short_option[0] = '\0';
+        }
+        if (options[i].has_arg)
+        {
+            WriterWriteF(w, "  --%-12s%s value - %s\n", options[i].name, short_option, hints[i]);
+        }
+        else
+        {
+            WriterWriteF(w, "  --%-12s%-10s - %s\n", options[i].name, short_option, hints[i]);
+        }
+    }
+
+    WriterWriteF(w, "\nWebsite: http://www.cfengine.com\n");
+    WriterWriteF(w, "This software is Copyright (C) 2008,2010-present CFEngine AS.\n");
+}

--- a/libutils/writer.h
+++ b/libutils/writer.h
@@ -61,4 +61,6 @@ FILE *FileWriterDetach(Writer *writer);
 /* Commonly used on a FileWriter(stdout), ignoring return; so don't
  * try to warn on unused result ! */
 
+ void WriterWriteHelp(Writer *w, const char *comp, const struct option options[], const char *const hints[], bool accepts_file_argument);
+
 #endif

--- a/tests/acceptance/mock_package_manager.c
+++ b/tests/acceptance/mock_package_manager.c
@@ -444,7 +444,7 @@ int main(int argc, char *argv[])
         default:
             {
                 Writer *w = FileWriter(stdout);
-                GenericAgentWriteHelp(w, "mock-package-manager - pretend that you are managing packages!", OPTIONS, HINTS, false);
+                WriterWriteHelp(w, "mock-package-manager - pretend that you are managing packages!", OPTIONS, HINTS, false);
                 FileWriterDetach(w);
             }
             exit(EXIT_FAILURE);


### PR DESCRIPTION
Must be merged with: https://github.com/cfengine/nova/pull/989

I'm doing this since cf-net tool should not depend on libpromises, but should use this function, like the other binaries.