### PR TITLE
Revert "CFE-2918: Fixed small memory leaks of environment variable strings"

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -308,7 +308,6 @@ int main(int argc, char *argv[])
         xmlCleanupParser();
 #endif
 
-    putenv_static_destroy();
     return ret;
 }
 
@@ -347,7 +346,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
 
         case 'w':
             Log(LOG_LEVEL_INFO, "Setting workdir to '%s'", optarg);
-            putenv_static(StringConcatenate(2, "CFENGINE_TEST_OVERRIDE_WORKDIR=", optarg));
+            putenv(StringConcatenate(2, "CFENGINE_TEST_OVERRIDE_WORKDIR=", optarg));
             break;
 
         case 'f':
@@ -932,10 +931,13 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
 
             if (strcmp(cp->lval, CFA_CONTROLBODY[AGENT_CONTROL_CHILDLIBPATH].lval) == 0)
             {
-                char env_var[CF_BUFSIZE];
-                snprintf(env_var, CF_BUFSIZE - 1, "LD_LIBRARY_PATH=%s", (const char *)value);
-                Log(LOG_LEVEL_VERBOSE, "Setting '%s'", env_var);
-                putenv_static(xstrdup(env_var));
+                char output[CF_BUFSIZE];
+
+                snprintf(output, CF_BUFSIZE, "Setting LD_LIBRARY_PATH to '%s'", (const char *)value);
+                if (putenv(xstrdup(output)) == 0)
+                {
+                    Log(LOG_LEVEL_VERBOSE, "Setting '%s'", output);
+                }
                 continue;
             }
 
@@ -1096,7 +1098,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
                 for (const Rlist *rp = value; rp != NULL; rp = rp->next)
                 {
                     assert(strchr(RlistScalarValue(rp), '=')); /* Valid for putenv() */
-                    if (putenv_static(xstrdup(RlistScalarValue(rp))) != 0)
+                    if (putenv(xstrdup(RlistScalarValue(rp))) != 0)
                     {
                         Log(LOG_LEVEL_ERR, "Failed to set environment variable '%s'. (putenv: %s)",
                             RlistScalarValue(rp), GetErrorStr());

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
     GenericAgentFinalize(ctx, config);
     ExecConfigDestroy(exec_config);
     ExecdConfigDestroy(execd_config);
-    putenv_static_destroy();
+
     return 0;
 }
 
@@ -174,6 +174,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int c;
+    char ld_library_path[CF_BUFSIZE];
 
     GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_EXECUTOR, GetTTYInteractive());
 
@@ -246,13 +247,10 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             break;
 
         case 'L':
-            {
-                char env_var[CF_BUFSIZE];
-                snprintf(env_var, CF_BUFSIZE - 1, "LD_LIBRARY_PATH=%s", optarg);
-                Log(LOG_LEVEL_VERBOSE, "Setting '%s'", env_var);
-                putenv_static(xstrdup(env_var));
-                break;
-            }
+            snprintf(ld_library_path, CF_BUFSIZE - 1, "LD_LIBRARY_PATH=%s", optarg);
+            putenv(xstrdup(ld_library_path));
+            break;
+
         case 'W':
             WINSERVICE = false;
             break;

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -278,7 +278,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
 
         case 'w':
             Log(LOG_LEVEL_INFO, "Setting workdir to '%s'", optarg);
-            putenv_static(StringConcatenate(2, "CFENGINE_TEST_OVERRIDE_WORKDIR=", optarg));
+            putenv(StringConcatenate(2, "CFENGINE_TEST_OVERRIDE_WORKDIR=", optarg));
             break;
 
         case 'c':

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -222,10 +222,10 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
 
         case 'L':
         {
-            static char env_var[CF_BUFSIZE]; /* GLOBAL_A */
+            static char ld_library_path[CF_BUFSIZE]; /* GLOBAL_A */
             Log(LOG_LEVEL_VERBOSE, "Setting LD_LIBRARY_PATH to '%s'", optarg);
-            snprintf(env_var, CF_BUFSIZE - 1, "LD_LIBRARY_PATH=%s", optarg);
-            putenv_static(xstrdup(env_var));
+            snprintf(ld_library_path, CF_BUFSIZE - 1, "LD_LIBRARY_PATH=%s", optarg);
+            putenv(ld_library_path);
             break;
         }
 

--- a/cf-serverd/cf-serverd.c
+++ b/cf-serverd/cf-serverd.c
@@ -81,6 +81,5 @@ int main(int argc, char *argv[])
         CleanReportBookFilterSet();
     }
 
-    putenv_static_destroy();
     return 0;
 }

--- a/libutils/misc_lib.c
+++ b/libutils/misc_lib.c
@@ -27,7 +27,6 @@
 #include <platform.h>
 #include <alloc.h>
 #include <logging.h>
-#include <sequence.h>
 
 #include <stdarg.h>
 
@@ -133,46 +132,4 @@ void xsnprintf(char *str, size_t str_size, const char *format, ...)
                          format, str_size);
 #endif
     }
-}
-
-static Seq *PUTENV_STATIC_STRINGS;
-
-// Similar to putenv, but stores the string in a Sequence for free later
-// This doesn't make a copy - usually, but not always, you want to:
-// putenv_static(xstrdup(s));
-// The string is always stored, so you don't have to free on error
-int putenv_static(char *s)
-{
-    if (PUTENV_STATIC_STRINGS == NULL)
-    {
-        PUTENV_STATIC_STRINGS = SeqNew(10, free);
-    }
-    SeqAppend(PUTENV_STATIC_STRINGS, s);
-    return putenv(s);
-}
-
-void putenv_static_destroy()
-{
-    if (PUTENV_STATIC_STRINGS == NULL)
-    {
-        return;
-    }
-    size_t len = SeqLength(PUTENV_STATIC_STRINGS);
-    for (int i = 0; i < len; ++i)
-    {
-        const char *env_var = SeqAt(PUTENV_STATIC_STRINGS, len);
-        size_t len = strlen(env_var);
-        char temp[len + 1];
-        strncpy(temp, env_var, len);
-        temp[len] = '\0'; // strncpy doesn't guarantee termination
-        char *equal_sign = strchr(temp, '=');
-        if (equal_sign == NULL)
-        {
-            // We don't care about errors, we're just cleaning up
-            continue;
-        }
-        *equal_sign = '\0';
-        unsetenv(env_var);
-    }
-    SeqDestroy(PUTENV_STATIC_STRINGS);
 }

--- a/libutils/misc_lib.h
+++ b/libutils/misc_lib.h
@@ -102,7 +102,5 @@ void __UnexpectedError(const char *file, int lineno, const char *format, ...) \
 void xclock_gettime(clockid_t clk_id, struct timespec *ts);
 void xsnprintf(char *str, size_t str_size, const char *format, ...);
 
-int putenv_static(char *s);
-void putenv_static_destroy();
 
 #endif


### PR DESCRIPTION
Reverts cfengine/core#3333