### PR TITLE
Revert "ENT-4136: Fixed memory leak in HashMapPrintStats and its unit test"

### DIFF
--- a/libutils/hash_map.c
+++ b/libutils/hash_map.c
@@ -297,7 +297,6 @@ void HashMapPrintStats(const HashMap *hmap, FILE *f)
                 longest_bucket_id, bucket_lengths[longest_bucket_id]);
         bucket_lengths[longest_bucket_id] = 0;
     }
-    free(bucket_lengths);
 }
 /******************************************************************************/
 

--- a/tests/unit/map_test.c
+++ b/tests/unit/map_test.c
@@ -134,9 +134,7 @@ static void test_remove_n_as_from_map(HashMap *hashmap, unsigned int i)
     s[i] = '\0';
 
     assert_true(HashMapGet(hashmap, s) != NULL);
-    char * dup = xstrdup(s);
-    assert_true(HashMapRemove(hashmap, dup));
-    free(dup);
+    assert_true(HashMapRemove(hashmap, xstrdup(s)));
     assert_true(HashMapGet(hashmap, s) == NULL);
 }
 


### PR DESCRIPTION
Reverts cfengine/core#3306