### PR TITLE
Inclusion of sysmacros.h by types.h is deprecated.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -656,6 +656,7 @@ AC_CHECK_HEADERS(winsock2.h)
 AC_CHECK_HEADERS(ws2tcpip.h)
 AC_CHECK_HEADERS(zone.h)
 AC_CHECK_HEADERS(sys/uio.h)
+AC_CHECK_HEADERS_ONCE([sys/sysmacros.h]) dnl glibc deprecated inclusion in sys/type.h
 AC_CHECK_HEADERS(sys/types.h)
 AC_CHECK_HEADERS(sys/mpctl.h) dnl For HP-UX $(sys.cpus) - Mantis #1069
 AC_CHECK_HEADERS(shadow.h)

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -79,6 +79,7 @@
 /* POSIX but available in all platforms. */
 #include <strings.h>
 #include <limits.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -79,7 +79,11 @@
 /* POSIX but available in all platforms. */
 #include <strings.h>
 #include <limits.h>
-#include <sys/sysmacros.h>
+
+#ifdef HAVE_SYS_SYSMACROS_H
+# include <sys/sysmacros.h>
+#endif
+
 #include <sys/types.h>
 #include <sys/stat.h>
 


### PR DESCRIPTION
Release notes for glibc-2.25 state:

The inclusion of <sys/sysmacros.h> by <sys/types.h> is deprecated.
This means that in a future release, the macros “major”, “minor”, and
“makedev” will only be available from <sys/sysmacros.h>.

These macros are not part of POSIX nor XSI, and their names frequently
collide with user code; see for instance glibc bug 19239 and Red Hat
bug 130601. <stdlib.h> includes <sys/types.h> under _GNU_SOURCE, and
C++ code presently cannot avoid being compiled under _GNU_SOURCE,
exacerbating the problem.

evalfunction.c: In function ‘FnCallFileStatDetails’:
evalfunction.c:3191:64: error: implicit declaration of function ‘minor’; did you mean ‘mknod’? [-Werror=implicit-function-declaration]
             snprintf(buffer, CF_MAXVARSIZE, "%jd", (uintmax_t) minor(statbuf.st_dev) );
                                                                ^~~~~
                                                                mknod
evalfunction.c:3199:64: error: implicit declaration of function ‘major’ [-Werror=implicit-function-declaration]
             snprintf(buffer, CF_MAXVARSIZE, "%jd", (uintmax_t) major(statbuf.st_dev) );