### PR TITLE
CFE-2066 3.7.x Do not ignore meta promises in server bundles

### DIFF
--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -541,6 +541,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
 /* Sequence in which server promise types should be evaluated */
 static const char *const SERVER_TYPESEQUENCE[] =
 {
+    "meta",
     "vars",
     "classes",
     "roles",


### PR DESCRIPTION
meta type promises are valid in all bundle types.