### PR TITLE
Change the 'Adding class to heap' message to DEBUG

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -765,7 +765,7 @@ void EvalContextHeapPersistentLoadAll(EvalContext *ctx)
         {
             Log(LOG_LEVEL_VERBOSE, "Persistent class '%s' for %jd more minutes",
                 key, (intmax_t) ((info.expires - now) / 60));
-            Log(LOG_LEVEL_VERBOSE, "Adding persistent class '%s' to heap", key);
+            Log(LOG_LEVEL_DEBUG, "Adding persistent class '%s'", key);
 
             ClassRef ref = ClassRefParse(key);
             EvalContextClassPut(ctx, ref.ns, ref.name, true, CONTEXT_SCOPE_NAMESPACE, tags);

--- a/tests/acceptance/08_commands/01_modules/set-persistent-class.cf
+++ b/tests/acceptance/08_commands/01_modules/set-persistent-class.cf
@@ -24,7 +24,7 @@ bundle agent check
       # verbose: Adding persistent class 'Cx4eXfWrHT0zsSbrAXh5jFnRnDLKqNsP' to heap
 
       # note we check that Ax4eXfWrHT0zsSbrAXh5jFnRnDLKqNsP and Bx4eXfWrHT0zsSbrAXh5jFnRnDLKqNsP are not set persistently!
-      "check" usebundle => dcs_passif_output(".*Module set persistent class 'Cx4eXfWrHT0zsSbrAXh5jFnRnDLKqNsP' for 20 minutes.*Adding persistent class 'Cx4eXfWrHT0zsSbrAXh5jFnRnDLKqNsP' to heap", ".*Module set persistent class '[AB]x4eXfWrHT0zsSbrAXh5jFnRnDLKqNsP'.*", $(command), $(this.promise_filename));
+      "check" usebundle => dcs_passif_output(".*Module set persistent class 'Cx4eXfWrHT0zsSbrAXh5jFnRnDLKqNsP' for 20 minutes.*", ".*Module set persistent class '[AB]x4eXfWrHT0zsSbrAXh5jFnRnDLKqNsP'.*", $(command), $(this.promise_filename));
 
 }
 ### PROJECT_ID: core


### PR DESCRIPTION
This is an internal debugging information that is more confusing
than useful to the user.