### PR TITLE
Shorten the WaitForIncoming() loop in cf-testd

### DIFF
--- a/cf-testd/cf-testd.c
+++ b/cf-testd/cf-testd.c
@@ -65,7 +65,7 @@
 #endif
 
 #define CFTESTD_QUEUE_SIZE 10
-#define WAIT_CHECK_TIMEOUT 10
+#define WAIT_CHECK_TIMEOUT 5
 
 /* Strictly speaking/programming, this should use a lock, but it's not needed
  * for this testing tool. The worst that can happen is that some threads would


### PR DESCRIPTION
Waiting for up to 10 seconds means that cf-testd can terminate
quite a while after being terminated (signalled).