### PR TITLE
CFE-2719: Fix rare cf-execd hang

### DIFF
--- a/libpromises/exec_tools.c
+++ b/libpromises/exec_tools.c
@@ -256,11 +256,12 @@ char **ArgSplitCommand(const char *comm)
 
 void ArgFree(char **args)
 {
-    char **arg = args;
-
-    for (; *arg; ++arg)
+    if (args != NULL)
     {
-        free(*arg);
+        for (char **arg = args; *arg; ++arg)
+        {
+            free(*arg);
+        }
+        free(args);
     }
-    free(args);
 }

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -165,7 +165,7 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
 
     pid_t pid = -1;
 
-    if ((pid = fork()) == -1)
+    if ((pid = fork()) == (pid_t) -1)
     {
         /* One pipe will be always here. */
         close(pipes[0].pipe_desc[0]);
@@ -254,7 +254,7 @@ IOData cf_popen_full_duplex(const char *command, bool capture_stderr, bool requi
     fflush(NULL); /* Empty file buffers */
     pid = CreatePipesAndFork("r+t", child_pipe, parent_pipe);
 
-    if (pid < 0)
+    if (pid == (pid_t) -1)
     {
         Log(LOG_LEVEL_ERR, "Couldn't fork child process: %s", GetErrorStr());
         return (IOData) {-1, -1};

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -250,9 +250,8 @@ static pid_t CreatePipesAndFork(const char *type, int *pd, int *pdb)
 
 IOData cf_popen_full_duplex(const char *command, bool capture_stderr, bool require_full_path)
 {
-/* For simplifying reading and writing directions */
-#define READ  0
-#define WRITE 1
+    /* For simplifying reading and writing directions */
+    const int READ=0, WRITE=1;
     int child_pipe[2];  /* From child to parent */
     int parent_pipe[2]; /* From parent to child */
     pid_t pid;
@@ -337,8 +336,6 @@ IOData cf_popen_full_duplex(const char *command, bool capture_stderr, bool requi
         /* We shouldn't reach this point */
         _exit(EXIT_FAILURE);
     }
-#undef READ
-#undef WRITE
 }
 
 FILE *cf_popen(const char *command, const char *type, bool capture_stderr)

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -477,7 +477,7 @@ FILE *cf_popensetuid(const char *command, const char *type, uid_t uid, gid_t gid
             {
                 Log(LOG_LEVEL_ERR, "Couldn't chroot to '%s'. (chroot: %s)", chrootv, GetErrorStr());
                 ArgFree(argv);
-                return NULL;
+                _exit(EXIT_FAILURE);
             }
         }
 
@@ -487,7 +487,7 @@ FILE *cf_popensetuid(const char *command, const char *type, uid_t uid, gid_t gid
             {
                 Log(LOG_LEVEL_ERR, "Couldn't chdir to '%s'. (chdir: %s)", chdirv, GetErrorStr());
                 ArgFree(argv);
-                return NULL;
+                _exit(EXIT_FAILURE);
             }
         }
 
@@ -669,7 +669,7 @@ FILE *cf_popen_shsetuid(const char *command, const char *type, uid_t uid, gid_t 
             if (chroot(chrootv) == -1)
             {
                 Log(LOG_LEVEL_ERR, "Couldn't chroot to '%s'. (chroot: %s)", chrootv, GetErrorStr());
-                return NULL;
+                _exit(EXIT_FAILURE);
             }
         }
 
@@ -678,7 +678,7 @@ FILE *cf_popen_shsetuid(const char *command, const char *type, uid_t uid, gid_t 
             if (safe_chdir(chdirv) == -1)
             {
                 Log(LOG_LEVEL_ERR, "Couldn't chdir to '%s'. (chdir: %s)", chdirv, GetErrorStr());
-                return NULL;
+                _exit(EXIT_FAILURE);
             }
         }
 

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -814,18 +814,19 @@ int cf_pclose(FILE *pp)
         Log(LOG_LEVEL_ERR,
             "File descriptor %d of child higher than MAX_FD in cf_pclose!",
             fd);
-        pid = 0;
-    }
-    else
-    {
-        pid = CHILDREN[fd];
-        CHILDREN[fd] = 0;
-        ThreadUnlock(cft_count);
+        fclose(pp);
+        return -1;
     }
 
-    if (fclose(pp) == EOF || pid == 0)
+    pid = CHILDREN[fd];
+    CHILDREN[fd] = 0;
+    ThreadUnlock(cft_count);
+
+    if (fclose(pp) == EOF)
     {
-        return -1;
+        Log(LOG_LEVEL_ERR,
+            "Could not close the pipe to the executed subcommand (fclose: %s)",
+            GetErrorStr());
     }
 
     return cf_pwait(pid);

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -445,6 +445,10 @@ FILE *cf_popen(const char *command, const char *type, bool capture_stderr)
 
 /*****************************************************************************/
 
+/*
+ * WARNING: this is only allowed to be called from single-threaded code,
+ *          because of the safe_chdir() call in the forked child.
+ */
 FILE *cf_popensetuid(const char *command, const char *type,
                      uid_t uid, gid_t gid, char *chdirv, char *chrootv,
                      ARG_UNUSED int background)
@@ -505,8 +509,6 @@ FILE *cf_popensetuid(const char *command, const char *type,
 
         if (chdirv && (strlen(chdirv) != 0))
         {
-            /* TODO: safe_chdir is probably not signal-handler safe, so it's
-             * not allowed in child. */
             if (safe_chdir(chdirv) == -1)
             {
                 Log(LOG_LEVEL_ERR, "Couldn't chdir to '%s'. (chdir: %s)", chdirv, GetErrorStr());
@@ -652,6 +654,10 @@ FILE *cf_popen_sh(const char *command, const char *type)
 
 /******************************************************************************/
 
+/*
+ * WARNING: this is only allowed to be called from single-threaded code,
+ *          because of the safe_chdir() call in the forked child.
+ */
 FILE *cf_popen_shsetuid(const char *command, const char *type,
                         uid_t uid, gid_t gid, char *chdirv, char *chrootv,
                         ARG_UNUSED int background)
@@ -709,8 +715,6 @@ FILE *cf_popen_shsetuid(const char *command, const char *type,
 
         if (chdirv && (strlen(chdirv) != 0))
         {
-            /* TODO: safe_chdir is probably not signal-handler safe, so it's
-             * not allowed in child. */
             if (safe_chdir(chdirv) == -1)
             {
                 Log(LOG_LEVEL_ERR, "Couldn't chdir to '%s'. (chdir: %s)", chdirv, GetErrorStr());

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -65,6 +65,9 @@ static bool ChildrenFDInit()
  * about to exec() or _exit(), and only async-signal-safe code is allowed. */
 static void ChildrenFDUnsafeClose()
 {
+    /* GenericCreatePipeAndFork() must have been called to init this. */
+    assert(CHILDREN != NULL);
+
     for (int i = 0; i < MAX_FD; i++)
     {
         if (CHILDREN[i] > 0)

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -40,6 +40,7 @@ static int cf_pwait(pid_t pid);
 static pid_t *CHILDREN = NULL; /* GLOBAL_X */
 static int MAX_FD = 128; /* GLOBAL_X */ /* Max number of simultaneous pipes */
 
+
 static int InitChildrenFD()
 {
     if (!ThreadLock(cft_count))
@@ -58,6 +59,23 @@ static int InitChildrenFD()
 
 /*****************************************************************************/
 
+/* This leaks memory and is not thread-safe! To be used only when you are
+ * about to exec() or _exit(), and only async-signal-safe code is allowed. */
+static void CloseChildrenFDUnsafe()
+{
+    for (int i = 0; i < MAX_FD; i++)
+    {
+        if (CHILDREN[i] > 0)
+        {
+            close(i);
+        }
+    }
+    CHILDREN = NULL;                                    /* leaks on purpose */
+}
+
+/* This is the original safe version, but not signal-handler-safe.
+   It's currently unused. */
+#if 0
 static void CloseChildrenFD()
 {
     ThreadLock(cft_count);
@@ -73,6 +91,7 @@ static void CloseChildrenFD()
     CHILDREN = NULL;
     ThreadUnlock(cft_count);
 }
+#endif
 
 /*****************************************************************************/
 
@@ -279,7 +298,7 @@ IOData cf_popen_full_duplex(const char *command, bool capture_stderr, bool requi
         close(child_pipe[WRITE]);
         close(parent_pipe[READ]);
 
-        CloseChildrenFD();
+        CloseChildrenFDUnsafe();
 
         char **argv  = ArgSplitCommand(command);
         int res = -1;
@@ -360,7 +379,7 @@ FILE *cf_popen(const char *command, const char *type, bool capture_stderr)
             }
         }
 
-        CloseChildrenFD();
+        CloseChildrenFDUnsafe();
 
         argv = ArgSplitCommand(command);
 
@@ -448,7 +467,7 @@ FILE *cf_popensetuid(const char *command, const char *type, uid_t uid, gid_t gid
             }
         }
 
-        CloseChildrenFD();
+        CloseChildrenFDUnsafe();
 
         argv = ArgSplitCommand(command);
 
@@ -562,7 +581,7 @@ FILE *cf_popen_sh(const char *command, const char *type)
             }
         }
 
-        CloseChildrenFD();
+        CloseChildrenFDUnsafe();
 
         execl(SHELL_PATH, "sh", "-c", command, NULL);
         _exit(EXIT_FAILURE);
@@ -643,7 +662,7 @@ FILE *cf_popen_shsetuid(const char *command, const char *type, uid_t uid, gid_t 
             }
         }
 
-        CloseChildrenFD();
+        CloseChildrenFDUnsafe();
 
         if (chrootv && (strlen(chrootv) != 0))
         {

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -180,8 +180,14 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
         return -1;
     }
 
-    /* TODO fix: UNDEFINED BEHAVIOUR if the program is multi-threaded! */
-    signal(SIGCHLD, SIG_DFL);
+    /* Ignore SIGCHLD, by setting the handler to SIG_DFL. NOTE: this is
+     * different than setting to SIG_IGN. In the latter case no zombies are
+     * generated ever and you can't wait() for the child to finish. */
+    struct sigaction sa = {
+        .sa_handler = SIG_DFL,
+    };
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGCHLD, &sa, NULL);
 
     if (pid == 0)                                               /* child */
     {


### PR DESCRIPTION
cf-execd uses cf_popen_sh() to launch exec_command every 5 minutes. In
this function, fork() and exec() are called. But after fork() and before
exec(), the child process calls CloseChildrenFD(), which locks a mutex,
and also free()s memory, which internally also locks mutexes!  However
cf-execd is multi-threaded at that point, and every non-reentrant
non-signal-handler-safe function is strictly forbidden in this context.

Solution: avoid all unsafe operations, even if that entails race
conditions and memory leaks. Races don't matter because all secondary
threads are frozen after fork(), leaks don't matter either as exec()
overwrites the whole process.
