### PR TITLE
Add contrib/cf-log.sh (shows promise_summary.log)

### DIFF
--- a/contrib/cf-log/cf-log.pl
+++ b/contrib/cf-log/cf-log.pl
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+
+open (CFELOG, "</var/cfengine/promise_summary.log") or die;
+while (<CFELOG>) {
+  s/(\d+),(\d+)/localtime($1) . " - " . localtime($2)/e;
+  print;
+}
+close (CFELOG);
+
+# Can also be run as a one-liner:
+#perl -pe 's/(\d+),(\d+)/localtime($1) . " - " . localtime($2)/e;' /var/cfengine/promise_summary.log


### PR DESCRIPTION
contrib/cf-log.sh shows promise_summary.log but converts epoch times to
human-readable. This is convenient for handling reports of "my
application was having issues at 8:57 PM, did CFEngine break it?"
"Why, no, CFEngine wasn't running then, it ran at 8:59 PM."