### PR TITLE
fix detection of libacl headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -496,6 +496,7 @@ dnl  define is not generated!  Or use AC_SEARCH_LIBS for a better
 dnl  interface.
 
 dnl libacl
+dnl It is enough for any of the header files [acl.h sys/acl.h acl/libacl.h] to be present
 
 AC_ARG_WITH([libacl],
     [AS_HELP_STRING([--with-libacl[[=PATH]]], [Specify libacl path])], [], [with_libacl=check])
@@ -507,8 +508,11 @@ then
       [],
       [if test "x$with_libacl" != xcheck; then AC_MSG_ERROR(Cannot find libacl library); fi])
     AC_CHECK_HEADERS([acl.h sys/acl.h acl/libacl.h],
-      [libacl_header_found=yes],
-      [if test "x$with_libacl" != xcheck; then AC_MSG_ERROR(Cannot find libacl header files); fi])
+      [libacl_header_found=yes])
+    if test "x$libacl_header_found" != "xyes" && test "x$with_libacl" != xcheck;
+    then
+      AC_MSG_ERROR(Cannot find libacl library headers);
+    fi
   ])
 fi
 


### PR DESCRIPTION
Commit 41c0afd ("Improve readability") moved the error handling for a
missing libacl header into AC_CHECK_HEADER's action-if-not-found.  This
was a mistake, though, as this action is executed for each header not
found, which was not the intent of the original check.

For libacl, it is enough for any of the header files [acl.h sys/acl.h
acl/libacl.h] to be present.