### PR TITLE
CFE-2504: restore old getvalues(v) behaviour;

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2930,6 +2930,7 @@ void GetSysVars(EvalContext *ctx)
     {
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "user_data", info, CF_DATA_TYPE_CONTAINER,
                                       "source=agent,user_info");
+        JsonDestroy(info);
     }
 }
 

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2928,7 +2928,8 @@ void GetSysVars(EvalContext *ctx)
     JsonElement *info = GetUserInfo(NULL);
     if (info != NULL)
     {
-        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "user_data", info, CF_DATA_TYPE_CONTAINER,
+        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "user_data",
+                                      info, CF_DATA_TYPE_CONTAINER,
                                       "source=agent,user_info");
         JsonDestroy(info);
     }
@@ -2938,8 +2939,10 @@ void GetSysVars(EvalContext *ctx)
 
 void GetDefVars(EvalContext *ctx)
 {
-    EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_DEF, "jq", "jq --compact-output --monochrome-output --ascii-output --unbuffered --sort-keys",
-                                  CF_DATA_TYPE_STRING, "invocation,source=agent,command_name=jq");
+    EvalContextVariablePutSpecial(
+        ctx, SPECIAL_SCOPE_DEF, "jq",
+        "jq --compact-output --monochrome-output --ascii-output --unbuffered --sort-keys",
+        CF_DATA_TYPE_STRING, "invocation,source=agent,command_name=jq");
 }
 /*****************************************************************************/
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -2523,13 +2523,7 @@ static FnCallResult FnCallGetValues(EvalContext *ctx, ARG_UNUSED const Policy *p
         return (FnCallResult) { FNCALL_SUCCESS, { NULL, RVAL_TYPE_LIST } };
     }
 
-    Rlist *values = NULL;
-    if (JsonGetElementType(json) != JSON_ELEMENT_TYPE_CONTAINER)
-    {
-        JsonDestroyMaybe(json, allocated);
-        return (FnCallResult) { FNCALL_SUCCESS, { values, RVAL_TYPE_LIST } };
-    }
-
+    Rlist *values = NULL;                      /* start with an empty Rlist */
     CollectContainerValues(ctx, &values, json);
 
     JsonDestroyMaybe(json, allocated);

--- a/tests/acceptance/01_vars/02_functions/211.cf
+++ b/tests/acceptance/01_vars/02_functions/211.cf
@@ -1,6 +1,6 @@
 #######################################################
 #
-# Test getvalues(), size 0
+# Test getvalues(string), should return the string itself
 #
 #######################################################
 
@@ -17,10 +17,24 @@ bundle agent init
 {
   vars:
       "dummy" string => "dummy";
+      "expected" string => "blah";
 
   files:
       "$(G.testfile).expected"
-      create => "true";
+      create => "true",
+      edit_line => init_insert("$(init.expected)"),
+      edit_defaults => init_empty;
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+body edit_defaults init_empty
+{
+      empty_file_before_editing => "true";
 }
 
 #######################################################
@@ -28,7 +42,7 @@ bundle agent init
 bundle agent test
 {
   vars:
-      "array" string => "zero"; # Intentionally not an array
+      "array" string => "blah"; # Intentionally not an array
 
       "vals" slist => getvalues("array");
 

--- a/tests/acceptance/01_vars/02_functions/getvalues_array_string.cf
+++ b/tests/acceptance/01_vars/02_functions/getvalues_array_string.cf
@@ -1,0 +1,45 @@
+#######################################################
+#
+# Test getvalues()
+#
+#######################################################
+
+# If we run getvalues on a classic array index that contains a string
+# we should end up with a list made up of that single value
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+
+  vars:
+      "array[string]" string => "scrumdiddlyumptious";
+      "values" slist => getvalues("array[string]");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "expected" slist => { "scrumdiddlyumptious" };
+    "diff" slist => difference( expected, "test.values" );
+ 
+  classes:
+    "_pass" expression => strcmp( length( diff ), 0 );
+
+  methods:
+   
+    _pass:: 
+      "pass" usebundle => dcs_pass("$(this.promise_filename)");
+
+    !_pass::
+      "pass" usebundle => dcs_fail("$(this.promise_filename)");
+}

--- a/tests/acceptance/01_vars/02_functions/getvalues_array_string.cf
+++ b/tests/acceptance/01_vars/02_functions/getvalues_array_string.cf
@@ -18,7 +18,6 @@ body common control
 
 bundle agent test
 {
-
   vars:
       "array[string]" string => "scrumdiddlyumptious";
       "values" slist => getvalues("array[string]");
@@ -31,13 +30,13 @@ bundle agent check
   vars:
     "expected" slist => { "scrumdiddlyumptious" };
     "diff" slist => difference( expected, "test.values" );
- 
+
   classes:
     "_pass" expression => strcmp( length( diff ), 0 );
 
   methods:
-   
-    _pass:: 
+
+    _pass::
       "pass" usebundle => dcs_pass("$(this.promise_filename)");
 
     !_pass::

--- a/tests/acceptance/01_vars/02_functions/getvalues_plain_string.cf
+++ b/tests/acceptance/01_vars/02_functions/getvalues_plain_string.cf
@@ -1,0 +1,44 @@
+#######################################################
+#
+# Test getvalues()
+#
+#######################################################
+
+# If we run getvalues on a plan string, we should end up with a list of one
+# element being that string value.
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "string" string => "scrumdiddlyumptious";
+      "values" slist => getvalues("string");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "expected" slist => { "scrumdiddlyumptious" };
+    "diff" slist => difference( expected, "test.values" );
+ 
+  classes:
+    "_pass" expression => strcmp( length( diff ), 0 );
+
+  methods:
+   
+    _pass:: 
+      "pass" usebundle => dcs_pass("$(this.promise_filename)");
+
+    !_pass::
+      "pass" usebundle => dcs_fail("$(this.promise_filename)");
+}

--- a/tests/acceptance/01_vars/02_functions/getvalues_plain_string.cf
+++ b/tests/acceptance/01_vars/02_functions/getvalues_plain_string.cf
@@ -30,13 +30,13 @@ bundle agent check
   vars:
     "expected" slist => { "scrumdiddlyumptious" };
     "diff" slist => difference( expected, "test.values" );
- 
+
   classes:
     "_pass" expression => strcmp( length( diff ), 0 );
 
   methods:
-   
-    _pass:: 
+
+    _pass::
       "pass" usebundle => dcs_pass("$(this.promise_filename)");
 
     !_pass::

--- a/tests/acceptance/01_vars/03_lists/001.cf
+++ b/tests/acceptance/01_vars/03_lists/001.cf
@@ -34,7 +34,8 @@ c z
 a cf_null
 b cf_null
 c cf_null
-cf_null";
+cf_null
+blah";
 
   files:
       "$(G.testfile).$(states)"
@@ -73,7 +74,7 @@ bundle edit_line test_insert
       "null" slist => { "cf_null" };
       "nulls" slist => { "cf_null", "cf_null", "cf_null" };
 
-      "not_an_array" string => "zero";
+      "not_an_array" string => "blah";
       "no_values" slist => getvalues("not_an_array");
 
   insert_lines:


### PR DESCRIPTION
it should always return a list, even when v is a simple string.