### PR TITLE
Removed unnecessary const in return type

### DIFF
--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -553,7 +553,7 @@ long byte_magnitude(long bytes)
 // Use this with byte_magnitude
 // Note that the cutoff is at 8x unit, because 3192 bytes is arguably more
 // useful than 3KiB
-const char * const byte_unit(long bytes)
+const char *byte_unit(long bytes)
 {
     const long Ki = 1024;
     const long Mi = Ki * 1024;

--- a/libutils/logging.h
+++ b/libutils/logging.h
@@ -124,6 +124,6 @@ bool LogEnableModulesFromString(char *s);
 
 // byte_magnitude and byte_unit are used to print readable byte counts
 long byte_magnitude(long bytes);
-const char * const byte_unit(long bytes);
+const char *byte_unit(long bytes);
 
 #endif


### PR DESCRIPTION
This const does nothing and can be confusing.

Reported by LGTM:
https://lgtm.com/rules/2157860314/

Changelog: None
Signed-off-by: Ole Herman Schumacher Elgesem <ole.elgesem@northern.tech>