### PR TITLE
Added a log message for the case that the output file has ceased to exist by the time cf-execd tries to mail it.

### DIFF
--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -583,6 +583,7 @@ static void MailResult(const ExecConfig *config, const char *file)
         struct stat statbuf;
         if (stat(file, &statbuf) == -1)
         {
+            Log(LOG_LEVEL_ERR, "Mail report: failed to stat file '%s' [errno: %d]", file, errno);
             return;
         }
 


### PR DESCRIPTION
Admittedly rare, but the absence of this log statement made trouble-shooting an issue more difficult for me.