### PR TITLE
CFE-2310: Add IPv6 hard classes with the "ipv6_" prefix

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -54,6 +54,8 @@
 #define CF_IFREQ 2048           /* Reportedly the largest size that does not segfault 32/64 bit */
 #define CF_IGNORE_INTERFACES "ignore_interfaces.rx"
 
+#define IPV6_PREFIX "ipv6_"
+
 #ifndef __MINGW32__
 
 # if defined(HAVE_STRUCT_SOCKADDR_SA_LEN) && !defined(__NetBSD__)
@@ -656,9 +658,13 @@ static void FindV6InterfacesInfo(EvalContext *ctx)
 
                 if ((IsIPV6Address(ip->name)) && ((strcmp(ip->name, "::1") != 0)))
                 {
+                    char prefixed_ip[CF_MAX_IP_LEN + sizeof(IPV6_PREFIX)] = {0};
                     Log(LOG_LEVEL_VERBOSE, "Found IPv6 address %s", ip->name);
                     EvalContextAddIpAddress(ctx, ip->name, NULL); // interface unknown
                     EvalContextClassPutHard(ctx, ip->name, "inventory,attribute_name=none,source=agent");
+
+                    xsnprintf(prefixed_ip, sizeof(prefixed_ip), IPV6_PREFIX"%s", ip->name);
+                    EvalContextClassPutHard(ctx, prefixed_ip, "inventory,attribute_name=none,source=agent");
                 }
             }
 

--- a/tests/acceptance/02_classes/01_basic/ipaddr_classes.cf
+++ b/tests/acceptance/02_classes/01_basic/ipaddr_classes.cf
@@ -1,0 +1,34 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent check
+{
+  vars:
+      "ipv6_classes" slist => classesmatching("ipv6_.*");
+
+  classes:
+      "has_ipv6" expression => returnszero("ifconfig -a | grep 'inet6 [a-z0-9].*'", "useshell");
+
+    has_ipv6::
+      "ok" expression => some(".*", "ipv6_classes");
+
+    !has_ipv6::
+      "ok" expression => "any";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+
+    !ok::
+      "$(this.promise_filename) FAIL";
+
+    DEBUG::
+      "ipv6_classes: $(ipv6_classes)";
+
+    DEBUG.has_ipv6::
+      "Has IPv6";
+}


### PR DESCRIPTION
Hard classes for the IPv4 addresses have the "ipv4_" prefix so
the IPv6 ones should use the same pattern. However, we shouldn't
just prefix the existing hard classes as users may rely on them
being available without the prefix. Thus add new ones.

Changelog: Title
(cherry picked from commit 307dd25e2379765724c334e8b4278f5c56e20ce1)