### PR TITLE
CFE-2084: Improve multiple augments logging

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -378,7 +378,7 @@ bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonElement*
                         bool further_loaded = LoadAugmentsFiles(ctx, filename);
                         if (further_loaded)
                         {
-                            Log(LOG_LEVEL_VERBOSE, "Installed further augments from file '%s'", filename);
+                            Log(LOG_LEVEL_VERBOSE, "Completed augmenting from file '%s'", filename);
                         }
                         else
                         {


### PR DESCRIPTION
This change makes it more apparent that an additional augments file has
completed its processing rather than seeming like it was processed
multiple times.