### PR TITLE
Change: Warning about depth_search on a non directory to DEBUG

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -390,7 +390,7 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
         {
             if (a.havedepthsearch)
             {
-                Log(LOG_LEVEL_WARNING,
+                Log(LOG_LEVEL_DEBUG,
                     "depth_search (recursion) is promised for a base object '%s' that is not a directory",
                       path);
                 goto exit;


### PR DESCRIPTION
When promising to copy remote paths recursively if the paht is a non
directory a warning is emitted but the file is copied anyway so it does
what the use meant. The warning in this case end up being useless noise.
Perhaps it is useful for debugging, but for policy writers it only poses
a challenge to be worked around. This removes the need to implement
additional policy in order to differentate between files and directories
only for the suppression of the warning.

Ref: https://groups.google.com/forum/#!topic/help-cfengine/ekSgRU3j1W4

Changelog: Title