### PR TITLE
Add parsed policy files hashes/digests to Policy

### DIFF
--- a/libpromises/policy.h
+++ b/libpromises/policy.h
@@ -55,6 +55,7 @@ struct Policy_
 
     Seq *bundles;
     Seq *bodies;
+    StringMap *policy_files_hashes;
 };
 
 typedef struct
@@ -145,6 +146,7 @@ void PolicyDestroy(Policy *policy);
 unsigned PolicyHash(const Policy *policy);
 
 StringSet *PolicySourceFiles(const Policy *policy);
+const char *PolicyGetPolicyFileHash(const Policy *policy, const char *policy_file_path);
 
 Policy *PolicyMerge(Policy *a, Policy *b);
 Body *PolicyGetBody(const Policy *policy, const char *ns, const char *type, const char *name);


### PR DESCRIPTION
We are computing hashes/digests of policy files when loading them
to detect duplicate policy files etc. However, this information
is useful even later, e.g. for logging where it allows us to tie
the promise outcome with a particular version of the policy file
the promise appeared in.

Ticket: ENT-3996