### PR TITLE
CFE-2066 3.10.x Do not ignore meta promises in server bundles

### DIFF
--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -550,6 +550,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
 /* Sequence in which server promise types should be evaluated */
 static const char *const SERVER_TYPESEQUENCE[] =
 {
+    "meta",
     "vars",
     "classes",
     "roles",


### PR DESCRIPTION
meta type promises are valid in all bundle types.

Changelog: Title
(cherry picked from commit 05036fe47749b3b51f35a87d8fd7ee775dd61a44)