### PR TITLE
FreeBSD Build Tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1488,7 +1488,7 @@ dnl #####################################################################
 AC_MSG_CHECKING(for Xen cpuid-based HVM detection)
 if test x"$GCC" = "xyes"; then
     case $host_cpu in
-        i[[3456]]86*|x86_64*)
+        i[[3456]]86*|x86_64*|amd64)
             AC_DEFINE(XEN_CPUID_SUPPORT, 1, [Define if XEN cpuid-based HVM detection is available.])
             AC_MSG_RESULT(yes)
             ;;

--- a/misc/determine-version.py
+++ b/misc/determine-version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import print_function
 import re


### PR DESCRIPTION
On FreeBSD, python is installed via the ports system which by default will place binaries in /usr/local/bin. Switching the shebang line to `/usr/bin/env python` in misc/determine-version.py will make this script a bit more portable across different platforms

Add 'amd64' to the list of accepted x86 platforms when checking the value of $host_cpu. On FreeBSD this was preventing XEN_CPUID_SUPPORT from being defined which compiled out the functions to detect if the machine was running as a domU under Xen. This addresses the issues documented in CFE-2203