### PR TITLE
Install cf-net binary in bin instead of sbin.

### DIFF
--- a/cf-net/Makefile.am
+++ b/cf-net/Makefile.am
@@ -38,7 +38,7 @@ libcf_net_la_LIBADD = ../libpromises/libpromises.la
 libcf_net_la_SOURCES = cf-net.c
 
 if !BUILTIN_EXTENSIONS
- sbin_PROGRAMS = cf-net
+ bin_PROGRAMS = cf-net
  cf_net_LDADD = libcf-net.la
  cf_net_SOURCES =
 endif


### PR DESCRIPTION
All other binaries were moved to bin from sbin. See here: https://github.com/cfengine/core/commit/72054384c17c34f3e0662ea0b0f3221ac5151c95. This is to install cf-net in bin as well.