### PR TITLE
CFE-2922 Correct log level for data_readstringarray*

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -6774,7 +6774,7 @@ static FnCallResult DataRead(EvalContext *ctx, const FnCall *fp, const Rlist *fi
 
     if (json == NULL)
     {
-        Log(LOG_LEVEL_INFO, "%s: error reading from file '%s'", fp->name, filename);
+        Log(LOG_LEVEL_ERR, "%s: error reading from file '%s'", fp->name, filename);
         return FnFailure();
     }
 
@@ -7410,7 +7410,7 @@ static char *CfReadFile(const char *filename, int maxsize)
     {
         if (THIS_AGENT_TYPE == AGENT_TYPE_COMMON)
         {
-            Log(LOG_LEVEL_INFO, "CfReadFile: Could not examine file '%s'", filename);
+            Log(LOG_LEVEL_ERR, "CfReadFile: Could not examine file '%s'", filename);
         }
         else
         {
@@ -7421,7 +7421,7 @@ static char *CfReadFile(const char *filename, int maxsize)
             }
             else
             {
-                Log(LOG_LEVEL_INFO, "CfReadFile: Could not examine file '%s' (stat: %s)",
+                Log(LOG_LEVEL_ERR, "CfReadFile: Could not examine file '%s' (stat: %s)",
                       filename, GetErrorStr());
             }
         }
@@ -7441,7 +7441,7 @@ static char *CfReadFile(const char *filename, int maxsize)
 
     if (!w)
     {
-        Log(LOG_LEVEL_INFO, "CfReadFile: Error while reading file '%s' (%s)",
+        Log(LOG_LEVEL_ERR, "CfReadFile: Error while reading file '%s' (%s)",
             filename, GetErrorStr());
         return NULL;
     }


### PR DESCRIPTION
data_readstringarray and data_readstringarrayidx were logging errors in inform mode. This change sets the correct log level for the error logs.

Changelog: Title