### PR TITLE
[3.10.x] Add contrib/cf-log (shows promise_summary.log with human times)

### DIFF
--- a/contrib/cf-log/cf-log.pl
+++ b/contrib/cf-log/cf-log.pl
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+
+open (CFELOG, "</var/cfengine/promise_summary.log") or die;
+while (<CFELOG>) {
+  s/(\d+),(\d+)/localtime($1) . " - " . localtime($2)/e;
+  print;
+}
+close (CFELOG);
+
+# Can also be run as a one-liner:
+#perl -pe 's/(\d+),(\d+)/localtime($1) . " - " . localtime($2)/e;' /var/cfengine/promise_summary.log


### PR DESCRIPTION
contrib/cf-log/cf-log.pl shows promise_summary.log but converts
epoch times to human-readable.

This is convenient for handling reports of:
- "My application was having issues at 8:57 PM, did CFEngine break it?"
- "Why, no, CFEngine wasn't running then, it ran at 8:59 PM (which
  I can quickly tell by running cf-log.pl)."

(cherry picked from commit b7da0a5a4c381235797236798c24f103b5492a96)