### PR TITLE
ENT-3430: Add a script to run cf-serverd tests with various versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
     - os: linux
       sudo: required
       env: JOB_TYPE=acceptance_tests_unsafe_serial_network_etc
+    - os: linux
+      sudo: required
+      env: JOB_TYPE=serverd_multi_versions
     - os: osx
       env: JOB_TYPE=compile_only
       sudo: false

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_inexistent_file_connection_closed-classic_protocol.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_inexistent_file_connection_closed-classic_protocol.cf.sub
@@ -46,6 +46,6 @@ bundle agent check
 
   reports:
 
-    copy1_repaired.exists1.!copy1_failed . copy3_repaired.exists3.!copy3_failed . !copy2_repaired.!exists2.copy2_failed ::
+    copy1_repaired.exists1.!copy1_failed.copy3_repaired.exists3.!copy3_failed.!copy2_repaired.!exists2.copy2_failed::
       "$(fn[1]) Pass";
 }

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_inexistent_file_connection_closed.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_inexistent_file_connection_closed.cf.sub
@@ -45,6 +45,6 @@ bundle agent check
 
   reports:
 
-    copy1_repaired.exists1.!copy1_failed . copy3_repaired.exists3.!copy3_failed . !copy2_repaired.!exists2.copy2_failed ::
+    copy1_repaired.exists1.!copy1_failed.copy3_repaired.exists3.!copy3_failed.!copy2_repaired.!exists2.copy2_failed::
       "$(fn[1]) Pass";
 }

--- a/tests/acceptance/serverd-multi-versions-blacklist.txt
+++ b/tests/acceptance/serverd-multi-versions-blacklist.txt
@@ -1,0 +1,20 @@
+# This file contains cf-serverd tests to be excluded from multi-version testing
+# Lines starting from # are ignored, so are embty lines
+
+# Default behaviour in absence of "allowlegacyconnects" parameter changed
+# since 3.9.0, ref https://tracker.mender.io/browse/CFE-2339
+copy_from_classic_protocol_fail.cf
+copy_from_classic_protocol_success.cf
+
+# This is a test for a feature which appeared first in 3.10.0
+# ref https://github.com/cfengine/core/commit/1ac4e0c8a177c32f8c47614ac7ea082e38092a52
+copied_files_can_be_sparse.cf
+
+# These tests run two cf-serverd instances, and it is currently unsupported
+allow_path1_then_deny_path2_a.cf
+copy_from_ciphers_fail.cf
+copy_from_ciphers_success.cf
+copy_from_digest_different.cf
+copy_from_digest_different_expand_ip_and_shortcut.cf
+simple_copy_from_admit_localhost.cf
+tcp_port_copy_from_within_range.cf

--- a/tests/acceptance/serverd-multi-versions.sh
+++ b/tests/acceptance/serverd-multi-versions.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+logdir=serverd-multi-versions-logs
+statsdir=serverd-multi-versions-stats
+
+mkdir -p hub
+mkdir -p client
+mkdir -p $logdir
+mkdir -p $statsdir
+cat >server.sh <<EOF
+#!/bin/sh
+
+LD_LIBRARY_PATH=$PWD/hub/var/cfengine/lib \
+CFENGINE_TEST_OVERRIDE_EXTENSION_LIBRARY_DIR=$PWD/hub/var/cfengine/lib \
+CFENGINE_TEST_OVERRIDE_WORKDIR=$PWD/work_here \
+$PWD/hub/var/cfengine/bin/cf-serverd "\$@"
+EOF
+cat >agent.sh <<EOF
+#!/bin/sh
+LD_LIBRARY_PATH=$PWD/agent/var/cfengine/lib \
+CFENGINE_TEST_OVERRIDE_EXTENSION_LIBRARY_DIR=$PWD/agent/var/cfengine/lib \
+CFENGINE_TEST_OVERRIDE_WORKDIR=$PWD/work_here \
+$PWD/agent/var/cfengine/bin/cf-agent "\$@"
+EOF
+chmod a+x *.sh
+sed -i "s%\$(sys.cf_agent)%$PWD/agent.sh%g;s%\$(sys.cf_serverd)%$PWD/server.sh%g" \
+tests/acceptance/run_with_server.cf.sub
+chmod -R 700 tests
+sed -i 's/\s*#.*//;/^\s*$/d' tests/acceptance/serverd-multi-versions-blacklist.txt
+
+# Prepare stub workdir
+mkdir -p work_stub/inputs/
+cp -a tests/acceptance work_stub/inputs/
+rm -rf work_stub/inputs/acceptance/0*
+mkdir -p work_stub/bin/
+touch work_stub/bin/cf-promises
+chmod a+x work_stub/bin/cf-promises
+
+sudo hostname localhost
+# Ensure reverse hostname resolution is correct and 127.0.0.1 is always 'localhost'.
+# There's no nice shell command to test it but this one:
+# python -c 'import socket;print socket.gethostbyaddr("127.0.0.1")'
+sudo sed -i -e '1s/^/127.0.0.1 localhost localhost.localdomain\n/' /etc/hosts
+
+# downloads $3 (if provided), saves it as $2 and extracts it to $1
+# if $2 not provided - installs currently built version
+function install(){
+    test -z "$1" && return 1
+    rm -rf "$1"
+    if test -z "$2"
+    then
+        make install prefix=$PWD/$1/var/cfengine 2>&1 >/dev/null
+    else
+        test ! -z "$3" -a ! -f "$2" && wget "$3" -O "$2"
+        dpkg -x "$2" "$1"
+    fi
+}
+
+function testit(){
+    echo "===== $1"
+    ./server.sh -V
+    ./agent.sh -V
+    ls tests/acceptance/16_cf-serverd/serial/*.cf \
+        | grep -v -f tests/acceptance/serverd-multi-versions-blacklist.txt \
+        | sed 's%^tests/%%' \
+        | while read file
+    do
+        logfilename="$1-$(basename $file)"
+        logfile="$logdir/$logfilename"
+        ./server.sh -V >> $logfile.log
+        ./agent.sh -V >> $logfile.log
+        # delete dirs left here from previous testing round, if any.
+        # We keep deleting them until they disappear - they can be kept back by
+        # still-running process from previous testing round.
+        while test -d /tmp/TESTDIR.cfengine
+	do
+            rm -rf /tmp/TESTDIR.cfengine
+        done
+        while test -d work_here
+        do
+            rm -rf work_here
+        done
+        cp -a work_stub work_here
+        # actually run the test
+        ./agent.sh -Kf $file -D AUTO,debug_server >> $logfile.log
+        retval=$?
+        result=unknown
+        if expr "$file" : '.*\.x\.cf$' >/dev/null
+        then
+                # test should exit with non-zero status
+                # if it exits with status 128 or higher - then it's a CRASH
+                if [ $retval -gt 0 ] && [ $retval -lt 128 ]
+                then
+                    result=passed
+                else
+                    result=failed
+                fi
+        else
+                # test is expected to pass
+                grep "R: $PWD/work_here/inputs/$file FAIL" $logfile.log && result=failed
+                grep "R: $PWD/work_here/inputs/$file Pass" $logfile.log && result=passed
+        fi
+        echo $logfile>$statsdir/$result-$logfilename
+        if [ "$result" != "passed" ]
+        then
+                mv work_here $logfile.workdir
+                mv /tmp/TESTDIR.cfengine $logfile.testdir
+        fi
+    done
+}
+
+install hub
+install agent 3.10.deb https://cfengine-package-repos.s3.amazonaws.com/community_binaries/Community-3.10.2/agent_debian7_x86_64/cfengine-community_3.10.2-1_amd64-debian7.deb
+testit master-hub-with-3.10.2-agent
+
+install agent 3.7.deb https://cfengine-package-repos.s3.amazonaws.com/community_binaries/Community-3.7.6/agent_deb_x86_64/cfengine-community_3.7.6-1_amd64-debian4.deb
+testit master-hub-with-3.7.6-agent
+
+install agent
+install hub 3.10.deb
+testit master-agent-with-3.10.2-hub
+
+install hub 3.7.deb
+testit master-agent-with-3.7.6-hub
+
+echo '===== Printing results ====='
+echo "Passed tests:   $(ls $statsdir/pass* 2>/dev/null | wc -l)"
+echo "FAILED tests:   $(ls $statsdir/fail* 2>/dev/null | wc -l)"
+echo "Unknown result: $(ls $statsdir/unknown* 2>/dev/null | wc -l)"
+echo '===== Failed tests ====='
+cat $statsdir/fail* 2>/dev/null || NO_FAILED=true
+echo '===== Unknown results ====='
+cat $statsdir/unknown* 2>/dev/null || NO_UNKNOWNS=true
+
+# Return code
+test -z "$NO_FAILED" && exit 1
+test -z "$NO_UNKNOWNS" && exit 2
+exit 0

--- a/travis-scripts/after_script.sh
+++ b/travis-scripts/after_script.sh
@@ -1,8 +1,22 @@
 #!/bin/sh
 cd $TRAVIS_BUILD_DIR || return 1
+sudo apt-get -qy install curl
 mkdir artifacts
-test "x$DIST_TARBALL" != x  &&  cp --verbose "$DIST_TARBALL" artifacts/
-gzip config.log  &&  mv config.log.gz artifacts/
-gzip tests/acceptance/summary.log  &&  mv tests/acceptance/summary.log.gz artifacts/acceptance_summary.log.gz
-gzip tests/acceptance/test.log     &&  mv tests/acceptance/test.log.gz    artifacts/acceptance.log.gz
-zip -r artifacts/acceptance_workdir.zip tests/acceptance/workdir
+test "x$DIST_TARBALL" != x  &&  cp "$DIST_TARBALL" artifacts/
+mv config.log                   artifacts/ 2>/dev/null
+mv tests/acceptance/summary.log artifacts/ 2>/dev/null
+mv tests/acceptance/test.log    artifacts/ 2>/dev/null
+mv tests/acceptance/workdir     artifacts/ 2>/dev/null
+mv serverd-multi-versions-logs  artifacts/ 2>/dev/null
+
+VERSION=$(expr "$DIST_TARBALL" : "cfengine-\(.*\).tar.gz")
+VERSION=${VERSION:-master}
+test "$TRAVIS_PULL_REQUEST" == "false" && BRANCH_OR_PULL_REQUEST=$TRAVIS_BRANCH || BRANCH_OR_PULL_REQUEST=PULL_$TRAVIS_PULL_REQUEST
+
+filename=cfengine-$VERSION-$BRANCH_OR_PULL_REQUEST-$JOB_TYPE.artifacts.zip
+zip -q -r $filename artifacts/
+
+echo ===== uploading $filename to transfer.sh =====
+curl --upload-file $filename https://transfer.sh/$filename
+
+cd - >/dev/null

--- a/travis-scripts/script.sh
+++ b/travis-scripts/script.sh
@@ -59,3 +59,12 @@ then
     ./testall --gainroot=sudo --tests=timed,slow,errorexit,libxml2,libcurl,serial,network,unsafe
     return
 fi
+
+if [ "$JOB_TYPE" = serverd_multi_versions ]
+then
+    cd ../..
+    set +e
+    tests/acceptance/serverd-multi-versions.sh
+    return
+fi
+


### PR DESCRIPTION
And add this as a new job to Travis.

These versions are tested so far:
* currently built server with 3.10.2 agent
* currently built server with 3.7.6 agent
* currently built agent with 3.10.2 server
* currently built agent with 3.7.6 server