### PR TITLE
Fix segfault when no show-evaluated-vars/classes is specified

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -272,16 +272,16 @@ int main(int argc, char *argv[])
     PurgeLocks();
     BackupLockDatabase();
 
-    if (config->agent_specific.common.show_classes != NULL)
+    if (config->agent_specific.agent.show_evaluated_classes != NULL)
     {
-        GenericAgentShowContextsFormatted(ctx, config->agent_specific.common.show_classes);
-        free(config->agent_specific.common.show_classes);
+        GenericAgentShowContextsFormatted(ctx, config->agent_specific.agent.show_evaluated_classes);
+        free(config->agent_specific.agent.show_evaluated_classes);
     }
 
-    if (config->agent_specific.common.show_variables != NULL)
+    if (config->agent_specific.agent.show_evaluated_variables != NULL)
     {
-        GenericAgentShowVariablesFormatted(ctx, config->agent_specific.common.show_variables);
-        free(config->agent_specific.common.show_variables);
+        GenericAgentShowVariablesFormatted(ctx, config->agent_specific.agent.show_evaluated_variables);
+        free(config->agent_specific.agent.show_evaluated_variables);
     }
 
     PolicyDestroy(policy); /* Can we safely do this earlier ? */
@@ -570,7 +570,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 {
                     optarg = ".*";
                 }
-                config->agent_specific.common.show_classes = xstrdup(optarg);
+                config->agent_specific.agent.show_evaluated_classes = xstrdup(optarg);
             }
             else if (strcmp(OPTIONS[longopt_idx].name, "show-evaluated-vars") == 0)
             {
@@ -578,7 +578,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 {
                     optarg = ".*";
                 }
-                config->agent_specific.common.show_variables = xstrdup(optarg);
+                config->agent_specific.agent.show_evaluated_variables = xstrdup(optarg);
             }
     break;
 

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1863,12 +1863,17 @@ GenericAgentConfig *GenericAgentConfigNewDefault(AgentType agent_type, bool tty_
     {
     case AGENT_TYPE_COMMON:
         config->agent_specific.common.eval_functions = true;
-        config->agent_specific.common.show_classes = false;
-        config->agent_specific.common.show_variables = false;
+        config->agent_specific.common.show_classes = NULL;
+        config->agent_specific.common.show_variables = NULL;
         config->agent_specific.common.policy_output_format = GENERIC_AGENT_CONFIG_COMMON_POLICY_OUTPUT_FORMAT_NONE;
         /* Bitfields of warnings to be recorded, or treated as errors. */
         config->agent_specific.common.parser_warnings = PARSER_WARNING_ALL;
         config->agent_specific.common.parser_warnings_error = 0;
+        break;
+
+    case AGENT_TYPE_AGENT:
+        config->agent_specific.agent.show_evaluated_classes = NULL;
+        config->agent_specific.agent.show_evaluated_variables = NULL;
         break;
 
     default:

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -87,6 +87,8 @@ typedef struct
             char *bootstrap_port;
             char *bootstrap_ip;
             bool bootstrap_trust_server;
+            char *show_evaluated_classes;
+            char *show_evaluated_variables;
 
             // BODY AGENT CONTROL
             bool report_class_log;


### PR DESCRIPTION
When running cf-agent (compiled on Fedora 27), I get a segfault in pcre because of no initial value for the `show_classes` and `show_variables` regexes.