### PR TITLE
CFE-2482: Load augments at the end of context discovery

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -494,8 +494,6 @@ void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config)
     EvalContextHeapPersistentLoadAll(ctx);
     LoadSystemConstants(ctx);
 
-    LoadAugments(ctx, config);
-
     const char *bootstrap_arg =
         config->agent_specific.agent.bootstrap_argument;
     const char *bootstrap_ip =
@@ -574,22 +572,24 @@ void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config)
             EvalContextSetPolicyServer(ctx, existing_policy_server);
             free(existing_policy_server);
             UpdateLastPolicyUpdateTime(ctx);
+            if (GetAmPolicyHub())
+            {
+                MarkAsPolicyServer(ctx);
+
+                /* Should this go in MarkAsPolicyServer() ? */
+                CheckAndSetHAState(GetWorkDir(), ctx);
+            }
         }
         else
         {
             Log(LOG_LEVEL_VERBOSE, "This agent is not bootstrapped -"
                 " can't find policy_server.dat in: %s", GetWorkDir());
-            return;
-        }
-
-        if (GetAmPolicyHub())
-        {
-            MarkAsPolicyServer(ctx);
-
-            /* Should this go in MarkAsPolicyServer() ? */
-            CheckAndSetHAState(GetWorkDir(), ctx);
         }
     }
+
+    /* load augments here so that they can make use of the classes added above
+     * (especially 'am_policy_hub' and 'policy_server') */
+    LoadAugments(ctx, config);
 }
 
 static bool IsPolicyPrecheckNeeded(GenericAgentConfig *config, bool force_validation)

--- a/tests/acceptance/00_basics/def.json/policy_server_classes.cf
+++ b/tests/acceptance/00_basics/def.json/policy_server_classes.cf
@@ -1,0 +1,29 @@
+# basic test of the def.json facility: classes
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+      "" usebundle => file_make("$(sys.statedir)/am_policy_hub", '');
+      "" usebundle => file_make("$(sys.workdir)/policy_server.dat", 'fake-server');
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf|$(G.grep) test_class";
+
+  methods:
+      "" usebundle => dcs_passif_output("test_class_policy_server\s+source=augments_file,hardclass", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/policy_server_classes.cf.json
+++ b/tests/acceptance/00_basics/def.json/policy_server_classes.cf.json
@@ -1,0 +1,6 @@
+{
+ "classes":
+ {
+  "test_class_policy_server": [ "am_policy_hub" ],
+ }
+}


### PR DESCRIPTION
This means that classes defined as part of the context discovery
(e.g. 'am_policy_hub' and 'policy_server') can be used in the
augments.

Changelog: Commit