### PR TITLE
Increase the connection backlog/queue size in cf-serverd

### DIFF
--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -49,7 +49,7 @@
 #include <printsize.h>
 
 
-static const size_t QUEUESIZE = 50;
+static const size_t QUEUESIZE = 128;
 int NO_FORK = false; /* GLOBAL_A */
 
 /*******************************************************************/


### PR DESCRIPTION
This number is used in the listen() syscall and determines the
maximum number of established connections that could be waiting
to be accepted. Any connections beyond this limit are either
refused or, worse, fed cookies (see tcp_syncookies in
man:tcp(7)).

Kernel has its own limit for this number (per socket) and it
defaults to 128. So let's use this maximal possible value,
there's nothing to lose for us. We have a capability to handle
many connections in threads (specified in 'body server control'
-> maxconnections), but if too many connections are attempted at
once, we need a big enough backlog/queue to give us enough time
to process them. Starting threads may just not be fast enough,
especially in combination with our bad way of counting threads
and other things using locks all the threads are fighting over
for.