### PR TITLE
Update URL for help-cfengine mailing list.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -61,7 +61,7 @@ different tools or versions of tools, please report it to help-cfengine@ mailing
 list[1]. Please consider running a testsuite (see below), and posting results to
 mailing list too.
 
-[1] https://cfengine.org/mailman/listinfo/help-cfengine
+[1] https://groups.google.com/forum/#!forum/help-cfengine
 
 BUILD INSTRUCTIONS
 ------------------


### PR DESCRIPTION
The project documentation still references the old URL for the help-cfengine mailing list. This change updates it to the current one.