### PR TITLE
unix_iface: try to look for ifconfig in /bin as well

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -612,7 +612,8 @@ static void FindV6InterfacesInfo(EvalContext *ctx)
         return;
     }
 #else
-    if (!FileCanOpen("/sbin/ifconfig", "r") || ((pp = cf_popen("/sbin/ifconfig -a", "r", true)) == NULL))
+    if ((!FileCanOpen("/sbin/ifconfig", "r") || ((pp = cf_popen("/sbin/ifconfig -a", "r", true)) == NULL)) &&
+        (!FileCanOpen("/bin/ifconfig", "r") || ((pp = cf_popen("/bin/ifconfig -a", "r", true)) == NULL)))
     {
         Log(LOG_LEVEL_VERBOSE, "Could not find interface info");
         return;


### PR DESCRIPTION
ifconfig utility is installed into the BINDIR by default since commit https://sourceforge.net/p/net-tools/code/ci/36b541c9f3efe55c5871674ee926be8b20339497/, made on 2011-12-02.