### PR TITLE
Revert "CFE-741 Do not error when file does not exist with isexecutable()"

### DIFF
--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -120,7 +120,7 @@ int IsExecutable(const char *file)
 
     if (stat(file, &sb) == -1)
     {
-        Log(LOG_LEVEL_VERBOSE, "Proposed executable file '%s' doesn't exist", file);
+        Log(LOG_LEVEL_ERR, "Proposed executable file '%s' doesn't exist", file);
         return false;
     }
 


### PR DESCRIPTION
This reverts commit 0df7a2a3fa18e710a24c1c040d5bb2f43e73aa1a.

This change was found to affect more areas than desired.