### PR TITLE
INF-311: fix failing tests on Solaris 10, because of gmake not found.

### DIFF
--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -68,6 +68,7 @@ bundle common G
       "paths[usr_xpg4_bin]" string           => "/usr/xpg4/bin";
       "paths[usr_ucb_sparcv7]" string        => "/usr/ucb/sparcv7";
       "paths[opt_csw_bin]" string            => "/opt/csw/bin";
+      "paths[usr_sfw_bin]" string            => "/usr/sfw/bin";
     !windows::
       "paths[bin]" string                    => "/bin";
       "paths[usr_bin]" string                => "/usr/bin";


### PR DESCRIPTION
(cherry picked from commit 84c81f4701a2e8e8f8f5473377ae858dc9c40597)