### PR TITLE
CFE-1915: Allow dots in variable identifiers with no such bundle

### DIFF
--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -134,6 +134,12 @@ ClassTableIterator *EvalContextClassTableIteratorNewLocal(const EvalContext *ctx
 const StringSet *EvalContextAllClassesGet(const EvalContext *ctx);
 void EvalContextAllClassesLoggingEnable(EvalContext *ctx, bool enable);
 
+void EvalContextPushBundleName(const EvalContext *ctx, const char *bundle_name);
+const StringSet *EvalContextGetBundleNames(const EvalContext *ctx);
+
+void EvalContextPushRemoteVarPromise(EvalContext *ctx, const char *bundle_name, const Promise *pp);
+const Seq *EvalContextGetRemoteVarPromises(const EvalContext *ctx, const char *bundle_name);
+
 void EvalContextClear(EvalContext *ctx);
 
 Rlist *EvalContextGetPromiseCallerMethods(EvalContext *ctx);

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -539,6 +539,13 @@ Policy *LoadPolicy(EvalContext *ctx, GenericAgentConfig *config)
 
     if (policy)
     {
+        /* store names of all bundles in the EvalContext */
+        for (size_t i = 0; i < SeqLength(policy->bundles); i++)
+        {
+            Bundle *bp = SeqAt(policy->bundles, i);
+            EvalContextPushBundleName(ctx, bp->name);
+        }
+
         for (size_t i = 0; i < SeqLength(policy->bundles); i++)
         {
             Bundle *bp = SeqAt(policy->bundles, i);

--- a/libutils/sequence.c
+++ b/libutils/sequence.c
@@ -105,6 +105,22 @@ void SeqAppend(Seq *seq, void *item)
     ++(seq->length);
 }
 
+void SeqAppendOnce(Seq *seq, void *item, SeqItemComparator Compare)
+{
+    if (SeqLookup(seq, item, Compare) == NULL)
+    {
+        SeqAppend(seq, item);
+    }
+    else
+    {
+        /* swallow the item anyway */
+        if (seq->ItemDestroy != NULL)
+        {
+            seq->ItemDestroy(item);
+        }
+    }
+}
+
 void SeqAppendSeq(Seq *seq, const Seq *items)
 {
     for (size_t i = 0; i < SeqLength(items); i++)

--- a/libutils/sequence.h
+++ b/libutils/sequence.h
@@ -104,6 +104,16 @@ void SeqSet(Seq *set, size_t index, void *item);
 void SeqAppend(Seq *seq, void *item);
 
 /**
+  @brief Append a new item to the Sequence if it's not already present in the Sequence.
+  @note  This calls SeqLookup() and thus linearly searches through the sequence.
+  @param seq [in] The Sequence to append to.
+  @param item [in] The item to append. Note that this item will be passed to the item destructor specified in the constructor.
+                   Either immediately if the same item (according to Compare()) is found in the Sequence or once the Sequence
+                   is destroyed with SeqDestroy().
+  */
+void SeqAppendOnce(Seq *seq, void *item, SeqItemComparator Compare);
+
+/**
  * @brief Append a sequence to this sequence. Only copies pointers.
  * @param seq Sequence to append to
  * @param items Sequence to copy pointers from.

--- a/tests/acceptance/01_vars/01_basic/can_not_define_variables_in_remote_bundles.cf
+++ b/tests/acceptance/01_vars/01_basic/can_not_define_variables_in_remote_bundles.cf
@@ -22,6 +22,11 @@ bundle agent test
                     of the variable should be canonified, or it should
                     be a parser error";
 
+      "prefix.variable"
+        string => "value-ok",
+        comment => "This should be allowed because there is no such
+                    bundle called 'prefix'";
+
       "array[with.a.dot]"
 	string => "value",
 	comment => "dots should be allowed in array keys";
@@ -37,9 +42,10 @@ bundle agent check
   classes:
       "variable_defined" expression => isvariable("variable");
       "variable_has_content" expression => regcmp(".*", "$(variable)");
+      "prefixed_var_fail" expression => not(strcmp("$(prefix.variable)", "value-ok"));
       "array_with_a_dot_fail" expression => not(strcmp("$(test.array[with.a.dot])", "value"));
 
-      "fail" expression => "(variable_defined|variable_has_content|array_with_a_dot_fail)";
+      "fail" expression => "(variable_defined|variable_has_content|prefixed_var_fail|array_with_a_dot_fail)";
 
   reports:
     DEBUG::
@@ -48,6 +54,9 @@ bundle agent check
 
       "'variable' in bundle '$(this.bundle)' = '$(variable)'"
         ifvarclass => "variable_has_content";
+
+      "'prefix.variable' = $(prefix.variable)"
+        ifvarclass => "prefixed_var_fail";
 
       "array[with.a.dot] has the value '$(test.array[with.a.dot])'"
         ifvarclass => "array_with_a_dot_fail";

--- a/tests/acceptance/08_commands/01_modules/set-context.cf
+++ b/tests/acceptance/08_commands/01_modules/set-context.cf
@@ -78,9 +78,14 @@ bundle agent check
       "ok_c5" expression => strcmp($(e5) , $(c5));
       "ok_c6" expression => strcmp($(e6) , $(c6));
 
+      "ok_injected_var" -> { "CFE-1915" }
+        expression => strcmp($(test.myvar), "hello there"),
+        comment => "This remote variable injection should work, BUT IS A DIRTY HACK!";
+
       "ok" and => { "myclass", "var0ok", "var1ok", "var2ok", "var3ok", "var4ok",
                     "hello_xyz_123___456_ok", "hello__456_ok", "hello_456_ok", "hello___ok", "hello_a__456___ok", "hello___a___ok",
-                    "ok_c1", "ok_c2", "ok_c3", "ok_c4", "ok_c5", "ok_c6" };
+                    "ok_c1", "ok_c2", "ok_c3", "ok_c4", "ok_c5", "ok_c6",
+                    "ok_injected_var" };
 
   reports:
     DEBUG::
@@ -88,6 +93,9 @@ bundle agent check
       ifvarclass => "!ok_c$(c)";
 
       "context $(hello_contexts) failed" ifvarclass => "!hello_$(hello_contexts)_ok";
+
+      "test.myvar = $(test.myvar)"
+        ifvarclass => "!ok_injected_var";
 
     EXTRA::
       "context $(hello_contexts) worked" ifvarclass => "hello_$(hello_contexts)_ok";

--- a/tests/acceptance/08_commands/01_modules/set-context.cf.txt
+++ b/tests/acceptance/08_commands/01_modules/set-context.cf.txt
@@ -21,3 +21,5 @@
 =myvar=hello there
 ^context=__a__
 =myvar=hello there
+^context=test
+=myvar=hello there

--- a/tests/unit/sequence_test.c
+++ b/tests/unit/sequence_test.c
@@ -50,6 +50,30 @@ static int CompareNumbers(const void *a, const void *b,
     return *(size_t *) a - *(size_t *) b;
 }
 
+static void test_append_once(void)
+{
+    Seq *seq = SequenceCreateRange(10, 0, 9);
+
+    for (size_t i = 0; i <= 9; i++)
+    {
+        size_t *item = xmalloc(sizeof(size_t));
+
+        *item = i;
+        SeqAppendOnce(seq, item, CompareNumbers);
+    }
+
+    /* none of the numbers above should have been inserted second time */
+    assert_int_equal(seq->length, 10);
+
+    size_t *item = xmalloc(sizeof(size_t));
+
+    *item = 10;
+    SeqAppendOnce(seq, item, CompareNumbers);
+
+    /* 10 should have been inserted (as the first instance) */
+    assert_int_equal(seq->length, 11);
+}
+
 static void test_lookup(void)
 {
     Seq *seq = SequenceCreateRange(10, 0, 9);
@@ -412,6 +436,7 @@ int main()
     {
         unit_test(test_create_destroy),
         unit_test(test_append),
+        unit_test(test_append_once),
         unit_test(test_lookup),
         unit_test(test_binary_lookup),
         unit_test(test_index_of),


### PR DESCRIPTION
As described and discussed in CFE-1915, defining remote variables
(injecting variables into remote bundles) is dangerous and must
be blocked. However, using a dot-separated common prefix for
variables raises no security concerns and can be considered
valid.

Changelog: Commit