### PR TITLE
Set default digest based on version (ENT-3201)

### DIFF
--- a/cf-net/cf-net.c
+++ b/cf-net/cf-net.c
@@ -38,6 +38,7 @@
 #include <string_lib.h>         // ToLowerStrInplace
 #include <writer.h>
 #include <policy_server.h>      // PolicyServerReadFile
+#include <generic_agent.h>      // GenericAgentSetDefaultDigest TODO: rm dep
 
 typedef struct
 {
@@ -179,6 +180,7 @@ int main(int argc, char **argv)
     char *hostnames = NULL;
     int ret = CFNetParse(argc, argv,                // Inputs
                          &opts, &args, &hostnames); // Outputs
+    GenericAgentSetDefaultDigest(&CF_DEFAULT_DIGEST, &CF_DEFAULT_DIGEST_LEN);
     if (ret != 0)
     {
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Enterprise should not use md5

Ticket: ENT-3201
Signed-off-by: Ole Herman Schumacher Elgesem <ole.elgesem@cfengine.com>