### PR TITLE
CFE-2897 Test that iterating over paths with backreferences does not confuse match results

### DIFF
--- a/tests/acceptance/10_files/rename/main.cf
+++ b/tests/acceptance/10_files/rename/main.cf
@@ -1,0 +1,92 @@
+body file control
+{
+        inputs => { "../../default.cf.sub" };
+}
+
+bundle agent main
+{
+  methods:
+      "init,test,check,cleanup"
+        usebundle => default("$(this.promise_filename)") ;
+}
+
+bundle agent init
+{
+  files:
+
+      # First we initialize some directories to iterate over and some files that
+      # will be renamed during the test
+
+      "$(G.testdir)/test/$(check.dirs)/incoming/$(check.files)"
+        create => "true";
+}
+
+bundle agent test
+{
+  meta:
+
+      "description"
+        string => "Test that files can be renamed using regular expression
+        matches from the promiser";
+
+      "test_soft_fail"
+        string => "any",
+        meta => { "CFE-2879" };
+
+  files:
+
+      # We promise that the target is a copy of the source file Since preserve
+      # is set to false, we expect the original permissions on the target file
+      # to remain unchanged.
+
+      "$(G.testdir)/test/$(check.dirs)/incoming/((?!.*renamed)[a-z]*)"
+        rename => to( "$(G.testdir)/test/$(check.dirs)/incoming/$(match.1)_renamed" );
+
+}
+
+body rename to(file)
+{
+        newname => "$(file)";
+}
+
+bundle agent check
+{
+  vars:
+      "dirs"
+        slist => { "knuth", "lamport", "turing" };
+
+      "files"
+        slist => { "one", "two", "three" };
+
+      # Append _renamed to each of the files
+      "expected_files" slist => maplist( "$(this)_renamed", files );
+
+      "expected_paths" slist => {
+                                  "$(G.testdir)/test/knuth/incoming/one_renamed",
+                                  "$(G.testdir)/test/knuth/incoming/two_renamed",
+                                  "$(G.testdir)/test/knuth/incoming/three_renamed",
+                                  "$(G.testdir)/test/lamport/incoming/one_renamed",
+                                  "$(G.testdir)/test/lamport/incoming/two_renamed",
+                                  "$(G.testdir)/test/lamport/incoming/three_renamed",
+                                  "$(G.testdir)/test/turing/incoming/one_renamed",
+                                  "$(G.testdir)/test/turing/incoming/two_renamed",
+                                  "$(G.testdir)/test/turing/incoming/three_renamed",
+      };
+
+  classes:
+      "all_expected_files_exist"
+        expression => filesexist( @(expected_paths) );
+
+  methods:
+
+      "Pass orFail"
+        usebundle => dcs_passif( "all_expected_files_exist",
+                                 $(this.promise_filename));
+
+  reports:
+      DEBUG|EXTRA::
+      "Expected path exists '$(expected_paths)'"
+        if => fileexists( $(expected_paths) );
+      "Expected path MISSING '$(expected_paths)'"
+        unless => fileexists( $(expected_paths) );
+}


### PR DESCRIPTION
Changelog: None

As seen in these test results, during the first iteration of dirs (knuth)
match.1 was correct as expected and results in each filename being renamed with
a _renamed suffix. When iteration moves to the second element of dirs (lamport)
match.1 seems to be stuck on "three" as one is renamed to three_renamed and two
is renamed to three_renamed also.

```
cf-agent -KIf ./10_files/rename/main.cf -D AUTO,DEBUG
    info: Created directory '/tmp/TESTDIR.cfengine/.'
R: test description: Test that files can be renamed using regular expression
        matches from the promiser
R: /home/nickanderson/Northern.Tech/CFEngine/core/tests/acceptance/./10_files/rename/../../dcs.cf.sub SFAIL/CFE-2879
    info: Created file '/tmp/TESTDIR.cfengine/test/knuth/incoming/one', mode 0600
    info: Created file '/tmp/TESTDIR.cfengine/test/knuth/incoming/two', mode 0600
    info: Created file '/tmp/TESTDIR.cfengine/test/knuth/incoming/three', mode 0600
    info: Created file '/tmp/TESTDIR.cfengine/test/lamport/incoming/one', mode 0600
    info: Created file '/tmp/TESTDIR.cfengine/test/lamport/incoming/two', mode 0600
    info: Created file '/tmp/TESTDIR.cfengine/test/lamport/incoming/three', mode 0600
    info: Created file '/tmp/TESTDIR.cfengine/test/turing/incoming/one', mode 0600
    info: Created file '/tmp/TESTDIR.cfengine/test/turing/incoming/two', mode 0600
    info: Created file '/tmp/TESTDIR.cfengine/test/turing/incoming/three', mode 0600
    info: Renaming file '/tmp/TESTDIR.cfengine/test/knuth/incoming/two' to '/tmp/TESTDIR.cfengine/test/knuth/incoming/two_renamed'
    info: Renaming file '/tmp/TESTDIR.cfengine/test/knuth/incoming/one' to '/tmp/TESTDIR.cfengine/test/knuth/incoming/one_renamed'
    info: Renaming file '/tmp/TESTDIR.cfengine/test/knuth/incoming/three' to '/tmp/TESTDIR.cfengine/test/knuth/incoming/three_renamed'
    info: Renaming file '/tmp/TESTDIR.cfengine/test/lamport/incoming/two' to '/tmp/TESTDIR.cfengine/test/lamport/incoming/three_renamed'
    info: Renaming file '/tmp/TESTDIR.cfengine/test/lamport/incoming/one' to '/tmp/TESTDIR.cfengine/test/lamport/incoming/three_renamed'
    info: Renaming file '/tmp/TESTDIR.cfengine/test/lamport/incoming/three' to '/tmp/TESTDIR.cfengine/test/lamport/incoming/three_renamed'
    info: Renaming file '/tmp/TESTDIR.cfengine/test/turing/incoming/two' to '/tmp/TESTDIR.cfengine/test/turing/incoming/three_renamed'
    info: Renaming file '/tmp/TESTDIR.cfengine/test/turing/incoming/one' to '/tmp/TESTDIR.cfengine/test/turing/incoming/three_renamed'
    info: Renaming file '/tmp/TESTDIR.cfengine/test/turing/incoming/three' to '/tmp/TESTDIR.cfengine/test/turing/incoming/three_renamed'
R: /home/nickanderson/Northern.Tech/CFEngine/core/tests/acceptance/./10_files/rename/main.cf FAIL
R: dcs_passif: failing based on class 'all_expected_files_exist'
R: Expected path exists '/tmp/TESTDIR.cfengine/test/knuth/incoming/one_renamed'
R: Expected path exists '/tmp/TESTDIR.cfengine/test/knuth/incoming/two_renamed'
R: Expected path exists '/tmp/TESTDIR.cfengine/test/knuth/incoming/three_renamed'
R: Expected path exists '/tmp/TESTDIR.cfengine/test/lamport/incoming/three_renamed'
R: Expected path exists '/tmp/TESTDIR.cfengine/test/turing/incoming/three_renamed'
R: Expected path MISSING '/tmp/TESTDIR.cfengine/test/lamport/incoming/one_renamed'
R: Expected path MISSING '/tmp/TESTDIR.cfengine/test/lamport/incoming/two_renamed'
R: Expected path MISSING '/tmp/TESTDIR.cfengine/test/turing/incoming/one_renamed'
R: Expected path MISSING '/tmp/TESTDIR.cfengine/test/turing/incoming/two_renamed'
```