### PR TITLE
CFE-2482: Load augments at the end of context discovery

### DIFF
--- a/tests/acceptance/00_basics/def.json/policy_server_classes.cf
+++ b/tests/acceptance/00_basics/def.json/policy_server_classes.cf
@@ -1,0 +1,29 @@
+# basic test of the def.json facility: classes
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+      "" usebundle => file_make("$(sys.statedir)/am_policy_hub", '');
+      "" usebundle => file_make("$(sys.workdir)/policy_server.dat", 'fake-server');
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf|$(G.grep) test_class";
+
+  methods:
+      "" usebundle => dcs_passif_output("test_class_policy_server\s+source=augments_file,hardclass", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/policy_server_classes.cf.json
+++ b/tests/acceptance/00_basics/def.json/policy_server_classes.cf.json
@@ -1,0 +1,6 @@
+{
+ "classes":
+ {
+  "test_class_policy_server": [ "am_policy_hub" ],
+ }
+}


### PR DESCRIPTION
This means that classes defined as part of the context discovery
(e.g. 'am_policy_hub' and 'policy_server') can be used in the
augments.

Changelog: Commit
(cherry picked from commit 5214d9347f03138c8c270968eb078bfcf5a4f3d6)