### PR TITLE
CFE-2844: Make sure 'augments' from def.json are applied last

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -92,6 +92,7 @@
 	  variables raises no security concerns and can be considered
 	  valid. (CFE-1915)
 	- Classes failsafe_fallback and bootstrap_mode are now reported by default
+	- Apply augments after vars, classes and inputs in def.json (CFE-2844)
 
 	Bug fixes:
 	- Disallow modifications of variables from a remote bundle (CFE-1915)

--- a/tests/acceptance/00_basics/def.json/augments_order.cf
+++ b/tests/acceptance/00_basics/def.json/augments_order.cf
@@ -1,0 +1,38 @@
+# test that 'augments' in def.json are applied last
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2844" }
+        string => "'augments' in def.json should be applied last and thus override values of variables from 'vars'";
+
+  methods:
+      "" usebundle => file_make("$(sys.inputdir)/promises.cf", '
+body common control
+{
+    inputs => { "@(def.inputs)" };
+}
+');
+
+      "" usebundle => file_copy("$(this.promise_filename).augmenter.json", "$(sys.inputdir)/augmenter.json");
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) --show-vars -f $(sys.inputdir)/promises.cf|$(G.grep) test_var";
+
+  methods:
+      "" usebundle => dcs_passif_output("default:def.test_var\s+\{\"defined in augments.vars\"\}\s+source=augments_file", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/augments_order.cf.augmenter.json
+++ b/tests/acceptance/00_basics/def.json/augments_order.cf.augmenter.json
@@ -1,0 +1,5 @@
+{
+    "vars" : {
+        "test_var": [ "defined in augments.vars" ]
+    }
+}

--- a/tests/acceptance/00_basics/def.json/augments_order.cf.json
+++ b/tests/acceptance/00_basics/def.json/augments_order.cf.json
@@ -1,0 +1,6 @@
+{
+    "augments": [ "$(sys.inputdir)/augmenter.json" ],
+    "vars": {
+        "test_var" : "defined in vars"
+    }
+}


### PR DESCRIPTION
These are supposed to be most specialized and finest-granularity
policies (based on e.g. $(sys.flavor) and similar things). So
they should override values of any variables defined in 'vars' in
def.json if they defined the same variables, of course.

See the discussion in CFE-2741 for more details.

Changelog: CFE-2844: Apply augments after vars, classes and inputs in def.json
(cherry picked from commit 8bdc87c26f69e1886ac863bc9e62b68b6125f75e)