### PR TITLE
CFE-2779: Make sure parameters are set only for the method evaluation

### DIFF
--- a/cf-agent/verify_methods.c
+++ b/cf-agent/verify_methods.c
@@ -102,7 +102,6 @@ PromiseResult VerifyMethod(EvalContext *ctx, const Rval call, Attributes a, cons
            args = args->next;
         }
         args = fp->args;
-        EvalContextSetBundleArgs(ctx, args);
     }
     break;
 
@@ -150,6 +149,7 @@ PromiseResult VerifyMethod(EvalContext *ctx, const Rval call, Attributes a, cons
         else
         {
             BundleBanner(bp, args);
+            EvalContextSetBundleArgs(ctx, args);
             EvalContextStackPushBundleFrame(ctx, bp, args, a.inherit);
 
             /* Clear all array-variables that are already set in the sub-bundle.
@@ -175,6 +175,7 @@ PromiseResult VerifyMethod(EvalContext *ctx, const Rval call, Attributes a, cons
             GetReturnValue(ctx, bp, pp);
 
             EvalContextStackPopFrame(ctx);
+            EvalContextSetBundleArgs(ctx, NULL);
             switch (result)
             {
             case PROMISE_RESULT_SKIPPED:


### PR DESCRIPTION
Method parameters have to be set for method evaluation and then
unset when the evaluation is done. Otherwise they may appear in
wrong places in the logs and/or incorrectly influence who knows
what.

(cherry picked from commit bb14f5a00c22747cfd86a5dc80f6b1dc9672e6b4)