### PR TITLE
DO NOT MERGE: Disable silent rules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ AC_DEFINE_UNQUOTED(ABS_TOP_SRCDIR,
 "`cd -- "$srcdir"; pwd`",
 [Absolute path of source tree])
 
-m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
+dnl m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
 AC_CONFIG_HEADERS([libutils/config.h])
 


### PR DESCRIPTION
So that we see the flags things are compiled and linked with.