### PR TITLE
CFE-741 Do not error when file does not exist with isexecutable()

### DIFF
--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -120,7 +120,7 @@ int IsExecutable(const char *file)
 
     if (stat(file, &sb) == -1)
     {
-        Log(LOG_LEVEL_ERR, "Proposed executable file '%s' doesn't exist", file);
+        Log(LOG_LEVEL_VERBOSE, "Proposed executable file '%s' doesn't exist", file);
         return false;
     }
 


### PR DESCRIPTION
Changelog: Title

Since isexecutable() is only checking to see if a file is executable we do not
need to have an error message that is always emitted if the file does not exist.
The function will return non-true and the class will not be set. If the file
does not exist, it's not executable.