### PR TITLE
Pass Averages struct by pointer

### DIFF
--- a/cf-monitord/history.c
+++ b/cf-monitord/history.c
@@ -379,7 +379,7 @@ static Item *NovaReSample(EvalContext *ctx, int slot, Attributes a, const Promis
     return ENTERPRISE_DATA[slot].output;
 }
 
-void HistoryUpdate(EvalContext *ctx, Averages newvals)
+void HistoryUpdate(EvalContext *ctx, const Averages *const newvals)
 {
     CfLock thislock;
     time_t now = time(NULL);
@@ -425,7 +425,7 @@ void HistoryUpdate(EvalContext *ctx, Averages newvals)
     YieldCurrentLock(thislock);
     PolicyDestroy(history_db_policy);
 
-    Nova_HistoryUpdate(CFSTARTTIME, &newvals);
+    Nova_HistoryUpdate(CFSTARTTIME, newvals);
 
     Nova_DumpSlowlyVaryingObservations();
 }

--- a/cf-monitord/history.h
+++ b/cf-monitord/history.h
@@ -31,7 +31,7 @@
 
 PromiseResult VerifyMeasurement(EvalContext *ctx, double *this,
                                 Attributes a, const Promise *pp);
-void HistoryUpdate(EvalContext *ctx, Averages newvals);
+void HistoryUpdate(EvalContext *ctx, const Averages *newvals);
 
 
 #endif


### PR DESCRIPTION
This struct is 3208 bytes and shouldn't be copied.

Reported by LGTM:
https://lgtm.com/rules/2163210742/
