### PR TITLE
CFE-2593: Test that iterating variablesmatching() results does not crash the agent

### DIFF
--- a/tests/acceptance/01_vars/02_functions/iterating_variablesmatching_results.cf
+++ b/tests/acceptance/01_vars/02_functions/iterating_variablesmatching_results.cf
@@ -1,0 +1,23 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+}
+
+bundle agent test {
+  meta:
+    "description" -> { "CFE-2593" }
+      string => "Test that the agent won't crash trying to iterate over variablesmatching() results";
+}
+bundle agent check {
+  vars:
+    "some_var"
+      string => "some value";
+ 
+    "make_cfe_crash"
+      slist => variablesmatching("$(this.namespace):$(this.bundle)\..*");
+ 
+  reports:
+    "DEBUG: '$(make_cfe_crash)' = '$($(make_cfe_crash))'";
+    "$(this.promise_filename) Pass";
+}


### PR DESCRIPTION
(cherry picked from commit 9925ead74fd8e94603b86feda28ce4934a06218b)