### PR TITLE
CFE-2886: Changed ScheduleEditXmlOperations() to use Attributes *

### DIFF
--- a/cf-agent/files_editxml.c
+++ b/cf-agent/files_editxml.c
@@ -146,15 +146,18 @@ static int XmlAttributeCount(const xmlNodePtr node);
 /* Level                                                                     */
 /*****************************************************************************/
 
-int ScheduleEditXmlOperations(EvalContext *ctx, const Bundle *bp, Attributes a, const Promise *parentp, EditContext *edcontext)
+int ScheduleEditXmlOperations(EvalContext *ctx, const Bundle *bp, const Attributes *a, const Promise *parentp, EditContext *edcontext)
 {
+    assert(a != NULL);
     enum editxmltypesequence type;
     char lockname[CF_BUFSIZE];
     CfLock thislock;
     int pass;
 
     snprintf(lockname, CF_BUFSIZE - 1, "masterfilelock-%s", edcontext->filename);
-    thislock = AcquireLock(ctx, lockname, VUQNAME, CFSTARTTIME, a.transaction.ifelapsed, a.transaction.expireafter, parentp, true);
+    const int ifelapsed = a->transaction.ifelapsed;
+    const int expireafter = a->transaction.expireafter;
+    thislock = AcquireLock(ctx, lockname, VUQNAME, CFSTARTTIME, ifelapsed, expireafter, parentp, true);
 
     if (thislock.lock == NULL)
     {

--- a/cf-agent/files_editxml.h
+++ b/cf-agent/files_editxml.h
@@ -25,7 +25,7 @@
 #ifndef CFENGINE_FILES_EDITXML_H
 #define CFENGINE_FILES_EDITXML_H
 
-int ScheduleEditXmlOperations(EvalContext *ctx, const Bundle *bp, Attributes a, const Promise *parentp, EditContext *edcontext);
+int ScheduleEditXmlOperations(EvalContext *ctx, const Bundle *bp, const Attributes *a, const Promise *parentp, EditContext *edcontext);
 #ifdef HAVE_LIBXML2
 int XmlCompareToFile(xmlDocPtr doc, char *file, EditDefaults edits);
 #endif

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -801,7 +801,7 @@ PromiseResult ScheduleEditOperation(EvalContext *ctx, char *filename, Attributes
             EvalContextStackPushBundleFrame(ctx, bp, args, a.edits.inherit);
             BundleResolve(ctx, bp);
 
-            ScheduleEditXmlOperations(ctx, bp, a, pp, edcontext);
+            ScheduleEditXmlOperations(ctx, bp, &a, pp, edcontext);
 
             EvalContextStackPopFrame(ctx);
         }


### PR DESCRIPTION
Reported by LGTM:
https://lgtm.com/rules/2163210742/