### PR TITLE
Add permission statement to cfengine-code-style.el

### DIFF
--- a/contrib/cfengine-code-style.el
+++ b/contrib/cfengine-code-style.el
@@ -3,6 +3,18 @@
 ;; Author: Mikhail Gusarov <mikhail.gusarov@cfengine.com>
 ;; URL: https://github.com/cfengine/core
 
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; version 3.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 
 ;; Usage:


### PR DESCRIPTION
It is the convention to have such a header in every Emacs lisp
library.  One benefit is that it helps tools that extract Emacs
packages from repositories that contain much more than just the
Emacs lisp.  Without this change the tools used to maintain the
Emacsmirror does not see the license because it only extracts
the library itself from the repository and discards all other
history.

Note that I have used a variation that says "version 3" and thereby implies "exactly version 3, but not any later version". I can do that because the `LICENSE` files says so. However `cfengine.el` is releases under "version 3, or (at your option) any later version", and it would be best to do that here too. But I cannot legally do that.

Please add a **second commit** (do not change my commit) to make this change **in your own name**.

```diff
diff --git a/contrib/cfengine-code-style.el b/contrib/cfengine-code-style.el
index b51bf2594..0c55b08aa 100644
--- a/contrib/cfengine-code-style.el
+++ b/contrib/cfengine-code-style.el
@@ -5,7 +5,8 @@
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; version 3.
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
 
 ;; This file is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
```

Or just merge this as-is.