### PR TITLE
Fixes #2564: Splayclass is not properly spread

### DIFF
--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -77,7 +77,7 @@ unsigned int StringHash(const char *str, unsigned int seed, unsigned int max)
     h ^= (h >> 11);
     h += (h << 15);
 
-    return (h & (max - 1));
+    return (h % max);
 }
 
 unsigned int StringHash_untyped(const void *str, unsigned int seed, unsigned int max)


### PR DESCRIPTION
See https://tracker.mender.io/browse/CFE-2564

@jimis  I couldn't do the double version because it is hard to be right with the rounding that happen when we are near to 1, and we don't want to hot max.