### PR TITLE
CFE-1960: fix storage mount promise when existing mountpoint has a si…

### DIFF
--- a/cf-agent/nfs.c
+++ b/cf-agent/nfs.c
@@ -667,13 +667,23 @@ PromiseResult VerifyUnmount(EvalContext *ctx, char *name, Attributes a, const Pr
 static int MatchFSInFstab(char *match)
 {
     Item *ip;
+    const char delimit[]=" \t\r\n\v\f";
+    char *fstab_line, *token;
 
     for (ip = FSTABLIST; ip != NULL; ip = ip->next)
     {
-        if (strstr(ip->name, match))
+        fstab_line = xstrdup(ip->name);
+        token = strtok(fstab_line, delimit);
+        while (token != NULL)
         {
-            return true;
+            if(strcmp(token, match) == 0)
+            {
+                free(fstab_line);
+                return true;
+            }
+            token = strtok(NULL, delimit);
         }
+        free(fstab_line);
     }
 
     return false;

--- a/cf-agent/nfs.c
+++ b/cf-agent/nfs.c
@@ -673,15 +673,18 @@ static int MatchFSInFstab(char *match)
     for (ip = FSTABLIST; ip != NULL; ip = ip->next)
     {
         fstab_line = xstrdup(ip->name);
-        token = strtok(fstab_line, delimit);
-        while (token != NULL)
+        if(strncmp(fstab_line, "#", 1) != 0)
         {
-            if(strcmp(token, match) == 0)
+            token = strtok(fstab_line, delimit);
+            while (token != NULL)
             {
-                free(fstab_line);
-                return true;
+                if(strcmp(token, match) == 0)
+                {
+                    free(fstab_line);
+                    return true;
+                }
+                token = strtok(NULL, delimit);
             }
-            token = strtok(NULL, delimit);
         }
         free(fstab_line);
     }

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -456,6 +456,10 @@ cf_upgrade_test_CFLAGS = -I$(CFUPGRADE)
 queue_test_SOURCES = queue_test.c
 
 if !NT
+check_PROGRAMS += nfs_test
+nfs_test_SOURCES = nfs_test.c
+nfs_test_LDADD = ../../libpromises/libpromises.la libtest.la
+
 init_script_test_helper_SOURCES = init_script_test_helper.c
 init_script_test.sh: init_script_test_helper
 CLEANFILES += init_script_test_helper

--- a/tests/unit/nfs_test.c
+++ b/tests/unit/nfs_test.c
@@ -1,0 +1,35 @@
+#include <test.h>
+#include <nfs.c>
+#include <nfs.h>
+#include <item_lib.h>
+
+static void test_MatchFSInFstab(void)
+{
+    AppendItem(&FSTABLIST, "fileserver1:/vol/vol10      /mnt/fileserver1/vol10     nfs     rw,intr,tcp,fg,rdirplus,noatime,_netdev", NULL);
+    AppendItem(&FSTABLIST, "fileserver1:/vol/vol11      /mnt/fileserver1/vol11     nfs     rw,intr,tcp,fg,rdirplus,noatime,_netdev", NULL);
+    AppendItem(&FSTABLIST, "UUID=4a147232-42f7-4e56-aa9e-744b09bce719 /               ext4    errors=remount-ro 0       1", NULL);
+    AppendItem(&FSTABLIST, "UUID=b2cf5462-a10f-4d7d-b356-ecec5aea2103 none            swap    sw              0       0", NULL);
+    AppendItem(&FSTABLIST, "none                     /proc/sys/fs/binfmt_misc             binfmt_misc defaults 0 0", NULL);
+    AppendItem(&FSTABLIST, "fileserver2:/vol/vol10 	 /mnt/fileserver2/vol10 	 nfs 	 rw,intr,tcp,fg,noatime", NULL);
+    AppendItem(&FSTABLIST, "fileserver2:/vol/vol11 	 /mnt/fileserver2/vol11 	 nfs 	 rw,intr,tcp,fg,noatime", NULL);
+
+    assert_true(MatchFSInFstab("/mnt/fileserver1/vol10"));
+    assert_true(MatchFSInFstab("/mnt/fileserver1/vol11"));
+    assert_false(MatchFSInFstab("/mnt/fileserver1/vol1"));
+
+    assert_true(MatchFSInFstab("/mnt/fileserver2/vol10"));
+    assert_true(MatchFSInFstab("/mnt/fileserver2/vol11"));
+    assert_false(MatchFSInFstab("/mnt/fileserver2/vol1"));
+}
+
+int main()
+{
+    PRINT_TEST_BANNER();
+    const UnitTest tests[] = {
+        unit_test(test_MatchFSInFstab),
+    };
+
+    return run_tests(tests);
+}
+
+

--- a/tests/unit/nfs_test.c
+++ b/tests/unit/nfs_test.c
@@ -7,11 +7,15 @@ static void test_MatchFSInFstab(void)
 {
     AppendItem(&FSTABLIST, "fileserver1:/vol/vol10      /mnt/fileserver1/vol10     nfs     rw,intr,tcp,fg,rdirplus,noatime,_netdev", NULL);
     AppendItem(&FSTABLIST, "fileserver1:/vol/vol11      /mnt/fileserver1/vol11     nfs     rw,intr,tcp,fg,rdirplus,noatime,_netdev", NULL);
+    AppendItem(&FSTABLIST, "#fileserver1:/vol/vol12     /mnt/fileserver1/vol12     nfs     rw,intr,tcp,fg,rdirplus,noatime,_netdev", NULL);
     AppendItem(&FSTABLIST, "UUID=4a147232-42f7-4e56-aa9e-744b09bce719 /               ext4    errors=remount-ro 0       1", NULL);
     AppendItem(&FSTABLIST, "UUID=b2cf5462-a10f-4d7d-b356-ecec5aea2103 none            swap    sw              0       0", NULL);
     AppendItem(&FSTABLIST, "none                     /proc/sys/fs/binfmt_misc             binfmt_misc defaults 0 0", NULL);
     AppendItem(&FSTABLIST, "fileserver2:/vol/vol10 	 /mnt/fileserver2/vol10 	 nfs 	 rw,intr,tcp,fg,noatime", NULL);
     AppendItem(&FSTABLIST, "fileserver2:/vol/vol11 	 /mnt/fileserver2/vol11 	 nfs 	 rw,intr,tcp,fg,noatime", NULL);
+    AppendItem(&FSTABLIST, "#fileserver2:/vol/vol12 	 /mnt/fileserver2/vol12 	 nfs 	 rw,intr,tcp,fg,noatime", NULL);
+    AppendItem(&FSTABLIST, "fileserver3:/vol/vol10 	 /mnt/fileserver3/vol10 	 nfs 	 rw,intr,tcp,fg #,noatime", NULL);
+    AppendItem(&FSTABLIST, "fileserver3:/vol/vol11 	 /mnt/fileserver3/vol11 	 nfs 	 rw,intr,tcp,fg ,noatime # do we want noatime?", NULL);
 
     assert_true(MatchFSInFstab("/mnt/fileserver1/vol10"));
     assert_true(MatchFSInFstab("/mnt/fileserver1/vol11"));
@@ -20,6 +24,13 @@ static void test_MatchFSInFstab(void)
     assert_true(MatchFSInFstab("/mnt/fileserver2/vol10"));
     assert_true(MatchFSInFstab("/mnt/fileserver2/vol11"));
     assert_false(MatchFSInFstab("/mnt/fileserver2/vol1"));
+
+    assert_false(MatchFSInFstab("/mnt/fileserver1/vol12"));
+    assert_false(MatchFSInFstab("/mnt/fileserver2/vol12"));
+
+    assert_true(MatchFSInFstab("/mnt/fileserver3/vol10"));
+    assert_true(MatchFSInFstab("/mnt/fileserver3/vol11"));
+    assert_false(MatchFSInFstab("/mnt/fileserver3/vol1"));
 }
 
 int main()


### PR DESCRIPTION
…milar path

The MatchFSInFstab will parse the each line of the fstab looking for the
existence of a mountpoint as a substring. In certain cases the call to strstr
would incorrectly match if a nfs volume with a similar mount point was already
mounted. Instead of using strstr, tokenize the line and look at each token for
an exact match.

 ChangeLog: Title