### PR TITLE
CFE-741 Backport Don't error when calling isexecutable on broken link to 3.7.x

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -3273,7 +3273,7 @@ static FnCallResult FnCallFileStat(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const
 
     if (lstat(path, &statbuf) == -1)
     {
-        if (!strcmp(fp->name, "filesize"))
+        if (StringSafeEqual(fp->name, "filesize"))
         {
             return FnFailure();
         }
@@ -3282,6 +3282,11 @@ static FnCallResult FnCallFileStat(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const
 
     if (!strcmp(fp->name, "isexecutable"))
     {
+        if (S_ISLNK(statbuf.st_mode) && stat(path, &statbuf) == -1)
+        {
+            // stat on link target failed - probably broken link
+            return FnReturnContext(false);
+        }
         return FnReturnContext(IsExecutable(path));
     }
     if (!strcmp(fp->name, "isdir"))


### PR DESCRIPTION
This introduces another stat() syscall which is
inefficient, isexecutable() now does:

lstat() -> stat() -> stat()

It becomes quite a bit more complex if you want
to refactor this nicely. You have to take into
account:

 * Other functions like returnszero()
 * IsExecutable() C function is used by commands promises
 * The error message for world writable executables
 * Windows compatibility functions

Thus, I kept the existing codebase and behavior as is,
and only fixed this specific issue.

Ticket: CFE-741
Changelog: Title
Signed-off-by: Ole Herman Schumacher Elgesem <ole.elgesem@northern.tech>
(cherry picked from commit 1c16772d1167de359d5560a7c836dbeb221de6f3)