### PR TITLE
ENT-2841: Ensure synchronous start and stop with systmectl

### DIFF
--- a/misc/systemd/cfengine3.service.in
+++ b/misc/systemd/cfengine3.service.in
@@ -8,6 +8,26 @@ WantedBy=multi-user.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/true
-ExecReload=/bin/true
 RemainAfterExit=yes
+
+# ENT-2841: Ensure synchronous start behavior
+ExecStart=/bin/systemctl start cf-serverd
+ExecStart=/bin/systemctl start cf-execd
+ExecStart=/bin/systemctl start cf-monitord
+ExecStart=/bin/systemctl start cf-postgres
+ExecStart=/bin/systemctl start cf-apache
+ExecStart=/bin/systemctl start cf-redis-server
+ExecStart=/bin/systemctl start cf-consumer
+ExecStart=/bin/systemctl start cf-runalerts
+ExecStart=/bin/systemctl start cf-hub
+
+# ENT-2841: Ensure synchronous stop behavior
+ExecStop=/bin/systemctl stop cf-serverd
+ExecStop=/bin/systemctl stop cf-execd
+ExecStop=/bin/systemctl stop cf-monitord
+ExecStop=/bin/systemctl stop cf-hub
+ExecStop=/bin/systemctl stop cf-runalerts
+ExecStop=/bin/systemctl stop cf-apache
+ExecStop=/bin/systemctl stop cf-consumer
+ExecStop=/bin/systemctl stop cf-redis-server
+ExecStop=/bin/systemctl stop cf-postgres


### PR DESCRIPTION
Changelog: Title

Historically stopping or starting the cfengine3 service has been a
synchronous process. This preserves that synchronous behaviour for the
umbrella service under systemd.