### PR TITLE
ENT-3756: missed cleanup.h include due to only building --enable-debug

### DIFF
--- a/libutils/misc_lib.c
+++ b/libutils/misc_lib.c
@@ -27,6 +27,7 @@
 #include <platform.h>
 #include <alloc.h>
 #include <logging.h>
+#include <cleanup.h>
 
 #include <stdarg.h>
 


### PR DESCRIPTION
 Conflicts:
	libutils/misc_lib.c