### PR TITLE
Compile against OpenSSL 1.1

### DIFF
--- a/cf-key/cf-key-functions.c
+++ b/cf-key/cf-key-functions.c
@@ -48,6 +48,7 @@ RSA *LoadPublicKey(const char *filename)
 {
     FILE *fp;
     RSA *key;
+    const BIGNUM *n, *e;
 
     fp = safe_fopen(filename, "r");
     if (fp == NULL)
@@ -69,7 +70,9 @@ RSA *LoadPublicKey(const char *filename)
 
     fclose(fp);
 
-    if (BN_num_bits(key->e) < 2 || !BN_is_odd(key->e))
+    RSA_get0_key(key, &n, &e, NULL);
+
+    if (BN_num_bits(e) < 2 || !BN_is_odd(e))
     {
         Log(LOG_LEVEL_ERR, "Error while reading public key '%s' - RSA Exponent is too small or not odd. (BN_num_bits: %s)",
             filename, GetErrorStr());

--- a/configure.ac
+++ b/configure.ac
@@ -435,7 +435,7 @@ fi
 
 CF3_WITH_LIBRARY(openssl, [
    AC_CHECK_LIB(crypto, RSA_generate_key_ex, [], [])
-   AC_CHECK_LIB(ssl, SSL_library_init, [], [])
+   AC_CHECK_LIB(ssl, SSL_free, [], [])
    AC_CHECK_DECLS([SSL_CTX_clear_options], [], [], [[#include <openssl/ssl.h>]])
    AC_CHECK_HEADERS([openssl/opensslv.h], [], [AC_MSG_ERROR(Cannot find OpenSSL)])
 

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -88,12 +88,6 @@ static int CompareCertToRSA(X509 *cert, RSA *rsa_key)
             TLSErrorString(ERR_get_error()));
         goto ret1;
     }
-    if (EVP_PKEY_type(cert_pkey->type) != EVP_PKEY_RSA)
-    {
-        Log(LOG_LEVEL_ERR,
-            "Received key of unknown type, only RSA currently supported!");
-        goto ret2;
-    }
 
     RSA *cert_rsa_key = EVP_PKEY_get1_RSA(cert_pkey);
     if (cert_rsa_key == NULL)
@@ -299,13 +293,6 @@ int TLSVerifyPeer(ConnectionInfo *conn_info, const char *remoteip, const char *u
             TLSErrorString(ERR_get_error()));
         retval = -1;
         goto ret2;
-    }
-    if (EVP_PKEY_type(received_pubkey->type) != EVP_PKEY_RSA)
-    {
-        Log(LOG_LEVEL_ERR,
-            "Received key of unknown type, only RSA currently supported!");
-        retval = -1;
-        goto ret3;
     }
 
     RSA *remote_key = EVP_PKEY_get1_RSA(received_pubkey);

--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -220,11 +220,15 @@ bool LoadSecretKeys(void)
         fclose(fp);
     }
 
-    if (PUBKEY != NULL
-        && ((BN_num_bits(PUBKEY->e) < 2) || (!BN_is_odd(PUBKEY->e))))
+    if (PUBKEY != NULL)
     {
-        Log(LOG_LEVEL_ERR, "The public key RSA exponent is too small or not odd");
-        return false;
+        const BIGNUM *n, *e;
+        RSA_get0_key(PUBKEY, &n, &e, NULL);
+        if ((BN_num_bits(e) < 2) || (!BN_is_odd(e)))
+        {
+            Log(LOG_LEVEL_ERR, "The public key RSA exponent is too small or not odd");
+            return false;
+        }
     }
 
     return true;
@@ -366,12 +370,16 @@ RSA *HavePublicKey(const char *username, const char *ipaddress, const char *dige
 
     fclose(fp);
 
-    if ((BN_num_bits(newkey->e) < 2) || (!BN_is_odd(newkey->e)))
     {
-        Log(LOG_LEVEL_ERR, "RSA Exponent too small or not odd for key: %s",
-            newname);
-        RSA_free(newkey);
-        return NULL;
+        const BIGNUM *n, *e;
+        RSA_get0_key(newkey, &n, &e, NULL);
+        if ((BN_num_bits(e) < 2) || (!BN_is_odd(e)))
+        {
+            Log(LOG_LEVEL_ERR, "RSA Exponent too small or not odd for key: %s",
+                newname);
+            RSA_free(newkey);
+            return NULL;
+        }
     }
 
     return newkey;
@@ -438,7 +446,7 @@ int EncryptString(char *out, size_t out_size, const char *in, int plainlen,
     int cipherlen = 0, tmplen;
     unsigned char iv[32] =
         { 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8 };
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     if (key == NULL)
         ProgrammingError("EncryptString: session key == NULL");
@@ -451,18 +459,18 @@ int EncryptString(char *out, size_t out_size, const char *in, int plainlen,
                           max_ciphertext_size, out_size);
     }
 
-    EVP_CIPHER_CTX_init(&ctx);
-    EVP_EncryptInit_ex(&ctx, CfengineCipher(type), NULL, key, iv);
+    EVP_CIPHER_CTX_init(ctx);
+    EVP_EncryptInit_ex(ctx, CfengineCipher(type), NULL, key, iv);
 
-    if (!EVP_EncryptUpdate(&ctx, out, &cipherlen, in, plainlen))
+    if (!EVP_EncryptUpdate(ctx, out, &cipherlen, in, plainlen))
     {
-        EVP_CIPHER_CTX_cleanup(&ctx);
+        EVP_CIPHER_CTX_free(ctx);
         return -1;
     }
 
-    if (!EVP_EncryptFinal_ex(&ctx, out + cipherlen, &tmplen))
+    if (!EVP_EncryptFinal_ex(ctx, out + cipherlen, &tmplen))
     {
-        EVP_CIPHER_CTX_cleanup(&ctx);
+        EVP_CIPHER_CTX_free(ctx);
         return -1;
     }
 
@@ -474,7 +482,7 @@ int EncryptString(char *out, size_t out_size, const char *in, int plainlen,
                           cipherlen, max_ciphertext_size);
     }
 
-    EVP_CIPHER_CTX_cleanup(&ctx);
+    EVP_CIPHER_CTX_free(ctx);
     return cipherlen;
 }
 
@@ -521,7 +529,7 @@ int DecryptString(char *out, size_t out_size, const char *in, int cipherlen,
     int plainlen = 0, tmplen;
     unsigned char iv[32] =
         { 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8 };
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     if (key == NULL)
         ProgrammingError("DecryptString: session key == NULL");
@@ -534,22 +542,22 @@ int DecryptString(char *out, size_t out_size, const char *in, int cipherlen,
                           max_plaintext_size, out_size);
     }
 
-    EVP_CIPHER_CTX_init(&ctx);
-    EVP_DecryptInit_ex(&ctx, CfengineCipher(type), NULL, key, iv);
+    EVP_CIPHER_CTX_init(ctx);
+    EVP_DecryptInit_ex(ctx, CfengineCipher(type), NULL, key, iv);
 
-    if (!EVP_DecryptUpdate(&ctx, out, &plainlen, in, cipherlen))
+    if (!EVP_DecryptUpdate(ctx, out, &plainlen, in, cipherlen))
     {
         Log(LOG_LEVEL_ERR, "Failed to decrypt string");
-        EVP_CIPHER_CTX_cleanup(&ctx);
+        EVP_CIPHER_CTX_free(ctx);
         return -1;
     }
 
-    if (!EVP_DecryptFinal_ex(&ctx, out + plainlen, &tmplen))
+    if (!EVP_DecryptFinal_ex(ctx, out + plainlen, &tmplen))
     {
         unsigned long err = ERR_get_error();
 
         Log(LOG_LEVEL_ERR, "Failed to decrypt at final of cipher length %d. (EVP_DecryptFinal_ex: %s)", cipherlen, ERR_error_string(err, NULL));
-        EVP_CIPHER_CTX_cleanup(&ctx);
+        EVP_CIPHER_CTX_free(ctx);
         return -1;
     }
 
@@ -561,7 +569,7 @@ int DecryptString(char *out, size_t out_size, const char *in, int cipherlen,
                           plainlen, max_plaintext_size);
     }
 
-    EVP_CIPHER_CTX_cleanup(&ctx);
+    EVP_CIPHER_CTX_free(ctx);
 
     return plainlen;
 }

--- a/libpromises/files_hashes.c
+++ b/libpromises/files_hashes.c
@@ -40,7 +40,7 @@
 void HashFile(const char *filename, unsigned char digest[EVP_MAX_MD_SIZE + 1], HashMethod type)
 {
     FILE *file;
-    EVP_MD_CTX context;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int len, md_len;
     unsigned char buffer[1024];
     const EVP_MD *md = NULL;
@@ -53,14 +53,15 @@ void HashFile(const char *filename, unsigned char digest[EVP_MAX_MD_SIZE + 1], H
     {
         md = EVP_get_digestbyname(HashNameFromId(type));
 
-        EVP_DigestInit(&context, md);
+        EVP_DigestInit(context, md);
 
         while ((len = fread(buffer, 1, 1024, file)))
         {
-            EVP_DigestUpdate(&context, buffer, len);
+            EVP_DigestUpdate(context, buffer, len);
         }
 
-        EVP_DigestFinal(&context, digest, &md_len);
+        EVP_DigestFinal(context, digest, &md_len);
+        EVP_MD_CTX_free(context);
 
         /* Digest length stored in md_len */
         fclose(file);
@@ -71,7 +72,7 @@ void HashFile(const char *filename, unsigned char digest[EVP_MAX_MD_SIZE + 1], H
 
 void HashString(const char *buffer, int len, unsigned char digest[EVP_MAX_MD_SIZE + 1], HashMethod type)
 {
-    EVP_MD_CTX context;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     const EVP_MD *md = NULL;
     int md_len;
 
@@ -89,10 +90,11 @@ void HashString(const char *buffer, int len, unsigned char digest[EVP_MAX_MD_SIZ
         {
             Log(LOG_LEVEL_INFO, "Digest type %s not supported by OpenSSL library", HashNameFromId(type));
         }
-        else if (EVP_DigestInit(&context, md))
+        else if (EVP_DigestInit(context, md))
         {
-            EVP_DigestUpdate(&context, (unsigned char *) buffer, (size_t) len);
-            EVP_DigestFinal(&context, digest, &md_len);
+            EVP_DigestUpdate(context, (unsigned char *) buffer, (size_t) len);
+            EVP_DigestFinal(context, digest, &md_len);
+            EVP_MD_CTX_free(context);
         }
         else
         {
@@ -108,23 +110,25 @@ void HashString(const char *buffer, int len, unsigned char digest[EVP_MAX_MD_SIZ
 
 void HashPubKey(RSA *key, unsigned char digest[EVP_MAX_MD_SIZE + 1], HashMethod type)
 {
-    EVP_MD_CTX context;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     const EVP_MD *md = NULL;
     int md_len, i, buf_len, actlen;
     unsigned char *buffer;
+    const BIGNUM *n, *e;
+    RSA_get0_key(key, &n, &e, NULL);
 
-    if (key->n)
+    if (n)
     {
-        buf_len = (size_t) BN_num_bytes(key->n);
+        buf_len = (size_t) BN_num_bytes(n);
     }
     else
     {
         buf_len = 0;
     }
 
-    if (key->e)
+    if (e)
     {
-        if (buf_len < (i = (size_t) BN_num_bytes(key->e)))
+        if (buf_len < (i = (size_t) BN_num_bytes(e)))
         {
             buf_len = i;
         }
@@ -146,13 +150,14 @@ void HashPubKey(RSA *key, unsigned char digest[EVP_MAX_MD_SIZE + 1], HashMethod 
             Log(LOG_LEVEL_INFO, "Digest type %s not supported by OpenSSL library", HashNameFromId(type));
         }
 
-        EVP_DigestInit(&context, md);
+        EVP_DigestInit(context, md);
 
-        actlen = BN_bn2bin(key->n, buffer);
-        EVP_DigestUpdate(&context, buffer, actlen);
-        actlen = BN_bn2bin(key->e, buffer);
-        EVP_DigestUpdate(&context, buffer, actlen);
-        EVP_DigestFinal(&context, digest, &md_len);
+        actlen = BN_bn2bin(n, buffer);
+        EVP_DigestUpdate(context, buffer, actlen);
+        actlen = BN_bn2bin(e, buffer);
+        EVP_DigestUpdate(context, buffer, actlen);
+        EVP_DigestFinal(context, digest, &md_len);
+        EVP_MD_CTX_free(context);
         break;
     }
 

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1163,16 +1163,17 @@ static bool GeneratePolicyReleaseIDFromTree(char *release_id_out, size_t out_siz
     }
 
     // fallback, produce some pseudo sha1 hash
-    EVP_MD_CTX crypto_ctx;
-    EVP_DigestInit(&crypto_ctx, EVP_get_digestbyname(HashNameFromId(GENERIC_AGENT_CHECKSUM_METHOD)));
+    EVP_MD_CTX *crypto_ctx = EVP_MD_CTX_new();
+    EVP_DigestInit(crypto_ctx, EVP_get_digestbyname(HashNameFromId(GENERIC_AGENT_CHECKSUM_METHOD)));
 
     bool success = HashDirectoryTree(policy_dir,
                                      (const char *[]) { ".cf", ".dat", ".txt", ".conf", ".mustache", ".json", ".yaml", NULL},
-                                     &crypto_ctx);
+                                     crypto_ctx);
 
     int md_len;
     unsigned char digest[EVP_MAX_MD_SIZE + 1] = { 0 };
-    EVP_DigestFinal(&crypto_ctx, digest, &md_len);
+    EVP_DigestFinal(crypto_ctx, digest, &md_len);
+    EVP_MD_CTX_free(crypto_ctx);
 
     HashPrintSafe(release_id_out, out_size, digest,
                   GENERIC_AGENT_CHECKSUM_METHOD, false);

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -509,7 +509,7 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt, unsigned char diges
 {
     static const char PACK_UPIFELAPSED_SALT[] = "packageuplist";
 
-    EVP_MD_CTX context;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int md_len;
     const EVP_MD *md = NULL;
     Rlist *rp;
@@ -520,29 +520,29 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt, unsigned char diges
 
     md = EVP_get_digestbyname(HashNameFromId(type));
 
-    EVP_DigestInit(&context, md);
+    EVP_DigestInit(context, md);
 
 // multiple packages (promisers) may share same package_list_update_ifelapsed lock
     if ( (!salt) || strcmp(salt, PACK_UPIFELAPSED_SALT) )
     {
-        EVP_DigestUpdate(&context, pp->promiser, strlen(pp->promiser));
+        EVP_DigestUpdate(context, pp->promiser, strlen(pp->promiser));
     }
 
     if (pp->comment)
     {
-        EVP_DigestUpdate(&context, pp->comment, strlen(pp->comment));
+        EVP_DigestUpdate(context, pp->comment, strlen(pp->comment));
     }
 
     if (pp->parent_promise_type && pp->parent_promise_type->parent_bundle)
     {
         if (pp->parent_promise_type->parent_bundle->ns)
         {
-            EVP_DigestUpdate(&context, pp->parent_promise_type->parent_bundle->ns, strlen(pp->parent_promise_type->parent_bundle->ns));
+            EVP_DigestUpdate(context, pp->parent_promise_type->parent_bundle->ns, strlen(pp->parent_promise_type->parent_bundle->ns));
         }
 
         if (pp->parent_promise_type->parent_bundle->name)
         {
-            EVP_DigestUpdate(&context, pp->parent_promise_type->parent_bundle->name, strlen(pp->parent_promise_type->parent_bundle->name));
+            EVP_DigestUpdate(context, pp->parent_promise_type->parent_bundle->name, strlen(pp->parent_promise_type->parent_bundle->name));
         }
     }
 
@@ -550,7 +550,7 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt, unsigned char diges
 
     if (salt)
     {
-        EVP_DigestUpdate(&context, salt, strlen(salt));
+        EVP_DigestUpdate(context, salt, strlen(salt));
     }
 
     if (pp->conlist)
@@ -559,7 +559,7 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt, unsigned char diges
         {
             Constraint *cp = SeqAt(pp->conlist, i);
 
-            EVP_DigestUpdate(&context, cp->lval, strlen(cp->lval));
+            EVP_DigestUpdate(context, cp->lval, strlen(cp->lval));
 
             // don't hash rvals that change (e.g. times)
             doHash = true;
@@ -581,13 +581,13 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt, unsigned char diges
             switch (cp->rval.type)
             {
             case RVAL_TYPE_SCALAR:
-                EVP_DigestUpdate(&context, cp->rval.item, strlen(cp->rval.item));
+                EVP_DigestUpdate(context, cp->rval.item, strlen(cp->rval.item));
                 break;
 
             case RVAL_TYPE_LIST:
                 for (rp = cp->rval.item; rp != NULL; rp = rp->next)
                 {
-                    EVP_DigestUpdate(&context, RlistScalarValue(rp), strlen(RlistScalarValue(rp)));
+                    EVP_DigestUpdate(context, RlistScalarValue(rp), strlen(RlistScalarValue(rp)));
                 }
                 break;
 
@@ -597,18 +597,18 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt, unsigned char diges
 
                 fp = (FnCall *) cp->rval.item;
 
-                EVP_DigestUpdate(&context, fp->name, strlen(fp->name));
+                EVP_DigestUpdate(context, fp->name, strlen(fp->name));
 
                 for (rp = fp->args; rp != NULL; rp = rp->next)
                 {
                     switch (rp->val.type)
                     {
                     case RVAL_TYPE_SCALAR:
-                        EVP_DigestUpdate(&context, RlistScalarValue(rp), strlen(RlistScalarValue(rp)));
+                        EVP_DigestUpdate(context, RlistScalarValue(rp), strlen(RlistScalarValue(rp)));
                         break;
 
                     case RVAL_TYPE_FNCALL:
-                        EVP_DigestUpdate(&context, RlistFnCallValue(rp)->name, strlen(RlistFnCallValue(rp)->name));
+                        EVP_DigestUpdate(context, RlistFnCallValue(rp)->name, strlen(RlistFnCallValue(rp)->name));
                         break;
 
                     default:
@@ -624,7 +624,8 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt, unsigned char diges
         }
     }
 
-    EVP_DigestFinal(&context, digest, &md_len);
+    EVP_DigestFinal(context, digest, &md_len);
+    EVP_MD_CTX_free(context);
 
 /* Digest length stored in md_len */
 }

--- a/libutils/hash.c
+++ b/libutils/hash.c
@@ -204,21 +204,24 @@ Hash *HashNewFromKey(const RSA *rsa, HashMethod method)
     unsigned char *buffer = NULL;
     int buffer_length = 0;
     int actual_length = 0;
+    const BIGNUM *n, *e;
 
-    if (rsa->n)
+    RSA_get0_key(rsa, &n, &e, NULL);
+
+    if (n)
     {
-        buffer_length = (size_t) BN_num_bytes(rsa->n);
+        buffer_length = (size_t) BN_num_bytes(n);
     }
     else
     {
         buffer_length = 0;
     }
 
-    if (rsa->e)
+    if (e)
     {
-        if (buffer_length < (size_t) BN_num_bytes(rsa->e))
+        if (buffer_length < (size_t) BN_num_bytes(e))
         {
-            buffer_length = (size_t) BN_num_bytes(rsa->e);
+            buffer_length = (size_t) BN_num_bytes(e);
         }
     }
     md = EVP_get_digestbyname(CF_DIGEST_TYPES[method]);
@@ -231,9 +234,9 @@ Hash *HashNewFromKey(const RSA *rsa, HashMethod method)
     context = EVP_MD_CTX_create();
     EVP_DigestInit_ex(context, md, NULL);
     buffer = xmalloc(buffer_length);
-    actual_length = BN_bn2bin(rsa->n, buffer);
+    actual_length = BN_bn2bin(n, buffer);
     EVP_DigestUpdate(context, buffer, actual_length);
-    actual_length = BN_bn2bin(rsa->e, buffer);
+    actual_length = BN_bn2bin(e, buffer);
     EVP_DigestUpdate(context, buffer, actual_length);
     EVP_DigestFinal_ex(context, hash->digest, &md_len);
     EVP_MD_CTX_destroy(context);

--- a/libutils/hashes.c
+++ b/libutils/hashes.c
@@ -47,18 +47,19 @@ int FileChecksum(const char *filename, unsigned char digest[EVP_MAX_MD_SIZE + 1]
             return 0;
         }
 
-        EVP_MD_CTX context;
-        EVP_DigestInit(&context, md);
+        EVP_MD_CTX *context = EVP_MD_CTX_new();
+        EVP_DigestInit(context, md);
 
         int len = 0;
         unsigned char buffer[1024];
         while ((len = fread(buffer, 1, 1024, file)))
         {
-            EVP_DigestUpdate(&context, buffer, len);
+            EVP_DigestUpdate(context, buffer, len);
         }
 
         unsigned int md_len = 0;
-        EVP_DigestFinal(&context, digest, &md_len);
+        EVP_DigestFinal(context, digest, &md_len);
+        EVP_MD_CTX_free(context);
         fclose(file);
 
         return md_len;

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -420,18 +420,6 @@ mon_load_test_LDADD = ../../libpromises/libpromises.la libtest.la
 mon_processes_test_SOURCES = mon_processes_test.c ../../cf-monitord/mon.h ../../cf-monitord/mon_processes.c
 mon_processes_test_LDADD = ../../libpromises/libpromises.la libtest.la
 
-# tls_generic_test uses stub functions interposition which does not work (yet)
-# under OS X. Another way of stubbing functions from libpromises is needed.
-if !XNU
-check_PROGRAMS += tls_generic_test
-tls_generic_test_SOURCES = tls_generic_test.c
-tls_generic_test_LDADD = libtest.la \
-	../../libutils/libutils.la \
-	../../libpromises/libpromises.la \
-	../../libcfnet/libcfnet.la \
-	../../cf-serverd/libcf-serverd.la
-endif
-
 version_test_SOURCES = version_test.c
 
 hash_test_SOURCES = hash_test.c

--- a/tests/unit/crypto_symmetric_test.c
+++ b/tests/unit/crypto_symmetric_test.c
@@ -30,11 +30,11 @@ static void test_cipher_init(void)
 {
     unsigned char key[] = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
     unsigned char iv[] = {1,2,3,4,5,6,7,8};
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
-    EVP_CIPHER_CTX_init(&ctx);
-    EVP_EncryptInit_ex(&ctx, EVP_bf_cbc(), NULL, key, iv);
-    EVP_CIPHER_CTX_cleanup(&ctx);
+    EVP_CIPHER_CTX_init(ctx);
+    EVP_EncryptInit_ex(ctx, EVP_bf_cbc(), NULL, key, iv);
+    EVP_CIPHER_CTX_free(ctx);
 }
 
 static void test_symmetric_encrypt(void)


### PR DESCRIPTION
These changes make cfengine build against OpenSSL 1.1.0.

This mostly involves just a few small changes in how APIs work; using accessors, or not having stack allocated objects.

The major changes for review are:

 * `tls_generic_test.c` just cannot work anymore. It is reimplementing an old version of OpenSSL, relying too heavily on the OpenSSL internals, which are no-longer exposed. I have removed it from `Makefile.am`, but not deleted the code, in this pull request. I attempted to port it, but it's pretty impossible.
 * The `session_key` changes in `libcfnet/client_protocol.c` look like they leak a `malloc`, but they don't; the `session_key` is eventually freed by normal libc-`free` already; making assumptions about old OpenSSL internals. This code is actually arguably more correct like this.
 * I have deleted the key type checks in `libcfnet/tls_generic.c`. The functions that are called immediately after this are documented to safely fail if the key is not of the right format. Checking the type directly isn't really supported anymore.

I have run the build and unit tests. I am unable to get the acceptance tests to pass without my changes (all kinds of syntax errors with `chown` and `fakeroot`), so I didn't try them with the changes.

A patch for 3.9 (instead of HEAD) is attached to the Debian bug: https://bugs.debian.org/863568
