### PR TITLE
Revert "ENT-4136: Prevent OOB read in ApplyPlatformExtraTable and free in unit test"

### DIFF
--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -1477,7 +1477,7 @@ static void ApplyPlatformExtraTable(char **names, char **columns)
         }
     }
 
-    if (pidcol == -1 || !StringMapHasKey(UCB_PS_MAP, columns[pidcol]))
+    if (!StringMapHasKey(UCB_PS_MAP, columns[pidcol]))
     {
         return;
     }

--- a/tests/unit/split_process_line_test.c
+++ b/tests/unit/split_process_line_test.c
@@ -463,11 +463,6 @@ static void test_platform_extra_table(void)
     };
     char *name[CF_PROCCOLS]; /* Headers */
     char *field[CF_PROCCOLS]; /* Content */
-    for (int i = 0; i < CF_PROCCOLS; ++i)
-    {
-        name[i] = NULL;
-        field[i] = NULL;
-    }
     int start[CF_PROCCOLS] = { 0 };
     int end[CF_PROCCOLS] = { 0 };
     int user = 0, pid = 1, sz = 4, rss = 5, command = 10;
@@ -604,11 +599,6 @@ static void test_platform_extra_table(void)
         assert_string_equal(field[sz], "0");
         assert_string_equal(field[rss], "0");
         assert_string_equal(field[command], "");
-    }
-    for (int i=0; i < CF_PROCCOLS; ++i)
-    {
-        free(field[i]);
-        field[i] = NULL;
     }
 
     fclose(cmd_output);


### PR DESCRIPTION
Reverts cfengine/core#3305