### PR TITLE
CFE-2504: Add test for getvalues with subkeys on foreign bundle

### DIFF
--- a/tests/acceptance/01_vars/02_functions/getvalues_foreign_bundle_array_with_subkeys.cf
+++ b/tests/acceptance/01_vars/02_functions/getvalues_foreign_bundle_array_with_subkeys.cf
@@ -1,0 +1,50 @@
+# Similar to getvalues_array_returns_first_index_values.cf but getvalues on array in foreign bundle
+
+bundle agent main
+{
+  methods:
+    "init";
+    "test";
+    "check";
+}
+
+bundle agent init
+{
+  vars:
+      "array[key1]" string => "k1v";
+      "array[key2]" slist => { "k2v" };
+      "array[key1][subkey1]" string => "k1s1v"; # getvalues(array) should not return these
+      "array[key2][subkey1]" slist => { "k2s1v" }; # getvalues(array) should not returen these
+}
+bundle agent test
+{
+  vars:
+      # Expected { "k1v1", "k2v2" };
+      "array_values" slist => getvalues("init.array");
+
+  reports:
+    DEBUG::
+      "array_values= $(array_values)";
+}
+bundle agent check
+{
+  vars:
+    "expected_values" slist => { "k1v", "k2v" };
+
+    # diff_values contains unique values test.array_values not in expected_values
+    "diff_values" slist => difference( "test.array_values", expected_values );
+    # intersection_values contains values in test.array_values that are also in expected_values
+    "intersection_values" slist => intersection( "test.array_values", expected_values );
+
+  classes:
+    "pass_diff" expression => strcmp( length(diff_values), 0 );
+    "pass_intersection" expression => strcmp( length(intersection_values), 2);
+    "pass" expression => "pass_diff.pass_intersection";
+
+  reports:
+    pass::
+      "$(this.promise_filename) Pass";
+    !pass::
+      "$(this.promise_filename) FAIL";
+
+}


### PR DESCRIPTION
Found this segfaulting on 3.10.0.b1 but passing as expected on 3.7.4