### PR TITLE
CFE-2793: Bundle name is now part of the log message when aborting a bundle

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -428,7 +428,7 @@ static void EvalContextStackFrameAddSoft(EvalContext *ctx, const char *context, 
 
     if (IsRegexItemIn(ctx, ctx->heap_abort_current_bundle, copy))
     {
-        Log(LOG_LEVEL_ERR, "Bundle aborted on defined class '%s'", copy);
+        Log(LOG_LEVEL_ERR, "Bundle '%s' aborted on defined class '%s'", frame.owner->name, copy);
         SetBundleAborted(ctx);
     }
 
@@ -1605,7 +1605,15 @@ static bool EvalContextClassPut(EvalContext *ctx, const char *ns, const char *na
 
         if (IsRegexItemIn(ctx, ctx->heap_abort_current_bundle, context_copy))
         {
-            Log(LOG_LEVEL_ERR, "Bundle aborted on defined class '%s'", context_copy);
+            const Bundle *bundle = EvalContextStackCurrentBundle(ctx);
+            if (bundle != NULL)
+            {
+                Log(LOG_LEVEL_ERR, "Bundle '%s' aborted on defined class '%s'", bundle->name, context_copy);
+            }
+            else
+            {
+                Log(LOG_LEVEL_ERR, "Bundle (unknown) aborted on defined class '%s'", context_copy);
+            }
             SetBundleAborted(ctx);
         }
 


### PR DESCRIPTION
Ticket: https://tracker.mender.io/browse/CFE-2793