### PR TITLE
Don't segfault if a JSON policy file contains no bundles and bodies

### DIFF
--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -111,6 +111,15 @@ Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_path)
         }
 
         policy = PolicyFromJson(json_policy);
+        if (policy == NULL)
+        {
+            Log(LOG_LEVEL_ERR,
+                "Failed to deserialize a policy from the JSON input file '%s'",
+                input_path);
+            JsonDestroy(json_policy);
+            WriterClose(contents);
+            return NULL;
+        }
 
         JsonDestroy(json_policy);
         WriterClose(contents);

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2290,17 +2290,24 @@ Policy *PolicyFromJson(JsonElement *json_policy)
 {
     Policy *policy = PolicyNew();
 
+    JsonElement *json_bundles = JsonObjectGetAsArray(json_policy, "bundles");
+    JsonElement *json_bodies = JsonObjectGetAsArray(json_policy, "bodies");
+
+    if ((json_bundles == NULL) && (json_bodies == NULL))
     {
-        JsonElement *json_bundles = JsonObjectGetAsArray(json_policy, "bundles");
+        return NULL;
+    }
+
+    if (json_bundles != NULL)
+    {
         for (size_t i = 0; i < JsonLength(json_bundles); i++)
         {
             JsonElement *json_bundle = JsonArrayGetAsObject(json_bundles, i);
             PolicyAppendBundleJson(policy, json_bundle);
         }
     }
-
+    if (json_bodies != NULL)
     {
-        JsonElement *json_bodies = JsonObjectGetAsArray(json_policy, "bodies");
         for (size_t i = 0; i < JsonLength(json_bodies); i++)
         {
             JsonElement *json_body = JsonArrayGetAsObject(json_bodies, i);


### PR DESCRIPTION
Somebody may accidentally run cf-agent or cf-promises on a JSON
file that is not a valid policy file in the JSON format.