### PR TITLE
CFE-2600: Fixed missing class with mustache templates in warn_only mode

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -640,7 +640,9 @@ static PromiseResult RenderTemplateMustache(EvalContext *ctx, const Promise *pp,
         {
             if (a.transaction.action == cfa_warn || DONTDO)
             {
-                Log(LOG_LEVEL_WARNING, "Need to render '%s' from mustache template '%s' but policy is dry-run", pp->promiser, message);
+                cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, &a, 
+                     "Need to update rendering of '%s' from mustache template '%s' but policy is dry-run",
+                     pp->promiser, message);
                 result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
             }
             else

--- a/tests/acceptance/10_files/mustache_respects_warn_only.cf
+++ b/tests/acceptance/10_files/mustache_respects_warn_only.cf
@@ -39,7 +39,8 @@ bundle agent test
     "$(template_target)"
       edit_template => "$(this.promise_filename).mustache",
       template_method => "mustache",
-      action => warn_only;
+      action => warn_only,
+      classes => classes_generic("mustache_warn");
 }
 
 #######################################################
@@ -48,10 +49,11 @@ bundle agent check
 {
   classes:
     "fail" expression => regline("SHOULD NOT RENDER", $(test.template_target) );
+    "defined_class" expression => "mustache_warn_failed";
 
   reports:
-    !fail::
+    !fail.defined_class::
       "$(this.promise_filename) Pass";
-    fail::
+    fail|!defined_class::
       "$(this.promise_filename) FAIL";
 }


### PR DESCRIPTION
The outcome classes were not defined when rendering a mustache template
in warn_only mode.