### PR TITLE
ENT-3483: Do not tag large volatile data for inventory

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -1101,7 +1101,7 @@ JsonElement* GetProcFileInfo(EvalContext *ctx, const char* filename, const char*
                 Buffer *varname = BufferNew();
                 BufferPrintf(varname, "%s", key);
                 EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, BufferData(varname), info, CF_DATA_TYPE_CONTAINER,
-                                              "inventory,networking,/proc,source=agent,attribute_name=none,procfs");
+                                              "networking,/proc,source=agent,procfs");
                 BufferDestroy(varname);
             }
 
@@ -1175,7 +1175,7 @@ void GetNetworkingInfo(EvalContext *ctx)
     }
 
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "inet", inet, CF_DATA_TYPE_CONTAINER,
-                                  "inventory,networking,/proc,source=agent,attribute_name=none,procfs");
+                                  "networking,/proc,source=agent,procfs");
     JsonDestroy(inet);
 
     JsonElement *inet6 = JsonObjectCreate(3);
@@ -1237,7 +1237,7 @@ void GetNetworkingInfo(EvalContext *ctx)
     }
 
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "inet6", inet6, CF_DATA_TYPE_CONTAINER,
-                                  "inventory,networking,/proc,source=agent,attribute_name=none,procfs");
+                                  "networking,/proc,source=agent,procfs");
     JsonDestroy(inet6);
 
     // Inter-|   Receive                                                |  Transmit


### PR DESCRIPTION
interfaces_data is commonly larger than the maximum data size allowed to be
collected by cf-hub. Data larger than 1k is truncated. Instead of reporting
truncated data this change stops tagging the variable so that it will not be
collected to the Enterprise hub.

Changelog: Title