### PR TITLE
CFE-2125: Do not iterate over JSON objects' properties in mustache

### DIFF
--- a/tests/acceptance/01_vars/02_functions/mustache_iterating_object_should_use_context_for_single_block_render.cf
+++ b/tests/acceptance/01_vars/02_functions/mustache_iterating_object_should_use_context_for_single_block_render.cf
@@ -73,16 +73,16 @@ bundle agent test
         string => "Test that iterating over object results in single block with
                    correct context (CFE-2125).";
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "CFE-2125" };
-
   vars:
       "got" string => string_mustache( $(init.template), @(init.data) );
 }
 
 bundle agent check
 {
+  reports:
+    DEBUG::
+      "got output: $(test.got)";
+
   vars:
       "expected" string => "# Test1
 Data = v1


### PR DESCRIPTION
Only lists are supposed to be iterated over. Otherwise duplicates
appear when using JSON with objects that have multiple
properties. See CFE-2125 for details.

However, our '{{@}}' extension to the mustache specification
requires JSON objects' properties to be iterated over because
it's the names of these properties (keys) it should be
substituted with.

Changelog: title
(cherry picked from commit 1d3c7313b85c2d27dcfdf29f51e5fe038f12f9e9)