### PR TITLE
Set AR_FLAGS to 'cr' to avoid autotools default of 'cru'.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,8 @@ AC_MSG_RESULT(AUTOMAKE_VERSION)
 AM_INIT_AUTOMAKE([tar-ustar] SERIAL_TESTS)
 AM_MAINTAINER_MODE([enable])
 
+m4_divert_text([DEFAULTS], [: "${AR_FLAGS=cr}"])
+
 cfengine_version=cfversion
 
 m4_undefine([cfversion])


### PR DESCRIPTION
The 'u' in the autotools default generates a lot of warnings when passed to
'ar'. Setting the flags to just 'cr' will prevent the "`u' modifier ignored
since `D' is the default (see `U')" message.