### PR TITLE
Unpluck unused bodies and bundles from test framework

### DIFF
--- a/tests/acceptance/Makefile.am
+++ b/tests/acceptance/Makefile.am
@@ -103,4 +103,4 @@ CLEANFILES = *.gcno *.gcda Makefile.testall
 
 pluck:
 	echo '### This is an auto-generated file, see Makefile.am and `make pluck` ###' > plucked.cf.sub
-	../../contrib/cf-locate/cf-locate -f -p '( if_|run_|warn_only|INI_section|kept_successful_command|edit_line|set_user_field|set_variable_values\(|edit_field|set_line_based|location|replace_with|_cp|_dcp|empty|shell|immediate|perms| m\b|recurse|tidy| all|classes_generic|results| start|always|^value|edit_field line|insert_lines|(link|copy)from| file_mustache| (file|dir)_(copy|tidy|sync|make|empty|link|hardlink))' ../../../masterfiles/lib/*.cf >> plucked.cf.sub
+	../../contrib/cf-locate/cf-locate -f -p '( if_|run_|warn_only|\skept_successful_command|append_if_no_line\(|regex_replace|set_user_field|set_variable_values\(|edit_field|set_line_based|location|replace_with|_cp|_dcp|empty|shell|immediate|body\s+perms\s+m\(|body\s+perms\s+g\(|body\s+perms\s+mode\(|perms\s+mog\(| m\b|recurse|tidy| all|classes_generic|classes\s+results\(| start|always|^value|edit_field line|insert_lines|(link|copy)from| file_mustache| (file|dir)_(copy|tidy|sync|make\(|empty|link|hardlink))' ../../../masterfiles/lib/*.cf >> plucked.cf.sub

--- a/tests/acceptance/plucked.cf.sub
+++ b/tests/acceptance/plucked.cf.sub
@@ -319,19 +319,6 @@ body classes kept_successful_command
       kept_returncodes => { "0" };
 }
 
-bundle edit_line insert_before_if_no_line(before, string)
-# @brief Insert `string` before `before` if `string` is not found in the file
-# @param before The regular expression matching the line which `string` will be
-# inserted before
-# @param string The string to be prepended
-#
-{
-  insert_lines:
-      "$(string)"
-        location => before($(before)),
-        comment => "Prepend a line to the file if it doesn't already exist";
-}
-
 bundle edit_line insert_lines(lines)
 # @brief Append `lines` if they don't exist in the file
 # @param lines The lines to be appended
@@ -345,108 +332,6 @@ bundle edit_line insert_lines(lines)
       comment => "Append lines if they don't exist";
 }
 
-bundle edit_line insert_file(templatefile)
-# @brief Reads the lines from `templatefile` and inserts those into the
-# file being edited.
-# @param templatefile The name of the file from which to import lines.
-{
-  insert_lines:
-
-      "$(templatefile)"
-      comment => "Insert the template file into the file being edited",
-      insert_type => "file";
-}
-
-bundle edit_line comment_lines_matching(regex,comment)
-# @brief Comment lines in the file that matching an [anchored] regex
-# @param regex Anchored regex that the entire line needs to match
-# @param comment A string that is prepended to matching lines
-{
-  replace_patterns:
-
-      "^($(regex))$"
-
-      replace_with => comment("$(comment)"),
-      comment => "Search and replace string";
-}
-
-bundle edit_line uncomment_lines_matching(regex,comment)
-# @brief Uncomment lines of the file where the regex matches
-# the entire text after the comment string
-# @param regex The regex that lines need to match after `comment`
-# @param comment The prefix of the line that is removed
-{
-  replace_patterns:
-
-      "^$(comment)\s?($(regex))$"
-
-      replace_with => uncomment,
-      comment => "Uncomment lines matching a regular expression";
-}
-
-bundle edit_line comment_lines_containing(regex,comment)
-# @brief Comment lines of the file matching a regex
-# @param regex A regex that a part of the line needs to match
-# @param comment A string that is prepended to matching lines
-{
-  replace_patterns:
-
-      "^((?!$(comment)).*$(regex).*)$"
-
-      replace_with => comment("$(comment)"),
-      comment => "Comment out lines in a file";
-}
-
-bundle edit_line uncomment_lines_containing(regex,comment)
-# @brief Uncomment lines of the file where the regex matches
-# parts of the text after the comment string
-# @param regex The regex that lines need to match after `comment`
-# @param comment The prefix of the line that is removed
-{
-  replace_patterns:
-
-      "^$(comment)\s?(.*$(regex).*)$"
-
-      replace_with => uncomment,
-      comment => "Uncomment a line containing a fragment";
-}
-
-bundle edit_line delete_lines_matching(regex)
-# @brief Delete lines matching a regular expression
-# @param regex The regular expression that the lines need to match
-{
-  delete_lines:
-
-      "$(regex)"
-
-      comment => "Delete lines matching regular expressions";
-}
-
-bundle edit_line warn_lines_matching(regex)
-# @brief Warn about lines matching a regular expression
-# @param regex The regular expression that the lines need to match
-{
-  delete_lines:
-
-      "$(regex)"
-
-      comment => "Warn about lines in a file",
-      action => warn_only;
-}
-
-bundle edit_line prepend_if_no_line(string)
-# @brief Prepend `string` if it doesn't exist in the file
-# @param string The string to be prepended
-#
-# **See also:** [`insert_lines`][insert_lines] in
-# [`edit_line`][bundle edit_line]
-{
-  insert_lines:
-      "$(string)"
-      location => start,
-      comment => "Prepend a line to the file if it doesn't already exist";
-}
-
 bundle edit_line append_if_no_line(str)
 # @ignore
 # This duplicates the insert_lines bundle
@@ -456,72 +341,6 @@ bundle edit_line append_if_no_line(str)
       "$(str)"
 
       comment => "Append a line to the file if it doesn't already exist";
-}
-
-bundle edit_line append_if_no_lines(list)
-# @ignore
-# This duplicates the insert_lines bundle
-{
-  insert_lines:
-
-      "$(list)"
-
-      comment => "Append lines to the file if they don't already exist";
-}
-
-bundle edit_line replace_line_end(start,end)
-# @brief Give lines starting with `start` the ending given in `end`
-#
-# Whitespaces will be left unmodified. For example,
-# `replace_line_end("ftp", "2121/tcp")` would replace
-#
-# `"ftp             21/tcp"`
-#
-# with
-#
-# `"ftp             2121/tcp"`
-#
-# @param start The string lines have to start with
-# @param end The string lines should end with
-{
-  field_edits:
-
-      "\s*$(start)\s.*"
-      comment => "Replace lines with $(this.start) and $(this.end)",
-      edit_field => line("(^|\s)$(start)\s*", "2", "$(end)","set");
-}
-
-bundle edit_line append_to_line_end(start,end)
-# @brief Append `end` to any lines beginning with `start`
-#
-# `end` will be appended to all lines starting with `start` and not
-# already ending with `end`.  Whitespaces will be left unmodified.
-#
-# For example, `append_to_line_end("kernel", "vga=791")` would replace
-# `kernel /boot/vmlinuz root=/dev/sda7`
-#
-# with
-#
-# `kernel /boot/vmlinuz root=/dev/sda7 vga=791`
-#
-# **WARNING**: Be careful not to have multiple promises matching the same line, which would result in the line growing indefinitely.
-#
-# @param start pattern to match lines of interest
-# @param end string to append to matched lines
-#
-# **Example:**
-#
-# ```cf3
-#  files:
-#      "/tmp/boot-options" edit_line => append_to_line_end("kernel", "vga=791");
-# ```
-#
-{
-  field_edits:
-
-      "\s*$(start)\s.*"
-      comment => "Append lines with $(this.start) and $(this.end)",
-      edit_field => line("(^|\s)$(start)\s*", "2", "$(end)","append");
 }
 
 bundle edit_line regex_replace(find,replace)
@@ -535,242 +354,6 @@ bundle edit_line regex_replace(find,replace)
       "$(find)"
       replace_with => value("$(replace)"),
       comment => "Search and replace string";
-}
-
-bundle edit_line resolvconf(search,list)
-# @brief Adds search domains and name servers to the system
-# resolver configuration.
-#
-# Use this bundle to modify `resolv.conf`. Existing entries for
-# `search` and `nameserver` are replaced.
-#
-# @param search The search domains with space
-# @param list An slist of nameserver addresses
-{
-  delete_lines:
-
-      "search.*"     comment => "Reset search lines from resolver";
-      "nameserver.*" comment => "Reset nameservers in resolver";
-
-  insert_lines:
-
-      "search $(search)"    comment => "Add search domains to resolver";
-      "nameserver $(list)"  comment => "Add name servers to resolver";
-}
-
-bundle edit_line resolvconf_o(search,list,options)
-# @brief Adds search domains, name servers and options to the system
-# resolver configuration.
-#
-# Use this bundle to modify `resolv.conf`. Existing entries for
-# `search`, `nameserver` and `options` are replaced.
-#
-# @param search The search domains with space
-# @param list An slist of nameserver addresses
-# @param options is an slist of variables to modify the resolver
-
-{
-  delete_lines:
-
-      "search.*"     comment => "Reset search lines from resolver";
-      "nameserver.*" comment => "Reset nameservers in resolver";
-      "options.*"    comment => "Reset options in resolver";
-
-  insert_lines:
-
-      "search $(search)"    comment => "Add search domains to resolver";
-      "nameserver $(list)"  comment => "Add name servers to resolver";
-      "options $(options)"  comment => "Add options to resolver";
-}
-
-bundle edit_line manage_variable_values_ini(tab, sectionName)
-# @brief Sets the RHS of configuration items in the file of the form
-# `LHS=RHS`
-#
-# If the line is commented out with `#`, it gets uncommented first.
-# Adds a new line if none exists.
-# Removes any variable value pairs not defined for the ini section.
-#
-# @param tab An associative array containing `tab[sectionName][LHS]="RHS"`.
-# The value is not changed when the `RHS` is "dontchange"
-# @param sectionName The section in the file within which values should be
-# modified
-#
-# **See also:** `set_variable_values_ini()`
-{
-  vars:
-      "index" slist => getindices("$(tab)[$(sectionName)]");
-
-      # Be careful if the index string contains funny chars
-      "cindex[$(index)]" string => canonify("$(index)");
-
-  classes:
-      "edit_$(cindex[$(index)])"     not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange"),
-      comment => "Create conditions to make changes";
-
-  field_edits:
-
-      # If the line is there, but commented out, first uncomment it
-      "#+\s*$(index)\s*=.*"
-      select_region => INI_section("$(sectionName)"),
-      edit_field => col("=","1","$(index)","set"),
-      ifvarclass => "edit_$(cindex[$(index)])";
-
-      # match a line starting like the key something
-      "$(index)\s*=.*"
-      edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
-      select_region => INI_section("$(sectionName)"),
-      classes => results("bundle", "manage_variable_values_ini_not_$(cindex[$(index)])"),
-      ifvarclass => "edit_$(cindex[$(index)])";
-
-  delete_lines:
-      ".*"
-      select_region => INI_section("$(sectionName)"),
-      comment       => "Remove all entries in the region so there are no extra entries";
-
-  insert_lines:
-      "[$(sectionName)]"
-      location => start,
-      comment => "Insert lines";
-
-      "$(index)=$($(tab)[$(sectionName)][$(index)])"
-      select_region => INI_section("$(sectionName)"),
-        ifvarclass => "!(manage_variable_values_ini_not_$(cindex[$(index)])_kept|manage_variable_values_ini_not_$(cindex[$(index)])_repaired).edit_$(cindex[$(index)])";
-
-}
-
-bundle edit_line set_variable_values_ini(tab, sectionName)
-# @brief Sets the RHS of configuration items in the file of the form
-# `LHS=RHS`
-#
-# If the line is commented out with `#`, it gets uncommented first.
-# Adds a new line if none exists.
-#
-# @param tab An associative array containing `tab[sectionName][LHS]="RHS"`.
-# The value is not changed when the `RHS` is "dontchange"
-# @param sectionName The section in the file within which values should be
-# modified
-#
-# **See also:** `manage_variable_values_ini()`
-{
-  vars:
-      "index" slist => getindices("$(tab)[$(sectionName)]");
-
-      # Be careful if the index string contains funny chars
-      "cindex[$(index)]" string => canonify("$(index)");
-
-  classes:
-      "edit_$(cindex[$(index)])"     not => strcmp("$($(tab)[$(sectionName)][$(index)])","dontchange"),
-      comment => "Create conditions to make changes";
-
-  field_edits:
-
-      # If the line is there, but commented out, first uncomment it
-      "#+\s*$(index)\s*=.*"
-      select_region => INI_section("$(sectionName)"),
-      edit_field => col("=","1","$(index)","set"),
-      ifvarclass => "edit_$(cindex[$(index)])";
-
-      # match a line starting like the key something
-      "$(index)\s*=.*"
-      edit_field => col("=","2","$($(tab)[$(sectionName)][$(index)])","set"),
-      select_region => INI_section("$(sectionName)"),
-      classes => results("bundle", "set_variable_values_ini_not_$(cindex[$(index)])"),
-      ifvarclass => "edit_$(cindex[$(index)])";
-
-  insert_lines:
-      "[$(sectionName)]"
-      location => start,
-      comment => "Insert lines";
-
-      "$(index)=$($(tab)[$(sectionName)][$(index)])"
-      select_region => INI_section("$(sectionName)"),
-        ifvarclass => "!(set_variable_values_ini_not_$(cindex[$(index)])_kept|set_variable_values_ini_not_$(cindex[$(index)])_repaired).edit_$(cindex[$(index)])";
-
-}
-
-bundle edit_line insert_ini_section(name, config)
-# @brief Inserts a INI section with content
-#
-# ```
-# # given an array "barray"
-# files:
-#     "myfile.ini" edit_line => insert_innit_section("foo", "barray");
-# ```
-#
-# Inserts a section in an INI file with the given configuration
-# key-values from the array `config`.
-#
-# @param name the name of the INI section
-# @param config The fully-qualified name of an associative array containing `v[LHS]="rhs"`
-{
-  vars:
-      "k" slist => getindices($(config));
-
-  insert_lines:
-      "[$(name)]"
-      location => start,
-      comment => "Prepend a line to the file if it doesn't already exist";
-
-      "$(k)=$($(config)[$(k)])";
-}
-
-bundle edit_line set_quoted_values(v)
-# @brief Sets the RHS of variables in shell-like files of the form:
-#
-# ```
-#      LHS="RHS"
-# ```
-#
-# Adds a new line if no LHS exists, and replaces RHS values if one does exist.
-# If the line is commented out with #, it gets uncommented first.
-#
-# @param v The fully-qualified name of an associative array containing `v[LHS]="rhs"`
-#
-# **Example:**
-#
-# ```cf3
-#     vars:
-#        "stuff[lhs-1]" string => "rhs1";
-#        "stuff[lhs-2]" string => "rhs2";
-#
-#     files:
-#        "myfile"
-#          edit_line => set_quoted_values(stuff)
-# ```
-#
-# **See also:** `set_variable_values()`
-{
-  meta:
-      "tags"
-      slist =>
-      {
-        "deprecated=3.6.0",
-        "deprecation-reason=Generic reimplementation",
-        "replaced-by=set_line_based"
-      };
-
-  vars:
-      "index" slist => getindices("$(v)");
-      # Be careful if the index string contains funny chars
-
-      "cindex[$(index)]" string => canonify("$(index)");
-
-  field_edits:
-      # If the line is there, but commented out, first uncomment it
-      "#+\s*$(index)\s*=.*"
-      edit_field => col("=","1","$(index)","set");
-
-      # match a line starting like the key = something
-      "\s*$(index)\s*=.*"
-      edit_field => col("=","2",'"$($(v)[$(index)])"',"set"),
-      classes    => results("bundle", "$(cindex[$(index)])_in_file"),
-      comment    => "Match a line starting like key = something";
-
-  insert_lines:
-      '$(index)="$($(v)[$(index)])"'
-      comment    => "Insert a variable definition",
-        ifvarclass => "!($(cindex[$(index)])_in_file_kept|$(cindex[$(index)])_in_file_repaired)";
 }
 
 bundle edit_line set_variable_values(v)
@@ -833,91 +416,6 @@ bundle edit_line set_variable_values(v)
 
       comment => "Insert a variable definition",
         ifvarclass => "!($(cv)_$(cindex[$(index)])_in_file_kept|$(cv)_$(cindex[$(index)])_in_file_repaired)";
-}
-
-bundle edit_line set_config_values(v)
-# @brief Sets the RHS of configuration items in the file of the form:
-#
-# ```
-#   LHS RHS
-# ```
-#
-# If the line is commented out with `#`, it gets uncommented first.
-#
-# Adds a new line if none exists.
-#
-# @param v The fully-qualified name of an associative array containing `v[LHS]="rhs"`
-{
-  meta:
-      "tags"
-      slist =>
-      {
-        "deprecated=3.6.0",
-        "deprecation-reason=Generic reimplementation",
-        "replaced-by=set_line_based"
-      };
-
-  vars:
-      "index" slist => getindices("$(v)");
-
-      # Be careful if the index string contains funny chars
-      "cindex[$(index)]" string => canonify("$(index)");
-
-      # Escape the value (had a problem with special characters and regex's)
-      "ev[$(index)]" string => escape("$($(v)[$(index)])");
-
-      # Do we have more than one line commented out?
-      "index_comment_matches_$(cindex[$(index)])"
-        int => countlinesmatching("^\s*#\s*($(index)\s+.*|$(index))$","$(edit.filename)");
-
-
-  classes:
-      # Check to see if this line exists
-      "line_exists_$(cindex[$(index)])"
-        expression => regline("^\s*($(index)\s.*|$(index))$","$(edit.filename)"),
-        scope => "bundle";
-
-      # if there's more than one comment, just add new (don't know who to use)
-      "multiple_comments_$(cindex[$(index)])"
-        expression => isgreaterthan("$(index_comment_matches_$(cindex[$(index)]))","1"),
-        scope => "bundle";
-
-  replace_patterns:
-      # If the line is commented out, uncomment and replace with
-      # the correct value
-      "^\s*#\s*($(index)\s+.*|$(index))$"
-        comment => "If we find a single commented entry we can uncomment it to
-                    keep the settings near any inline documentation. If there
-                    are multiple comments, then we don't try to replace them and
-                    instead will later append the new value after the first
-                    commented occurrence of $(index).",
-        handle => "set_config_values_replace_commented_line",
-        replace_with => value("$(index) $($(v)[$(index)])"),
-          ifvarclass => "!line_exists_$(cindex[$(index)]).!replace_attempted_$(cindex[$(index)])_reached.!multiple_comments_$(cindex[$(index)])",
-             classes => results("bundle", "uncommented_$(cindex[$(index)])");
-
-      # If the line is there with the wrong value, replace with
-      # the correct value
-      "^\s*($(index)\s+(?!$(ev[$(index)])$).*|$(index))$"
-           comment => "Correct the value $(index)",
-      replace_with => value("$(index) $($(v)[$(index)])"),
-           classes => results("bundle", "replace_attempted_$(cindex[$(index)])");
-
-  insert_lines:
-      # If the line doesn't exist, or there is more than one occurrence
-      # of the LHS commented out, insert a new line and try to place it
-      # after the commented LHS (keep new line with old comments)
-      "$(index) $($(v)[$(index)])"
-         comment => "Insert the value, marker exists $(index)",
-        location => after("^\s*#\s*($(index)\s+.*|$(index))$"),
-      ifvarclass => "replace_attempted_$(cindex[$(index)])_reached.multiple_comments_$(cindex[$(index)])";
-
-      # If the line doesn't exist and there are no occurrences
-      # of the LHS commented out, insert a new line at the eof
-      "$(index) $($(v)[$(index)])"
-         comment => "Insert the value, marker doesn't exist $(index)",
-      ifvarclass => "replace_attempted_$(cindex[$(index)])_reached.!multiple_comments_$(cindex[$(index)])";
-
 }
 
 bundle edit_line set_line_based(v, sep, bp, kp, cp)
@@ -1030,156 +528,6 @@ bundle edit_line set_line_based(v, sep, bp, kp, cp)
       "$(this.bundle): Line for '$(i)' does not exist" ifvarclass => "!exists_$(ci[$(i)])";
 }
 
-bundle edit_line set_config_values_matching(v,pat)
-# @brief Sets the RHS of configuration items in the file of the form
-#
-# ```
-#   LHS RHS
-# ```
-#
-# If the line is commented out with `#`, it gets uncommented first.
-# Adds a new line if none exists.
-#
-# @param v the fully-qualified name of an associative array containing v[LHS]="rhs"
-# @param pat Only elements of `v` that match the regex `pat` are use
-{
-  meta:
-      "tags"
-      slist =>
-      {
-        "deprecated=3.6.0",
-        "deprecation-reason=Generic reimplementation",
-        "replaced-by=set_line_based"
-      };
-
-  vars:
-      "allparams" slist => getindices("$(v)");
-      "index"     slist => grep("$(pat)", "allparams");
-
-      # Be careful if the index string contains funny chars
-      "cindex[$(index)]" string => canonify("$(index)");
-
-  replace_patterns:
-      # If the line is there, maybe commented out, uncomment and replace with
-      # the correct value
-      "^\s*($(index)\s+(?!$($(v)[$(index)])).*|# ?$(index)\s+.*)$"
-      comment => "Correct the value",
-      replace_with => value("$(index) $($(v)[$(index)])"),
-      classes => results("bundle", "replace_attempted_$(cindex[$(index)])");
-
-  insert_lines:
-      "$(index) $($(v)[$(index)])"
-      ifvarclass => "replace_attempted_$(cindex[$(index)])_reached";
-
-}
-
-bundle edit_line maintain_key_values(v,sep)
-# @ignore
-# @brief Sets the RHS of configuration items with an giving separator
-#
-# Contributed by David Lee
-{
-  meta:
-      "tags"
-      slist =>
-      {
-        "deprecated=3.6.0",
-        "deprecation-reason=Generic reimplementation",
-        "replaced-by=set_line_based"
-      };
-
-  vars:
-      "index" slist => getindices("$(v)");
-      # Be careful if the index string contains funny chars
-      "cindex[$(index)]" string => canonify("$(index)");
-      # Matching pattern for line (basically key-and-separator)
-      "keypat[$(index)]" string => "\s*$(index)\s*$(sep)\s*";
-
-      # Values may contain regexps. Escape them for replace_pattern matching.
-      "ve[$(index)]" string => escape("$($(v)[$(index)])");
-
-  classes:
-      "$(cindex[$(index)])_key_in_file"
-      comment => "Dynamic Class created if patterns matching",
-      expression => regline("^$(keypat[$(index)]).*", "$(edit.filename)");
-
-  replace_patterns:
-      # For convergence need to use negative lookahead on value:
-      # "key sep (?!value).*"
-      "^($(keypat[$(index)]))(?!$(ve[$(index)])$).*"
-      comment => "Replace definition of $(index)",
-      replace_with => value("$(match.1)$($(v)[$(index)])");
-
-  insert_lines:
-      "$(index)$(sep)$($(v)[$(index)])"
-      comment => "Insert definition of $(index)",
-      ifvarclass => "!$(cindex[$(index)])_key_in_file";
-}
-
-bundle edit_line append_users_starting(v)
-# @brief For adding to `/etc/passwd` or `etc/shadow`
-# @param v An array `v[username] string => "line..."`
-#
-# **Note:** To manage local users with CFEngine 3.6 and later,
-# consider making `users` promises instead of modifying system files.
-{
-  vars:
-
-      "index"        slist => getindices("$(v)");
-
-  classes:
-
-      "add_$(index)"     not => userexists("$(index)"),
-      comment => "Class created if user does not exist";
-
-  insert_lines:
-
-      "$($(v)[$(index)])"
-
-      comment => "Append users into a password file format",
-      ifvarclass => "add_$(index)";
-}
-
-bundle edit_line append_groups_starting(v)
-# @brief For adding groups to `/etc/group`
-# @param v An array `v[groupname] string => "line..."`
-#
-# **Note:** To manage local users with CFEngine 3.6 and later,
-# consider making `users` promises instead of modifying system files.
-{
-  vars:
-
-      "index"        slist => getindices("$(v)");
-
-  classes:
-
-      "add_$(index)"     not => groupexists("$(index)"),
-      comment => "Class created if group does not exist";
-
-  insert_lines:
-
-      "$($(v)[$(index)])"
-
-      comment => "Append users into a group file format",
-      ifvarclass => "add_$(index)";
-
-}
-
-bundle edit_line set_colon_field(key,field,val)
-# @brief Set the value of field number `field` of the line whose
-# first field is `key` to the value `val`, in a colon-separated file.
-# @param key The value the first field has to match
-# @param field The field to be modified
-# @param val The new value of `field`
-{
-  field_edits:
-
-      "$(key):.*"
-
-      comment => "Edit a colon-separated file, using the first field as a key",
-      edit_field => col(":","$(field)","$(val)","set");
-}
-
 bundle edit_line set_user_field(user,field,val)
 # @brief Set the value of field number "field" in a `:-field`
 # formatted file like `/etc/passwd`
@@ -1196,109 +544,6 @@ bundle edit_line set_user_field(user,field,val)
 
       comment => "Edit a user attribute in the password file",
       edit_field => col(":","$(field)","$(val)","set");
-}
-
-bundle edit_line append_user_field(group,field,allusers)
-# @brief For adding users to to a file like `/etc/group`
-# at field position `field`, comma separated subfields
-# @param group The group to be modified
-# @param field The field where users should be added
-# @param allusers The list of users to add to `field`
-#
-# **Note:** To manage local users with CFEngine 3.6 and later,
-# consider making `users` promises instead of modifying system files.
-{
-  vars:
-
-      "val" slist => { @(allusers) };
-
-  field_edits:
-
-      "$(group):.*"
-
-      comment => "Append users into a password file format",
-      edit_field => col(":","$(field)","$(val)","alphanum");
-}
-
-bundle edit_line expand_template(templatefile)
-# @brief Read in the named text file and expand `$(var)` inside the file
-# @param templatefile The name of the file
-{
-  insert_lines:
-
-      "$(templatefile)"
-
-      insert_type => "file",
-      comment => "Expand variables in the template file",
-      expand_scalars => "true";
-}
-
-bundle edit_line replace_or_add(pattern,line)
-# @brief Replace a pattern in a file with a single line.
-#
-# If the pattern is not found, add the line to the file.
-#
-# @param pattern The pattern that should be replaced
-# The pattern must match the whole line (it is automatically
-# anchored to the start and end of the line) to avoid
-# ambiguity.
-# @param line The line with which to replace matches of `pattern`
-{
-  vars:
-      "cline" string => canonify("$(line)");
-      "eline" string => escape("$(line)");
-
-  replace_patterns:
-      "^(?!$(eline)$)$(pattern)$"
-      comment => "Replace a pattern here",
-      replace_with => value("$(line)"),
-      classes => results("bundle", "replace_$(cline)");
-
-  insert_lines:
-      "$(line)"
-      ifvarclass => "replace_$(cline)_reached";
-}
-
-bundle edit_line converge(marker, lines)
-# @brief Converge `lines` marked with `marker`
-#
-# Any content marked with `marker` is removed, then `lines` are
-# inserted.  Every `line` should contain `marker`.
-#
-# @param marker The marker (not a regular expression; will be escaped)
-# @param lines The lines to insert; all must contain `marker`
-{
-  vars:
-      "regex" string => escape($(marker));
-
-  delete_lines:
-      "$(regex)" comment => "Delete lines matching the marker";
-  insert_lines:
-      "$(lines)" comment => "Insert the given lines";
-}
-
-bundle edit_line fstab_option_editor(method, mount, option)
-# @brief Add or remove `/etc/fstab` options for a mount
-#
-# This bundle edits the options field of a mount.  The `method` is a
-# `field_operation` which can be `append`, `prepend`, `set`, `delete`,
-# or `alphanum`.  The option is OS-specific.
-#
-# @param method `field_operation` to apply
-# @param mount the mount point
-# @param option the option to add or remove
-#
-# **Example:**
-#
-# ```cf3
-#  files:
-#      "/etc/fstab" edit_line => fstab_option_editor("delete", "/", "acl");
-#      "/etc/fstab" edit_line => fstab_option_editor("append", "/", "acl");
-# ```
-{
-   field_edits:
-      "(?!#)\S+\s+$(mount)\s.+"
-      edit_field => fstab_options($(option), $(method));
 }
 
 body edit_field fstab_options(newval, method)
@@ -1378,14 +623,6 @@ body replace_with value(x)
 {
       replace_value => "$(x)";
       occurrences => "all";
-}
-
-body select_region INI_section(x)
-# @brief Restrict the `edit_line` promise to the lines in section `[x]`
-# @param x The name of the section in an INI-like configuration file
-{
-      select_start => "\[$(x)\]\s*";
-      select_end => "\[.*\]\s*";
 }
 
 body edit_defaults empty
@@ -1468,6 +705,8 @@ body copy_from remote_dcp(from,server)
 #
 # @param from The location of the file on the remote server
 # @param server The hostname or IP of the server from which to download
+#
+# **See Also:** `local_dcp()`
 {
       servers     => { "$(server)" };
       source      => "$(from)";
@@ -1475,17 +714,42 @@ body copy_from remote_dcp(from,server)
 }
 
 body copy_from local_cp(from)
-# @brief Copy a local file.
-#
+# @brief Copy a file if the modification time or creation time of the source
+# file is newer (the default comparison mechanism).
 # @param from The path to the source file.
+#
+# **Example:**
+#
+# ```cf3
+# bundle agent example
+# {
+#   files:
+#       "/tmp/file.bak"
+#         copy_from => local_cp("/tmp/file");
+# }
+# ```
+#
+# **See Also:** `local_dcp()`
 {
       source      => "$(from)";
 }
 
 body copy_from local_dcp(from)
-# @brief Copy a local file if it is different from the existing copy.
-#
+# @brief Copy a local file if the hash on the source file differs.
 # @param from The path to the source file.
+#
+# **Example:**
+#
+# ```cf3
+# bundle agent example
+# {
+#   files:
+#       "/tmp/file.bak"
+#       copy_from => local_dcp("/tmp/file");
+# }
+# ```
+#
+# **See Also:** `local_cp()`, `remote_dcp()`
 {
       source      => "$(from)";
       compare     => "digest";
@@ -1521,19 +785,52 @@ body copy_from backup_local_cp(from)
 }
 
 body copy_from seed_cp(from)
-# @brief Copy a local file if the file does not already exist, i.e. seed the placement
-#
+# @brief Copy a local file if the file does not already exist, i.e. seed the
+# placement
 # @param from The path to the source file.
+#
+# **Example:**
+#
+# ```cf3
+# bundle agent home_dir_init
+# {
+#   files:
+#       "/home/mark.burgess/."
+#       copy_from => seed_cp("/etc/skel"),
+#       depth_search => recurse(inf),
+#       file_select => all,
+#       comment => "We want to be sure that the home directory has files that are
+#                   present in the skeleton.";
+# }
+# ```
 {
       source      => "$(from)";
       compare     => "exists";
 }
 
 body copy_from sync_cp(from,server)
-# @brief Download a file if the local copy does not already exist, i.e. seed the placement
+# @brief Synchronize a file with a remote server.
+#
+# * If the file does not exist on the remote server then it should be purged.
+# * Allow types to change (directories to files and vice versa).
+# * The mode of the remote file should be preserved.
+# * Files are compared using the default comparison (mtime or ctime).
 #
 # @param from The location of the file on the remote server
 # @param server The hostname or IP of the server from which to download
+#
+# **Example**:
+#
+# ```cf3
+# files:
+#   "/tmp/masterfiles/."
+#     copy_from => sync_cp( "/var/cfengine/masterfiles", $(sys.policy_server) ),
+#     depth_search => recurse(inf),
+#     file_select => all,
+#     comment => "Mirror masterfiles from the hub to a temporary directory";
+# ```
+#
+# **See Also:** `dir_sync()`, `copyfrom_sync()`
 {
       servers     => { "$(server)" };
       source      => "$(from)";
@@ -1578,15 +875,6 @@ body perms m(mode)
       mode   => "$(mode)";
 }
 
-body perms mo(mode,user)
-# @brief Set the file's mode and owners
-# @param mode The new mode
-# @param user The username of the new owner
-{
-      owners => { "$(user)" };
-      mode   => "$(mode)";
-}
-
 body perms mog(mode,user,group)
 # @brief Set the file's mode, owner and group
 # @param mode The new mode
@@ -1596,46 +884,6 @@ body perms mog(mode,user,group)
       owners => { "$(user)" };
       groups => { "$(group)" };
       mode   => "$(mode)";
-}
-
-body perms og(u,g)
-# @brief Set the file's owner and group
-# @param u The username of the new owner
-# @param g The group name
-{
-      owners => { "$(u)" };
-      groups => { "$(g)" };
-}
-
-body perms owner(user)
-# @brief Set the file's owner
-# @param user The username of the new owner
-{
-      owners => { "$(user)" };
-}
-
-body perms system_owned(mode)
-# @brief Set the file owner and group to the system default
-# @param mode the access permission in octal format
-#
-# **Example:**
-#
-# ```cf3
-# files:
-#     "/etc/passwd" perms => system_owned("0644");
-# ```
-{
-      mode   => "$(mode)";
-      owners => { "root" };
-
-    freebsd|openbsd|netbsd|darwin::
-      groups => { "wheel" };
-
-    linux::
-      groups => { "root" };
-
-    solaris::
-      groups => { "sys" };
 }
 
 body depth_search recurse(d)
@@ -1849,47 +1097,6 @@ bundle agent file_make(file, str)
       ifvarclass => "summarize";
 }
 
-bundle agent file_make_mog(file, str, mode, owner, group)
-# @brief Make a file from a string with mode, owner, group
-# @param file target
-# @param str the string data
-# @param mode the file permissions in octal
-# @param owner the file owner as a name or UID
-# @param group the file group as a name or GID
-#
-# **Example:**
-#
-# ```cf3
-# methods:
-#      "" usebundle => file_make_mog("/tmp/z.txt", "Some text
-# and some more text here", "0644", "root", "root");
-# ```
-{
-  vars:
-      "len" int => string_length($(str));
-    summarize::
-      "summary" string => format("%s...%s",
-                                string_head($(str), 18),
-                                string_tail($(str), 18));
-  classes:
-      "summarize" expression => isgreaterthan($(len), 40);
-
-  files:
-      "$(file)"
-      create => "true",
-      edit_line => insert_lines($(str)),
-      perms => mog($(mode), $(owner), $(group)),
-      edit_defaults => empty;
-
-  reports:
-    "DEBUG|DEBUG_$(this.bundle)"::
-      "DEBUG $(this.bundle): creating $(file) with contents '$(str)', mode '$(mode)', owner '$(owner)' and group '$(group)'"
-      ifvarclass => "!summarize";
-
-      "DEBUG $(this.bundle): creating $(file) with contents '$(summary)', mode '$(mode)', owner '$(owner)' and group '$(group)'"
-      ifvarclass => "summarize";
-}
-
 bundle agent file_empty(file)
 # @brief Make an empty file
 # @param file target
@@ -1953,15 +1160,4 @@ bundle agent file_link(target, link)
   reports:
     "DEBUG|DEBUG_$(this.bundle)"::
       "DEBUG $(this.bundle): $(link) will be a symlink to $(target)";
-}
-
-bundle edit_line create_solaris_admin_file
-# @brief The following bundle is part of a package setup for solaris
-#
-# See unit examples.
-{
-  insert_lines:
-
-      "$(solaris_knowledge.admin_nocheck)"
-      comment => "Insert contents of Solaris admin file (automatically install packages)";
 }


### PR DESCRIPTION
While working on CFE-2519 the presense of manage_variable_values_ini in
the plucked library was being used instead of the MPF and no error was
thrown since the body was found complicating test development.

None of the bodies or bundles removed from the plucked library were used
in any tests.