### PR TITLE
CFE-2793 Identify bundle name when triggering bundle abortion

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -396,7 +396,7 @@ static void EvalContextStackFrameAddSoft(EvalContext *ctx, const char *context, 
 
     if (IsRegexItemIn(ctx, ctx->heap_abort_current_bundle, copy))
     {
-        Log(LOG_LEVEL_ERR, "Bundle aborted on defined class '%s'", copy);
+        Log(LOG_LEVEL_ERR, "Bundle '%s' aborted on defined class '%s'", frame.owner->name, copy);
         SetBundleAborted(ctx);
     }
 

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1565,6 +1565,7 @@ static bool EvalContextClassPut(EvalContext *ctx, const char *ns, const char *na
         {
             /* Log(LOG_LEVEL_ERR, "Bundle aborted on defined class '%s'", context_copy); */
 
+            StackFrame *frame = LastStackFrameByType(ctx, STACK_FRAME_TYPE_BUNDLE);
             Log(LOG_LEVEL_ERR, "Bundle '%s' aborted on defined class '%s'", frame.owner->name, context_copy);
             SetBundleAborted(ctx);
         }

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1563,7 +1563,9 @@ static bool EvalContextClassPut(EvalContext *ctx, const char *ns, const char *na
 
         if (IsRegexItemIn(ctx, ctx->heap_abort_current_bundle, context_copy))
         {
-            Log(LOG_LEVEL_ERR, "Bundle aborted on defined class '%s'", context_copy);
+            /* Log(LOG_LEVEL_ERR, "Bundle aborted on defined class '%s'", context_copy); */
+
+            Log(LOG_LEVEL_ERR, "Bundle '%s' aborted on defined class '%s'", frame.owner->name, context_copy);
             SetBundleAborted(ctx);
         }
 


### PR DESCRIPTION
Changelog: Title

This change is intended to make it easier to identify what bundle was aborted when `abortbundleclasses` are triggered.

Now when a bundle is aborted the log message says Bundle x aborted on defined class y. Previously when a bundle was aborted the log message only indicated the class that triggered the abortion.