### PR TITLE
Rename PartialMatch to PartialRegexMatch

### DIFF
--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -508,7 +508,7 @@ static void ShowContextsFormatted(EvalContext *ctx, const char *regexp)
     {
         char *class_name = ClassRefToString(cls->ns, cls->name);
 
-        if (!PartialMatch(rx, class_name))
+        if (!RegexPartialMatch(rx, class_name))
         {
             free(class_name);
             continue;
@@ -563,7 +563,7 @@ static void ShowVariablesFormatted(EvalContext *ctx, const char *regexp)
     {
         char *varname = VarRefToString(v->ref, true);
 
-        if (!PartialMatch(rx, varname))
+        if (!RegexPartialMatch(rx, varname))
         {
             free(varname);
             continue;

--- a/libpromises/match_scope.c
+++ b/libpromises/match_scope.c
@@ -88,7 +88,7 @@ static int RegExMatchFullString(EvalContext *ctx, pcre *rx, const char *teststri
  * This is a fast partial match function. It checks that the compiled rx matches
  * anywhere inside teststring. It does not allocate or free rx!
  */
-bool PartialMatch(const pcre *rx, const char *teststring)
+bool RegexPartialMatch(const pcre *rx, const char *teststring)
 {
     int ovector[OVECCOUNT];
     int rc = pcre_exec(rx, NULL, teststring, strlen(teststring), 0, 0, ovector, OVECCOUNT);

--- a/libpromises/match_scope.c
+++ b/libpromises/match_scope.c
@@ -84,18 +84,6 @@ static int RegExMatchFullString(EvalContext *ctx, pcre *rx, const char *teststri
     }
 }
 
-/*
- * This is a fast partial match function. It checks that the compiled rx matches
- * anywhere inside teststring. It does not allocate or free rx!
- */
-bool RegexPartialMatch(const pcre *rx, const char *teststring)
-{
-    int ovector[OVECCOUNT];
-    int rc = pcre_exec(rx, NULL, teststring, strlen(teststring), 0, 0, ovector, OVECCOUNT);
-
-    return rc >= 0;
-}
-
 int FullTextMatch(EvalContext *ctx, const char *regexp, const char *teststring)
 {
     pcre *rx;

--- a/libpromises/match_scope.h
+++ b/libpromises/match_scope.h
@@ -26,10 +26,6 @@
 #define CFENGINE_MATCH_SCOPE_H
 
 #include <cf3.defs.h>
-#include <regex.h>
-
-/* Does not free rx! */
-bool RegexPartialMatch(const pcre *rx, const char *teststring);
 
 int FullTextMatch(EvalContext *ctx, const char *regptr, const char *cmpptr); /* Sets variables */
 int BlockTextMatch(EvalContext *ctx, const char *regexp, const char *teststring, int *s, int *e); /* Sets variables */

--- a/libpromises/match_scope.h
+++ b/libpromises/match_scope.h
@@ -29,7 +29,7 @@
 #include <regex.h>
 
 /* Does not free rx! */
-bool PartialMatch(const pcre *rx, const char *teststring);
+bool RegexPartialMatch(const pcre *rx, const char *teststring);
 
 int FullTextMatch(EvalContext *ctx, const char *regptr, const char *cmpptr); /* Sets variables */
 int BlockTextMatch(EvalContext *ctx, const char *regexp, const char *teststring, int *s, int *e); /* Sets variables */

--- a/libutils/regex.c
+++ b/libutils/regex.c
@@ -271,3 +271,15 @@ bool CompareStringOrRegex(const char *value, const char *compareTo, bool regex)
     }
     return true;
 }
+
+/*
+ * This is a fast partial match function. It checks that the compiled rx matches
+ * anywhere inside teststring. It does not allocate or free rx!
+ */
+bool RegexPartialMatch(const pcre *rx, const char *teststring)
+{
+    int ovector[STRING_MATCH_OVECCOUNT];
+    int rc = pcre_exec(rx, NULL, teststring, strlen(teststring), 0, 0, ovector, STRING_MATCH_OVECCOUNT);
+
+    return rc >= 0;
+}

--- a/libutils/regex.h
+++ b/libutils/regex.h
@@ -46,4 +46,7 @@ Seq *StringMatchCaptures(const char *regex, const char *str, const bool return_n
 Seq *StringMatchCapturesWithPrecompiledRegex(const pcre *pattern, const char *str, const bool return_names);
 bool CompareStringOrRegex(const char *value, const char *compareTo, bool regex);
 
+/* Does not free rx! */
+bool RegexPartialMatch(const pcre *rx, const char *teststring);
+
 #endif  /* CFENGINE_REGEX_H */


### PR DESCRIPTION
Trivial.

As requested in https://github.com/cfengine/core/pull/2480#discussion_r116465231 by @jimis 