### PR TITLE
Allow function calls in promiser through new "with" attribute.

### DIFF
--- a/examples/with.cf
+++ b/examples/with.cf
@@ -1,0 +1,69 @@
+#  Copyright (C) Cfengine AS
+
+#  This file is part of Cfengine 3 - written and maintained by Cfengine AS.
+
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License as published by the
+#  Free Software Foundation; version 3.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+# To the extent this program is licensed as part of the Enterprise
+# versions of Cfengine, the applicable Commercial Open Source License
+# (COSL) may apply to this file if you as a licensee so wish it. See
+# included file COSL.txt.
+
+#+begin_src cfengine3
+bundle agent main
+{
+  vars:
+      "todo" slist => { "a 1", "b 2", "c 3" };
+      # Here, `with` is the canonified version of $(todo), letting us avoid an
+      # intermediate canonification array.
+      "$(with)" string => "$(todo)", with => canonify($(todo));
+
+      "complex" data => '
+{
+  "x": 200,
+  "y": [ 1, 2, null, true, false ]
+}
+';
+
+  reports:
+      "For iterable '$(todo)' we created variable '$(with)' and its value is '$(todo)'"
+        with => canonify($(todo));
+
+      "We can print a data container compactly without creating a temporary variable: $(with)"
+        with => format("%S", complex);
+
+      "We can print a data container fully without creating a temporary variable: $(with)"
+        with => storejson(complex);
+}
+
+#+end_src
+###############################################################################
+#+begin_src example_output
+#@ ```
+#@ R: For iterable 'a 1' we created variable 'a_1' and its value is 'a 1'
+#@ R: For iterable 'b 2' we created variable 'b_2' and its value is 'b 2'
+#@ R: For iterable 'c 3' we created variable 'c_3' and its value is 'c 3'
+#@ R: We can print a data container compactly without creating a temporary variable: {"x":200,"y":[1,2,null,true,false]}
+#@ R: We can print a data container fully without creating a temporary variable: {
+#@   "x": 200,
+#@   "y": [
+#@     1,
+#@     2,
+#@     null,
+#@     true,
+#@     false
+#@   ]
+#@ }
+#@ ```
+#+end_src

--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -493,6 +493,7 @@ const ConstraintSyntax CF_COMMON_BODIES[] =
     ConstraintSyntaxNewString("if", "", "Extended classes ANDed with context", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("unless", "", "Negated 'if'", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewStringList("meta", "", "User-data associated with policy, e.g. key=value strings", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewString("with", "", "A string that will replace every instance of $(with)", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewNull()
 };
 

--- a/tests/acceptance/00_basics/01_compiler/with_iteration.cf
+++ b/tests/acceptance/00_basics/01_compiler/with_iteration.cf
@@ -1,0 +1,41 @@
+###########################################################
+#
+# Test the "with" promise attribute
+#
+###########################################################
+
+body common control
+{
+    inputs => { "../../default.cf.sub" };
+    bundlesequence => { default($(this.promise_filename)) };
+    version => "1.0";
+}
+
+###########################################################
+
+bundle agent test
+{
+  vars:
+      "probe" string => "0";
+      "iter" slist => { "1", "2", "3" };
+      "A$(with)" string => "promiser addition = $(with)", with => canonify(concat("promiser ", canonify("addition")));
+      "B$(with)" string => "clean = $(with)", with => canonify("clean");
+      "C$(with)" string => "my name is = $(with)", with => canonify("my name is canonified");
+      "D1$(with)" string => "iter1 = $(with)", with => $(iter);
+      "D2$(with)" string => "iter2 = $(with)", with => $(iter);
+      "E$(with)" string => "probe = $(with)", with => $(probe);
+      "F$(with)" string => "iter = $(with)", with => concat("iter_canon_", canonify($(iter)));
+      "G1$(with)" string => "iter = $(with)", with => concat("iter_canon_", canonify($(iter)));
+      "G2$(with)" string => "iter = $(with)", with => canonify($(iter));
+      "H" string => "$(with)", with => format("%S", iter);
+}
+
+###########################################################
+
+bundle agent check
+{
+  methods:
+      "check"  usebundle => dcs_check_state(test,
+                                           "$(this.promise_filename).expected.json",
+                                           $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/01_compiler/with_iteration.cf.expected.json
+++ b/tests/acceptance/00_basics/01_compiler/with_iteration.cf.expected.json
@@ -1,0 +1,28 @@
+{
+  "Apromiser_addition": "promiser addition = promiser_addition",
+  "Bclean": "clean = clean",
+  "Cmy_name_is_canonified": "my name is = my_name_is_canonified",
+  "D11": "iter1 = 1",
+  "D12": "iter1 = 2",
+  "D13": "iter1 = 3",
+  "D21": "iter2 = 1",
+  "D22": "iter2 = 2",
+  "D23": "iter2 = 3",
+  "E0": "probe = 0",
+  "Fiter_canon_1": "iter = iter_canon_1",
+  "Fiter_canon_2": "iter = iter_canon_2",
+  "Fiter_canon_3": "iter = iter_canon_3",
+  "G1iter_canon_1": "iter = iter_canon_1",
+  "G1iter_canon_2": "iter = iter_canon_2",
+  "G1iter_canon_3": "iter = iter_canon_3",
+  "G21": "iter = 1",
+  "G22": "iter = 2",
+  "G23": "iter = 3",
+  "H": "{ \"1\", \"2\", \"3\" }",
+  "iter": [
+    "1",
+    "2",
+    "3"
+  ],
+  "probe": "0"
+}

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -815,8 +815,9 @@ done
 
 #
 # Close stdin file descriptor to avoid tty_interactive check in cf-agent being success.
+# Do this iff GDB AND Valgrind are not in use.
 #
-if [ "$GDB" != 1 ] || [ "$USE_VALGRIND" != 1 ]
+if [ "$GDB" != 1 ] && [ "$USE_VALGRIND" != 1 ]
 then
     exec </dev/null
 fi


### PR DESCRIPTION
Fixes https://tracker.mender.io/browse/CFE-1092

Add universal "with" attribute to allow functions calls in promiser on $(item).
Add acceptance test.

Changelog: CFE-1092: allow function calls in promiser using universal "with" attribute.