### PR TITLE
fix detection of libacl headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -507,8 +507,11 @@ then
       [],
       [if test "x$with_libacl" != xcheck; then AC_MSG_ERROR(Cannot find libacl library); fi])
     AC_CHECK_HEADERS([acl.h sys/acl.h acl/libacl.h],
-      [libacl_header_found=yes],
-      [if test "x$with_libacl" != xcheck; then AC_MSG_ERROR(Cannot find libacl header files); fi])
+      [libacl_header_found=yes])
+    if test "x$libacl_header_found" != "xyes" && test "x$with_libacl" != xcheck;
+    then
+      AC_MSG_ERROR(Cannot find libacl library headers);
+    fi
   ])
 fi
 


### PR DESCRIPTION
Commit 41c0afd ("Improve readability") moved the error handling for a
missing libacl header into AC_CHECK_HEADER's action-if-not-found.  This
was a mistake, though, as this action is executed for each header not
found, which was not the intent of the original check.