### PR TITLE
Various memory leaks (valgrind cf-promises)

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -127,7 +127,7 @@ bundletype_values:     typeid
                                INSTALL_SKIP = true;
                            }
                        }
-                     | error 
+                     | error
                        {
                            yyclearin;
                            ParseError("Expected bundle type, wrong input '%s'", yytext);
@@ -141,7 +141,7 @@ bundleid:              bundleid_values
                        }
 
 bundleid_values:       symbol
-                     | error 
+                     | error
                        {
                            yyclearin;
                            ParseError("Expected bundle identifier, wrong input '%s'", yytext);
@@ -211,7 +211,7 @@ symbol:                IDSYNTAX
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-arglist:               /* Empty */ 
+arglist:               /* Empty */
                      | arglist_begin aitems arglist_end
                      | arglist_begin arglist_end
                      | arglist_begin error
@@ -312,12 +312,12 @@ bundle_decl:           /* empty */
 
 bundle_statements:     bundle_statement
                      | bundle_statements bundle_statement
-                     | error 
+                     | error
                        {
                           INSTALL_SKIP = true;
                           ParseError("Expected promise type, got '%s'", yytext);
                           ParserDebug("P:promise_type:error yychar = %d, %c, yyempty = %d\n", yychar, yychar, YYEMPTY);
-                          yyclearin; 
+                          yyclearin;
                        }
 
 
@@ -586,10 +586,12 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
                                                (item[1] == '(' || item[1] == '{'))
                                            {
                                                Rlist *synthetic_args = NULL;
-                                               RlistAppendScalar(&synthetic_args, xstrndup(P.rval.item+2, strlen(P.rval.item)-3 ));
+                                               char *tmp = xstrndup(P.rval.item+2, strlen(P.rval.item)-3 );
+                                               RlistAppendScalar(&synthetic_args, tmp);
+                                               free(tmp);
                                                RvalDestroy(P.rval);
 
-                                               P.rval = (Rval) { FnCallNew(xstrdup("mergedata"), synthetic_args), RVAL_TYPE_FNCALL };
+                                               P.rval = (Rval) { FnCallNew("mergedata", synthetic_args), RVAL_TYPE_FNCALL };
                                            }
                                            // convert 'json or yaml' to direct container or parsejson(x) or parseyaml(x)
                                            else if (P.rval.type == RVAL_TYPE_SCALAR &&
@@ -881,7 +883,7 @@ selection:             selection_id                         /* BODY ONLY */
                                    }
                                }
                            }
-                           
+
                            RvalDestroy(P.rval);
                            P.rval = RvalNew(NULL, RVAL_TYPE_NOPROMISEE);
                        }

--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -189,7 +189,10 @@ char *DBIdToPath(dbid id)
 static
 bool IsSubHandle(DBHandle *handle, dbid id, const char *name)
 {
-    return StringSafeEqual(handle->filename, DBIdToSubPath(id, name));
+    char *sub_path = DBIdToSubPath(id, name);
+    bool result = StringSafeEqual(handle->filename, sub_path);
+    free(sub_path);
+    return result;
 }
 
 static DBHandle *DBHandleGetSubDB(dbid id, const char *name)
@@ -642,4 +645,3 @@ StringMap *LoadDatabaseToStringMap(dbid database_id)
 
     return db_map;
 }
-

--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -331,6 +331,7 @@ void CloseAllDBExit()
         db_dynamic_handles_list = db_dynamic_handles_list->next;
         free(handle);
     }
+    free(db_dynamic_handles);
     db_dynamic_handles = NULL;
 }
 

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -897,6 +897,7 @@ void FreePackagePromiseContext(PackagePromiseContext *pp_ctx)
 {
     SeqDestroy(pp_ctx->package_modules_bodies);
     RlistDestroy(pp_ctx->control_package_inventory);
+    free(pp_ctx->control_package_module);
     free(pp_ctx);
 }
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -4690,8 +4690,8 @@ static FnCallResult FnCallNth(EvalContext *ctx, ARG_UNUSED const Policy *policy,
         return FnFailure();
     }
 
-
-    char *jstring = NULL;
+    const char *jstring = NULL;
+    FnCallResult result;
     if (JsonGetElementType(json) == JSON_ELEMENT_TYPE_CONTAINER)
     {
         JsonContainerType ct = JsonGetContainerType(json);
@@ -4717,7 +4717,11 @@ static FnCallResult FnCallNth(EvalContext *ctx, ARG_UNUSED const Policy *policy,
         if (jelement != NULL &&
             JsonGetElementType(jelement) == JSON_ELEMENT_TYPE_PRIMITIVE)
         {
-            jstring = xstrdup(JsonPrimitiveGetAsString(jelement));
+            jstring = JsonPrimitiveGetAsString(jelement);
+            if (jstring != NULL)
+            {
+                result = FnReturn(jstring);
+            }
         }
     }
 
@@ -4728,7 +4732,7 @@ static FnCallResult FnCallNth(EvalContext *ctx, ARG_UNUSED const Policy *policy,
         return FnFailure();
     }
 
-    return FnReturn(jstring);
+    return result;
 }
 
 /*********************************************************************/

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -890,6 +890,8 @@ static void ResolvePackageManagerBody(EvalContext *ctx, const Body *pm_body)
         {
             Log(LOG_LEVEL_VERBOSE, "have invalid constraint while resolving"
                     "package promise body: %s", cp->lval);
+
+            RvalDestroy(returnval);
             continue;
         }
 
@@ -912,6 +914,7 @@ static void ResolvePackageManagerBody(EvalContext *ctx, const Body *pm_body)
             /* This should be handled by the parser. */
             assert(0);
         }
+        RvalDestroy(returnval);
     }
     AddPackageModuleToContext(ctx, new_manager);
 }

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -1477,17 +1477,21 @@ Constraint *PromiseAppendConstraint(Promise *pp, const char *lval, Rval rval, bo
                 {
                 case RVAL_TYPE_FNCALL: // case 1: merge FnCall with scalar
                 {
-                    Log(LOG_LEVEL_DEBUG, "PromiseAppendConstraint: merging PREVIOUS %s string context rval %s", old_cp->lval, RvalToString(old_cp->rval));
-                    Log(LOG_LEVEL_DEBUG, "PromiseAppendConstraint: merging NEW %s rval %s", old_cp->lval, RvalToString(old_cp->rval));
+                    char * rval_string = RvalToString(old_cp->rval);
+                    Log(LOG_LEVEL_DEBUG, "PromiseAppendConstraint: merging PREVIOUS %s string context rval %s", old_cp->lval, rval_string);
+                    Log(LOG_LEVEL_DEBUG, "PromiseAppendConstraint: merging NEW %s rval %s", old_cp->lval, rval_string);
+                    free(rval_string);
 
                     Rlist *synthetic_args = NULL;
-                    RlistAppendScalar(&synthetic_args, xstrdup(RvalScalarValue(old_cp->rval)));
+                    RlistAppendScalar(&synthetic_args, RvalScalarValue(old_cp->rval));
 
                     // append the old Rval (a function call) under the arguments of the new one
                     RlistAppend(&synthetic_args, rval.item, RVAL_TYPE_FNCALL);
 
-                    Rval replacement = (Rval) { FnCallNew(xstrdup("and"), synthetic_args), RVAL_TYPE_FNCALL };
-                    Log(LOG_LEVEL_DEBUG, "PromiseAppendConstraint: MERGED %s rval %s", old_cp->lval, RvalToString(replacement));
+                    Rval replacement = (Rval) { FnCallNew("and", synthetic_args), RVAL_TYPE_FNCALL };
+                    rval_string = RvalToString(replacement);
+                    Log(LOG_LEVEL_DEBUG, "PromiseAppendConstraint: MERGED %s rval %s", old_cp->lval, rval_string);
+                    free(rval_string);
 
                     // overwrite the old Constraint rval with its replacement
                     RvalDestroy(cp->rval);


### PR DESCRIPTION
`master` before fixes:
```
23:23:20 client:vagrant core $ sudo valgrind --leak-check=full --track-origins=yes /var/cfengine/bin/cf-promises
==18603== Memcheck, a memory error detector
==18603== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==18603== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==18603== Command: /var/cfengine/bin/cf-promises
==18603==
==18603==
==18603== HEAP SUMMARY:
==18603==     in use at exit: 187,199 bytes in 155 blocks
==18603==   total heap usage: 1,261,910 allocs, 1,261,755 frees, 308,693,390 bytes allocated
==18603==
==18603== 8 bytes in 1 blocks are definitely lost in loss record 2 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x5434729: strdup (strdup.c:42)
==18603==    by 0x4EE497E: xstrdup (alloc.c:57)
==18603==    by 0x4EE6750: SafeStringDuplicate (string_lib.c:148)
==18603==    by 0x4E918C2: AddDefaultPackageModuleToContext (eval_context.c:159)
==18603==    by 0x4EADCEB: ResolveControlBody (expand.c:855)
==18603==    by 0x4EAE13B: PolicyResolve (expand.c:960)
==18603==    by 0x4EBE3C5: LoadPolicy (loading.c:512)
==18603==    by 0x402102: main (cf-promises.c:163)
==18603==
==18603== 12 bytes in 2 blocks are definitely lost in loss record 4 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x5434779: strndup (strndup.c:45)
==18603==    by 0x4EE49B7: xstrndup (alloc.c:62)
==18603==    by 0x4E790FD: yyparse (cf3parse.y:589)
==18603==    by 0x4ECE5CE: ParserParseFile (parser.c:129)
==18603==    by 0x4EBD31A: Cf3ParseFile (loading.c:122)
==18603==    by 0x4EBD9F3: LoadPolicyFile (loading.c:275)
==18603==    by 0x4EBD4F6: LoadPolicyInputFiles (loading.c:164)
==18603==    by 0x4EBD52D: LoadPolicyInputFiles (loading.c:168)
==18603==    by 0x4EBDD8B: LoadPolicyFile (loading.c:335)
==18603==    by 0x4EBD4F6: LoadPolicyInputFiles (loading.c:164)
==18603==    by 0x4EBD52D: LoadPolicyInputFiles (loading.c:168)
==18603==
==18603== 16 bytes in 1 blocks are definitely lost in loss record 6 of 66
==18603==    at 0x4C2CC70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x4EE4907: xcalloc (alloc.c:47)
==18603==    by 0x4E8D7E3: DBHandleGetSubDB (dbm_api.c:226)
==18603==    by 0x4E8DDB2: OpenSubDB (dbm_api.c:416)
==18603==    by 0x4E9B53E: GetPackagesMatching (evalfunction.c:1509)
==18603==    by 0x4E9B9E9: FnCallPackagesMatching (evalfunction.c:1610)
==18603==    by 0x4EB2864: CallFunction (fncall.c:304)
==18603==    by 0x4EB2D01: FnCallEvaluate (fncall.c:403)
==18603==    by 0x4EAD207: EvaluateFinalRval (expand.c:608)
==18603==    by 0x4ED32A9: EvaluateConstraintIteration (promises.c:480)
==18603==    by 0x4ED3A78: ExpandDeRefPromise (promises.c:687)
==18603==    by 0x4E94738: EvalContextStackPushPromiseIterationFrame (eval_context.c:1394)
==18603==
==18603== 20 bytes in 2 blocks are definitely lost in loss record 7 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x5434729: strdup (strdup.c:42)
==18603==    by 0x4EE497E: xstrdup (alloc.c:57)
==18603==    by 0x4E79145: yyparse (cf3parse.y:592)
==18603==    by 0x4ECE5CE: ParserParseFile (parser.c:129)
==18603==    by 0x4EBD31A: Cf3ParseFile (loading.c:122)
==18603==    by 0x4EBD9F3: LoadPolicyFile (loading.c:275)
==18603==    by 0x4EBD4F6: LoadPolicyInputFiles (loading.c:164)
==18603==    by 0x4EBD52D: LoadPolicyInputFiles (loading.c:168)
==18603==    by 0x4EBDD8B: LoadPolicyFile (loading.c:335)
==18603==    by 0x4EBD4F6: LoadPolicyInputFiles (loading.c:164)
==18603==    by 0x4EBD52D: LoadPolicyInputFiles (loading.c:168)
==18603==
==18603== 32 bytes in 1 blocks are definitely lost in loss record 40 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x541E227: vasprintf (vasprintf.c:76)
==18603==    by 0x4EE4AF3: xvasprintf (alloc.c:83)
==18603==    by 0x4EE6439: StringVFormat (string_lib.c:40)
==18603==    by 0x4EE64EE: StringFormat (string_lib.c:55)
==18603==    by 0x4E883F3: PolicyServerFilename (bootstrap.c:145)
==18603==    by 0x4E88458: ReadPolicyServerFile (bootstrap.c:157)
==18603==    by 0x4E885ED: ParsePolicyServerFile (bootstrap.c:212)
==18603==    by 0x4E886BB: LookUpPolicyServerFile (bootstrap.c:243)
==18603==    by 0x4EB568B: GenericAgentInitialize (generic_agent.c:1009)
==18603==    by 0x4EB3E98: GenericAgentDiscoverContext (generic_agent.c:421)
==18603==    by 0x4020EF: main (cf-promises.c:162)
==18603==
==18603== 32 bytes in 1 blocks are definitely lost in loss record 41 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x541E227: vasprintf (vasprintf.c:76)
==18603==    by 0x4EE4AF3: xvasprintf (alloc.c:83)
==18603==    by 0x4EE6439: StringVFormat (string_lib.c:40)
==18603==    by 0x4EE64EE: StringFormat (string_lib.c:55)
==18603==    by 0x4E883F3: PolicyServerFilename (bootstrap.c:145)
==18603==    by 0x4E88458: ReadPolicyServerFile (bootstrap.c:157)
==18603==    by 0x4EB41DD: GenericAgentDiscoverContext (generic_agent.c:509)
==18603==    by 0x4020EF: main (cf-promises.c:162)
==18603==
==18603== 33 bytes in 3 blocks are definitely lost in loss record 42 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x5434729: strdup (strdup.c:42)
==18603==    by 0x4EE497E: xstrdup (alloc.c:57)
==18603==    by 0x4EA3780: FnCallNth (evalfunction.c:4719)
==18603==    by 0x4EB2864: CallFunction (fncall.c:304)
==18603==    by 0x4EB2D01: FnCallEvaluate (fncall.c:403)
==18603==    by 0x4EAD207: EvaluateFinalRval (expand.c:608)
==18603==    by 0x4ED32A9: EvaluateConstraintIteration (promises.c:480)
==18603==    by 0x4ED3A78: ExpandDeRefPromise (promises.c:687)
==18603==    by 0x4E94738: EvalContextStackPushPromiseIterationFrame (eval_context.c:1394)
==18603==    by 0x4EAC183: ExpandPromiseAndDo (expand.c:206)
==18603==    by 0x4EAC3E3: ExpandPromise (expand.c:283)
==18603==
==18603== 56 bytes in 14 blocks are definitely lost in loss record 45 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x5434729: strdup (strdup.c:42)
==18603==    by 0x4EE497E: xstrdup (alloc.c:57)
==18603==    by 0x4ECA43B: PromiseAppendConstraint (policy.c:1489)
==18603==    by 0x4E79619: yyparse (cf3parse.y:675)
==18603==    by 0x4ECE5CE: ParserParseFile (parser.c:129)
==18603==    by 0x4EBD31A: Cf3ParseFile (loading.c:122)
==18603==    by 0x4EBD9F3: LoadPolicyFile (loading.c:275)
==18603==    by 0x4EBD4F6: LoadPolicyInputFiles (loading.c:164)
==18603==    by 0x4EBD52D: LoadPolicyInputFiles (loading.c:168)
==18603==    by 0x4EBDD8B: LoadPolicyFile (loading.c:335)
==18603==    by 0x4EBD4F6: LoadPolicyInputFiles (loading.c:164)
==18603==
==18603== 64 bytes in 1 blocks are definitely lost in loss record 47 of 66
==18603==    at 0x4C2CE8E: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x4EE494E: xrealloc (alloc.c:52)
==18603==    by 0x4EF4CE5: StringWriterReallocate (writer.c:82)
==18603==    by 0x4EF4D2A: StringWriterWriteChar (writer.c:89)
==18603==    by 0x4EF5095: WriterWriteChar (writer.c:196)
==18603==    by 0x4ED62F8: ScalarWrite (rlist.c:1253)
==18603==    by 0x4EB24F9: FnCallWrite (fncall.c:226)
==18603==    by 0x4ED6391: RvalWriteParts (rlist.c:1275)
==18603==    by 0x4ED63F8: RvalWrite (rlist.c:1290)
==18603==    by 0x4ED646A: RvalToString (rlist.c:1301)
==18603==    by 0x4ECA464: PromiseAppendConstraint (policy.c:1490)
==18603==    by 0x4E79619: yyparse (cf3parse.y:675)
==18603==
==18603== 89 bytes in 1 blocks are definitely lost in loss record 48 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x5434729: strdup (strdup.c:42)
==18603==    by 0x4EE497E: xstrdup (alloc.c:57)
==18603==    by 0x4EF6907: MapNameCopy (file_lib.c:308)
==18603==    by 0x4E8D4BC: DBIdToSubPath (dbm_api.c:152)
==18603==    by 0x4E8D68B: IsSubHandle (dbm_api.c:192)
==18603==    by 0x4E8D713: DBHandleGetSubDB (dbm_api.c:206)
==18603==    by 0x4E8DDB2: OpenSubDB (dbm_api.c:416)
==18603==    by 0x4E9B53E: GetPackagesMatching (evalfunction.c:1509)
==18603==    by 0x4E9B9E9: FnCallPackagesMatching (evalfunction.c:1610)
==18603==    by 0x4EB2864: CallFunction (fncall.c:304)
==18603==    by 0x4EB2D01: FnCallEvaluate (fncall.c:403)
==18603==
==18603== 128 bytes in 1 blocks are definitely lost in loss record 52 of 66
==18603==    at 0x4C2CE8E: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x4EE494E: xrealloc (alloc.c:52)
==18603==    by 0x4EF4CE5: StringWriterReallocate (writer.c:82)
==18603==    by 0x4EF4D2A: StringWriterWriteChar (writer.c:89)
==18603==    by 0x4EF5095: WriterWriteChar (writer.c:196)
==18603==    by 0x4ED62F8: ScalarWrite (rlist.c:1253)
==18603==    by 0x4EB24F9: FnCallWrite (fncall.c:226)
==18603==    by 0x4EB2519: FnCallWrite (fncall.c:230)
==18603==    by 0x4EB2519: FnCallWrite (fncall.c:230)
==18603==    by 0x4ED6391: RvalWriteParts (rlist.c:1275)
==18603==    by 0x4ED63F8: RvalWrite (rlist.c:1290)
==18603==    by 0x4ED646A: RvalToString (rlist.c:1301)
==18603==
==18603== 378 bytes in 14 blocks are definitely lost in loss record 57 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x5434729: strdup (strdup.c:42)
==18603==    by 0x4EE497E: xstrdup (alloc.c:57)
==18603==    by 0x4ECA401: PromiseAppendConstraint (policy.c:1484)
==18603==    by 0x4E79619: yyparse (cf3parse.y:675)
==18603==    by 0x4ECE5CE: ParserParseFile (parser.c:129)
==18603==    by 0x4EBD31A: Cf3ParseFile (loading.c:122)
==18603==    by 0x4EBD9F3: LoadPolicyFile (loading.c:275)
==18603==    by 0x4EBD4F6: LoadPolicyInputFiles (loading.c:164)
==18603==    by 0x4EBD52D: LoadPolicyInputFiles (loading.c:168)
==18603==    by 0x4EBDD8B: LoadPolicyFile (loading.c:335)
==18603==    by 0x4EBD4F6: LoadPolicyInputFiles (loading.c:164)
==18603==
==18603== 672 bytes in 14 blocks are definitely lost in loss record 60 of 66
==18603==    at 0x4C2CE8E: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x4EE494E: xrealloc (alloc.c:52)
==18603==    by 0x4EF4CE5: StringWriterReallocate (writer.c:82)
==18603==    by 0x4EF4D2A: StringWriterWriteChar (writer.c:89)
==18603==    by 0x4EF5095: WriterWriteChar (writer.c:196)
==18603==    by 0x4ED62D1: ScalarWrite (rlist.c:1249)
==18603==    by 0x4ED6367: RvalWriteParts (rlist.c:1267)
==18603==    by 0x4ED63F8: RvalWrite (rlist.c:1290)
==18603==    by 0x4ED646A: RvalToString (rlist.c:1301)
==18603==    by 0x4ECA375: PromiseAppendConstraint (policy.c:1480)
==18603==    by 0x4E79619: yyparse (cf3parse.y:675)
==18603==    by 0x4ECE5CE: ParserParseFile (parser.c:129)
==18603==
==18603== 672 bytes in 14 blocks are definitely lost in loss record 61 of 66
==18603==    at 0x4C2CE8E: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x4EE494E: xrealloc (alloc.c:52)
==18603==    by 0x4EF4CE5: StringWriterReallocate (writer.c:82)
==18603==    by 0x4EF4D2A: StringWriterWriteChar (writer.c:89)
==18603==    by 0x4EF5095: WriterWriteChar (writer.c:196)
==18603==    by 0x4ED62D1: ScalarWrite (rlist.c:1249)
==18603==    by 0x4ED6367: RvalWriteParts (rlist.c:1267)
==18603==    by 0x4ED63F8: RvalWrite (rlist.c:1290)
==18603==    by 0x4ED646A: RvalToString (rlist.c:1301)
==18603==    by 0x4ECA3B3: PromiseAppendConstraint (policy.c:1481)
==18603==    by 0x4E79619: yyparse (cf3parse.y:675)
==18603==    by 0x4ECE5CE: ParserParseFile (parser.c:129)
==18603==
==18603== 1,536 bytes in 12 blocks are definitely lost in loss record 62 of 66
==18603==    at 0x4C2CE8E: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x4EE494E: xrealloc (alloc.c:52)
==18603==    by 0x4EF4CE5: StringWriterReallocate (writer.c:82)
==18603==    by 0x4EF4D2A: StringWriterWriteChar (writer.c:89)
==18603==    by 0x4EF5095: WriterWriteChar (writer.c:196)
==18603==    by 0x4ED62D1: ScalarWrite (rlist.c:1249)
==18603==    by 0x4EB24F9: FnCallWrite (fncall.c:226)
==18603==    by 0x4EB2519: FnCallWrite (fncall.c:230)
==18603==    by 0x4EB2519: FnCallWrite (fncall.c:230)
==18603==    by 0x4ED6391: RvalWriteParts (rlist.c:1275)
==18603==    by 0x4ED63F8: RvalWrite (rlist.c:1290)
==18603==    by 0x4ED646A: RvalToString (rlist.c:1301)
==18603==
==18603== 49,152 bytes in 12 blocks are definitely lost in loss record 64 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x4EE48AB: xmalloc (alloc.c:42)
==18603==    by 0x4EF0588: BufferNewWithCapacity (buffer.c:37)
==18603==    by 0x4EF05C3: BufferNew (buffer.c:47)
==18603==    by 0x4EAC927: ExpandScalar (expand.c:433)
==18603==    by 0x4EAC48A: ExpandPrivateRval (expand.c:308)
==18603==    by 0x4EADE43: ResolvePackageManagerBody (expand.c:885)
==18603==    by 0x4EAE16B: PolicyResolve (expand.c:966)
==18603==    by 0x4EBDB88: LoadPolicyFile (loading.c:306)
==18603==    by 0x4EBD4F6: LoadPolicyInputFiles (loading.c:164)
==18603==    by 0x4EBD52D: LoadPolicyInputFiles (loading.c:168)
==18603==    by 0x4EBDD8B: LoadPolicyFile (loading.c:335)
==18603==
==18603== 49,152 bytes in 12 blocks are definitely lost in loss record 65 of 66
==18603==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18603==    by 0x4EE48AB: xmalloc (alloc.c:42)
==18603==    by 0x4EF0588: BufferNewWithCapacity (buffer.c:37)
==18603==    by 0x4EF05C3: BufferNew (buffer.c:47)
==18603==    by 0x4EAC927: ExpandScalar (expand.c:433)
==18603==    by 0x4EAC48A: ExpandPrivateRval (expand.c:308)
==18603==    by 0x4EADE43: ResolvePackageManagerBody (expand.c:885)
==18603==    by 0x4EAE16B: PolicyResolve (expand.c:966)
==18603==    by 0x4EBE3C5: LoadPolicy (loading.c:512)
==18603==    by 0x402102: main (cf-promises.c:163)
==18603==
==18603== LEAK SUMMARY:
==18603==    definitely lost: 102,052 bytes in 106 blocks
==18603==    indirectly lost: 0 bytes in 0 blocks
==18603==      possibly lost: 0 bytes in 0 blocks
==18603==    still reachable: 85,147 bytes in 49 blocks
==18603==         suppressed: 0 bytes in 0 blocks
==18603== Reachable blocks (those to which a pointer was found) are not shown.
==18603== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==18603==
==18603== For counts of detected and suppressed errors, rerun with: -v
==18603== ERROR SUMMARY: 17 errors from 17 contexts (suppressed: 0 from 0)
```