### PR TITLE
CFE-2886: Changed Attr parameter to Attr * in FileChangesCheckAndUpdateHash

### DIFF
--- a/cf-agent/files_changes.c
+++ b/cf-agent/files_changes.c
@@ -523,13 +523,14 @@ bool FileChangesCheckAndUpdateHash(EvalContext *ctx,
                                    const char *filename,
                                    unsigned char digest[EVP_MAX_MD_SIZE + 1],
                                    HashMethod type,
-                                   Attributes attr,
+                                   const Attributes *attr,
                                    const Promise *pp,
                                    PromiseResult *result)
 {
-    bool ret = FileChangesCheckAndUpdateHash_impl(filename, digest, type, attr.change.update, pp, result);
+    assert(attr != NULL);
+    bool ret = FileChangesCheckAndUpdateHash_impl(filename, digest, type, attr->change.update, pp, result);
     // TODO: Move cfPS even further up the call stack.
-    cfPS(ctx, LOG_LEVEL_DEBUG, *result, pp, attr, "Updating promise status for files changes promise");
+    cfPS(ctx, LOG_LEVEL_DEBUG, *result, pp, *attr, "Updating promise status for files changes promise");
     return ret;
 }
 

--- a/cf-agent/files_changes.h
+++ b/cf-agent/files_changes.h
@@ -40,7 +40,7 @@ bool FileChangesCheckAndUpdateHash(EvalContext *ctx,
                                    const char *filename,
                                    unsigned char digest[EVP_MAX_MD_SIZE + 1],
                                    HashMethod type,
-                                   Attributes attr,
+                                   const Attributes *attr,
                                    const Promise *pp,
                                    PromiseResult *result);
 bool FileChangesGetDirectoryList(const char *path, Seq *files);

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -3064,8 +3064,8 @@ static PromiseResult VerifyFileIntegrity(EvalContext *ctx, const char *file, Att
             HashFile(file, digest1, HASH_METHOD_MD5);
             HashFile(file, digest2, HASH_METHOD_SHA1);
 
-            one = FileChangesCheckAndUpdateHash(ctx, file, digest1, HASH_METHOD_MD5, attr, pp, &result);
-            two = FileChangesCheckAndUpdateHash(ctx, file, digest2, HASH_METHOD_SHA1, attr, pp, &result);
+            one = FileChangesCheckAndUpdateHash(ctx, file, digest1, HASH_METHOD_MD5, &attr, pp, &result);
+            two = FileChangesCheckAndUpdateHash(ctx, file, digest2, HASH_METHOD_SHA1, &attr, pp, &result);
 
             if (one || two)
             {
@@ -3079,7 +3079,7 @@ static PromiseResult VerifyFileIntegrity(EvalContext *ctx, const char *file, Att
         {
             HashFile(file, digest1, attr.change.hash);
 
-            if (FileChangesCheckAndUpdateHash(ctx, file, digest1, attr.change.hash, attr, pp, &result))
+            if (FileChangesCheckAndUpdateHash(ctx, file, digest1, attr.change.hash, &attr, pp, &result))
             {
                 changed = true;
             }


### PR DESCRIPTION
This struct is 2304 bytes, and shouldn't be copied around so frequently.
I didn't change it everywhere yet, the cfPS function is used in so many places.

Reported by LGTM:
https://lgtm.com/rules/2163210742/