### PR TITLE
Add cf-info.sh diagnostic script

### DIFF
--- a/contrib/cf-info/cf-info.sh
+++ b/contrib/cf-info/cf-info.sh
@@ -1,17 +1,27 @@
 #!/bin/sh
 # Author: Mike Weilgart, 19 September 2016
+# Updated by: Aleksey Tsalolikhin, 30 Aug 2018
 echo
 /var/cfengine/bin/cf-agent -V
 echo
 ps -ef | grep 'cf-[a-z]*d' || echo "No CFEngine daemons running"
-echo
-printf 'Policy version: '
-cat /var/cfengine/inputs/policy_version.dat
-echo
-printf 'Policy commit id: '
-cat /var/cfengine/inputs/policy_commit_id.dat
-echo
-printf "Bootstrapped to: %s\n" "$(cat /var/cfengine/policy_server.dat)"
+if [ -f /var/cfengine/inputs/policy_version.dat ]; then
+  echo
+  printf 'Policy version: '
+  cat /var/cfengine/inputs/policy_version.dat
+fi
+if [ -f /var/cfengine/inputs/policy_commit_id.dat ]; then
+  echo
+  printf 'Policy commit id: '
+  cat /var/cfengine/inputs/policy_commit_id.dat
+fi
+if [ -f /var/cfengine/policy_server.dat ]; then
+  echo
+  printf "Bootstrapped to: %s\n" "$(cat /var/cfengine/policy_server.dat)"
+else
+  echo
+  echo "Not bootstrapped to a policy server"
+fi
 echo
 printf 'Policy channel assignment: %s\n' "$(cat /var/cfengine/state/policy_channel.txt 2>/dev/null || echo Not assigned)"
 echo

--- a/contrib/cf-info/cf-info.sh
+++ b/contrib/cf-info/cf-info.sh
@@ -22,7 +22,7 @@ awk -F '[:,]' -v time="$(date +%s)" 'END {printf "Last cf-agent run started %d m
 echo
 tail -n 2 /var/cfengine/promise_summary.log | sed 's/.*Total promise compliance: \([^.]*\).*/\1/;1s/^/update.cf compliance:   /;2s/^/promises.cf compliance: /'
 echo
-touch /var/cfengine/test.tmp && echo Filesystem writeable
+touch /var/cfengine/test.tmp && ( echo Filesystem writeable ; \rm /var/cfengine/test.tmp)
 echo
 df -P /var/cfengine | awk 'END {printf "Filesystem utilization: %s %s\n", $6, $5}'
 echo

--- a/contrib/cf-info/cf-info.sh
+++ b/contrib/cf-info/cf-info.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Author: Mike Weilgart, 19 September 2016
+echo
+/var/cfengine/bin/cf-agent -V
+echo
+ps -ef | grep 'cf-[a-z]*d' || echo "No CFEngine daemons running"
+echo
+printf 'Policy version: '
+cat /var/cfengine/inputs/policy_version.dat
+echo
+printf 'Policy commit id: '
+cat /var/cfengine/inputs/policy_commit_id.dat
+echo
+printf "Bootstrapped to: %s\n" "$(cat /var/cfengine/policy_server.dat)"
+echo
+printf 'Policy channel assignment: %s\n' "$(cat /var/cfengine/state/policy_channel.txt 2>/dev/null || echo Not assigned)"
+echo
+echo "Host key:"
+/var/cfengine/bin/cf-key -p /var/cfengine/ppkeys/localhost.pub
+echo
+awk -F '[:,]' -v time="$(date +%s)" 'END {printf "Last cf-agent run started %d minutes ago and lasted %d seconds\n", (time - $1)/60, $2 - $1}' /var/cfengine/promise_summary.log
+echo
+tail -n 2 /var/cfengine/promise_summary.log | sed 's/.*Total promise compliance: \([^.]*\).*/\1/;1s/^/update.cf compliance:   /;2s/^/promises.cf compliance: /'
+echo
+touch /var/cfengine/test.tmp && echo Filesystem writeable
+echo
+df -P /var/cfengine | awk 'END {printf "Filesystem utilization: %s %s\n", $6, $5}'
+echo
+pgrep -fl cf-twin && printf "\ncf-twin process is running. Check for failed CFEngine upgrade (if found wipe and reinstall).\n\n"


### PR DESCRIPTION
cf-info was the precursor to cf-diag (see https://github.com/cfengine/core/blob/master/contrib/cf-diag/cf-diag.sh)

Purpose: facilitate diagnostics when investigating issues with CFEngine reporting.

It works by checking common pain points (e.g. read-only filesystem, old policy version) in large infrastructures.

This script is meant to be run on hosts managed by CFEngine by human
operators investigating problems with CFEngine reporting.

Intended for use with policy channels (see https://github.com/cfengine/core/tree/master/contrib/masterfiles-stage)