### PR TITLE
ENT-3326: Properly redirect init script to systemd on debian systems

### DIFF
--- a/misc/init.d/cfengine3.in
+++ b/misc/init.d/cfengine3.in
@@ -103,6 +103,10 @@ fi
 # default control file
 if [ "$DEBIAN" = "1" ]; then
     DEFAULT=/etc/default/cfengine3
+    INIT_FUNCTIONS=/lib/lsb/init-functions
+    if [ -e "$INIT_FUNCTIONS" ]; then
+        . "$INIT_FUNCTIONS"
+    fi
 else
     DEFAULT=/etc/sysconfig/cfengine3
 fi


### PR DESCRIPTION
Without the lsb init functions included systemv init scripts will not
automatically redirect to systemctl.

Changelog: Title