### PR TITLE
CFE-2736: Fix libxml2 tests not being skipped

### DIFF
--- a/tests/acceptance/Makefile.am
+++ b/tests/acceptance/Makefile.am
@@ -85,7 +85,7 @@ endif
 check-local:
         # Keep the '+' in front for the command, needed for the sub-make
         # to run in parallel; TODO fix "make -n" not working.
-	+ MAKE=$(MAKE) ./testall
+	+ $(TESTS_ENVIRONMENT) MAKE=$(MAKE) ./testall
 
 
 EXTRA_DIST = default.cf.sub dcs.cf.sub plucked.cf.sub run_with_server.cf.sub \


### PR DESCRIPTION
This exports now properly environment variables to testall, so other
unidentified breakage should also be fixed.