### PR TITLE
CFE-2788: Added __main__ bundles with special semantics

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -137,6 +137,8 @@ struct EvalContext_
     // Full path to directory that the binary was launched from.
     char *launch_directory;
 
+    char *entry_point;
+
     /* new package promise evaluation context */
     PackagePromiseContext *package_promise_context;
 
@@ -969,6 +971,7 @@ void EvalContextDestroy(EvalContext *ctx)
     if (ctx)
     {
         free(ctx->launch_directory);
+        free(ctx->entry_point);
 
         {
             LoggingPrivContext *pctx = LoggingPrivGetContext();
@@ -2879,6 +2882,20 @@ void EvalContextSetLaunchDirectory(EvalContext *ctx, const char *path)
 {
     free(ctx->launch_directory);
     ctx->launch_directory = xstrdup(path);
+}
+
+void EvalContextSetEntryPoint(
+    EvalContext *const ctx, const char *const entry_point)
+{
+    assert(ctx != NULL);
+    free(ctx->entry_point);
+    ctx->entry_point = SafeStringDuplicate(entry_point);
+}
+
+const char *EvalContextGetEntryPoint(EvalContext *const ctx)
+{
+    assert(ctx != NULL);
+    return ctx->entry_point;
 }
 
 void EvalContextSetIgnoreLocks(EvalContext *ctx, bool ignore)

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -223,6 +223,8 @@ bool EvalContextIsIgnoringLocks(const EvalContext *ctx);
 void EvalContextSetIgnoreLocks(EvalContext *ctx, bool ignore);
 
 void EvalContextSetLaunchDirectory(EvalContext *ctx, const char *path);
+void EvalContextSetEntryPoint(EvalContext* ctx, const char *entry_point);
+const char *EvalContextGetEntryPoint(EvalContext* ctx);
 
 bool Abort(EvalContext *ctx);
 void NotifyDependantPromises(EvalContext *ctx, const Promise *pp, PromiseResult result);

--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -641,6 +641,10 @@ bool CompressPath(char *dest, size_t dest_size, const char *src)
  **/
 char *GetAbsolutePath(const char *path)
 {
+    if (NULL_OR_EMPTY(path))
+    {
+        return NULL;
+    }
     char abs_path[PATH_MAX] = { 0 };
     if (IsAbsoluteFileName(path))
     {
@@ -661,6 +665,22 @@ char *GetAbsolutePath(const char *path)
         CompressPath(abs_path, PATH_MAX, full_path);
         return xstrdup(abs_path);
     }
+}
+
+char *GetRealPath(const char *const path)
+{
+    if (NULL_OR_EMPTY(path))
+    {
+        return NULL;
+    }
+    char *const abs_path = GetAbsolutePath(path);
+    if (abs_path == NULL || abs_path[0] == '\0')
+    {
+        return abs_path;
+    }
+    char *const real_path = realpath(abs_path, NULL);
+    free(abs_path);
+    return real_path;
 }
 
 /*********************************************************************/

--- a/libpromises/files_names.h
+++ b/libpromises/files_names.h
@@ -55,6 +55,7 @@ char *CanonifyChar(const char *str, char ch);
 const char *ReadLastNode(const char *str);
 bool CompressPath(char *dest, size_t dest_size, const char *src);
 char *GetAbsolutePath(const char *path);
+char *GetRealPath(const char *path);
 bool IsFileOutsideDefaultRepository(const char *f);
 int RootDirLength(const char *f);
 const char *GetSoftwareCacheFilename(char *buffer);

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -452,6 +452,7 @@ static void AddPolicyEntryVariables (EvalContext *ctx, const GenericAgentConfig 
     /* both dirname() and basename() may actually modify the string they are given (see man:basename(3)) */
     char *dirname_path = xstrdup(abs_input_path);
     char *basename_path = xstrdup(abs_input_path);
+    EvalContextSetEntryPoint(ctx, abs_input_path);
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS,
                                   "policy_entry_filename",
                                   abs_input_path,

--- a/libutils/sequence.c
+++ b/libutils/sequence.c
@@ -407,3 +407,25 @@ int SeqStringLength(Seq *seq)
 
     return total_length;
 }
+
+void SeqRemoveNulls(Seq *s)
+{
+    int length = SeqLength(s);
+    int from = 0;
+    int to = 0;
+    while (from < length)
+    {
+        if (s->data[from] == NULL)
+        {
+            ++from; // Skip NULL elements
+        }
+        else
+        {
+            // Copy elements in place, DON'T use SeqSet, which will free()
+            s->data[to] = s->data[from];
+            ++from;
+            ++to;
+        }
+    }
+    s->length = to;
+}

--- a/libutils/sequence.h
+++ b/libutils/sequence.h
@@ -225,4 +225,6 @@ Seq *SeqStringFromString(const char *str, char delimiter);
  */
 int SeqStringLength(Seq *seq);
 
+void SeqRemoveNulls(Seq *s);
+
 #endif


### PR DESCRIPTION
Example usage:
```
root@dev core $ cat imported.cf
bundle agent __main__
{
        reports:
                "Hello __main__, imported.cf can be executed directly";
}

bundle agent useful_functionality(caller)
{
        reports:
                "$(this.promise_filename) is used as a library from $(caller)";
}
root@dev core $ cat entry.cf
body common control
{
        inputs => {"${sys.policy_entry_dirname}/imported.cf"};
}

bundle agent main
{
        methods:
                "Library call"
                         usebundle => useful_functionality("$(sys.policy_entry_basename)");
        reports:
                "Hello main";
}
root@dev core $ sudo /var/cfengine/bin/cf-agent -f ./entry.cf -K
R: /home/vagrant/cfe/core/imported.cf is used as a library from entry.cf
R: Hello main
root@dev core $ sudo /var/cfengine/bin/cf-agent -f ./imported.cf -K
R: Hello __main__, imported.cf can be executed directly
root@dev core $
```