### PR TITLE
ENT-3395: cf-execd systemd service now only kills cf-execd itself

### DIFF
--- a/misc/systemd/cf-execd.service.in
+++ b/misc/systemd/cf-execd.service.in
@@ -10,6 +10,7 @@ Type=simple
 ExecStart=@workdir@/bin/cf-execd --no-fork
 Restart=always
 RestartSec=10
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Changelog: Title