### PR TITLE
Disable codecov comments

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -12,9 +12,11 @@ coverage:
     patch: yes
     changes: yes
 
-comment:
-  layout: "header, diff, tree, changes, reach, footer"
-  behavior: default
+# comment:
+#   layout: "header, diff, tree, changes, reach, footer"
+#   behavior: default
+
+comment: off
 
 # Ignore source files connected to tests.
 ignore:


### PR DESCRIPTION
I'm tired of the spam. The comment is huge. Because of
fluctuations in coverage it has far more noise than useful
information.