### PR TITLE
Remove mention of CFEngine versions from README

### DIFF
--- a/contrib/cf-profile/README.md
+++ b/contrib/cf-profile/README.md
@@ -4,15 +4,8 @@ This simple perl script is aimed at giving more information about cf-agent runs.
 together with timings and classes augmented so that you can see clearly the order of execution together with what
 part of your policy cf-agent is spending most time on.
 
-For version < 3.5.0 >=3.7.0:
-
 ```shell
 # cf-agent -v | ./cf-profile.pl -a 
-```
-
-For version >= 3.5.0 <3.7.0:
-```shell
-# cf-agent -v --legacy-output | ./cf-profile.pl -a
 ```
 
 Requires Perl module Time::HiRes.


### PR DESCRIPTION
`cf-agent -v | ./cf-profile.pl -a` will work on currently supported versions of CFEngine (3.7 and 3.10)

Rather than have three sections (before 3.5.0, up to 3.7.0, and after 3.7.1) in the README, it is cleaner to just give the command that worked originally and works again now.

I don't feel super strongly about my proposed wording (feel free to edit it) but the README definitely needs to be updated as the current instructions are out of date, for example, `cf-agent -v --legacy-output | ./cf-profile.pl -a` will not work on 3.7.3 as the "legacy-output" option has been removed.