### PR TITLE
CFE-2506: Fix crash on Solaris when ps ucb variant is not available.

### DIFF
--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -1451,7 +1451,8 @@ static void LoadPlatformExtraTable(void)
     {
         Log(LOG_LEVEL_WARNING, "Command returned non-zero while gathering "
             "extra process information.");
-        ClearPlatformExtraTable();
+        // Make an empty map, in this case. The information can't be trusted.
+        StringMapClear(UCB_PS_MAP);
     }
 }
 


### PR DESCRIPTION
The correct approach when it is not available is to make the list of
ps information empty, not to delete it. This is already what happens
if the command can't be executed, but if executed with the wrong
arguments (ucb arguments for a non-ucb ps variant), the list would be
deleted.

Changelog: Title
Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>