### PR TITLE
Hashes in file paths in filesexist()

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -6942,48 +6942,44 @@ static FnCallResult FnCallStringSplit(ARG_UNUSED EvalContext *ctx,
 
 static FnCallResult FnCallFileSexist(EvalContext *ctx, ARG_UNUSED const Policy *policy, ARG_UNUSED const FnCall *fp, const Rlist *finalargs)
 {
-    char naked[CF_MAXVARSIZE];
-    char *listvar = RlistScalarValue(finalargs);
+    bool allocated = false;
+    JsonElement *json = VarNameOrInlineToJson(ctx, fp, finalargs, false, &allocated);
 
-    if (IsVarList(listvar))
-    {
-        GetNaked(naked, listvar);
-    }
-    else
-    {
-        Log(LOG_LEVEL_VERBOSE, "Function filesexist was promised a list called '%s' but this was not found", listvar);
-        return FnFailure();
-    }
-
-    VarRef *ref = VarRefParse(naked);
-    DataType input_list_type;
-    const Rlist *input_list = EvalContextVariableGet(ctx, ref, &input_list_type);
-    VarRefDestroy(ref);
-    if (input_list_type == CF_DATA_TYPE_NONE)
+    // we failed to produce a valid JsonElement, so give up
+    if (json == NULL)
     {
         Log(LOG_LEVEL_VERBOSE,
-            "Function filesexist was promised a list called"
-            " '%s' but this was not found", listvar);
+            "Cannot produce valid JSON from the argument '%s' of the function '%s'",
+            fp->name, RlistScalarValueSafe(finalargs));
         return FnFailure();
     }
-    else if (DataTypeToRvalType(input_list_type) != RVAL_TYPE_LIST)
+    else if (JsonGetElementType(json) != JSON_ELEMENT_TYPE_CONTAINER)
     {
-        Log(LOG_LEVEL_VERBOSE,
-            "Function filesexist was promised a list called"
-            " '%s' but this variable is not a list", listvar);
+        Log(LOG_LEVEL_VERBOSE, "Function '%s', argument '%s' was not a data container or list",
+            fp->name, RlistScalarValueSafe(finalargs));
+        JsonDestroyMaybe(json, allocated);
         return FnFailure();
     }
 
-    for (const Rlist *rp = input_list; rp != NULL; rp = rp->next)
+    JsonIterator iter = JsonIteratorInit(json);
+    const JsonElement *el = JsonIteratorNextValueByType(&iter, JSON_ELEMENT_TYPE_PRIMITIVE, true);
+
+    /* no elements mean 'false' should be returned, otherwise let's see if the files exist */
+    bool file_found = el != NULL;
+
+    while (file_found && (el != NULL))
     {
+        char *val = JsonPrimitiveToString(el);
         struct stat sb;
-        if (stat(RlistScalarValue(rp), &sb) == -1)
+        if (stat(val, &sb) == -1)
         {
-            return FnReturnContext(false);
+            file_found = false;
         }
+        el = JsonIteratorNextValueByType(&iter, JSON_ELEMENT_TYPE_PRIMITIVE, true);
     }
 
-    return FnReturnContext(true);
+    JsonDestroyMaybe(json, allocated);
+    return FnReturnContext(file_found);
 }
 
 /*********************************************************************/
@@ -8087,7 +8083,7 @@ static const FnCallArg FILESTAT_DETAIL_ARGS[] =
 
 static const FnCallArg FILESEXIST_ARGS[] =
 {
-    {CF_NAKEDLRANGE, CF_DATA_TYPE_STRING, "CFEngine list identifier"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "CFEngine variable identifier or inline JSON"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -8913,7 +8909,7 @@ const FnCallType CF_FNCALL_TYPES[] =
     FnCallTypeNew("fileexists", CF_DATA_TYPE_CONTEXT, FILESTAT_ARGS, &FnCallFileStat, "True if the named file can be accessed",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_FILES, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("filesexist", CF_DATA_TYPE_CONTEXT, FILESEXIST_ARGS, &FnCallFileSexist, "True if the named list of files can ALL be accessed",
-                  FNCALL_OPTION_NONE, FNCALL_CATEGORY_FILES, SYNTAX_STATUS_NORMAL),
+                  FNCALL_OPTION_COLLECTING, FNCALL_CATEGORY_FILES, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("filesize", CF_DATA_TYPE_INT, FILESTAT_ARGS, &FnCallFileStat, "Returns the size in bytes of the file",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_FILES, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("filestat", CF_DATA_TYPE_STRING, FILESTAT_DETAIL_ARGS, &FnCallFileStatDetails, "Returns stat() details of the file",

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -271,31 +271,23 @@ static FnCallResult CallFunction(EvalContext *ctx, const Policy *policy, const F
 
     if (argnum != RlistLen(expargs) && !(fncall_type->options & FNCALL_OPTION_VARARG))
     {
-        fprintf(stderr, "Argument template mismatch handling function %s(", fp->name);
-        {
-            Writer *w = FileWriter(stderr);
-            RlistWrite(w, expargs);
-            FileWriterDetach(w);
-        }
-
-        fprintf(stderr, ")\n");
+        char *args_str = RlistToString(expargs);
+        Log(LOG_LEVEL_ERR, "Argument template mismatch handling function %s(%s)", fp->name, args_str);
+        free(args_str);
 
         rp = expargs;
         for (int i = 0; i < argnum; i++)
         {
-            printf("  arg[%d] range %s\t", i, fncall_type->args[i].pattern);
             if (rp != NULL)
             {
-                Writer *w = FileWriter(stdout);
-                RvalWrite(w, rp->val);
-                FileWriterDetach(w);
-                rp = rp->next;
+                char *rval_str = RvalToString(rp->val);
+                Log(LOG_LEVEL_ERR, "  arg[%d] range %s\t %s ", i, fncall_type->args[i].pattern, rval_str);
+                free(rval_str);
             }
             else
             {
-                printf(" ? ");
+                Log(LOG_LEVEL_ERR, "  arg[%d] range %s\t ? ", i, fncall_type->args[i].pattern);
             }
-            printf("\n");
         }
 
         FatalError(ctx, "Bad arguments");

--- a/tests/acceptance/01_vars/02_functions/filesexist-can-detect-files-containing-hash-character.cf
+++ b/tests/acceptance/01_vars/02_functions/filesexist-can-detect-files-containing-hash-character.cf
@@ -1,0 +1,67 @@
+#######################################################
+#
+# Test that filesexist() can check for presence of files containing hashes
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "test_files" slist => { "example##4567", "example##123" };
+
+  files:
+      "$(G.testdir)/$(test_files)"
+        create => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2744" }
+        string => "Test that filesexist can verify files containing hashes exist";
+
+  vars:
+      "found_files" slist => findfiles( "$(G.testdir)/example##*");
+
+  classes:
+    # This should always be true.
+    # We check that the files that we found exist.
+
+    "found_expected_files_with_filesexist"
+      expression => filesexist( "@(found_files)" ),
+        scope => "namespace";
+
+}
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok" expression => "found_expected_files_with_filesexist";
+
+  reports:
+    DEBUG|EXTRA::
+      "Test files: $(init.test_files)";
+
+      "Found files: $(test.found_files)";
+
+      "filesexist() cannot validate files containing '#', not working as expected"
+        if => not( "ok" );
+
+    ok::
+      "$(this.promise_filename) Pass";
+
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/01_vars/02_functions/filesexist-is-collecting.cf
+++ b/tests/acceptance/01_vars/02_functions/filesexist-is-collecting.cf
@@ -1,0 +1,80 @@
+#######################################################
+#
+# Test that filesexist() can check for presence of files containing hashes
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "test_files" slist => { "example4567", "example123" };
+
+  files:
+      "$(G.testdir)/$(test_files)"
+        create => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2744" }
+        string => "Test that filesexist works as a collecting function";
+
+  classes:
+      "filesexist_slist_identifier_ok"
+        expression => filesexist( "init.test_files" ),
+        scope => "namespace";
+
+      "filesexist_slist_ref_ok"
+        expression => filesexist( @(init.test_files) ),
+        scope => "namespace";
+
+      "filesexist_findfiles_ok"
+        expression => filesexist( findfiles( "$(G.testdir)/example*" ) ),
+        scope => "namespace";
+
+      "filesexist_json_array_ok"
+        expression => filesexist( '[ "example4567", "example123" ]' ),
+        scope => "namespace";
+}
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok" and => { "filesexist_slist_identifier_ok", "filesexist_slist_ref_ok",
+                    "filesexist_findfiles_ok", "filesexist_json_array_ok" };
+
+  reports:
+    DEBUG|EXTRA::
+      "Test files: $(init.test_files)";
+
+      "filesexist() doesn't work with an slist identifier"
+        if => not( "filesexist_slist_identifier_ok" );
+
+      "filesexist() doesn't work with an slist reference"
+        if => not( "filesexist_slist_ref_ok" );
+
+      "filesexist() doesn't work properly with a nested findfiles() call"
+        if => not( "filesexist_findfiles_ok" );
+
+      "filesexist() doesn't work with a JSON array"
+        if => not( "filesexist_json_array_ok" );
+
+    ok::
+      "$(this.promise_filename) Pass";
+
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/02_classes/02_functions/empty_list_or_data_doesnt_return_true_for_filesexist.cf
+++ b/tests/acceptance/02_classes/02_functions/empty_list_or_data_doesnt_return_true_for_filesexist.cf
@@ -7,12 +7,8 @@ body common control
 bundle agent test
 {
   meta:
-      "description"
+      "description" -> { "CFE-2631" }
         string => "Test that empty lists or data containers do not return true with filesexist. There are no files provided to verify!";
-
-      "test_soft_fail"
-        string => "any",
-        meta => { "CFE-2631" };
 
   vars:
       "emptylist" slist => {};
@@ -23,7 +19,7 @@ bundle agent test
       expression => filesexist( @(emptylist) );
 
       "files_in_empty_data_exist"
-      expression => filesexist( @(emptdata) );
+      expression => filesexist( @(emptydata) );
 
       "pass"
         expression => "!(files_in_empty_list_exist|files_in_empty_data_exist)";


### PR DESCRIPTION
Adding a test in the first commit because it turns out things just work as [expected/documented](https://docs.cfengine.com/docs/3.10/reference-functions-filesexist.html). The other commit is a related minor fix-up.