### PR TITLE
[3.10.x] Read mustache-rendered files in text mode when comparing digest

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -602,7 +602,8 @@ static PromiseResult RenderTemplateMustache(EvalContext *ctx, const Promise *pp,
     unsigned char existing_output_digest[EVP_MAX_MD_SIZE + 1] = { 0 };
     if (access(pp->promiser, R_OK) == 0)
     {
-        HashFile(pp->promiser, existing_output_digest, CF_DEFAULT_DIGEST);
+        HashFile(pp->promiser, existing_output_digest, CF_DEFAULT_DIGEST,
+                 edcontext->new_line_mode == NewLineMode_Native);
     }
 
     int template_fd = safe_open(a.edit_template, O_RDONLY | O_TEXT);

--- a/cf-agent/verify_files_hashes.c
+++ b/cf-agent/verify_files_hashes.c
@@ -48,8 +48,8 @@ int CompareFileHashes(const char *file1, const char *file2, struct stat *sstat, 
 
     if (conn == NULL)
     {
-        HashFile(file1, digest1, CF_DEFAULT_DIGEST);
-        HashFile(file2, digest2, CF_DEFAULT_DIGEST);
+        HashFile(file1, digest1, CF_DEFAULT_DIGEST, false);
+        HashFile(file2, digest2, CF_DEFAULT_DIGEST, false);
 
         for (i = 0; i < EVP_MAX_MD_SIZE; i++)
         {

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -3044,8 +3044,8 @@ static PromiseResult VerifyFileIntegrity(EvalContext *ctx, const char *file, Att
     {
         if (!DONTDO)
         {
-            HashFile(file, digest1, HASH_METHOD_MD5);
-            HashFile(file, digest2, HASH_METHOD_SHA1);
+            HashFile(file, digest1, HASH_METHOD_MD5, false);
+            HashFile(file, digest2, HASH_METHOD_SHA1, false);
 
             one = FileChangesCheckAndUpdateHash(ctx, file, digest1, HASH_METHOD_MD5, &attr, pp, &result);
             two = FileChangesCheckAndUpdateHash(ctx, file, digest2, HASH_METHOD_SHA1, &attr, pp, &result);
@@ -3060,7 +3060,7 @@ static PromiseResult VerifyFileIntegrity(EvalContext *ctx, const char *file, Att
     {
         if (!DONTDO)
         {
-            HashFile(file, digest1, attr.change.hash);
+            HashFile(file, digest1, attr.change.hash, false);
 
             if (FileChangesCheckAndUpdateHash(ctx, file, digest1, attr.change.hash, &attr, pp, &result))
             {

--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -847,7 +847,7 @@ bool CompareLocalHash(const char *filename, const char digest[EVP_MAX_MD_SIZE + 
 
     unsigned char file_digest[EVP_MAX_MD_SIZE + 1] = { 0 };
     /* TODO connection might timeout if this takes long! */
-    HashFile(translated_filename, file_digest, CF_DEFAULT_DIGEST);
+    HashFile(translated_filename, file_digest, CF_DEFAULT_DIGEST, false);
 
     if (HashesMatch(digest, file_digest, CF_DEFAULT_DIGEST))
     {

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -429,7 +429,7 @@ int CompareHashNet(const char *file1, const char *file2, bool encrypt, AgentConn
     char *sp, sendbuffer[CF_BUFSIZE], recvbuffer[CF_BUFSIZE], in[CF_BUFSIZE], out[CF_BUFSIZE];
     int i, tosend, cipherlen;
 
-    HashFile(file2, d, CF_DEFAULT_DIGEST);
+    HashFile(file2, d, CF_DEFAULT_DIGEST, false);
 
     memset(recvbuffer, 0, CF_BUFSIZE);
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -939,7 +939,7 @@ static FnCallResult FnCallHandlerHash(ARG_UNUSED EvalContext *ctx, ARG_UNUSED co
 
     if (filehash_mode)
     {
-        HashFile(string_or_filename, digest, type);
+        HashFile(string_or_filename, digest, type, false);
     }
     else
     {
@@ -966,7 +966,7 @@ static FnCallResult FnCallHashMatch(ARG_UNUSED EvalContext *ctx, ARG_UNUSED cons
     char *compare = RlistScalarValue(finalargs->next->next);
 
     type = HashIdFromName(typestring);
-    HashFile(string, digest, type);
+    HashFile(string, digest, type, false);
 
     char hashbuffer[CF_HOSTKEY_STRING_SIZE];
     HashPrintSafe(hashbuffer, sizeof(hashbuffer),

--- a/libpromises/files_hashes.c
+++ b/libpromises/files_hashes.c
@@ -74,17 +74,31 @@ static void HashFile_Stream(
     EVP_MD_CTX_destroy(context);
 }
 
+/**
+ * @param text_mode whether to read the file in text mode or not (binary mode)
+ * @note Reading/writing file in text mode on Windows changes Unix newlines
+ *       into Windows newlines.
+ */
 void HashFile(
     const char *const filename,
     unsigned char digest[EVP_MAX_MD_SIZE + 1],
-    HashMethod type)
+    HashMethod type,
+    bool text_mode)
 {
     assert(filename != NULL);
     assert(digest != NULL);
 
     memset(digest, 0, EVP_MAX_MD_SIZE + 1);
 
-    FILE *file = safe_fopen(filename, "rb");
+    FILE *file = NULL;
+    if (text_mode)
+    {
+        file = safe_fopen(filename, "rt");
+    }
+    else
+    {
+        file = safe_fopen(filename, "rb");
+    }
     if (file == NULL)
     {
         Log(LOG_LEVEL_INFO,

--- a/libpromises/files_hashes.h
+++ b/libpromises/files_hashes.h
@@ -32,7 +32,7 @@
 #define CF_HOSTKEY_STRING_SIZE (4 + 2 * EVP_MAX_MD_SIZE + 1)
 
 
-void HashFile(const char *filename, unsigned char digest[EVP_MAX_MD_SIZE + 1], HashMethod type);
+void HashFile(const char *filename, unsigned char digest[EVP_MAX_MD_SIZE + 1], HashMethod type, bool text_mode);
 void HashString(const char *buffer, int len, unsigned char digest[EVP_MAX_MD_SIZE + 1], HashMethod type);
 int HashesMatch(const unsigned char digest1[EVP_MAX_MD_SIZE + 1],
                 const unsigned char digest2[EVP_MAX_MD_SIZE + 1],

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -259,7 +259,7 @@ static Policy *LoadPolicyFile(EvalContext *ctx, GenericAgentConfig *config, cons
     char hashbuffer[CF_HOSTKEY_STRING_SIZE] = { 0 };
     char hashprintbuffer[CF_BUFSIZE] = { 0 };
 
-    HashFile(policy_file, digest, CF_DEFAULT_DIGEST);
+    HashFile(policy_file, digest, CF_DEFAULT_DIGEST, false);
     snprintf(hashprintbuffer, CF_BUFSIZE - 1, "{checksum}%s",
              HashPrintSafe(hashbuffer, sizeof(hashbuffer), digest,
                            CF_DEFAULT_DIGEST, true));


### PR DESCRIPTION
On Windows writing a file in text mode means Unix newlines ("\n")
are transparently replaced by Windows newlines ("\r\n") and wise
versa for reading. We are using the text mode when writing
mustache-rendered contents into files and thus they end up having
Windows newlines. So in order to get comparable results for
digests of a file (Windows newlines) and in-memory string
representation (Unix newlines) we need to use the text mode when
reading the file and calculating the digest.

Other uses of the HashFile() function don't seem to be restricted
to working with text files and don't compare in-memory string
representations with file contents so we should use binary mode
there.

Changelog: Title
Ticket: ENT-2526
(cherry picked from commit 1f26996fe7526d58afe046a5a79bb5253697c026)