### PR TITLE
ENT-3414: Move promise comment to verbose

### DIFF
--- a/cf-agent/files_changes.c
+++ b/cf-agent/files_changes.c
@@ -477,7 +477,7 @@ bool FileChangesCheckAndUpdateHash_impl(const char *filename,
             Log(LOG_LEVEL_NOTICE, "Hash '%s' for '%s' changed!", HashNameFromId(type), filename);
             if (pp->comment)
             {
-                Log(LOG_LEVEL_NOTICE, "Preceding promise '%s'", pp->comment);
+                Log(LOG_LEVEL_VERBOSE, "Preceding promise '%s'", pp->comment);
             }
         }
     }
@@ -748,7 +748,7 @@ void FileChangesCheckAndUpdateStats(const char *file, struct stat *sb, bool upda
 
     if (pp->comment)
     {
-        Log(LOG_LEVEL_NOTICE, "Preceding promise '%s'", pp->comment);
+        Log(LOG_LEVEL_VERBOSE, "Preceding promise '%s'", pp->comment);
     }
 
     if (update && !DONTDO)


### PR DESCRIPTION
Promise comments are printed in verbose logs for all promise types except file
change monitoring. This can cause extra noise and multi-line promise comments
are not always handled well in syslog filtering.

Changelog: Title
(cherry picked from commit 0e4a1fd550bc18f60dd026ada11d324a39e4e208)