### PR TITLE
Fixing confusing log message

### DIFF
--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -629,7 +629,7 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
         if (ifvarclass && !IsVarClassDefined(ctx, ifvarclass, pcopy))
         {
             Log(LOG_LEVEL_VERBOSE, "Skipping promise '%s'"
-                " because 'if'/'ifvarclass' is not defined", pp->promiser);
+                " because it is not defined in this context.", pp->promiser);
 
             *excluded = true;
             return pcopy;


### PR DESCRIPTION
This makes the log more clear on why promises are being skipped when viewing verbose output.  After testing locally, I've discovered the reason the promise is skipped is NOT because 'if' or 'ifvarclass' are not defined; rather, it's because the promise being evaluated is not defined in that context.

See https://tracker.mender.io/browse/CFE-2697 for details.
