### PR TITLE
CFE-741: Don't error when calling isexecutable on broken link

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -3943,7 +3943,7 @@ static FnCallResult FnCallFileStat(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const
 
     if (lstat(path, &statbuf) == -1)
     {
-        if (!strcmp(fp->name, "filesize"))
+        if (StringSafeEqual(fp->name, "filesize"))
         {
             return FnFailure();
         }
@@ -3952,6 +3952,11 @@ static FnCallResult FnCallFileStat(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const
 
     if (!strcmp(fp->name, "isexecutable"))
     {
+        if (S_ISLNK(statbuf.st_mode) && stat(path, &statbuf) == -1)
+        {
+            // stat on link target failed - probably broken link
+            return FnReturnContext(false);
+        }
         return FnReturnContext(IsExecutable(path));
     }
     if (!strcmp(fp->name, "isdir"))


### PR DESCRIPTION
This introduces another stat() syscall which is
inefficient, isexecutable() now does:

lstat() -> stat() -> stat()

It becomes quite a bit more complex if you want
to refactor this nicely. You have to take into
account:

 * Other functions like returnszero()
 * IsExecutable() C function is used by commands promises
 * The error message for world writable executables
 * Windows compatibility functions

Thus, I kept the existing codebase and behavior as is,
and only fixed this specific issue.

Ticket: CFE-741
Changelog: Title
Signed-off-by: Ole Herman Schumacher Elgesem <ole.elgesem@northern.tech>