### PR TITLE
CFE-2802 Fix spelling in log messages

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -3440,7 +3440,7 @@ static void TruncateFile(char *name)
     {
         if ((fd = safe_creat(name, 000)) == -1)      /* dummy mode ignored */
         {
-            Log(LOG_LEVEL_ERR, "Failed to create or truncate file '%s'. (creat: %s)", name, GetErrorStr());
+            Log(LOG_LEVEL_ERR, "Failed to create or truncate file '%s'. (create: %s)", name, GetErrorStr());
         }
         else
         {
@@ -3753,7 +3753,7 @@ bool CfCreateFile(EvalContext *ctx, char *file, const Promise *pp, Attributes at
     if (!IsAbsoluteFileName(file))
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr,
-             "Cannot create a relative filename '%s' - has no invariant meaning. (creat: %s)", file, GetErrorStr());
+             "Cannot create a relative filename '%s' - has no invariant meaning. (create: %s)", file, GetErrorStr());
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
         return false;
     }
@@ -3768,7 +3768,7 @@ bool CfCreateFile(EvalContext *ctx, char *file, const Promise *pp, Attributes at
         {
             if (!MakeParentDirectory(file, attr.move_obstructions))
             {
-                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr, "Error creating directories for '%s'. (creat: %s)",
+                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr, "Error creating directories for '%s'. (create: %s)",
                      file, GetErrorStr());
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
                 return false;

--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -622,7 +622,7 @@ void RotateFiles(char *name, int number)
 
     if ((fd = safe_creat(name, statbuf.st_mode)) == -1)
     {
-        Log(LOG_LEVEL_ERR, "Failed to create new '%s' in disable(rotate). (creat: %s)",
+        Log(LOG_LEVEL_ERR, "Failed to create new '%s' in disable(rotate). (create: %s)",
             name, GetErrorStr());
     }
     else

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -647,7 +647,7 @@ static bool WritePolicyValidatedFile(ARG_UNUSED const GenericAgentConfig *config
     int fd = creat(filename, 0600);
     if (fd == -1)
     {
-        Log(LOG_LEVEL_ERR, "While writing policy validated marker file '%s', could not create file (creat: %s)", filename, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "While writing policy validated marker file '%s', could not create file (create: %s)", filename, GetErrorStr());
         return false;
     }
 
@@ -763,7 +763,7 @@ static bool WriteReleaseIdFile(const char *filename, const char *dirname)
     int fd = creat(filename, 0600);
     if (fd == -1)
     {
-        Log(LOG_LEVEL_ERR, "While writing policy release ID file '%s', could not create file (creat: %s)", filename, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "While writing policy release ID file '%s', could not create file (create: %s)", filename, GetErrorStr());
         return false;
     }
 

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -847,7 +847,7 @@ void YieldCurrentLock(CfLock lock)
 
     if (WriteLock(lock.last) == -1)
     {
-        Log(LOG_LEVEL_ERR, "Unable to create '%s'. (creat: %s)", lock.last, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "Unable to create '%s'. (create: %s)", lock.last, GetErrorStr());
         free(lock.last);
         free(lock.lock);
         free(lock.log);


### PR DESCRIPTION
(cherry picked from commit df970a9b80002fbc98ec02c432142f7b74d81e20)