### PR TITLE
CFE-2536: Resolve subkey conflicts when converting to JSON

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -292,6 +292,7 @@ static JsonElement* VarRefValueToJson(const EvalContext *ctx, const FnCall *fp, 
                 while ((var = VariableTableIteratorNext(iter)) != NULL)
                 {
                     JsonElement *holder = convert;
+                    JsonElement *holder_parent = NULL;
                     if (var->ref->num_indices - ref_num_indices == 1)
                     {
                         last_key = var->ref->indices[ref_num_indices];
@@ -310,6 +311,7 @@ static JsonElement* VarRefValueToJson(const EvalContext *ctx, const FnCall *fp, 
                             }
 
                             last_key = var->ref->indices[index+1];
+                            holder_parent = holder;
                             holder = local;
                         }
                     }
@@ -319,7 +321,44 @@ static JsonElement* VarRefValueToJson(const EvalContext *ctx, const FnCall *fp, 
                         switch (var->rval.type)
                         {
                         case RVAL_TYPE_SCALAR:
-                            JsonObjectAppendString(holder, last_key, var->rval.item);
+                            if (JsonGetElementType(holder) != JSON_ELEMENT_TYPE_CONTAINER)
+                            {
+                                Log(LOG_LEVEL_WARNING,
+                                    "Replacing a non-container JSON element '%s' with a new empty container"
+                                    " (for the '%s' subkey)",
+                                    JsonGetPropertyAsString(holder), last_key);
+
+                                assert(holder_parent != NULL);
+
+                                JsonElement *empty_container = JsonObjectCreate(10);
+
+                                /* we have to duplicate 'holder->propertyName'
+                                 * instead of just using a pointer to it here
+                                 * because 'holder' is destroyed as part of the
+                                 * JsonObjectAppendElement() call below */
+                                char *element_name = xstrdup(JsonGetPropertyAsString(holder));
+                                JsonObjectAppendElement(holder_parent,
+                                                        element_name,
+                                                        empty_container);
+                                free (element_name);
+                                holder = empty_container;
+                                JsonObjectAppendString(holder, last_key, var->rval.item);
+                            }
+                            else
+                            {
+                                JsonElement *child = JsonObjectGet(holder, last_key);
+                                if (child != NULL && JsonGetElementType(child) == JSON_ELEMENT_TYPE_CONTAINER)
+                                {
+                                    Log(LOG_LEVEL_WARNING,
+                                        "Not replacing the container '%s' with a non-container value '%s'",
+                                        JsonGetPropertyAsString(child), (char*) var->rval.item);
+                                }
+                                else
+                                {
+                                    /* everything ok, just append the string */
+                                    JsonObjectAppendString(holder, last_key, var->rval.item);
+                                }
+                            }
                             break;
 
                         case RVAL_TYPE_LIST:

--- a/tests/acceptance/01_vars/02_functions/array_subkey_collision.cf
+++ b/tests/acceptance/01_vars/02_functions/array_subkey_collision.cf
@@ -1,0 +1,47 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2536" }
+      string => "Converting arrays with colliding definitions for subkeys should work, somehow.";
+
+  vars:
+      "array[key1][subkey1]" string => "hey";
+      "array[key1]"          string => "hou";
+
+      "array_values"     slist  => getvalues("array");
+      "array_values_str" string => format("%S", array_values);
+
+      "array_data"     data   => mergedata(array);
+      "array_data_str" string => format("%S", array_data);
+}
+
+bundle agent check
+{
+  classes:
+      # the "more structured structure" should win when converting to JSON
+      "get_values_ok" expression => strcmp("$(test.array_values_str)", '{ "hey" }');
+      "array_data_ok" expression => strcmp("$(test.array_data_str)", '{"key1":{"subkey1":"hey"}}');
+
+      "ok" and => { "get_values_ok", "array_data_ok" };
+
+  reports:
+    "DEBUG"::
+      "array_values_str: $(test.array_values_str)"
+        ifvarclass => "!get_values_ok";
+
+      "array_data_str: $(test.array_data_str)"
+        ifvarclass => "!array_data_ok";
+
+    "ok"::
+      "$(this.promise_filename) Pass";
+
+    "!ok"::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Whenever there is a conflict of array variable definitions prefer
the container subkeys over simple values when converting to JSON.

Changelog: Commit
(cherry picked from commit baaad412021cfd7d9baf9c5863df23fae19e99b2)