### PR TITLE
cf-agent: learn --show-vars and --show-classes to show final state

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -189,6 +189,8 @@ static const struct option OPTIONS[] =
     {"timestamp", no_argument, 0, 'l'},
     /* Only long option for the rest */
     {"log-modules", required_argument, 0, 0},
+    {"show-evaluated-classes", optional_argument, 0, 0 },
+    {"show-evaluated-vars", optional_argument, 0, 0 },
     {NULL, 0, 0, '\0'}
 };
 
@@ -214,6 +216,8 @@ static const char *const HINTS[] =
     "Disable extension loading (used while upgrading)",
     "Log timestamps on each line of log output",
     "Enable even more detailed debug logging for specific areas of the implementation. Use together with '-d'. Use --log-modules=help for a list of available modules",
+    "Show *final* evaluated classes, including those defined in common bundles in policy. Optionally can take a regular expression.",
+    "Show *final* evaluated variables, including those defined without dependency to user-defined classes in policy. Optionally can take a regular expression.",
     NULL
 };
 
@@ -265,6 +269,18 @@ int main(int argc, char *argv[])
 
     PurgeLocks();
     BackupLockDatabase();
+
+    if (config->agent_specific.common.show_classes != NULL)
+    {
+        GenericAgentShowContextsFormatted(ctx, config->agent_specific.common.show_classes);
+        free(config->agent_specific.common.show_classes);
+    }
+
+    if (config->agent_specific.common.show_variables != NULL)
+    {
+        GenericAgentShowVariablesFormatted(ctx, config->agent_specific.common.show_variables);
+        free(config->agent_specific.common.show_variables);
+    }
 
     PolicyDestroy(policy); /* Can we safely do this earlier ? */
     int ret = 0;
@@ -546,7 +562,23 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                     exit(EXIT_FAILURE);
                 }
             }
-            break;
+            else if (strcmp(OPTIONS[longopt_idx].name, "show-evaluated-classes") == 0)
+            {
+                if (optarg == NULL)
+                {
+                    optarg = ".*";
+                }
+                config->agent_specific.common.show_classes = xstrdup(optarg);
+            }
+            else if (strcmp(OPTIONS[longopt_idx].name, "show-evaluated-vars") == 0)
+            {
+                if (optarg == NULL)
+                {
+                    optarg = ".*";
+                }
+                config->agent_specific.common.show_variables = xstrdup(optarg);
+            }
+    break;
 
         default:
             {

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1968,3 +1968,137 @@ void SetupSignalsForAgent(void)
     signal(SIGUSR1, HandleSignalsForAgent);
     signal(SIGUSR2, HandleSignalsForAgent);
 }
+
+void GenericAgentShowContextsFormatted(EvalContext *ctx, const char *regexp)
+{
+    assert(regexp != NULL);
+
+    ClassTableIterator *iter = EvalContextClassTableIteratorNewGlobal(ctx, NULL, true, true);
+    Class *cls = NULL;
+
+    Seq *seq = SeqNew(1000, free);
+
+    pcre *rx = CompileRegex(regexp);
+
+    if (rx == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Sorry, we could not compile regular expression %s", regexp);
+        return;
+    }
+
+    while ((cls = ClassTableIteratorNext(iter)))
+    {
+        char *class_name = ClassRefToString(cls->ns, cls->name);
+
+        if (!RegexPartialMatch(rx, class_name))
+        {
+            free(class_name);
+            continue;
+        }
+
+        StringSet *tagset = EvalContextClassTags(ctx, cls->ns, cls->name);
+        Buffer *tagbuf = StringSetToBuffer(tagset, ',');
+
+        char *line;
+        xasprintf(&line, "%-60s %-40s", class_name, BufferData(tagbuf));
+        SeqAppend(seq, line);
+
+        BufferDestroy(tagbuf);
+        free(class_name);
+    }
+
+    pcre_free(rx);
+
+    SeqSort(seq, (SeqItemComparator)strcmp, NULL);
+
+    printf("%-60s %-40s\n", "Class name", "Meta tags");
+
+    for (size_t i = 0; i < SeqLength(seq); i++)
+    {
+        const char *context = SeqAt(seq, i);
+        printf("%s\n", context);
+    }
+
+    SeqDestroy(seq);
+
+    ClassTableIteratorDestroy(iter);
+}
+
+void GenericAgentShowVariablesFormatted(EvalContext *ctx, const char *regexp)
+{
+    assert(regexp != NULL);
+
+    VariableTableIterator *iter = EvalContextVariableTableIteratorNew(ctx, NULL, NULL, NULL);
+    Variable *v = NULL;
+
+    Seq *seq = SeqNew(2000, free);
+
+    pcre *rx = CompileRegex(regexp);
+
+    if (rx == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Sorry, we could not compile regular expression %s", regexp);
+        return;
+    }
+
+    while ((v = VariableTableIteratorNext(iter)))
+    {
+        char *varname = VarRefToString(v->ref, true);
+
+        if (!RegexPartialMatch(rx, varname))
+        {
+            free(varname);
+            continue;
+        }
+
+        Writer *w = StringWriter();
+
+        switch (DataTypeToRvalType(v->type))
+        {
+        case RVAL_TYPE_CONTAINER:
+            JsonWriteCompact(w, RvalContainerValue(v->rval));
+            break;
+
+        default:
+            RvalWrite(w, v->rval);
+        }
+
+        const char *var_value;
+        if (StringIsPrintable(StringWriterData(w)))
+        {
+            var_value = StringWriterData(w);
+        }
+        else
+        {
+            var_value = "<non-printable>";
+        }
+
+
+        StringSet *tagset = EvalContextVariableTags(ctx, v->ref);
+        Buffer *tagbuf = StringSetToBuffer(tagset, ',');
+
+        char *line;
+        xasprintf(&line, "%-40s %-60s %-40s", varname, var_value, BufferData(tagbuf));
+
+        SeqAppend(seq, line);
+
+        BufferDestroy(tagbuf);
+        WriterClose(w);
+        free(varname);
+    }
+
+    pcre_free(rx);
+
+    SeqSort(seq, (SeqItemComparator)strcmp, NULL);
+
+    printf("%-40s %-60s %-40s\n", "Variable name", "Variable value", "Meta tags");
+
+    for (size_t i = 0; i < SeqLength(seq); i++)
+    {
+        const char *variable = SeqAt(seq, i);
+        printf("%s\n", variable);
+    }
+
+    SeqDestroy(seq);
+    VariableTableIteratorDestroy(iter);
+}

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -145,4 +145,7 @@ void SetupSignalsForAgent(void);
 
 void LoadAugments(EvalContext *ctx, GenericAgentConfig *config);
 
+void GenericAgentShowContextsFormatted(EvalContext *ctx, const char *regexp);
+void GenericAgentShowVariablesFormatted(EvalContext *ctx, const char *regexp);
+
 #endif


### PR DESCRIPTION
@nickanderson I got sick of writing stuff like this, which doesn't even show all the classes:

```
bundle agent main
{
  methods:
      "test";

  vars:
      "test_state" data => bundlestate(test);
      "test_string" string => storejson(test_state);

  reports:
      "$(this.bundle): state of things = $(test_string)";
}

bundle agent test
{
...
}
```

So I believe there's a practical need, especially for quick demos and for debugging.

If this is merged, I'll adjust #2480 as well (it needs rebasing anyway) and write docs as usual.

The options and code changes are minimal. We're just moving the support code for `--show-vars` and `--show-classes` (plus one enum) to `generic_agent.[ch]` and write the exact same glue as cf-promises in `cf-agent/cf-agent.c` to show vars and classes before destroying the policy. The only difference is that cf-promises doesn't run policy before showing vars and classes.

This code has no side effects, performance implications, or any compatibility problems. So I hope it is acceptable.