### PR TITLE
ENT-3526: expand reporting tests. 

### DIFF
--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -181,6 +181,8 @@ static void LogToConsole(const char *msg, LogLevel level, bool color)
         // Turn off the color again.
         fprintf(output_file, "\x1b[0m");
     }
+
+    fflush(stdout);
 }
 
 #if !defined(__MINGW32__)


### PR DESCRIPTION
Need to fflush() log output to help cf-consumer complete log output for tests.