### PR TITLE
Removing undeclared references

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -493,7 +493,7 @@ promiser:              QSTRING
                           INSTALL_SKIP = true;
                           ParserDebug("P:promiser:qstring::error yychar = %d\n", yychar);
 
-                          if (yychar == BUNDLE || yychar == BODY || yychar == YYEOF)
+                          if (yychar == BUNDLE || yychar == BODY)
                           {
                              ParseError("Expected '}', got '%s'", yytext);
                              /*
@@ -913,7 +913,7 @@ selection_id:          IDSYNTAX
                        {
                           ParserDebug("P:selection_id:idsyntax:error yychar = %d\n", yychar);
 
-                          if ( yychar == BUNDLE || yychar == BODY || yychar == YYEOF )
+                          if ( yychar == BUNDLE || yychar == BODY )
                           {
                              ParseError("Expected '}', got '%s'", yytext);
                              /*


### PR DESCRIPTION
This pull request is to fix the following bug found when running make install.  

$ make install
Making install in libcompat
Making install in libutils
Making install in libcfnet
Making install in libenv
Making install in libpromises
  YACC     cf3parse.c
byacc: 1 shift/reduce conflict.
updating cf3parse.h
  CC       cf3parse.lo
cf3parse.y: In function 'yyparse':
cf3parse.y:496:79: error: 'YYEOF' undeclared (first use in this function)
                           if (yychar == BUNDLE || yychar == BODY || yychar == YYEOF)
                                                                               ^
cf3parse.y:496:79: note: each undeclared identifier is reported only once for each function it appears in
make[3]: *** [cf3parse.lo] Error 1
make[2]: *** [install] Error 2
make[1]: *** [install-recursive] Error 1
make: *** [install] Error 2

I figured, since it's not declared and not used elsewhere in the file, perhaps it's not needed. 