### PR TITLE
ENT-3638: Add commit title to changelog by default, if it has ticket …

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -427,8 +427,9 @@ the behavior change which is important. This implies that refactorings that have
 no visible effect on behavior don't need a changelog entry.
 
 If a changelog entry is needed, your pull request should have at least one
-commit with a "Changelog:" line in it, after the title. This may be one of the
-following:
+commit either with a "Changelog:" line in it (anywhere after the title), or
+title should start with ticket number from our bug tracker ("CFE-1234").
+"Changelog:" line may be one of the following:
 
 * To write arbitrary message in the ChangeLog:
 ```Changelog: <message>```

--- a/misc/changelog-generator/changelog-generator
+++ b/misc/changelog-generator/changelog-generator
@@ -20,14 +20,17 @@ LINKED_SHAS = {}
 # messages.
 SHA_TO_TRACKER = {}
 
+# more relaxed regexp to find JIRA issues anywhere in commit message
 REDMINE_REGEX = "(?:Redmine:? *#?|(?:Redmine:? *)?https?://dev\.cfengine\.com/issues/)([0-9]+)"
 JIRA_REGEX = "(?:Jira:?)? *(?:https?://tracker.mender.io/browse/)?((?:CFE|ENT|INF|ARCHIVE|MEN|QA)-[0-9]+)"
 TRACKER_REGEX = "\(?(?:Ref:? *)?(?:(?:%s)|(?:%s))\)?:? *" % (REDMINE_REGEX, JIRA_REGEX)
+# more strict regexp to find JIRA issues only in the beginning of title
+JIRA_TITLE_REGEX = r"^(?:CFE|ENT|INF|ARCHIVE|MEN|QA)-[0-9]+"
 
 POSSIBLE_MISSED_TICKETS = {}
 
 # Only for testing.
-SORT_CHANGELOG = False
+SORT_CHANGELOG = True
 
 # Type of log to generate, this is bitwise.
 LOG_TYPE = 0
@@ -114,6 +117,7 @@ for repo in repos:
         title_fetched = False
         title = ""
         commit_msg = ""
+        log_entry_title = False
         log_entry_commit = False
         log_entry_local = False
         log_entry = ""
@@ -139,7 +143,10 @@ for repo in repos:
                     SHA_TO_TRACKER[sha] = set()
                 SHA_TO_TRACKER[sha].add("".join(match.groups("")))
                 tracker_removed = re.sub(TRACKER_REGEX, "", line, flags=re.IGNORECASE)
-                line = tracker_removed.strip(' ')
+                tracker_removed = tracker_removed.strip(' ')
+                if re.match(JIRA_TITLE_REGEX, line) and not title_fetched:
+                    log_entry_title = True
+                line = tracker_removed
 
             if not title_fetched:
                 title = line
@@ -147,6 +154,7 @@ for repo in repos:
 
             match = re.match("^ *Changelog: *(.*)", line, re.IGNORECASE)
             if match:
+                log_entry_title = False
                 if log_entry:
                     add_entry(sha, log_entry)
                     log_entry = ""
@@ -156,6 +164,8 @@ for repo in repos:
                     log_entry = title
                 elif re.match("^Commit[ .]*$", match.group(1), re.IGNORECASE):
                     log_entry_commit = True
+                elif re.match("^None[ .]*$", match.group(1), re.IGNORECASE):
+                    pass
                 else:
                     log_entry_local = True
                     log_entry = match.group(1)
@@ -210,6 +220,8 @@ for repo in repos:
 
         blob.wait()
 
+        if log_entry_title:
+            add_entry(sha, title)
         if log_entry_commit:
             add_entry(sha, commit_msg)
         if log_entry:

--- a/misc/changelog-generator/test-changelog-generator
+++ b/misc/changelog-generator/test-changelog-generator
@@ -333,6 +333,20 @@ Changelog: Make sure the bugtracker reference is taken from the title
 
 ################################################################################
 
+git commit --allow-empty -m 'MEN-1234 with JIRA tag in title. N68
+
+Title should be included, rest of commit - not'
+
+################################################################################
+
+git commit --allow-empty -m 'MEN-1234 with JIRA tag in title. N69
+
+Changelog: None
+
+Nothing should be included'
+
+################################################################################
+
 
 
 "$SRC_DIR/changelog-generator" --repo --sort-changelog HEAD > result.txt 2>stderr.txt
@@ -389,6 +403,7 @@ cat > expected.txt <<EOF
 	- This should be in changelog N8
 	  And this N9
 	- This too. N33
+	- with JIRA tag in title. N68 (MEN-1234)
 EOF
 diff -u expected.txt result.txt
 


### PR DESCRIPTION
…number

From now on, you don't need to write "Changelog: title" if you prepend
title with JIRA ticket number

Signed-off-by: Aleksei Shpakovskii <aleksei.shpakovskii@cfengine.com>

(cherry picked from commit d9f3c2428ff608eeafcbe93e193c7862decf1644)