### PR TITLE
Test deep delayed expansion

### DIFF
--- a/tests/acceptance/01_vars/deep_delayed_expansion/def.json
+++ b/tests/acceptance/01_vars/deep_delayed_expansion/def.json
@@ -1,0 +1,6 @@
+{
+	"vars": {
+		"policy_root": "$(this.promise_dirname)"
+	},
+	"inputs": ["my_globals.cf.sub"]
+}

--- a/tests/acceptance/01_vars/deep_delayed_expansion/main.cf
+++ b/tests/acceptance/01_vars/deep_delayed_expansion/main.cf
@@ -1,0 +1,25 @@
+body common control
+{
+  inputs => { "../../default.cf.sub", @(def.augments_inputs) };
+  bundlesequence => { default("$(this.promise_filename)") };
+}
+
+bundle agent test
+{
+  meta:
+    "description" string => "Test that variables containing other variales are de-referenced";
+}
+
+bundle agent check
+{
+  reports:
+    "$(this.promise_filename) Pass"
+      if => strcmp( $(this.promise_dirname), $(my_globals.policy_root) );
+
+    "$(this.promise_filename) FAIL"
+      unless => strcmp( $(this.promise_dirname), $(my_globals.policy_root) );
+
+    EXTRA:: 
+    "my_globals.policy_root = $(my_globals.policy_root)";
+    "def.policy_root = $(def.policy_root)";
+}

--- a/tests/acceptance/01_vars/deep_delayed_expansion/my_globals.cf.sub
+++ b/tests/acceptance/01_vars/deep_delayed_expansion/my_globals.cf.sub
@@ -1,0 +1,5 @@
+bundle common my_globals
+{
+  vars:
+    "policy_root" string => "$(def.policy_root)";
+}


### PR DESCRIPTION
When setting a cfengine variable from another cfengine variable that
contains an un-dereferenced variable the agnet should dereference
deeply.