### PR TITLE
ENT-3756: refactor use of atexit to use custom cleanup function instead.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -449,3 +449,23 @@ changes, and they should be mentioned in the ChangeLog entries. In fact
 if anywhere in the commit message the string ```CFE-1234``` is found
 (referring to a ticket from https://tracker.mender.io ), it will be
 automatically added to the ChangeLog.
+
+
+atexit() and Windows
+--------------------
+
+On Windows the atexit function works but the functions registered there are
+executed after or concurrently with DLL unloading. If registered functions
+rely on DLLs such as pthreads to do locking/unlocking deadlock scenarios can
+occur when exit is called. 
+
+In order to make behavior more explicit and predictable we migrated to always
+using a homegrown atexit system. RegisterCleanupFunction instead of atexit and
+DoCleanupAndExit instead of exit.
+
+If `_Exit` or `_exit` need to be called that is fine as they don't call atexit or
+cleanup functions.
+
+In some cases such as when exiting a forked process or in executables which don't
+register cleanup functions, exit() may be used but a comment should be added
+noting that this issue was considered.

--- a/cf-agent/findhub.c
+++ b/cf-agent/findhub.c
@@ -23,7 +23,7 @@
 */
 
 #include <findhub.h>
-#include <atexit.h>
+#include <cleanup.h>
 #include <string_lib.h>
 #include <misc_lib.h>
 #include <logging.h>
@@ -31,7 +31,7 @@
 
 List *hublist = NULL; 
 
-static void AtExitDlClose(void);
+static void CleanupDlClose(void);
 static int CompareHosts(const void  *a, const void *b);
 
 void client_callback(AvahiClient *c,
@@ -162,7 +162,7 @@ int ListHubs(List **list)
     spoll = NULL;
     avahi_handle = NULL;
 
-    RegisterAtExitFunction(&AtExitDlClose);
+    RegisterCleanupFunction(&CleanupDlClose);
 
     if (loadavahi() == -1)
     {
@@ -236,7 +236,7 @@ int ListHubs(List **list)
     return ListCount(*list);
 }
 
-static void AtExitDlClose(void)
+static void CleanupDlClose(void)
 {
     if (avahi_handle != NULL)
     {

--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -462,6 +462,9 @@ static ActionResult RepairExec(EvalContext *ctx, Attributes a,
     if ((a.transaction.background) && outsourced)
     {
         Log(LOG_LEVEL_VERBOSE, "Backgrounded command '%s' is done - exiting", cmdline);
+
+        /* exit() OK since this is a forked process and no functions are
+           registered for cleanup */
         exit(EXIT_SUCCESS);
     }
 #endif /* !__MINGW32__ */

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -39,6 +39,7 @@
 #include <time_classes.h>
 #include <loading.h>
 #include <printsize.h>
+#include <cleanup.h>
 
 #include <cf-windows-functions.h>
 
@@ -138,7 +139,7 @@ int main(int argc, char *argv[])
     if (!policy)
     {
         Log(LOG_LEVEL_ERR, "Error reading CFEngine policy. Exiting...");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     GenericAgentPostLoadInit(ctx);
@@ -270,7 +271,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             GenericAgentWriteVersion(w);
             FileWriterDetach(w);
         }
-        exit(EXIT_SUCCESS);
+        DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'h':
         {
@@ -278,7 +279,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             WriterWriteHelp(w, "cf-execd", OPTIONS, HINTS, true, NULL);
             FileWriterDetach(w);
         }
-        exit(EXIT_SUCCESS);
+        DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'M':
         {
@@ -289,17 +290,17 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                          OPTIONS, HINTS,
                          true);
             FileWriterDetach(out);
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
         }
 
         case 'x':
             Log(LOG_LEVEL_ERR, "Self-diagnostic functionality is retired.");
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
             {
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
 
@@ -313,7 +314,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             WriterWriteHelp(w, "cf-execd", OPTIONS, HINTS, true, NULL);
             FileWriterDetach(w);
         }
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
 
         }
     }
@@ -321,7 +322,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
     if (!GenericAgentConfigParseArguments(config, argc - optind, argv + optind))
     {
         Log(LOG_LEVEL_ERR, "Too many arguments");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     return config;

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -38,6 +38,7 @@
 #include <man.h>
 #include <signals.h>
 #include <string_lib.h>
+#include <cleanup.h>
 
 #include <cf-key-functions.h>
 
@@ -269,7 +270,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteVersion(w);
                 FileWriterDetach(w);
             }
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'v':
             LogSetGlobalLevel(LOG_LEVEL_VERBOSE);
@@ -315,7 +316,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 WriterWriteHelp(w, "cf-key", OPTIONS, HINTS, false, NULL);
                 FileWriterDetach(w);
             }
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'M':
             {
@@ -326,13 +327,13 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                              OPTIONS, HINTS,
                              false);
                 FileWriterDetach(out);
-                exit(EXIT_SUCCESS);
+                DoCleanupAndExit(EXIT_SUCCESS);
             }
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
             {
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
 
@@ -350,7 +351,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 WriterWriteHelp(w, "cf-key", OPTIONS, HINTS, false, NULL);
                 FileWriterDetach(w);
             }
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
 
         }
     }

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -37,6 +37,7 @@
 #include <timeout.h>
 #include <time_classes.h>
 #include <loading.h>
+#include <cleanup.h>
 
 typedef enum
 {
@@ -191,7 +192,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             GenericAgentWriteVersion(w);
             FileWriterDetach(w);
         }
-        exit(EXIT_SUCCESS);
+        DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'h':
         {
@@ -199,7 +200,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             WriterWriteHelp(w, "cf-monitord", OPTIONS, HINTS, true, NULL);
             FileWriterDetach(w);
         }
-        exit(EXIT_SUCCESS);
+        DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'M':
         {
@@ -210,17 +211,17 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                          OPTIONS, HINTS,
                          true);
             FileWriterDetach(out);
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
         }
 
         case 'x':
             Log(LOG_LEVEL_ERR, "Self-diagnostic functionality is retired.");
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
             {
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
 
@@ -234,14 +235,14 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             WriterWriteHelp(w, "cf-monitord", OPTIONS, HINTS, true, NULL);
             FileWriterDetach(w);
         }
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
         }
     }
 
     if (!GenericAgentConfigParseArguments(config, argc - optind, argv + optind))
     {
         Log(LOG_LEVEL_ERR, "Too many arguments");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     return config;

--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -49,6 +49,7 @@
 #include <probes.h>                      /* MonOtherInit,MonOtherGatherData */
 #include <history.h>                     /* HistoryUpdate */
 #include <monitoring.h>                  /* GetObservable */
+#include <cleanup.h>
 
 
 /*****************************************************************************/
@@ -377,7 +378,7 @@ static Averages EvalAvQ(EvalContext *ctx, char *t)
     if ((lastweek_vals = GetCurrentAverages(t)) == NULL)
     {
         Log(LOG_LEVEL_ERR, "Error reading average database");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
 /* Discard any apparently anomalous behaviour before renormalizing database */

--- a/cf-net/cf-net.c
+++ b/cf-net/cf-net.c
@@ -41,6 +41,7 @@
 #include <generic_agent.h>      // GenericAgentSetDefaultDigest TODO: rm dep
 #include <cf-windows-functions.h> // TODO: move this out of libpromises
 #include <known_dirs.h>           // TODO: move this 'out of libpromises
+#include <cleanup.h>
 
 #define ARG_UNUSED __attribute__((unused))
 
@@ -191,7 +192,7 @@ int main(int argc, char **argv)
     GenericAgentSetDefaultDigest(&CF_DEFAULT_DIGEST, &CF_DEFAULT_DIGEST_LEN);
     if (ret != 0)
     {
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
     ret = CFNetRun(&opts, args, hostnames);  // Commands return exit code
     free(hostnames);
@@ -233,7 +234,7 @@ static char *RequireHostname(char *hostnames)
         if (policy_server == NULL)
         {
             printf("Error: no host name (and no policy_server.dat)\n");
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
         return policy_server;
     }
@@ -276,7 +277,7 @@ static int CFNetParse(int argc, char **argv,
                              OPTIONS, HINTS,
                              true);
                 FileWriterDetach(out);
-                exit(EXIT_SUCCESS);
+                DoCleanupAndExit(EXIT_SUCCESS);
                 break;
             }
             case 'H':
@@ -315,7 +316,7 @@ static int CFNetParse(int argc, char **argv,
             {
                 // printf("Default optarg = '%s', c = '%c' = %i\n",
                 //        optarg, c, (int)c);
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
                 break;
             }
         }
@@ -358,7 +359,7 @@ static int CFNetCommandSwitch(CFNetOptions *opts, const char *hostname,
             break;
     }
     printf("Bug: CFNetCommandSwitch() is unable to pick a command\n");
-    exit(EXIT_FAILURE);
+    DoCleanupAndExit(EXIT_FAILURE);
     return -1;
 }
 
@@ -391,7 +392,7 @@ static int CFNetRun(CFNetOptions *opts, char **args, char *hostnames)
     if (NULL_OR_EMPTY(command_name))
     {
         printf("Error: Command missing, use cf-net --help for more info.\n");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
     ToUpperStrInplace(command_name);
 
@@ -526,7 +527,7 @@ static int CFNetHelp(const char *topic)
         Writer *w = FileWriter(stdout);
         WriterWriteHelp(w, "cf-net", OPTIONS, HINTS, false, COMMANDS);
         FileWriterDetach(w);
-        exit(EXIT_SUCCESS);
+        DoCleanupAndExit(EXIT_SUCCESS);
     }
     return 0;
 }

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -36,6 +36,7 @@
 #include <loading.h>
 #include <regex.h>                                        /* CompileRegex */
 #include <match_scope.h>
+#include <cleanup.h>
 
 #include <time.h>
 
@@ -139,7 +140,7 @@ int main(int argc, char *argv[])
     if (!policy)
     {
         Log(LOG_LEVEL_ERR, "Input files contain errors.");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     GenericAgentPostLoadInit(ctx);
@@ -155,7 +156,7 @@ int main(int argc, char *argv[])
         else
         {
             Log(LOG_LEVEL_ERR, "The given directory could not be tagged, sorry.");
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
     }
 
@@ -193,7 +194,7 @@ int main(int argc, char *argv[])
         }
 
         Policy *output_policy = Cf3ParseFile(config, config->input_file);
-        CF_ASSERT_FIX(output_policy != NULL, exit(EXIT_FAILURE),
+        CF_ASSERT_FIX(output_policy != NULL, DoCleanupAndExit(EXIT_FAILURE),
                       "File has already been parsed OK, but fails now!");
 
         Writer *writer = FileWriter(stdout);
@@ -331,7 +332,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
             else
             {
                 Log(LOG_LEVEL_ERR, "Invalid policy output format: '%s'. Possible values are 'none', 'cf', 'json', 'cf-full', 'json-full'", optarg);
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
 
@@ -347,12 +348,12 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 JsonWrite(out, json_syntax, 0);
                 FileWriterDetach(out);
                 JsonDestroy(json_syntax);
-                exit(EXIT_SUCCESS);
+                DoCleanupAndExit(EXIT_SUCCESS);
             }
             else
             {
                 Log(LOG_LEVEL_ERR, "Invalid syntax description output format: '%s'. Possible values are 'none', 'json'", optarg);
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
 
@@ -409,7 +410,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
             GenericAgentWriteVersion(w);
             FileWriterDetach(w);
         }
-        exit(EXIT_SUCCESS);
+        DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'h':
         {
@@ -417,7 +418,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
             WriterWriteHelp(w, "cf-promises", OPTIONS, HINTS, true, NULL);
             FileWriterDetach(w);
         }
-        exit(EXIT_SUCCESS);
+        DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'M':
         {
@@ -428,30 +429,30 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                          OPTIONS, HINTS,
                          true);
             FileWriterDetach(out);
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
         }
 
         case 'r':
             Log(LOG_LEVEL_ERR, "Option '-r' has been deprecated");
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
             break;
 
         case 'W':
             if (!GenericAgentConfigParseWarningOptions(config, optarg))
             {
                 Log(LOG_LEVEL_ERR, "Error parsing warning option");
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
 
         case 'x':
             Log(LOG_LEVEL_ERR, "Self-diagnostic functionality is retired.");
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
             {
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
 
@@ -473,7 +474,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 bool ret = LogEnableModulesFromString(optarg);
                 if (!ret)
                 {
-                    exit(EXIT_FAILURE);
+                    DoCleanupAndExit(EXIT_FAILURE);
                 }
             }
             break;
@@ -484,7 +485,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
             WriterWriteHelp(w, "cf-promises", OPTIONS, HINTS, true, NULL);
             FileWriterDetach(w);
         }
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
 
         }
     }
@@ -492,7 +493,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
     if (!GenericAgentConfigParseArguments(config, argc - optind, argv + optind))
     {
         Log(LOG_LEVEL_ERR, "Too many arguments");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     return config;

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -48,6 +48,7 @@
 #include <expand.h>                                 /* ProtocolVersionParse */
 #include <files_hashes.h>
 #include <string_lib.h>
+#include <cleanup.h>
 
 typedef enum
 {
@@ -181,7 +182,7 @@ int main(int argc, char *argv[])
     if (BACKGROUND && INTERACTIVE)
     {
         Log(LOG_LEVEL_ERR, "You cannot specify background mode and interactive mode together");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
 /* HvB */
@@ -207,7 +208,7 @@ int main(int argc, char *argv[])
                     if (fork() == 0)    /* child process */
                     {
                         HailServer(ctx, config, RlistScalarValue(rp));
-                        exit(EXIT_SUCCESS);
+                        DoCleanupAndExit(EXIT_SUCCESS);
                     }
                     else        /* parent process */
                     {
@@ -298,7 +299,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             if (len >= sizeof(SENDCLASSES))
             {
                 Log(LOG_LEVEL_ERR, "Argument too long (-s)");
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
         }
@@ -310,7 +311,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             if (len >= sizeof(DEFINECLASSES))
             {
                 Log(LOG_LEVEL_ERR, "Argument too long (-D)");
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
         }
@@ -321,7 +322,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 'o':
             Log(LOG_LEVEL_ERR, "Option \"-o\" has been deprecated,"
                 " you can not pass arbitrary arguments to remote cf-agent");
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
             break;
 
         case 'I':
@@ -355,7 +356,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             GenericAgentWriteVersion(w);
             FileWriterDetach(w);
         }
-        exit(EXIT_SUCCESS);
+        DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'h':
         {
@@ -363,7 +364,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             WriterWriteHelp(w, "cf-runagent", OPTIONS, HINTS, true, NULL);
             FileWriterDetach(w);
         }
-        exit(EXIT_SUCCESS);
+        DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'M':
         {
@@ -374,17 +375,17 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                          OPTIONS, HINTS,
                          true);
             FileWriterDetach(out);
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
         }
 
         case 'x':
             Log(LOG_LEVEL_ERR, "Option \"-x\" has been deprecated");
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
             {
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
 
@@ -400,7 +401,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 bool ret = LogEnableModulesFromString(optarg);
                 if (!ret)
                 {
-                    exit(EXIT_FAILURE);
+                    DoCleanupAndExit(EXIT_FAILURE);
                 }
             }
             else if (strcmp(OPTIONS[longopt_idx].name, "remote-bundles") == 0)
@@ -411,7 +412,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 if (len >= sizeof(REMOTEBUNDLES))
                 {
                     Log(LOG_LEVEL_ERR, "Argument too long (--remote-bundles)");
-                    exit(EXIT_FAILURE);
+                    DoCleanupAndExit(EXIT_FAILURE);
                 }
             }
             break;
@@ -422,7 +423,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             WriterWriteHelp(w, "cf-runagent", OPTIONS, HINTS, true, NULL);
             FileWriterDetach(w);
         }
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
 
         }
     }
@@ -430,7 +431,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
     if (!GenericAgentConfigParseArguments(config, argc - optind, argv + optind))
     {
         Log(LOG_LEVEL_ERR, "Too many arguments");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     return config;

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -49,6 +49,7 @@
 #include <file_lib.h>
 #include <loading.h>
 #include <printsize.h>
+#include <cleanup.h>
 
 #define WAIT_INCOMING_TIMEOUT 10
 
@@ -234,7 +235,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 GenericAgentWriteVersion(w);
                 FileWriterDetach(w);
             }
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'h':
             {
@@ -242,7 +243,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 WriterWriteHelp(w, "cf-serverd", OPTIONS, HINTS, true, NULL);
                 FileWriterDetach(w);
             }
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'M':
             {
@@ -253,31 +254,31 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                              OPTIONS, HINTS,
                              true);
                 FileWriterDetach(out);
-                exit(EXIT_SUCCESS);
+                DoCleanupAndExit(EXIT_SUCCESS);
             }
 
         case 'x':
             Log(LOG_LEVEL_ERR, "Self-diagnostic functionality is retired.");
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'A':
 #ifdef SUPPORT_AVAHI_CONFIG
             Log(LOG_LEVEL_NOTICE, "Generating Avahi configuration file.");
             if (GenerateAvahiConfig("/etc/avahi/services/cfengine-hub.service") != 0)
             {
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             cf_popen("/etc/init.d/avahi-daemon restart", "r", true);
             Log(LOG_LEVEL_NOTICE, "Avahi configuration file generated successfully.");
 #else
             Log(LOG_LEVEL_ERR, "Generating avahi configuration can only be done when avahi-daemon and libavahi are installed on the machine.");
 #endif
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
 
         case 'C':
             if (!GenericAgentConfigParseColor(config, optarg))
             {
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
 
@@ -291,14 +292,14 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 WriterWriteHelp(w, "cf-serverd", OPTIONS, HINTS, true, NULL);
                 FileWriterDetach(w);
             }
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
     }
 
     if (!GenericAgentConfigParseArguments(config, argc - optind, argv + optind))
     {
         Log(LOG_LEVEL_ERR, "Too many arguments");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     return config;
@@ -556,7 +557,7 @@ static void PrepareServer(int sd)
     SetCloseOnExec(sd, true);
 
     Log(LOG_LEVEL_NOTICE, "Server is starting...");
-    WritePID("cf-serverd.pid"); /* Arranges for atexit() to tidy it away */
+    WritePID("cf-serverd.pid"); /* Arranges for cleanup() to tidy it away */
 }
 
 /* Wait for connection-handler threads to finish their work.

--- a/cf-serverd/cf-serverd.c
+++ b/cf-serverd/cf-serverd.c
@@ -30,7 +30,7 @@
 #include <server_transform.h>
 #include <known_dirs.h>
 #include <loading.h>
-
+#include <cleanup.h>
 
 static void ThisAgentInit(void)
 {
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     if (!policy)
     {
         Log(LOG_LEVEL_ERR, "Error reading CFEngine policy. Exiting...");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     GenericAgentPostLoadInit(ctx);

--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -55,6 +55,7 @@
 #include "server_common.h"                         /* PreprocessRequestPath */
 #include "server_access.h"
 #include "strlist.h"
+#include <cleanup.h>
 
 
 static PromiseResult KeepServerPromise(EvalContext *ctx, const Promise *pp, void *param);
@@ -236,7 +237,7 @@ void KeepPromises(EvalContext *ctx, const Policy *policy, GenericAgentConfig *co
         roles_acl    == NULL || SERVER_ACCESS.path_shortcuts == NULL)
     {
         Log(LOG_LEVEL_CRIT, "calloc: %s", GetErrorStr());
-        exit(255);
+        DoCleanupAndExit(255);
     }
 
     KeepControlPromises(ctx, policy, config);
@@ -1153,7 +1154,7 @@ static void AccessPromise_AddAccessConstraints(const EvalContext *ctx,
             {
                 /* Should never happen, besides when allocation fails. */
                 Log(LOG_LEVEL_CRIT, "StrList_Append: %s", GetErrorStr());
-                exit(255);
+                DoCleanupAndExit(255);
             }
 
             break;
@@ -1261,7 +1262,7 @@ static void KeepFileAccessPromise(const EvalContext *ctx, const Promise *pp)
     {
         /* Should never happen, besides when allocation fails. */
         Log(LOG_LEVEL_CRIT, "acl_Insert: %s", GetErrorStr());
-        exit(255);
+        DoCleanupAndExit(255);
     }
 
     /* Legacy code */
@@ -1312,7 +1313,7 @@ void KeepLiteralAccessPromise(EvalContext *ctx, const Promise *pp, const char *t
         {
             /* Should never happen, besides when allocation fails. */
             Log(LOG_LEVEL_CRIT, "acl_Insert: %s", GetErrorStr());
-            exit(255);
+            DoCleanupAndExit(255);
         }
 
         AccessPromise_AddAccessConstraints(ctx, pp, &literals_acl->acls[pos],
@@ -1334,7 +1335,7 @@ void KeepLiteralAccessPromise(EvalContext *ctx, const Promise *pp, const char *t
             {
                 /* Should never happen, besides when allocation fails. */
                 Log(LOG_LEVEL_CRIT, "acl_Insert: %s", GetErrorStr());
-                exit(255);
+                DoCleanupAndExit(255);
             }
 
             AccessPromise_AddAccessConstraints(ctx, pp, &classes_acl->acls[pos],
@@ -1349,7 +1350,7 @@ void KeepLiteralAccessPromise(EvalContext *ctx, const Promise *pp, const char *t
             {
                 /* Should never happen, besides when allocation fails. */
                 Log(LOG_LEVEL_CRIT, "acl_Insert: %s", GetErrorStr());
-                exit(255);
+                DoCleanupAndExit(255);
             }
 
             AccessPromise_AddAccessConstraints(ctx, pp, &vars_acl->acls[pos],
@@ -1373,7 +1374,7 @@ static void KeepQueryAccessPromise(EvalContext *ctx, const Promise *pp)
     {
         /* Should never happen, besides when allocation fails. */
         Log(LOG_LEVEL_CRIT, "acl_Insert: %s", GetErrorStr());
-        exit(255);
+        DoCleanupAndExit(255);
     }
 
     AccessPromise_AddAccessConstraints(ctx, pp, &query_acl->acls[pos],
@@ -1387,7 +1388,7 @@ static void KeepBundlesAccessPromise(EvalContext *ctx, const Promise *pp)
     {
         /* Should never happen, besides when allocation fails. */
         Log(LOG_LEVEL_CRIT, "acl_Insert: %s", GetErrorStr());
-        exit(255);
+        DoCleanupAndExit(255);
     }
 
     /* Last params are NULL because we don't have
@@ -1411,7 +1412,7 @@ static void KeepServerRolePromise(EvalContext *ctx, const Promise *pp)
     {
         /* Should never happen, besides when allocation fails. */
         Log(LOG_LEVEL_CRIT, "acl_Insert: %s", GetErrorStr());
-        exit(255);
+        DoCleanupAndExit(255);
     }
 
     size_t i = SeqLength(pp->conlist);
@@ -1443,7 +1444,7 @@ static void KeepServerRolePromise(EvalContext *ctx, const Promise *pp)
                     {
                         /* Should never happen, besides when allocation fails. */
                         Log(LOG_LEVEL_CRIT, "StrList_Append: %s", GetErrorStr());
-                        exit(255);
+                        DoCleanupAndExit(255);
                     }
                 }
             }

--- a/cf-testd/cf-testd.c
+++ b/cf-testd/cf-testd.c
@@ -54,6 +54,7 @@
 #include <timeout.h>            // SetReferenceTime
 #include <tls_generic.h>        // TLSLogError
 #include <logging.h>            // thread-specific log prefix
+#include <cleanup.h>
 
 #ifndef __MINGW32__
 #include <sys/socket.h>
@@ -166,7 +167,7 @@ CFTestD_Config *CFTestD_CheckOpts(int argc, char **argv, long *n_threads)
             break;
         case 'h':
             CFTestD_Help();
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
         case 'I':
             LogSetGlobalLevel(LOG_LEVEL_INFO);
             break;
@@ -195,7 +196,7 @@ CFTestD_Config *CFTestD_CheckOpts(int argc, char **argv, long *n_threads)
             if (!ret)
             {
                 /* the function call above logs an error for us (if any) */
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
             break;
         }
@@ -211,10 +212,10 @@ CFTestD_Config *CFTestD_CheckOpts(int argc, char **argv, long *n_threads)
             GenericAgentWriteVersion(w);
             FileWriterDetach(w);
         }
-            exit(EXIT_SUCCESS);
+            DoCleanupAndExit(EXIT_SUCCESS);
         default:
             CFTestD_Help();
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
     }
 
@@ -625,14 +626,14 @@ static void *CFTestD_ServeReport(void *config_arg)
             Log(LOG_LEVEL_ERR,
                 "Can't open file '%s' for reading",
                 report_file);
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
 
         Writer *contents = FileRead(report_file, SIZE_MAX, NULL);
         if (!contents)
         {
             Log(LOG_LEVEL_ERR, "Error reading report file '%s'", report_file);
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
 
         size_t report_data_len = StringWriterLength(contents);
@@ -668,7 +669,7 @@ static void *CFTestD_ServeReport(void *config_arg)
         if (config->report_len <= 0)
         {
             Log(LOG_LEVEL_ERR, "Report file contained no bytes");
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
     }
 

--- a/cf-upgrade/alloc-mini.c
+++ b/cf-upgrade/alloc-mini.c
@@ -38,7 +38,7 @@ static void *CheckResult(void *ptr, const char *fn, bool check_result)
     {
         fputs(fn, stderr);
         fputs(": Unable to allocate memory\n", stderr);
-        exit(255);
+        exit(255); /* no cleanup() functions are registered so exit() is OK */
     }
     return ptr;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -1553,6 +1553,11 @@ if test "x$use_coverage" = "xyes"; then
   dnl Add the special gcc flags
   CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
   LDFLAGS="$LDFLAGS -lgcov"
+  # Need to set ENABLE_COVERAGE so that tests/unit/Makefile.am can adapt for one
+  # test which needs gcov stubs if core not built with coverage.
+  AM_CONDITIONAL([ENABLE_COVERAGE], true)
+else
+  AM_CONDITIONAL([ENABLE_COVERAGE], false)
 fi
 
 #

--- a/libcfnet/server_code.c
+++ b/libcfnet/server_code.c
@@ -6,6 +6,7 @@
 #include <printsize.h>                  // PRINTSIZE
 #include <systype.h>                    // CLASSTEXT
 #include <signals.h>                    // GetSignalPipe
+#include <cleanup.h>                    // DoCleanupAndExit
 
 /* Wait up to a minute for an in-coming connection.
  *
@@ -193,5 +194,5 @@ int InitServer(size_t queue_size, char *bind_address)
         return sd;
     }
 
-    exit(EXIT_FAILURE);
+    DoCleanupAndExit(EXIT_FAILURE);
 }

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -36,6 +36,7 @@
 #include <known_dirs.h>
 #include <ip_address.h>
 #include <file_lib.h>
+#include <cleanup.h>
 
 #ifdef HAVE_SYS_JAIL_H
 # include <sys/jail.h>
@@ -347,7 +348,7 @@ void GetInterfacesInfo(EvalContext *ctx)
     if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) == -1)
     {
         Log(LOG_LEVEL_ERR, "Couldn't open socket. (socket: %s)", GetErrorStr());
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     list.ifc_len = sizeof(ifbuf);
@@ -367,7 +368,7 @@ void GetInterfacesInfo(EvalContext *ctx)
         Log(LOG_LEVEL_ERR,
             "Couldn't get interfaces (ioctl(SIOCGIFCONF): %s)",
             GetErrorStr());
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     if (list.ifc_len < (int) sizeof(struct ifreq))

--- a/libpromises/audit.c
+++ b/libpromises/audit.c
@@ -27,6 +27,7 @@
 #include <conversion.h>
 #include <logging.h>
 #include <string_lib.h>
+#include <cleanup.h>
 
 int PR_KEPT = 0; /* GLOBAL_X */
 int PR_REPAIRED = 0; /* GLOBAL_X */
@@ -104,5 +105,6 @@ void FatalError(const EvalContext *ctx, char *s, ...)
     }
 
     EndAudit(ctx, 0);
-    exit(EXIT_FAILURE); // calling abort would bypass exit handlers and trigger subtle bugs
+    /* calling abort would bypass cleanup handlers and trigger subtle bugs */
+    DoCleanupAndExit(EXIT_FAILURE);
 }

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -38,6 +38,7 @@
 #include "string_lib.h"
 #include "logic_expressions.h"
 #include "json-yaml.h"
+#include "cleanup.h"
 
 // FIX: remove
 #include "syntax.h"
@@ -1262,7 +1263,7 @@ static void ParseErrorVColumnOffset(int column_offset, const char *s, va_list ap
     if (P.error_count > 12)
     {
         fprintf(stderr, "Too many errors\n");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
 }
@@ -1314,7 +1315,7 @@ static void ParseWarningV(unsigned int warning, const char *s, va_list ap)
     if (P.error_count > 12)
     {
         fprintf(stderr, "Too many errors\n");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 }
 
@@ -1341,7 +1342,7 @@ static void fatal_yyerror(const char *s)
     }
 
     fprintf(stderr, "%s: %d,%d: Fatal error during parsing: %s, near token \'%.20s\'\n", P.filename, P.line_no, P.line_pos, s, sp ? sp : "NULL");
-    exit(EXIT_FAILURE);
+    DoCleanupAndExit(EXIT_FAILURE);
 }
 
 static int RelevantBundle(const char *agent, const char *blocktype)

--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -28,7 +28,7 @@
 #include <dbm_api.h>
 #include <dbm_priv.h>
 #include <dbm_migration.h>
-#include <atexit.h>
+#include <cleanup.h>
 #include <logging.h>
 #include <misc_lib.h>
 #include <known_dirs.h>
@@ -337,7 +337,7 @@ void CloseAllDBExit()
 
 static void RegisterShutdownHandler(void)
 {
-    RegisterAtExitFunction(&CloseAllDBExit);
+    RegisterCleanupFunction(&CloseAllDBExit);
 }
 
 /**

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -50,6 +50,7 @@
 #include <regex.h>
 #include <map.h>
 #include <conversion.h>                               /* DataTypeIsIterable */
+#include <cleanup.h>
 
 
 static const char *STACK_FRAME_TYPE_STR[STACK_FRAME_TYPE_MAX] = {
@@ -2397,7 +2398,7 @@ void EvalContextAppendBodyParentsAndArgs(const EvalContext *ctx, const Policy *p
     if (depth > 30) // sanity check
     {
         Log(LOG_LEVEL_ERR, "EvalContextAppendBodyParentsAndArgs: body inheritance chain depth %d in body %s is too much, aborting", depth, bp->name);
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     for (size_t k = 0; bp->conlist && k < SeqLength(bp->conlist); k++)
@@ -2423,7 +2424,7 @@ void EvalContextAppendBodyParentsAndArgs(const EvalContext *ctx, const Policy *p
             if (strcmp(parent_ref.name, bp->name) == 0)
             {
                 Log(LOG_LEVEL_ERR, "EvalContextAppendBodyParentsAndArgs: self body inheritance in %s->%s, aborting", bp->name, parent_ref.name);
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
 
             const Body *parent = EvalContextFindFirstMatchingBody(policy, callee_type, parent_ref.ns, parent_ref.name);

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -34,6 +34,7 @@
 #include <promises.h>
 #include <syntax.h>
 #include <audit.h>
+#include <cleanup.h>
 
 /******************************************************************/
 /* Argument propagation                                           */
@@ -76,7 +77,7 @@ Rlist *NewExpArgs(EvalContext *ctx, const Policy *policy, const FnCall *fp, cons
                 Log(LOG_LEVEL_ERR, "Arguments to function '%s' do not tally. Expected %d not %d",
                       fp->name, FnNumArgs(fn), len);
                 PromiseRef(LOG_LEVEL_ERR, fp->caller);
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
         }
     }

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -45,7 +45,7 @@
 #include <expand.h>
 #include <locks.h>
 #include <scope.h>
-#include <atexit.h>
+#include <cleanup.h>
 #include <unix.h>
 #include <client_code.h>
 #include <string_lib.h>
@@ -69,6 +69,7 @@
 #include <openssl/evp.h>
 #include <libcrypto-compat.h>
 #include <libgen.h>
+#include <cleanup.h>
 
 static pthread_once_t pid_cleanup_once = PTHREAD_ONCE_INIT; /* GLOBAL_T */
 
@@ -508,14 +509,14 @@ void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config)
         {
             Log(LOG_LEVEL_ERR,
                 "Error removing existing input files prior to bootstrap");
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
 
         if (!WriteBuiltinFailsafePolicy(GetInputDir()))
         {
             Log(LOG_LEVEL_ERR,
                 "Error writing builtin failsafe to inputs prior to bootstrap");
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
         GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
 
@@ -535,7 +536,7 @@ void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config)
             {
                 Log(LOG_LEVEL_ERR, "In order to bootstrap as a policy server,"
                     " the file '%s/promises.cf' must exist.", GetMasterDir());
-                exit(EXIT_FAILURE);
+                DoCleanupAndExit(EXIT_FAILURE);
             }
 
             CheckAndSetHAState(GetWorkDir(), ctx);
@@ -1715,7 +1716,7 @@ static void CleanPidFile(void)
 
 static void RegisterPidCleanup(void)
 {
-    RegisterAtExitFunction(&CleanPidFile);
+    RegisterCleanupFunction(&CleanPidFile);
 }
 
 /********************************************************************/

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -37,6 +37,7 @@
 #include <known_dirs.h>
 #include <ornaments.h>
 #include <policy.h>
+#include <cleanup.h>
 
 // TODO: remove
 #include <vars.h>                                         /* IsCf3VarString */
@@ -65,7 +66,7 @@ Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_path)
         }
 
         Log(LOG_LEVEL_ERR, "Can't stat file '%s' for parsing. (stat: %s)", input_path, GetErrorStr());
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
     else if (S_ISDIR(statbuf.st_mode))
     {
@@ -75,14 +76,14 @@ Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_path)
         }
 
         Log(LOG_LEVEL_ERR, "Can't parse directory '%s'.", input_path);
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
 #ifndef _WIN32
     if (config->check_not_writable_by_others && (statbuf.st_mode & (S_IWGRP | S_IWOTH)))
     {
         Log(LOG_LEVEL_ERR, "File %s (owner %ju) is writable by others (security exception)", input_path, (uintmax_t)statbuf.st_uid);
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 #endif
 
@@ -91,7 +92,7 @@ Policy *Cf3ParseFile(const GenericAgentConfig *config, const char *input_path)
     if (!FileCanOpen(input_path, "r"))
     {
         Log(LOG_LEVEL_ERR, "Can't open file '%s' for parsing", input_path);
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     Policy *policy = NULL;
@@ -491,7 +492,7 @@ Policy *LoadPolicy(EvalContext *ctx, GenericAgentConfig *config)
     if (StringSetSize(failed_files) > 0)
     {
         Log(LOG_LEVEL_ERR, "There are syntax errors in policy files");
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     StringSetDestroy(parsed_files_and_checksums);
@@ -520,7 +521,7 @@ Policy *LoadPolicy(EvalContext *ctx, GenericAgentConfig *config)
                 PolicyErrorWrite(writer, errors->data[i]);
             }
             WriterClose(writer);
-            exit(EXIT_FAILURE); // TODO: do not exit
+            DoCleanupAndExit(EXIT_FAILURE); // TODO: do not exit
         }
 
         SeqDestroy(errors);

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -27,7 +27,7 @@
 #include <string_lib.h>
 #include <files_interfaces.h>
 #include <files_lib.h>
-#include <atexit.h>
+#include <cleanup.h>
 #include <policy.h>
 #include <files_hashes.h>
 #include <rb-tree.h>
@@ -376,7 +376,7 @@ static void LocksCleanup(void)
 
 static void RegisterLockCleanup(void)
 {
-    RegisterAtExitFunction(&LocksCleanup);
+    RegisterCleanupFunction(&LocksCleanup);
 }
 
 /**

--- a/libpromises/parser.c
+++ b/libpromises/parser.c
@@ -27,6 +27,7 @@
 
 #include <misc_lib.h>
 #include <file_lib.h>
+#include <cleanup.h>
 
 #include <errno.h>
 
@@ -121,7 +122,7 @@ Policy *ParserParseFile(AgentType agent_type, const char *path, unsigned int war
     if (yyin == NULL)
     {
         Log(LOG_LEVEL_ERR, "While opening file '%s' for parsing. (fopen: %s)", path, GetErrorStr());
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
 
     while (!feof(yyin))
@@ -131,7 +132,7 @@ Policy *ParserParseFile(AgentType agent_type, const char *path, unsigned int war
         if (ferror(yyin))
         {
             perror("cfengine");
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
     }
 

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -204,7 +204,7 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
             if (execl(SHELL_PATH, "sh", "-c", command, NULL) == -1)
             {
                 Log(LOG_LEVEL_ERR, "Command '%s' failed. (execl: %s)", command, GetErrorStr());
-                exit(EXIT_FAILURE);
+                exit(EXIT_FAILURE); /* OK since this is a forked proc and no registered cleanup functions */
             }
         }
         else
@@ -217,13 +217,13 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
                 if ((devnull = open("/dev/null", O_WRONLY)) == -1)
                 {
                     Log(LOG_LEVEL_ERR, "Command '%s' failed. (open: %s)", command, GetErrorStr());
-                    exit(EXIT_FAILURE);
+                    exit(EXIT_FAILURE); /* OK since this is a forked proc and no registered cleanup functions */
                 }
 
                 if (dup2(devnull, STDOUT_FILENO) == -1 || dup2(devnull, STDERR_FILENO) == -1)
                 {
                     Log(LOG_LEVEL_ERR, "Command '%s' failed. (dup2: %s)", command, GetErrorStr());
-                    exit(EXIT_FAILURE);
+                    exit(EXIT_FAILURE); /* OK since this is a forked proc and no registered cleanup functions */
                 }
 
                 close(devnull);
@@ -232,7 +232,7 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
             if (execv(argv[0], argv) == -1)
             {
                 Log(LOG_LEVEL_ERR, "Command '%s' failed. (execv: %s)", argv[0], GetErrorStr());
-                exit(EXIT_FAILURE);
+                exit(EXIT_FAILURE); /* OK since this is a forked proc and no registered cleanup functions */
             }
         }
     }

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -40,6 +40,7 @@
 #include <syntax.h>
 #include <audit.h>
 #include <string_lib.h>
+#include <cleanup.h>
 
 typedef struct
 {
@@ -289,7 +290,7 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
         if (Epimenides(ctx, PromiseGetBundle(pp)->ns, PromiseGetBundle(pp)->name, pp->promiser, rval, 0))
         {
             Log(LOG_LEVEL_ERR, "Variable '%s' contains itself indirectly - an unkeepable promise", pp->promiser);
-            exit(EXIT_FAILURE);
+            DoCleanupAndExit(EXIT_FAILURE);
         }
         else
         {

--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -33,7 +33,7 @@ libutils_la_LIBS     = $(PCRE_LIBS) $(OPENSSL_LIBS)
 
 libutils_la_SOURCES = \
 	alloc.c alloc.h \
-	atexit.c atexit.h \
+	cleanup.c cleanup.h \
 	compiler.h \
 	deprecated.h \
 	dir.h dir_priv.h \

--- a/libutils/alloc.c
+++ b/libutils/alloc.c
@@ -25,6 +25,7 @@
 #define ALLOC_IMPL
 #include <platform.h>
 #include <alloc.h>
+#include <cleanup.h>
 
 static void *CheckResult(void *ptr, const char *fn, bool check_result)
 {
@@ -32,7 +33,7 @@ static void *CheckResult(void *ptr, const char *fn, bool check_result)
     {
         fputs(fn, stderr);
         fputs("CRITICAL: Unable to allocate memory\n", stderr);
-        exit(255);
+        DoCleanupAndExit(255);
     }
     return ptr;
 }

--- a/libutils/cleanup.h
+++ b/libutils/cleanup.h
@@ -22,11 +22,13 @@
   included file COSL.txt.
 */
 
-#ifndef CFENGINE_ATEXIT_H
-#define CFENGINE_ATEXIT_H
+#ifndef CFENGINE_CLEANUP_H
+#define CFENGINE_CLEANUP_H
 
-typedef void (*AtExitFn)(void);
+typedef void (*CleanupFn)(void);
 
-void RegisterAtExitFunction(AtExitFn fn);
+void CallCleanupFunctions(void);
+void DoCleanupAndExit(int ret) FUNC_ATTR_NORETURN;
+void RegisterCleanupFunction(CleanupFn fn);
 
 #endif

--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -26,6 +26,7 @@
 #include <alloc.h>
 #include <string_lib.h>
 #include <misc_lib.h>
+#include <cleanup.h>
 
 
 char VPREFIX[1024] = ""; /* GLOBAL_C */
@@ -47,7 +48,7 @@ static void LoggingInitializeOnce(void)
          * that nothing else will work. */
 
         fprintf(stderr, "Unable to initialize logging subsystem\n");
-        exit(255);
+        DoCleanupAndExit(255);
     }
 }
 
@@ -512,7 +513,7 @@ void LogSetGlobalLevelArgOrExit(const char *const arg)
         // system. Using Log() can be considered incorrect, even though
         // it may "work". Let's just print an error to stderr:
         fprintf(stderr, "Invalid log level: '%s'\n", arg);
-        exit(1);
+        DoCleanupAndExit(1);
     }
     LogSetGlobalLevel(level);
 }

--- a/libutils/misc_lib.c
+++ b/libutils/misc_lib.c
@@ -27,6 +27,7 @@
 #include <platform.h>
 #include <alloc.h>
 #include <logging.h>
+#include <cleanup.h>
 
 #include <stdarg.h>
 
@@ -61,7 +62,7 @@ void __ProgrammingError(const char *file, int lineno, const char *format, ...)
 
     free(fmt);
 #ifdef NDEBUG
-    exit(255);
+    DoCleanupAndExit(255);
 #else
     abort();
 #endif

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -34,6 +34,7 @@
 #include <writer.h>
 #include <misc_lib.h>
 #include <logging.h>
+#include <cleanup.h>
 
 
 char *StringVFormat(const char *fmt, va_list ap)
@@ -558,7 +559,7 @@ long StringToLongExitOnError(const char *str)
     if (return_code != 0)
     {
         LogStringToLongError(str, "StringToLongExitOnError", return_code);
-        exit(EXIT_FAILURE);
+        DoCleanupAndExit(EXIT_FAILURE);
     }
     return result;
 }

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -84,19 +84,20 @@ libdb_la_SOURCES = db_stubs.c \
 	../../libpromises/dbm_migration.c \
 	../../libpromises/dbm_migration_lastseen.c \
 	../../libutils/logging.c \
-	../../libutils/atexit.c
+	../../libutils/cleanup.c
 if HPUX
 libdb_la_SOURCES += ../../libpromises/cf3globals.c
 endif
 libdb_la_LIBADD = libstr.la ../../libutils/libutils.la
 #libdb_la_CPPFLAGS = $(LMDB_CPPFLAGS) $(TOKYOCABINET_CPPFLAGS) $(QDBM_CPPFLAGS)
-# Make sure that source files are compiled to separate object files libdb_la-file.o
+# Make sure that source files are compiled to separate object files 
+# libdb_la-file.o
 libdb_la_CFLAGS = $(AM_CFLAGS)
 
 check_PROGRAMS = \
 	arg_split_test \
 	assoc_test \
-	atexit_test \
+	cleanup_test \
 	csv_writer_test \
 	item_test \
 	rlist_test \
@@ -215,10 +216,11 @@ endif
 #
 TESTS_ENVIRONMENT = DYLD_FORCE_FLAT_NAMESPACE=yes
 
-atexit_test_SOURCES = atexit_test.c
-atexit_test_LDADD = libtest.la libdb.la
+cleanup_test_SOURCES = cleanup_test.c
+cleanup_test_LDADD = libtest.la libdb.la
 
-csv_writer_test_SOURCES = csv_writer_test.c ../../libutils/csv_writer.c
+csv_writer_test_SOURCES = csv_writer_test.c ../../libutils/csv_writer.c \
+	../../libutils/cleanup.c
 csv_writer_test_LDADD = libtest.la libstr.la
 
 conversion_test_SOURCES = conversion_test.c ../../libpromises/conversion.c
@@ -241,7 +243,9 @@ set_domainname_test_LDADD = libstr.la ../../libpromises/libpromises.la
 str_test_SOURCES = str_test.c
 str_test_LDADD = libstr.la
 
-xml_writer_test_SOURCES = xml_writer_test.c ../../libutils/xml_writer.c
+xml_writer_test_SOURCES = xml_writer_test.c \
+	../../libutils/xml_writer.c \
+	../../libutils/cleanup.c
 xml_writer_test_LDADD = libtest.la libstr.la
 
 list_test_SOURCES = list_test.c
@@ -274,7 +278,9 @@ protocol_test_LDADD = ../../libpromises/libpromises.la libtest.la
 if HAVE_AVAHI_CLIENT
 if HAVE_AVAHI_COMMON
 
-findhub_test_SOURCES = findhub_test.c ../../cf-agent/findhub.c ../../cf-agent/load_avahi.c
+findhub_test_SOURCES = findhub_test.c \
+	../../cf-agent/findhub.c \
+	../../cf-agent/load_avahi.c
 
 avahi_config_test_SOURCES = avahi_config_test.c \
 	../../cf-serverd/server_common.c \
@@ -291,7 +297,11 @@ endif
 endif
 
 #file_writer_test_CPPFLAGS = -I$(top_srcdir)/libutils
-file_writer_test_SOURCES = file_writer_test.c gcov-stub.c
+file_writer_test_SOURCES = file_writer_test.c
+# ENABLE_COVERAGE is set in top-level configure.ac
+if !ENABLE_COVERAGE
+file_writer_test_SOURCES += gcov-stub.c
+endif
 
 db_test_SOURCES = db_test.c
 db_test_LDADD = libtest.la ../../libpromises/libpromises.la
@@ -301,21 +311,33 @@ db_concurrent_test_SOURCES = db_concurrent_test.c
 db_concurrent_test_LDADD = libdb.la
 
 lastseen_test_SOURCES = lastseen_test.c \
-	../../libpromises/item_lib.c  ../../libpromises/lastseen.c ../../libutils/statistics.c
+	../../libpromises/item_lib.c \
+	../../libpromises/lastseen.c \
+	../../libutils/statistics.c
 #lastseen_test_CPPFLAGS = $(libdb_la_CPPFLAGS)
 lastseen_test_LDADD = libdb.la ../../libpromises/libpromises.la
 
 lastseen_migration_test_SOURCES = lastseen_migration_test.c \
-	../../libpromises/lastseen.c ../../libutils/statistics.c ../../libpromises/item_lib.c
+	../../libpromises/lastseen.c \
+	../../libutils/statistics.c \
+	../../libpromises/item_lib.c
 #lastseen_migration_test_CPPFLAGS = $(libdb_la_CPPFLAGS)
 lastseen_migration_test_LDADD = libdb.la ../../libpromises/libpromises.la
 
 CLEANFILES = *.gcno *.gcda cfengine-enterprise.so
 
-package_versions_compare_test_SOURCES = package_versions_compare_test.c ../../cf-agent/package_module.c ../../cf-agent/verify_packages.c ../../cf-agent/verify_new_packages.c ../../cf-agent/vercmp.c ../../cf-agent/vercmp_internal.c ../../cf-agent/retcode.c ../../libpromises/match_scope.c
+package_versions_compare_test_SOURCES = package_versions_compare_test.c \
+	../../cf-agent/package_module.c \
+	../../cf-agent/verify_packages.c \
+	../../cf-agent/verify_new_packages.c \
+	../../cf-agent/vercmp.c \
+	../../cf-agent/vercmp_internal.c \
+	../../cf-agent/retcode.c \
+	../../libpromises/match_scope.c
 
 #package_versions_compare_test_CPPFLAGS = $(AM_CPPFLAGS)
-package_versions_compare_test_LDADD = ../../libpromises/libpromises.la libtest.la
+package_versions_compare_test_LDADD = ../../libpromises/libpromises.la \
+	libtest.la
 
 file_lib_test_SOURCES = file_lib_test.c \
 	../../libutils/file_lib.c \
@@ -330,6 +352,7 @@ file_lib_test_SOURCES = file_lib_test.c \
 	../../libutils/json.c \
 	../../libutils/json-yaml.c \
 	../../libutils/unix_dir.c \
+	../../libutils/cleanup.c \
 	../../libutils/writer.c
 file_lib_test_LDADD = libtest.la
 file_lib_test_CPPFLAGS = $(AM_CPPFLAGS) -DTEST_SYMLINK_ATOMICITY
@@ -343,11 +366,16 @@ sort_test_LDADD = libtest.la ../../libpromises/libpromises.la
 logging_test_SOURCES = logging_test.c ../../libpromises/syslog_client.c
 logging_test_LDADD = libtest.la ../../libutils/libutils.la
 
-logging_timestamp_test_SOURCES = logging_timestamp_test.c ../../libutils/logging.h
+logging_timestamp_test_SOURCES = logging_timestamp_test.c \
+	../../libutils/logging.h
 logging_timestamp_test_LDADD = libtest.la ../../libutils/libutils.la
 
-connection_management_test_SOURCES = connection_management_test.c ../../cf-serverd/server_common.c ../../cf-serverd/server_tls.c
-connection_management_test_LDADD = ../../libpromises/libpromises.la libtest.la ../../cf-serverd/libcf-serverd.la
+connection_management_test_SOURCES = connection_management_test.c \
+	../../cf-serverd/server_common.c \
+	../../cf-serverd/server_tls.c
+connection_management_test_LDADD = ../../libpromises/libpromises.la \
+	 libtest.la \
+	../../cf-serverd/libcf-serverd.la
 
 rlist_test_SOURCES = rlist_test.c \
 	../../libpromises/rlist.c
@@ -406,13 +434,19 @@ sysinfo_test_LDADD = libtest.la \
 	../../libenv/libenv.la \
 	../../libpromises/libpromises.la
 
-mon_cpu_test_SOURCES = mon_cpu_test.c ../../cf-monitord/mon.h ../../cf-monitord/mon_cpu.c
+mon_cpu_test_SOURCES = mon_cpu_test.c \
+	../../cf-monitord/mon.h \
+	../../cf-monitord/mon_cpu.c
 mon_cpu_test_LDADD = ../../libpromises/libpromises.la libtest.la
 
-mon_load_test_SOURCES = mon_load_test.c ../../cf-monitord/mon.h ../../cf-monitord/mon_load.c
+mon_load_test_SOURCES = mon_load_test.c \
+	../../cf-monitord/mon.h \
+	../../cf-monitord/mon_load.c
 mon_load_test_LDADD = ../../libpromises/libpromises.la libtest.la
 
-mon_processes_test_SOURCES = mon_processes_test.c ../../cf-monitord/mon.h ../../cf-monitord/mon_processes.c
+mon_processes_test_SOURCES = mon_processes_test.c \
+	../../cf-monitord/mon.h \
+	../../cf-monitord/mon_processes.c
 mon_processes_test_LDADD = ../../libpromises/libpromises.la libtest.la
 
 version_test_SOURCES = version_test.c
@@ -421,9 +455,13 @@ hash_test_SOURCES = hash_test.c
 hash_test_LDADD = ../../libutils/libutils.la libtest.la
 
 key_test_SOURCES = key_test.c
-key_test_LDADD = ../../libpromises/libpromises.la ../../libutils/libutils.la libtest.la
+key_test_LDADD = ../../libpromises/libpromises.la \
+	../../libutils/libutils.la \
+	libtest.la
 
-strlist_test_SOURCES = strlist_test.c ../../cf-serverd/strlist.c ../../cf-serverd/strlist.h
+strlist_test_SOURCES = strlist_test.c \
+	../../cf-serverd/strlist.c \
+	../../cf-serverd/strlist.h
 
 iteration_test_SOURCES = iteration_test.c
 
@@ -431,9 +469,17 @@ libcompat_test_CPPFLAGS = -I$(top_srcdir)/libcompat
 libcompat_test_SOURCES = libcompat_test.c
 
 CFUPGRADE=../../cf-upgrade
-cf_upgrade_test_SOURCES = cf_upgrade_test.c $(CFUPGRADE)/alloc-mini.c $(CFUPGRADE)/alloc-mini.h $(CFUPGRADE)/command_line.c \
-$(CFUPGRADE)/command_line.h $(CFUPGRADE)/configuration.c $(CFUPGRADE)/configuration.h $(CFUPGRADE)/log.c $(CFUPGRADE)/log.h \
-$(CFUPGRADE)/process.c $(CFUPGRADE)/process.h $(CFUPGRADE)/update.c $(CFUPGRADE)/update.h
+cf_upgrade_test_SOURCES = cf_upgrade_test.c \
+	$(CFUPGRADE)/alloc-mini.c \
+	$(CFUPGRADE)/alloc-mini.h \
+	$(CFUPGRADE)/command_line.c \
+	$(CFUPGRADE)/command_line.h \
+	$(CFUPGRADE)/configuration.c \
+	$(CFUPGRADE)/configuration.h \
+	$(CFUPGRADE)/log.c $(CFUPGRADE)/log.h \
+	$(CFUPGRADE)/process.c $(CFUPGRADE)/process.h \
+	$(CFUPGRADE)/update.c \
+	$(CFUPGRADE)/update.h
 cf_upgrade_test_CFLAGS = -I$(CFUPGRADE)
 
 queue_test_SOURCES = queue_test.c

--- a/tests/unit/cleanup_test.c
+++ b/tests/unit/cleanup_test.c
@@ -1,7 +1,7 @@
 #include <test.h>
 
 #include <cf3.defs.h>
-#include <atexit.h>
+#include <cleanup.h>
 
 bool FN1;
 bool FN2;
@@ -81,8 +81,8 @@ int main()
 {
     PRINT_TEST_BANNER();
 
-    RegisterAtExitFunction(&fn1);
-    atexit(&fn2);
-    RegisterAtExitFunction(&fn3);
+    RegisterCleanupFunction(&fn1);
+    RegisterCleanupFunction(&fn2);
+    atexit(&fn3);
     return 0;
 }


### PR DESCRIPTION
On Windows atexit() unloads DLLs before and/or during atexit functions being called which cases bad behavior.

merge together:
https://github.com/cfengine/nova/pull/1275
https://github.com/cfengine/enterprise/pull/451
https://github.com/cfengine/core/pull/3357

Changelog: title

(cherry picked from commit ba6429cdf3638be2574299ae18b55c7e38185336)
(cherry picked from commit 384213987f5b27af28ede7e94baa8f99ff49abbb)
(cherry picked from commit b2ff4788dab13ee8c6c8df712d7847d7f4e5171e)
(cherry picked from commit 7bec7d5a1e2b3be0e59d23c9b1d8212c27d9edd0)

 Conflicts:
	libutils/mutex.c - was removed
	tests/unit/Makefile.am - mutex.c removal caused a change here
	HACKING.md - added section about atexit and windows