### PR TITLE
CFE-2194: Do not render templates when passed invalid data

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -291,6 +291,18 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promiser", path, CF_DATA_TYPE_STRING, "source=promise");
     Attributes a = GetExpandedAttributes(ctx, pp, &attr);
 
+    /* if template_data was specified, it must have been resolved to a data
+     * container by now */
+    /* check this early to prevent creation of the file below in case of failure */
+    const Constraint *template_data_constraint = PromiseGetConstraint(pp, "template_data");
+    if (template_data_constraint != NULL &&
+        template_data_constraint->rval.type != RVAL_TYPE_CONTAINER)
+    {
+        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a,
+             "No template data for the promise '%s'", pp->promiser);
+        return PROMISE_RESULT_FAIL;
+    }
+
     PromiseResult result = PROMISE_RESULT_NOOP;
     if (lstat(path, &oslb) == -1)       /* Careful if the object is a link */
     {

--- a/tests/acceptance/10_files/templating/mustache_invalid_template_data.cf
+++ b/tests/acceptance/10_files/templating/mustache_invalid_template_data.cf
@@ -1,0 +1,94 @@
+#######################################################
+#
+# Test that invalid mustache template data is not replaced by datastate().
+# CFE-2194
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "template_content" string => '
+template_data:
+{{%-top-}}
+';
+
+  files:
+      "$(G.testfile).template"
+        create => "true",
+        edit_line => insert_lines($(template_content)),
+        edit_defaults => empty;
+
+      "$(G.testfile).output"
+        delete => init_delete;
+}
+
+body delete init_delete
+{
+      dirlinks => "delete";
+      rmdirs   => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+    "template_file" string => "$(G.testfile).template";
+
+    "invalid_data"
+      data => parsejson('{
+            "port": 3508,
+            "protocol": 2,
+            "filepath": "$(no_such_variable)",
+            "encryption-level": 256,
+            "loglevel": 1,
+            "users":
+               [
+                {"user": "thomas", "level": "admin"},
+                {"user": "malin", "level": "guest"}
+               ]
+          }');
+
+  files:
+      "$(G.testfile).output"
+        create => "true",
+        edit_template => "$(template_file)",
+        template_method => "mustache",
+        template_data => @(invalid_data);
+
+  classes:
+      "invalid_data_exists" expression => isvariable("invalid_data");
+
+  reports:
+    DEBUG::
+      "Rendering template file $(template_file) to $(G.testfile).output";
+
+      "invalid_data defined!"
+        ifvarclass => "invalid_data_exists";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok" -> {"CFE-2194"}
+        not => fileexists("$(G.testfile).output");
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Passing no template_data should result in using datastate()
instead as our documentation says. But passing invalid data is a
different case that should result in an error and the template
not being rendered.

(cherry picked from commit 5cdd998a21e2a70aa01a4fd55a88f746d3ddb669)