### PR TITLE
CFE-2125: Do not iterate over JSON objects' properties in mustache

### DIFF
--- a/tests/acceptance/01_vars/02_functions/mustache_iterating_object_should_use_context_for_single_block_render.cf
+++ b/tests/acceptance/01_vars/02_functions/mustache_iterating_object_should_use_context_for_single_block_render.cf
@@ -1,0 +1,100 @@
+body common control
+{
+        inputs => { "../../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+bundle agent init
+{
+  vars:
+
+      "template" string => "# Test1
+{{#testcase.test1}}
+{{#data}}
+Data = {{.}}
+{{/data}}
+{{/testcase.test1}}
+
+# Test2
+{{#testcase.test2}}
+{{#data}}
+Data = {{.}}
+{{/data}}
+{{#otherdata}}
+Other data = {{.}}
+{{/otherdata}}
+{{/testcase.test2}}";
+
+      "data" data => '{
+  "testcase": {
+    "test1": {
+      "data": [
+        "v1",
+        "v2"
+      ]
+    },
+    "test2": {
+      "data": [
+        "v1",
+        "v2"
+      ],
+      "otherdata": [
+        "v3",
+        "v4"
+      ]
+    }
+  }
+      }';
+
+}
+
+bundle agent test
+{
+  meta:
+
+      # https://mustache.github.io/#demo Try the template and data from above in
+      # the demo site. The issue we see in cfengine is that while iterating over
+      # testcase.test2 the rendering happens for each sub structure iterated
+      # duplicating the data.
+
+      # So we get          Instead of
+      # # Test2                |            # Test2
+      # Data = v1              |            Data = v1
+      # Data = v2              |            Data = v2
+      # Other data = v3        |            Other data = v3
+      # Other data = v4        |            Other data = v4
+      # Data = v1              |
+      # Data = v2              |
+      # Other data = v3        |
+      # Other data = v4        |
+
+      "description" -> { "CFE-2125" }
+        string => "Test that iterating over object results in single block with
+                   correct context (CFE-2125).";
+
+  vars:
+      "got" string => string_mustache( $(init.template), @(init.data) );
+}
+
+bundle agent check
+{
+  reports:
+    DEBUG::
+      "got output: $(test.got)";
+
+  vars:
+      "expected" string => "# Test1
+Data = v1
+Data = v2
+
+# Test2
+Data = v1
+Data = v2
+Other data = v3
+Other data = v4
+";
+
+  methods:
+      "check" usebundle => dcs_check_strcmp( $(test.got), $(check.expected), $(this.promise_filename), "no" );
+}


### PR DESCRIPTION
Only lists are supposed to be iterated over. Otherwise duplicates
appear when using JSON with objects that have multiple
properties. See CFE-2125 for details.

However, our '{{@}}' extension to the mustache specification
requires JSON objects' properties to be iterated over because
it's the names of these properties (keys) it should be
substituted with.

Changelog: title
(cherry picked from commit 1d3c7313b85c2d27dcfdf29f51e5fe038f12f9e9)