### PR TITLE
Added a log message at level ERR for the case that the output file ha…

### DIFF
--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -583,6 +583,7 @@ static void MailResult(const ExecConfig *config, const char *file)
         struct stat statbuf;
         if (stat(file, &statbuf) == -1)
         {
+            Log(LOG_LEVEL_ERR, "Mail report: failed to stat file '%s' [errno: %d]", file, errno);
             return;
         }
 


### PR DESCRIPTION
…s ceased

to exist by the time cf-execd tries to mail it.

(cherry picked from commit 2963a598f9c882e085793907e48525002d4edecb)