### PR TITLE
CFE-2748: Issue a warning on ignored locking attributes

### DIFF
--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -687,6 +687,28 @@ static PromiseResult KeepServerPromise(EvalContext *ctx, const Promise *pp, ARG_
         return VerifyClassPromise(ctx, pp, NULL);
     }
 
+    /* Warn if promise locking was used with a promise that doesn't support it.
+     * That applies to both of the below promise types while 'vars' and
+     * 'classes' handle this on their own. */
+    int ifelapsed = PromiseGetConstraintAsInt(ctx, "ifelapsed", pp);
+    if (ifelapsed != CF_NOINT)
+    {
+        Log(LOG_LEVEL_WARNING,
+            "ifelapsed attribute specified in action body for %s promise '%s',"
+            " but %s promises do not support promise locking",
+            pp->parent_promise_type->name, pp->promiser,
+            pp->parent_promise_type->name);
+    }
+    int expireafter = PromiseGetConstraintAsInt(ctx, "expireafter", pp);
+    if (expireafter != CF_NOINT)
+    {
+        Log(LOG_LEVEL_WARNING,
+            "expireafter attribute specified in action body for %s promise '%s',"
+            " but %s promises do not support promise locking",
+            pp->parent_promise_type->name, pp->promiser,
+            pp->parent_promise_type->name);
+    }
+
     if (strcmp(pp->parent_promise_type->name, "access") == 0)
     {
         const char *resource_type =


### PR DESCRIPTION
According to the recently updated documentation on promise
locking, there are several promise types that don't support any
form of promise locking:

  * access
  * classes
  * defaults
  * meta
  * roles
  * vars

When a policy writer uses "ifelapsed" or "expireafter" attributes
(via an action body) on these promise types which don't support
them, a warning should be issued rather than the setting being
silently ignored.

Codewise, it would be great if every promise evaluation called
GetTransactionConstraints(), that way we could only have the
check and warning in one place. Unfortunately, that's not the
case, VerifyVarPromise() is not calling that particular function
and neither is handling of 'access' and 'roles' in cf-serverd.

Changelog: Title