### PR TITLE
Add LGTM.com code quality badge for C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 | 3.7.x LTS  | [![Core Build Status](https://travis-ci.org/cfengine/core.svg?branch=3.7.x)](https://travis-ci.org/cfengine/core)  | [![MPF Build Status](https://travis-ci.org/cfengine/masterfiles.svg?branch=3.7.x)](https://travis-ci.org/cfengine/masterfiles)  |
 
 [![codecov](https://codecov.io/gh/cfengine/core/branch/master/graph/badge.svg)](https://codecov.io/gh/cfengine/core)
-
+[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/cfengine/core.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cfengine/core/)
 
 # CFEngine 3
 


### PR DESCRIPTION
Hi team,

I noticed that you've enabled automated code review by LGTM.com for pull requests, and that a significant number of alerts got fixed. Great! The code quality grade is ever improving; here's a badge to show it in your `README.md` if you like.

[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/cfengine/core.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cfengine/core/)

Keep up the good work!

(full disclosure: I'm on the LGTM team :slightly_smiling_face:)