### PR TITLE
Track code coverage for builds.

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,30 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach, diff, flags, files, footer"
+  behavior: default
+  require_changes: no
+
+# Ignore source files connected to tests.
+ignore:
+  - 'tests/*'

--- a/travis-scripts/before_install.sh
+++ b/travis-scripts/before_install.sh
@@ -15,4 +15,6 @@ else
     sudo apt-get install fakeroot
     # Optional
     sudo apt-get install -y libxml2-dev libacl1-dev
+    # code coverage dependency
+    sudo apt-get install -y lcov
 fi

--- a/travis-scripts/script.sh
+++ b/travis-scripts/script.sh
@@ -23,7 +23,7 @@ then
     ./configure --enable-debug --prefix=$INSTDIR --with-init-script --with-lmdb=/usr/local/Cellar/lmdb/  --with-openssl=/usr/local/opt/openssl
 else
     NO_CONFIGURE=1 ./autogen.sh
-    ./configure --enable-debug --with-tokyocabinet --prefix=$INSTDIR --with-init-script
+    ./configure --enable-debug --with-tokyocabinet --prefix=$INSTDIR --with-init-script --enable-coverage
 fi
 
 make dist
@@ -36,6 +36,7 @@ elif [ "$JOB_TYPE" = compile_and_unit_test ]
 then
     make CFLAGS=-Werror  &&
     make -C tests/unit check
+    bash <(curl -s https://codecov.io/bash) -F $JOB_TYPE -f '!.*test.c.gcov' -f '!.*test_lib.c.gcov' -g 'tests';
     return
 else
     make
@@ -47,6 +48,7 @@ chmod -R go-w .
 if [ "$JOB_TYPE" = acceptance_tests_common ]
 then
     ./testall --tests=common
+    bash <(curl -s https://codecov.io/bash) -F $JOB_TYPE -f '!.*test.c.gcov' -f '!.*test_lib.c.gcov' -g 'tests';
     return
 fi
 
@@ -54,5 +56,6 @@ fi
 if [ "$JOB_TYPE" = acceptance_tests_unsafe_serial_network_etc ]
 then
     ./testall --gainroot=sudo --tests=timed,slow,errorexit,libxml2,libcurl,serial,network,unsafe
+    bash <(curl -s https://codecov.io/bash) -F $JOB_TYPE -f '!.*test.c.gcov' -f '!.*test_lib.c.gcov' -g 'tests';
     return
 fi


### PR DESCRIPTION
Integrate with codecov and report coverage.
Install lcov as dependency for coverage report generation.
Exclude test source code from code coverage report.
Tag code coverage reports based of $JOB_TYPE.

Changelog: none

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>