### PR TITLE
3.10.x - Increase the connection backlog/queue size in cf-serverd

### DIFF
--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -44,12 +44,16 @@
 #include <sysinfo.h>
 #include <time_classes.h>
 #include <connection_info.h>
+#include <string_lib.h>
 #include <file_lib.h>
 #include <loading.h>
 #include <printsize.h>
 
 
-static const size_t QUEUESIZE = 50;
+/* see man:listen(3) */
+#define DEFAULT_LISTEN_QUEUE_SIZE 128
+#define MAX_LISTEN_QUEUE_SIZE 2048
+
 int NO_FORK = false; /* GLOBAL_A */
 
 /*******************************************************************/
@@ -861,6 +865,26 @@ static void AcceptAndHandle(EvalContext *ctx, int sd)
     ServerEntryPoint(ctx, MapAddress(ipaddr), info);
 }
 
+static size_t GetListenQueueSize(void)
+{
+    const char *const queue_size_var = getenv("CF_SERVERD_LISTEN_QUEUE_SIZE");
+    if (queue_size_var != NULL)
+    {
+        long queue_size;
+        int ret = StringToLong(queue_size_var, &queue_size);
+        if ((ret == 0) && (queue_size > 0) && (queue_size <= MAX_LISTEN_QUEUE_SIZE))
+        {
+            return (size_t) queue_size;
+        }
+        Log(LOG_LEVEL_WARNING,
+            "$CF_SERVERD_LISTEN_QUEUE_SIZE = '%s' doesn't specify a valid number for listen queue size, "
+            "falling back to default (%d).",
+            queue_size_var, DEFAULT_LISTEN_QUEUE_SIZE);
+    }
+
+    return DEFAULT_LISTEN_QUEUE_SIZE;
+}
+
 /**
  *  @retval >0 Number of threads still working
  *  @retval 0  All threads are done
@@ -876,7 +900,8 @@ int StartServer(EvalContext *ctx, Policy **policy, GenericAgentConfig *config)
         return -1;
     }
 
-    int sd = SetServerListenState(ctx, QUEUESIZE, SERVER_LISTEN, &InitServer);
+    size_t queue_size = GetListenQueueSize();
+    int sd = SetServerListenState(ctx, queue_size, SERVER_LISTEN, &InitServer);
 
     /* Necessary for our use of select() to work in WaitForIncoming(): */
     assert(sd < sizeof(fd_set) * CHAR_BIT &&


### PR DESCRIPTION
This number is used in the listen() syscall and determines the
maximum number of established connections that could be waiting
to be accepted. Any connections beyond this limit are either
refused or, worse, fed cookies (see tcp_syncookies in
man:tcp(7)).

Kernel has its own limit for this number (per socket) which is an
upper bound and it defaults to 128 [1]. So let's use this maximal
possible value as a default, there's nothing to lose for us. We
have a capability to handle many connections in threads
(specified in 'body server control' -> maxconnections), but if
too many connections are attempted at once, we need a big enough
backlog/queue to give us enough time to process them. Starting
threads may just not be fast enough, especially in combination
with our bad way of counting threads and other things using locks
all the threads are fighting over for.

[1] SOMAXCONN (defined in <sys/socket.h>), tunable on GNU/Linux
    via sysctl, other systems differ (e.g. 4096 on HP-UX)

And we should make this tunable, i.e. possible to change the
queue/backlog size without recompilation of the cf-serverd
binary. An environment variable is a simple and good enough
mechanism to do this (also being used in other similar places).

Ticket: CFE-2838
(cherry picked from commit 73acb17406b13f9a29e87c74165e466b1a792e22)

Conflicts:
  cf-serverd/cf-serverd-functions.c