### PR TITLE
ENT-3831: Added new thread safe queue data structure

### DIFF
--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -72,6 +72,7 @@ libutils_la_SOURCES = \
 	unicode.c unicode.h \
 	hash.c hash.h \
 	queue.c queue.h \
+	threaded_queue.c threaded_queue.h \
 	stack.c stack.h \
 	ring_buffer.c ring_buffer.h \
 	regex.c regex.h \

--- a/libutils/mutex.h
+++ b/libutils/mutex.h
@@ -27,12 +27,26 @@
 
 #include <platform.h>
 
-#define ThreadLock(m)     __ThreadLock(m, __func__, __FILE__, __LINE__)
-#define ThreadUnlock(m) __ThreadUnlock(m, __func__, __FILE__, __LINE__)
+#define THREAD_BLOCK_INDEFINITELY  -1
 
-void __ThreadLock(pthread_mutex_t *name,
+#define ThreadLock(m)       __ThreadLock(m, __func__, __FILE__, __LINE__)
+#define ThreadUnlock(m)   __ThreadUnlock(m, __func__, __FILE__, __LINE__)
+#define ThreadWait(m, n, t) __ThreadWait(m, n, t, __func__, __FILE__, __LINE__)
+
+void __ThreadLock(pthread_mutex_t *mutex,
                   const char *funcname, const char *filename, int lineno);
-void __ThreadUnlock(pthread_mutex_t *name,
+void __ThreadUnlock(pthread_mutex_t *mutex,
                     const char *funcname, const char *filename, int lineno);
+
+/**
+  @brief Function to wait for `timeout` seconds or until signalled.
+  @note Can use THREAD_BLOCK_INDEFINITELY to block until a signal is received.
+  @param [in] cond Thread condition to wait for.
+  @param [in] mutex Mutex lock to acquire once condition is met.
+  @param [in] timeout Seconds to wait for, can be THREAD_BLOCK_INDEFINITELY
+  @return 0 on success, -1 if timed out, exits if locking fails
+ */
+int __ThreadWait(pthread_cond_t *cond, pthread_mutex_t *mutex, int timeout,
+                 const char *funcname, const char *filename, int lineno);
 
 #endif

--- a/libutils/threaded_queue.c
+++ b/libutils/threaded_queue.c
@@ -1,0 +1,509 @@
+/*
+   Copyright 2018 Northern.tech AS
+
+   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <alloc.h>
+#include <logging.h>
+#include <mutex.h>
+#include <pthread.h>
+#include <threaded_queue.h>
+
+
+#define EXPAND_FACTOR     2
+#define DEFAULT_CAPACITY 16
+
+/** @struct ThreadedQueue_
+  @brief An implementation of a thread safe queue based on a circular array
+
+  Can enqueue, dequeue and give various statistics about its contents, like
+  amount of elements, capacity and if it is empty. Has the ability to block
+  if queue is empty, waiting for new elements to be queued.
+  */
+struct ThreadedQueue_ {
+    pthread_mutex_t *lock;            /**< Thread lock for accessing data. */
+    pthread_cond_t *cond_non_empty;   /**< Blocking condition if empty     */
+    pthread_cond_t *cond_empty;       /**< Blocking condition if not empty */
+    void (*ItemDestroy) (void *item); /**< Data-specific destroy function. */
+    void **data;                      /**< Internal array of elements.     */
+    size_t head;                      /**< Current position in queue.      */
+    size_t tail;                      /**< Current end of queue.           */
+    size_t size;                      /**< Current size of queue.          */
+    size_t capacity;                  /**< Current memory allocated.       */
+};
+
+static void DestroyRange(ThreadedQueue *queue, size_t start, size_t end);
+static void ExpandIfNecessary(ThreadedQueue *queue);
+
+ThreadedQueue *ThreadedQueueNew(size_t initial_capacity,
+                                void (ItemDestroy) (void *item))
+{
+    ThreadedQueue *queue = xcalloc(1, sizeof(ThreadedQueue));
+
+    if (initial_capacity == 0)
+    {
+        initial_capacity = DEFAULT_CAPACITY;
+    }
+
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    // enables errorchecking for deadlocks
+    int ret = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+    if (ret != 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to use error-checking mutexes for queue, "
+            "falling back to normal ones (pthread_mutexattr_settype: %s)",
+            GetErrorStrFromCode(ret));
+        pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
+    }
+
+    queue->lock = xmalloc(sizeof(pthread_mutex_t));
+    ret = pthread_mutex_init(queue->lock, &attr);
+    if (ret != 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to initialize mutex (pthread_mutex_init: %s)",
+            GetErrorStrFromCode(ret));
+        pthread_mutexattr_destroy(&attr);
+        free(queue->lock);
+        free(queue);
+        return NULL;
+    }
+
+    pthread_mutexattr_destroy(&attr);
+
+    queue->cond_non_empty = xmalloc(sizeof(pthread_cond_t));
+    ret = pthread_cond_init(queue->cond_non_empty, NULL);
+    if (ret != 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to initialize thread condition (pthread_cond_init: %s)",
+            GetErrorStrFromCode(ret));
+        free(queue->lock);
+        free(queue->cond_non_empty);
+        free(queue);
+        return NULL;
+    }
+
+    queue->cond_empty = xmalloc(sizeof(pthread_cond_t));
+    ret = pthread_cond_init(queue->cond_empty, NULL);
+    if (ret != 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to initialize thread condition "
+            "(pthread_cond_init: %s)",
+            GetErrorStrFromCode(ret));
+        free(queue->lock);
+        free(queue->cond_empty);
+        free(queue->cond_non_empty);
+        free(queue);
+        return NULL;
+    }
+
+    queue->capacity = initial_capacity;
+    queue->head = 0;
+    queue->tail = 0;
+    queue->size = 0;
+    queue->data = xmalloc(sizeof(void *) * initial_capacity);
+    queue->ItemDestroy = ItemDestroy;
+
+    return queue;
+}
+
+void ThreadedQueueDestroy(ThreadedQueue *queue)
+{
+    if (queue != NULL)
+    {
+        ThreadLock(queue->lock);
+        DestroyRange(queue, queue->head, queue->tail);
+        ThreadUnlock(queue->lock);
+
+        ThreadedQueueSoftDestroy(queue);
+    }
+}
+
+void ThreadedQueueSoftDestroy(ThreadedQueue *queue)
+{
+    if (queue != NULL)
+    {
+        if (queue->lock != NULL)
+        {
+            pthread_mutex_destroy(queue->lock);
+            free(queue->lock);
+        }
+
+        if (queue->cond_non_empty != NULL)
+        {
+            pthread_cond_destroy(queue->cond_non_empty);
+            free(queue->cond_non_empty);
+        }
+
+        if (queue->cond_empty != NULL)
+        {
+            pthread_cond_destroy(queue->cond_empty);
+            free(queue->cond_empty);
+        }
+
+        free(queue->data);
+        free(queue);
+    }
+}
+
+bool ThreadedQueuePop(ThreadedQueue *queue, void **item, int timeout)
+{
+    assert(queue != NULL);
+
+    ThreadLock(queue->lock);
+
+    if (queue->size == 0 && timeout != 0)
+    {
+        int res = 0;
+        do {
+            res = ThreadWait(queue->cond_non_empty, queue->lock, timeout);
+
+            if (res != 0)
+            {
+                /* Lock is reacquired even when timed out, so it needs to be
+                   released again. */
+                ThreadUnlock(queue->lock);
+                return false;
+            }
+        } while (queue->size == 0);
+        // Reevaluate predicate to protect against spurious wakeups
+    }
+
+    bool ret = true;
+    if (queue->size > 0)
+    {
+        size_t head = queue->head;
+        *item = queue->data[head];
+
+        queue->data[head++] = NULL;
+
+        head %= queue->capacity;
+        queue->head = head;
+        queue->size--;
+    } else {
+        ret = false;
+        *item = NULL;
+    }
+
+    if (queue->size == 0)
+    {
+        // Signals that the queue is empty for ThreadedQueueWaitEmpty
+        pthread_cond_broadcast(queue->cond_empty);
+    }
+
+    ThreadUnlock(queue->lock);
+
+    return ret;
+}
+
+size_t ThreadedQueuePopN(ThreadedQueue *queue,
+                         void ***data_array,
+                         size_t num,
+                         int timeout)
+{
+    assert(queue != NULL);
+
+    ThreadLock(queue->lock);
+
+    if (queue->size == 0 && timeout != 0)
+    {
+        int res = 0;
+        do {
+            res = ThreadWait(queue->cond_non_empty, queue->lock, timeout);
+
+            if (res != 0)
+            {
+                /* Lock is reacquired even when timed out, so it needs to be
+                   released again. */
+                ThreadUnlock(queue->lock);
+                *data_array = NULL;
+                return 0;
+            }
+        } while (queue->size == 0);
+        // Reevaluate predicate to protect against spurious wakeups
+    }
+
+    size_t size = num < queue->size ? num : queue->size;
+    void **data = NULL;
+
+    if (size > 0)
+    {
+        data = xcalloc(size, sizeof(void *));
+        size_t head = queue->head;
+
+        for (size_t i = 0; i < size; i++)
+        {
+            data[i] = queue->data[head];
+            queue->data[head++] = NULL;
+            head %= queue->capacity;
+        }
+
+        queue->head = head;
+        queue->size -= size;
+    }
+
+    if (queue->size == 0)
+    {
+        // Signals that the queue is empty for ThreadedQueueWaitEmpty
+        pthread_cond_broadcast(queue->cond_empty);
+    }
+
+    *data_array = data;
+
+    ThreadUnlock(queue->lock);
+
+    return size;
+}
+
+size_t ThreadedQueuePush(ThreadedQueue *queue, void *item)
+{
+    assert(queue != NULL);
+
+    ThreadLock(queue->lock);
+
+    ExpandIfNecessary(queue);
+    queue->data[queue->tail++] = item;
+    queue->size++;
+    size_t const size = queue->size;
+    pthread_cond_signal(queue->cond_non_empty);
+
+    ThreadUnlock(queue->lock);
+
+    return size;
+}
+
+size_t ThreadedQueueCount(ThreadedQueue const *queue)
+{
+    assert(queue != NULL);
+
+    ThreadLock(queue->lock);
+    size_t const count = queue->size;
+    ThreadUnlock(queue->lock);
+
+    return count;
+}
+
+size_t ThreadedQueueCapacity(ThreadedQueue const *queue)
+{
+    assert(queue != NULL);
+
+    ThreadLock(queue->lock);
+    size_t const capacity = queue->capacity;
+    ThreadUnlock(queue->lock);
+
+    return capacity;
+}
+
+bool ThreadedQueueIsEmpty(ThreadedQueue const *queue)
+{
+    assert(queue != NULL);
+
+    ThreadLock(queue->lock);
+    bool const empty = (queue->size == 0);
+    ThreadUnlock(queue->lock);
+
+    return empty;
+}
+
+bool ThreadedQueueWaitEmpty(ThreadedQueue const *queue, int timeout)
+{
+    assert(queue != NULL);
+    int ret = true;
+
+    ThreadLock(queue->lock);
+
+    if (queue->size != 0)
+    {
+        if (timeout != 0)
+        {
+            int res = 0;
+
+            do {
+                res = ThreadWait(queue->cond_empty, queue->lock, timeout);
+
+                if (res != 0)
+                {
+                    /* Lock is reacquired even when timed out, so it needs to
+                       be released again. */
+                    ThreadUnlock(queue->lock);
+                    return false;
+                }
+            } while (queue->size != 0);
+            // Reevaluate predicate to protect against spurious wakeups
+        }
+        else
+        {
+            ret = false;
+        }
+    }
+
+    ThreadUnlock(queue->lock);
+
+    return ret;
+}
+
+ThreadedQueue *ThreadedQueueCopy(ThreadedQueue *queue)
+{
+    assert(queue != NULL);
+
+    ThreadLock(queue->lock);
+
+    ThreadedQueue *new_queue = xmemdup(queue, sizeof(ThreadedQueue));
+    new_queue->data = xmalloc(sizeof(void *) * queue->capacity);
+    memcpy(new_queue->data, queue->data,
+           sizeof(void *) * new_queue->capacity);
+
+    ThreadUnlock(queue->lock);
+
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    // enables error checking for deadlocks
+    int ret = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+    if (ret != 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to use error-checking mutexes for queue, "
+            "falling back to normal ones (pthread_mutexattr_settype: %s)",
+            GetErrorStrFromCode(ret));
+        pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
+    }
+
+    new_queue->lock = xmalloc(sizeof(pthread_mutex_t));
+    ret = pthread_mutex_init(new_queue->lock, &attr);
+    if (ret != 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to initialize mutex (pthread_mutex_init: %s)",
+            GetErrorStrFromCode(ret));
+        pthread_mutexattr_destroy(&attr);
+        free(new_queue->lock);
+        free(new_queue);
+        return NULL;
+    }
+
+    new_queue->cond_non_empty = xmalloc(sizeof(pthread_cond_t));
+    ret = pthread_cond_init(new_queue->cond_non_empty, NULL);
+    if (ret != 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to initialize thread condition "
+            "(pthread_cond_init: %s)",
+            GetErrorStrFromCode(ret));
+        free(new_queue->lock);
+        free(new_queue->cond_non_empty);
+        free(new_queue);
+        return NULL;
+    }
+
+    new_queue->cond_empty = xmalloc(sizeof(pthread_cond_t));
+    ret = pthread_cond_init(new_queue->cond_empty, NULL);
+    if (ret != 0)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Failed to initialize thread condition "
+            "(pthread_cond_init: %s)",
+            GetErrorStrFromCode(ret));
+        free(new_queue->lock);
+        free(new_queue->cond_empty);
+        free(new_queue->cond_non_empty);
+        free(new_queue);
+        return NULL;
+    }
+
+    return new_queue;
+}
+
+/**
+  @brief Destroys data in range.
+  @warning Assumes that locks are acquired.
+  @note If start == end, this means that all elements in queue will be
+        destroyed. Since the internal array is circular, it will wrap around
+        when reaching the array bounds.
+  @param [in] queue Pointer to struct.
+  @param [in] start Position to start destroying from.
+  @param [in] end First position to not destroy. Can be same as start.
+  */
+static void DestroyRange(ThreadedQueue *queue, size_t start, size_t end)
+{
+    assert(queue != NULL);
+    if (start > queue->capacity || end > queue->capacity)
+    {
+        Log(LOG_LEVEL_DEBUG,
+            "Failed to destroy ThreadedQueue, index greater than capacity: "
+            "start = %zu, end = %zu, capacity = %zu",
+            start, end, queue->capacity);
+        return;
+    }
+
+    if ((queue->ItemDestroy != NULL) && queue->size > 0)
+    {
+        queue->ItemDestroy(queue->data[start]);
+
+        // In case start == end, start at second element in range
+        for (size_t i = start + 1; i != end; i++)
+        {
+            i %= queue->capacity;
+
+            queue->ItemDestroy(queue->data[i]);
+        }
+    }
+}
+
+/**
+  @brief Either expands capacity of queue, or shifts tail to beginning.
+  @warning Assumes that locks are acquired.
+  @param [in] queue Pointer to struct.
+  */
+static void ExpandIfNecessary(ThreadedQueue *queue)
+{
+    assert(queue != NULL);
+    assert(queue->size <= queue->capacity);
+
+    if (queue->size == queue->capacity)
+    {
+        if (queue->tail <= queue->head)
+        {
+            size_t old_capacity = queue->capacity;
+
+            queue->capacity *= EXPAND_FACTOR;
+            queue->data = xrealloc(queue->data,
+                                   sizeof(void *) * queue->capacity);
+
+            memmove(queue->data + old_capacity, queue->data,
+                    sizeof(void *) * queue->tail);
+
+            queue->tail += old_capacity;
+        }
+        else
+        {
+            queue->capacity *= EXPAND_FACTOR;
+            queue->data = xrealloc(queue->data,
+                                   sizeof(void *) * queue->capacity);
+        }
+    }
+
+    queue->tail %= queue->capacity;
+}

--- a/libutils/threaded_queue.h
+++ b/libutils/threaded_queue.h
@@ -1,0 +1,132 @@
+/*
+   Copyright 2018 Northern.tech AS
+
+   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#ifndef CFENGINE_THREADED_QUEUE_H
+#define CFENGINE_THREADED_QUEUE_H
+
+#include <platform.h>
+
+typedef struct ThreadedQueue_ ThreadedQueue;
+
+/**
+  @brief Creates a new thread safe queue with specified capacity.
+  @param [in] initial_capacity Initial capacity, defaults to 1.
+  @param [in] ItemDestroy Function used to destroy data elements.
+  */
+ThreadedQueue *ThreadedQueueNew(size_t initial_capacity,
+                                void (ItemDestroy) (void *item));
+
+/**
+  @brief Destroys the queue and frees the memory it occupies.
+  @warning ThreadedQueue should only be destroyed if all threads are joined
+  @param [in] queue The queue to destroy.
+  */
+void ThreadedQueueDestroy(ThreadedQueue *queue);
+
+/**
+  @brief Frees the memory allocated for the data pointer and the struct itself.
+  @param [in] queue The queue to free.
+  */
+void ThreadedQueueSoftDestroy(ThreadedQueue *queue);
+
+/**
+  @brief Returns and removes the first element of the queue.
+  @note If queue is empty, blocks for `timeout` seconds or until signalled.
+        If THREAD_WAIT_INDEFINITELY is specified, waits forever until signal
+        is given. If it times out, it returns false.
+  @param [in] queue The queue to pop from.
+  @param [out] item The item at the first poisition in the queue.
+  @param [in] timeout Timeout for blocking in seconds.
+  @return true on success, false if timed out or queue was empty.
+  */
+bool ThreadedQueuePop(ThreadedQueue *queue, void **item, int timeout);
+
+/**
+  @brief Pops num elements from the queue into data_array, returns amount.
+  @note If queue is empty, blocks for `timeout` seconds or until signalled.
+        If THREAD_WAIT_INDEFINITELY is specified, waits forever until
+        signalled. If it times out, it returns 0 and sets *data_array to NULL.
+  @warning The pointer array will have to be freed manually.
+  @param [in] queue The queue to pop from.
+  @param [out] data_array Pointer to location to put popped elements.
+  @param [in] timeout Timeout for blocking in seconds.
+  @return Amount of elements popped.
+  */
+size_t ThreadedQueuePopN(ThreadedQueue *queue,
+                         void ***data_array,
+                         size_t num,
+                         int timeout);
+
+/**
+  @brief Pushes a new item on top of the queue, returns current size.
+  @param [in] queue The queue to push to.
+  @param [in] item The item to push.
+  @return Current amount of elements in the queue.
+  */
+size_t ThreadedQueuePush(ThreadedQueue *queue, void *item);
+
+/**
+  @brief Get current number of items in queue.
+  @note On NULL queue, returns 0.
+  @param [in] queue The queue.
+  @return The amount of elements in the queue.
+  */
+size_t ThreadedQueueCount(ThreadedQueue const *queue);
+
+/**
+  @brief Get current capacity of queue.
+  @note On NULL queue, returns 0.
+  @param [in] queue The queue.
+  @return The current capacity of the queue.
+  */
+size_t ThreadedQueueCapacity(ThreadedQueue const *queue);
+
+/**
+  @brief Checks if a queue is empty.
+  @param [in] queue The queue.
+  @return Returns true if queue is empty, false otherwise.
+  */
+bool ThreadedQueueIsEmpty(ThreadedQueue const *queue);
+
+/**
+  @brief Waits until queue is empty.
+  @note Useful for situations where you want to wait before populating the
+        queue. Timeout can be set to THREAD_BLOCK_INDEFINITELY to wait
+        forever. Otherwise waits the amount of seconds specified.
+  @param [in] queue The queue.
+  @param [in] timeout Amount of seconds to wait before timing out.
+  @return True if it successfully waited, false if it timed out.
+  */
+bool ThreadedQueueWaitEmpty(ThreadedQueue const *queue, int timeout);
+
+/**
+  @brief Create a shallow copy of a given queue.
+  @note This makes a new queue pointing to the same memory as the old queue.
+  @note Is only thread safe if original queue was also thread safe.
+  @param [in] queue The queue.
+  @return A new queue pointing to the same data.
+  */
+ThreadedQueue *ThreadedQueueCopy(ThreadedQueue *queue);
+
+#endif

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -170,6 +170,7 @@ check_PROGRAMS = \
 	key_test \
 	cf_upgrade_test \
 	queue_test \
+	threaded_queue_test \
 	stack_test \
 	matching_test \
 	ring_buffer_test \
@@ -483,6 +484,8 @@ cf_upgrade_test_SOURCES = cf_upgrade_test.c \
 cf_upgrade_test_CFLAGS = -I$(CFUPGRADE)
 
 queue_test_SOURCES = queue_test.c
+
+threaded_queue_test_SOURCES = threaded_queue_test.c
 
 stack_test_SOURCES = stack_test.c
 

--- a/tests/unit/threaded_queue_test.c
+++ b/tests/unit/threaded_queue_test.c
@@ -1,0 +1,392 @@
+#include <test.h>
+
+#include <alloc.h>
+#include <mutex.h>
+#include <threaded_queue.h>
+
+/* Memory illustration legend:          *
+ *      | : memory bounds               *
+ *      > : head                        *
+ *      < : tail                        *
+ *      ^ : head + tail (empty)         *
+ *      v : head + tail (at capacity)   *
+ *      x : used memory                 *
+ *      - : unused memory               */
+
+static void test_push_pop(void)
+{
+    // Initialised with DEFAULT_CAPACITY = 16
+    ThreadedQueue *queue = ThreadedQueueNew(0, free);
+    // |^---------------|
+    ThreadedQueuePush(queue, xstrdup("1"));
+    // |><--------------|
+    ThreadedQueuePush(queue, xstrdup("2"));
+    // |>x<-------------|
+    ThreadedQueuePush(queue, xstrdup("3"));
+    // |>xx<------------|
+
+    char *str1; ThreadedQueuePop(queue, (void **)&str1, 0);
+    // |->x<------------|
+    char *str2; ThreadedQueuePop(queue, (void **)&str2, 0);
+    // |--><------------|
+    char *str3; ThreadedQueuePop(queue, (void **)&str3, 0);
+    // |---v------------|
+
+    assert_string_equal(str1, "1");
+    assert_string_equal(str2, "2");
+    assert_string_equal(str3, "3");
+
+    free(str1);
+    free(str2);
+    free(str3);
+
+    ThreadedQueueDestroy(queue);
+}
+
+static void test_pop_empty_and_push_null(void)
+{
+    ThreadedQueue *queue = ThreadedQueueNew(1, NULL);
+    // |^|
+
+    assert(ThreadedQueueIsEmpty(queue));
+
+    void *i_am_null = NULL; bool ret = ThreadedQueuePop(queue, &i_am_null, 0);
+    // |^|
+    assert(i_am_null == NULL);
+    assert_false(ret);
+    ThreadedQueuePush(queue, i_am_null);
+    // |v|
+    ret = ThreadedQueuePop(queue, &i_am_null, 0);
+    assert(i_am_null == NULL);
+    assert_true(ret);
+    // |^|
+
+    ThreadedQueueDestroy(queue);
+}
+
+static void test_copy(void)
+{
+    ThreadedQueue *queue = ThreadedQueueNew(4, free);
+    // queue: |^---|
+
+    ThreadedQueuePush(queue, xstrdup("1"));
+    // queue: |><--|
+    ThreadedQueuePush(queue, xstrdup("2"));
+    // queue: |>x<-|
+    ThreadedQueuePush(queue, xstrdup("3"));
+    // queue: |>xx<|
+
+    ThreadedQueue *new_queue = ThreadedQueueCopy(queue);
+    // new_queue: |>xx<|
+
+    assert(new_queue != NULL);
+    assert_int_equal(ThreadedQueueCount(queue),
+                     ThreadedQueueCount(new_queue));
+    assert_int_equal(ThreadedQueueCapacity(queue),
+                     ThreadedQueueCapacity(new_queue));
+
+    char *old_str1; ThreadedQueuePop(queue, (void **)&old_str1, 0);
+    // queue: |->x<|
+    char *old_str2; ThreadedQueuePop(queue, (void **)&old_str2, 0);
+    // queue: |--><|
+    char *old_str3; ThreadedQueuePop(queue, (void **)&old_str3, 0);
+    // queue: |---^|
+
+    char *new_str1; ThreadedQueuePop(new_queue, (void **)&new_str1, 0);
+    // new_queue: |->x<|
+    char *new_str2; ThreadedQueuePop(new_queue, (void **)&new_str2, 0);
+    // new_queue: |--><|
+    char *new_str3; ThreadedQueuePop(new_queue, (void **)&new_str3, 0);
+    // new_queue: |---^|
+
+    // Check if pointers are equal (since this is a shallow copy)
+    assert(old_str1 == new_str1);
+    assert(old_str2 == new_str2);
+    assert(old_str3 == new_str3);
+
+    free(old_str1);
+    free(old_str2);
+    free(old_str3);
+
+    ThreadedQueueSoftDestroy(queue);
+
+    // Tests expanding the copied queue
+    ThreadedQueuePush(new_queue, xstrdup("1"));
+    // Internal array wraps:
+    // new_queue: |<-->|
+    ThreadedQueuePush(new_queue, xstrdup("2"));
+    // new_queue: |x<->|
+    ThreadedQueuePush(new_queue, xstrdup("3"));
+    // new_queue: |xx<>|
+    ThreadedQueuePush(new_queue, xstrdup("4"));
+    // new_queue: |xxxv|
+    ThreadedQueuePush(new_queue, xstrdup("5"));
+    // Internal array restructured, array moved to end:
+    // new_queue: |<-->xxxx|
+
+    assert_int_equal(ThreadedQueueCount(new_queue), 5);
+    assert_int_equal(ThreadedQueueCapacity(new_queue), 8);
+
+    ThreadedQueuePop(new_queue, (void **)&new_str1, 0);
+    // new_queue: |<--->xxx|
+    ThreadedQueuePop(new_queue, (void **)&new_str2, 0);
+    // new_queue: |<---->xx|
+    ThreadedQueuePop(new_queue, (void **)&new_str3, 0);
+    // new_queue: |<----->x|
+    char *new_str4; ThreadedQueuePop(new_queue, (void **)&new_str4, 0);
+    // new_queue: |<------>|
+    char *new_str5; ThreadedQueuePop(new_queue, (void **)&new_str5, 0);
+    // new_queue: |^-------|
+
+    assert_string_equal(new_str1, "1");
+    assert_string_equal(new_str2, "2");
+    assert_string_equal(new_str3, "3");
+    assert_string_equal(new_str4, "4");
+    assert_string_equal(new_str5, "5");
+
+    free(new_str1);
+    free(new_str2);
+    free(new_str3);
+    free(new_str4);
+    free(new_str5);
+
+    ThreadedQueueDestroy(new_queue);
+}
+
+static void test_push_report_count(void)
+{
+    ThreadedQueue *queue = ThreadedQueueNew(0, free);
+
+    size_t size1 = ThreadedQueuePush(queue, xstrdup("1"));
+    size_t size2 = ThreadedQueuePush(queue, xstrdup("2"));
+    size_t size3 = ThreadedQueuePush(queue, xstrdup("3"));
+    size_t size4 = ThreadedQueuePush(queue, xstrdup("4"));
+
+    assert_int_equal(size1, 1);
+    assert_int_equal(size2, 2);
+    assert_int_equal(size3, 3);
+    assert_int_equal(size4, 4);
+
+    ThreadedQueueDestroy(queue);
+}
+
+static void test_expand(void)
+{
+    ThreadedQueue *queue = ThreadedQueueNew(1, free);
+    // |^|
+
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |v|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |vx|
+
+    char *tmp; ThreadedQueuePop(queue, (void **)&tmp, 0);
+    // |<>|
+    free(tmp);
+
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |xv|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // Internal array restructured:
+    // |<>xx|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |xvxx|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // Internal array restructured:
+    // |->xxxx<-|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |->xxxxx<|
+
+    ThreadedQueuePop(queue, (void **)&tmp, 0);
+    // |-->xxxx<|
+    free(tmp);
+    ThreadedQueuePop(queue, (void **)&tmp, 0);
+    // |--->xxx<|
+    free(tmp);
+
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |<-->xxxx|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |x<->xxxx|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |xx<>xxxx|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |xxxvxxxx|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // Internal array restructured
+    // |--->xxxxxxxx<---|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |--->xxxxxxxxx<--|
+    ThreadedQueuePush(queue, xstrdup("spam"));
+    // |--->xxxxxxxxxx<-|
+
+    assert_int_equal(ThreadedQueueCount(queue), 11);
+    assert_int_equal(ThreadedQueueCapacity(queue), 16);
+
+    ThreadedQueueDestroy(queue);
+}
+
+static void test_popn(void)
+{
+    ThreadedQueue *queue = ThreadedQueueNew(0, free);
+    // Initialised with default size 16
+    // |^---------------|
+
+    char *strs[] = {"spam1", "spam2", "spam3", "spam4", "spam5"};
+
+    for (int i = 0; i < 5; i++)
+    {
+        ThreadedQueuePush(queue, xstrdup(strs[i]));
+    }
+    // |>xxxx<----------|
+
+    void **data = NULL;
+    size_t count = ThreadedQueuePopN(queue, &data, 5, 0);
+    // |-----^----------|
+
+    for (size_t i = 0; i < count; i++)
+    {
+        assert_string_equal(data[i], strs[i]);
+        free(data[i]);
+    }
+
+    free(data);
+    ThreadedQueueDestroy(queue);
+}
+
+// Thread tests
+static ThreadedQueue *thread_queue;
+
+static void *thread_pop()
+{
+    char *tmp;
+    ThreadedQueuePop(thread_queue, (void **)&tmp, THREAD_BLOCK_INDEFINITELY);
+    assert_string_equal(tmp, "bla");
+    free(tmp);
+
+    return NULL;
+}
+
+static void *thread_push()
+{
+    char *str = "bla";
+    ThreadedQueuePush(thread_queue, xstrdup(str));
+
+    return NULL;
+}
+
+static void *thread_wait_empty()
+{
+    ThreadedQueueWaitEmpty(thread_queue, THREAD_BLOCK_INDEFINITELY);
+    ThreadedQueuePush(thread_queue, xstrdup("a_test"));
+
+    return NULL;
+}
+
+static void test_threads_wait_pop(void)
+{
+#define POP_ITERATIONS 100
+    thread_queue = ThreadedQueueNew(0, free);
+
+    pthread_t pops[POP_ITERATIONS] = {0};
+    for (int i = 0; i < POP_ITERATIONS; i++)
+    {
+        int res_create = pthread_create(&(pops[i]), NULL,
+                                        thread_pop, NULL);
+        assert_int_equal(res_create, 0);
+    }
+
+    pthread_t pushs[POP_ITERATIONS] = {0};
+    for (int i = 0; i < POP_ITERATIONS; i++)
+    {
+        int res_create = pthread_create(&(pushs[i]), NULL,
+                                        thread_push, NULL);
+        assert_int_equal(res_create, 0);
+    }
+
+    void *retval = NULL;
+    int res;
+
+    for (int i = 0; i < POP_ITERATIONS; i++)
+    {
+        res = pthread_join(pops[i], retval);
+        assert_int_equal(res, 0);
+        assert(retval == NULL);
+
+        res = pthread_join(pushs[i], retval);
+        assert_int_equal(res, 0);
+        assert(retval == NULL);
+    }
+
+    ThreadedQueueDestroy(thread_queue);
+}
+
+static void test_threads_wait_empty(void)
+{
+#define WAIT_ITERATIONS 100
+    thread_queue = ThreadedQueueNew(0, free);
+
+    pthread_t pushs[WAIT_ITERATIONS] = {0};
+    for (int i = 0; i < WAIT_ITERATIONS; i++)
+    {
+        int res_create = pthread_create(&(pushs[i]), NULL,
+                                        thread_push, NULL);
+        assert_int_equal(res_create, 0);
+    }
+    pthread_t wait_thread = 0;
+    int res_create = pthread_create(&wait_thread, NULL,
+                                    thread_wait_empty, NULL);
+    assert_int_equal(res_create, 0);
+
+    do {
+        sleep(1);
+    } while (ThreadedQueueCount(thread_queue) != WAIT_ITERATIONS);
+
+    char **data_array = NULL;
+    size_t arr_size = ThreadedQueuePopN(thread_queue, (void ***)&data_array,
+                                        WAIT_ITERATIONS, 0);
+
+    for (size_t i = 0; i < arr_size; i++)
+    {
+        free(data_array[i]);
+    }
+
+    free(data_array);
+
+    char *waited_str; ThreadedQueuePop(thread_queue, (void **)&waited_str, 1);
+    assert_string_equal(waited_str, "a_test");
+    free(waited_str);
+
+    void *retval = NULL;
+    int res;
+
+    for (int i = 0; i < WAIT_ITERATIONS; i++)
+    {
+        res = pthread_join(pushs[i], retval);
+        assert_int_equal(res, 0);
+        assert(retval == NULL);
+    }
+
+    res = pthread_join(wait_thread, retval);
+    assert_int_equal(res, 0);
+    assert(retval == NULL);
+
+    ThreadedQueueDestroy(thread_queue);
+}
+
+int main()
+{
+    PRINT_TEST_BANNER();
+    const UnitTest tests[] =
+    {
+        unit_test(test_push_pop),
+        unit_test(test_pop_empty_and_push_null),
+        unit_test(test_copy),
+        unit_test(test_push_report_count),
+        unit_test(test_expand),
+        unit_test(test_popn),
+        unit_test(test_threads_wait_empty),
+        unit_test(test_threads_wait_pop),
+    };
+    return run_tests(tests);
+}


### PR DESCRIPTION
Can push, pop, block before popping if queue is empty, return
amount of elements, capacity, copy, etc. Can also be created
as a non-thread safe queue, if that is needed.

Ticket: ENT-3831
Changelog: None