### PR TITLE
make cf-agent kill other expired (expireafter) agents on windows (CFE-2211)

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -758,8 +758,8 @@ CfLock AcquireLock(EvalContext *ctx, const char *operand, const char *host, time
         {
             if (elapsedtime >= tc.expireafter)
             {
-                Log(LOG_LEVEL_INFO, "Lock %s expired (after %jd/%u minutes)",
-                    cflock, (intmax_t) elapsedtime, tc.expireafter);
+                Log(LOG_LEVEL_INFO, "Lock expired after %jd/%u minutes: %s",
+                    (intmax_t) elapsedtime, tc.expireafter, cflock);
 
                 pid_t pid = FindLockPid(cflock);
 

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -466,16 +466,7 @@ static void PromiseTypeString(char *dst, size_t dst_size, const Promise *pp)
     }
 }
 
-#ifdef __MINGW32__
 
-static bool KillLockHolder(ARG_UNUSED const char *lock)
-{
-    Log(LOG_LEVEL_VERBOSE,
-          "Process is not running - ignoring lock (Windows does not support graceful processes termination)");
-    return true;
-}
-
-#else
 
 static bool KillLockHolder(const char *lock)
 {
@@ -513,8 +504,6 @@ static bool KillLockHolder(const char *lock)
 
     return GracefulTerminate(lock_data.pid, lock_data.process_start_time);
 }
-
-#endif
 
 void PromiseRuntimeHash(const Promise *pp, const char *salt, unsigned char digest[EVP_MAX_MD_SIZE + 1], HashMethod type)
 {


### PR DESCRIPTION
Example policy to test this:
```
body contain mypowershell
{
    !windows::
        useshell => "useshell";
    windows::
        useshell => "powershell";
}

body action fastlocks
{
    ifelapsed   => "0";    # disable ifelapsed lock
    expireafter => "1";    # promise expires after 1 minute
}

bundle agent main
{
    commands:
        "sleep"
            args => "3000",
            action => fastlocks,
            contain => mypowershell;
}
```