### PR TITLE
Additional error reporting around safe links.

### DIFF
--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -577,6 +577,10 @@ int safe_open(const char *pathname, int flags, ...)
                     (stat_before.st_uid != stat_after.st_uid || stat_before.st_gid != stat_after.st_gid))
                 {
                     close(currentfd);
+                    Log(LOG_LEVEL_ERR, "Cannot follow symlink '%s'; it is not "
+                        "owned by root or the user running this process, and "
+                        "the target owner and/or group differs from that of "
+                        "the symlink itself.", pathname);
                     // Return ENOLINK to signal that the link cannot be followed
                     // ('Link has been severed').
                     errno = ENOLINK;


### PR DESCRIPTION
This commit adds an additional log message (at level ERR) explaining
why we refuse to follow a symlink in certain conditions. I was
confused when it happened to me, and this error message would have
been a big help.

(cherry picked from commit 2c84b4e1b379a926cd5eab1056402ba090631e3d)