### PR TITLE
Made variablesmatching functions treat args regexes more correctly

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1366,9 +1366,7 @@ static JsonElement *VariablesMatching(const EvalContext *ctx, const FnCall *fp, 
     {
         char *expr = VarRefToString(v->ref, true);
 
-        /* FIXME: review this strcmp. Moved out from StringMatch */
-        if (!strcmp(regex, expr) ||
-            (rx && StringMatchFullWithPrecompiledRegex(rx, expr)))
+        if (rx != NULL && StringMatchFullWithPrecompiledRegex(rx, expr))
         {
             StringSet *tagset = EvalContextVariableTags(ctx, v->ref);
             bool pass = false;
@@ -1382,9 +1380,7 @@ static JsonElement *VariablesMatching(const EvalContext *ctx, const FnCall *fp, 
                     StringSetIterator it = StringSetIteratorInit(tagset);
                     while ((element = SetIteratorNext(&it)))
                     {
-                        /* FIXME: review this strcmp. Moved out from StringMatch */
-                        if (strcmp(tag_regex, element) == 0 ||
-                            StringMatchFull(tag_regex, element))
+                        if (StringMatchFull(tag_regex, element))
                         {
                             pass = true;
                             break;

--- a/tests/acceptance/01_vars/02_functions/variablesmatching.cf
+++ b/tests/acceptance/01_vars/02_functions/variablesmatching.cf
@@ -16,6 +16,8 @@ bundle common init
       "test_b37ce1b03955522848f0a82d0b2b2e21_1" slist => { "a", "b" }, meta => { "x" };
       "test_b37ce1b03955522848f0a82d0b2b2e21_2" data => '{ "a": "b" }', meta => { "x" };
       "test_b37ce1b03955522848f0a82d0b2b2e21_3" string => 'mydata', meta => { "y" };
+
+      "test_variable_with_weird_tag" string => 'some_data', meta => { "weird[tag]" };
 }
 
 bundle agent test
@@ -28,6 +30,11 @@ bundle agent test
       "fullvars" data => variablesmatching_as_data("default:init.test_b37ce1b03955522848f0a82d0b2b2e21.*");
       "x_fullvars" data => variablesmatching_as_data("default:init.test_b37ce1b03955522848f0a82d0b2b2e21.*", "x");
       "z_fullvars" data => variablesmatching_as_data("default:init.test_b37ce1b03955522848f0a82d0b2b2e21.*", "z");
+
+      "tag_match" slist => variablesmatching(".*", "weird\[tag\]");
+      "tag_no_match" slist => variablesmatching(".*", "weird[tag]");
+      "tag_match_data" data => variablesmatching_as_data(".*", "weird\[tag\]");
+      "tag_no_match_data" data => variablesmatching_as_data(".*", "weird[tag]");
 }
 
 bundle agent check

--- a/tests/acceptance/01_vars/02_functions/variablesmatching.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/variablesmatching.cf.expected.json
@@ -9,6 +9,15 @@
     },
     "default:init.test_b37ce1b03955522848f0a82d0b2b2e21_3": "mydata"
   },
+  "tag_match": [
+    "default:init.test_variable_with_weird_tag"
+  ],
+  "tag_match_data": {
+    "default:init.test_variable_with_weird_tag": "some_data"
+  },
+  "tag_no_match": [],
+  "tag_no_match_data": {
+  },
   "vars": [
     "default:init.test_fbeae67f3e347b5e0032302200141131_1",
     "default:init.test_fbeae67f3e347b5e0032302200141131_2",


### PR DESCRIPTION
variablesmatching() and variablesmatching_as_data() no longer
use string comparison to find matches. The documentation is clear;
arguments should be regexes (so you have to escape special
characters).

```
bundle agent main
{
    vars:
        "myvar"
            string => "example",
            meta => {"os[linux]"};
        "matches"
            slist => variablesmatching(".*", "os\[linux\]");
    reports:
        "Match: $(matches)";
}
```

The above example is correct. If you don't escape the brackets
like above, it will no longer work. (You probably shouldn't use
brackets in tags anyway).