### PR TITLE
zendesk#3739: Load process table when actually needed for a processes…

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1579,6 +1579,11 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
     }
     else if (strcmp("processes", pp->parent_promise_type->name) == 0)
     {
+        if (!LoadProcessTable())
+        {
+            Log(LOG_LEVEL_ERR, "Unable to read the process table - cannot keep processes: type promises");
+            return PROMISE_RESULT_FAIL;
+        }
         result = VerifyProcessesPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
         {
@@ -1732,11 +1737,6 @@ static int NewTypeContext(TypeSequence type)
         break;
 
     case TYPE_SEQUENCE_PROCESSES:
-        if (!LoadProcessTable())
-        {
-            Log(LOG_LEVEL_ERR, "Unable to read the process table - cannot keep processes: type promises");
-            return false;
-        }
         break;
 
     case TYPE_SEQUENCE_STORAGE:


### PR DESCRIPTION
… promise

Process table loading is not a particularly cheap operation and
thus should only run when really needed. Instead of running it
when the 'processes' type context is entered, run it when some
'processes' promise is actually evaluated -- it may be skipped
due to class restrictions.

Note that LoadProcessTable() has a caching mechanism and unless
the cache is invalidated by ClearProcessTable(), it is a noop. By
keeping ClearProcessTable() call intact this change should not
change behavior.

Changelog: Title
(cherry picked from commit ef111df2a736de17481078ff83eef71034f66a56)