### PR TITLE
ENT-4064: Added a new binary: cf-check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ stamp-h1
 # binaries
 /cf-agent/cf-agent
 /cf-agent/cf-agent.exe
+/cf-check/cf-check
+/cf-check/cf-check.exe
 /cf-execd/cf-execd
 /cf-execd/cf-execd.exe
 /cf-key/cf-key

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ SUBDIRS = libcompat \
 	libenv \
 	libpromises \
 	cf-agent \
+	cf-check \
 	cf-execd \
 	cf-key \
 	cf-monitord \

--- a/cf-check/Makefile.am
+++ b/cf-check/Makefile.am
@@ -1,0 +1,59 @@
+#
+#  Copyright 2018 Northern.tech AS
+#
+#  This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
+#
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License as published by the
+#  Free Software Foundation; version 3.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+#
+# To the extent this program is licensed as part of the Enterprise
+# versions of CFEngine, the applicable Commercial Open Source License
+# (COSL) may apply to this file if you as a licensee so wish it. See
+# included file COSL.txt.
+#
+noinst_LTLIBRARIES = libcf-check.la
+
+AM_CPPFLAGS = -I$(srcdir)/../libutils \
+	$(LMDB_CPPFLAGS)
+
+AM_CFLAGS = \
+	$(LMDB_CFLAGS) \
+	$(PTHREAD_CFLAGS)
+
+AM_LDFLAGS = \
+	$(LMDB_LDFLAGS)
+
+libcf_check_la_LIBADD = ../libutils/libutils.la \
+	$(LMDB_LIBS) \
+	$(PTHREAD_LIBS)
+
+libcf_check_la_SOURCES = \
+	lmdump.c lmdump.h \
+	cf-check.c
+
+if !BUILTIN_EXTENSIONS
+  bin_PROGRAMS = cf-check
+
+  # Workaround for automake madness (try removing it if you want to know why).
+  cf_check_CFLAGS = $(AM_CFLAGS)
+
+  # Build both a libcf-check.la library, and a cf-check executable
+  cf_check_LDADD = libcf-check.la
+endif
+
+CLEANFILES = *.gcno *.gcda
+
+#
+# Some basic clean ups
+#
+MOSTLYCLEANFILES = *~ *.orig *.rej

--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -1,0 +1,29 @@
+#include <lmdump.h>
+#include <string_lib.h>
+
+int main(int argc, char **argv)
+{
+    if (StringEndsWith(argv[0], "lmdump"))
+    {
+        // Compatibility mode; act like lmdump if symlinked or renamed:
+        return lmdump_main(argc, argv);
+    }
+
+    if (argc < 2)
+    {
+        printf("Need to supply a command, for example 'cf-check lmdump'\n");
+        return 1;
+    }
+
+    const int cmd_argc = argc - 1;
+    char **cmd_argv = argv + 1;
+    char *command = cmd_argv[0];
+
+    if (StringSafeEqual(command, "lmdump"))
+    {
+        return lmdump_main(cmd_argc, cmd_argv);
+    }
+
+    printf("Unrecognized command: '%s'\n", command);
+    return 1;
+}

--- a/cf-check/lmdump.c
+++ b/cf-check/lmdump.c
@@ -1,0 +1,135 @@
+#include <platform.h>
+#include <stdio.h>
+#include <lmdump.h>
+
+#ifdef LMDB
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+#include <lmdb.h>
+
+static void lmdump_print_hex(const char *s, size_t len)
+{
+    for (int i = 0; i < len; i++)
+    {
+        printf("%02x", s[i]);
+    }
+}
+
+static void lmdump_print_usage(void)
+{
+    printf("Lmdb database dumper\n");
+    printf("Usage: lmdump -d|-x|-a|-A filename\n\n");
+    printf("Has three modes :\n");
+    printf("    -a : print keys in ascii form\n");
+    printf("    -A : print keys and values in ascii form\n");
+    printf("    -x : print keys and values in hexadecimal form\n");
+    printf("    -d : print only the size of keys and values\n");
+}
+
+static int lmdump_report_error(int rc)
+{
+    printf("err(%d): %s\n", rc, mdb_strerror(rc));
+    return rc;
+}
+
+int lmdump_main(int argc, char * argv[])
+{
+    int rc;
+    MDB_env *env;
+    MDB_dbi dbi;
+    MDB_val key, data;
+    MDB_txn *txn;
+    MDB_cursor *cursor;
+
+    if (argc < 3)
+    {
+        lmdump_print_usage();
+        return 1;
+    }
+    int mode = -1;
+    if (strcmp(argv[1],"-a") == 0)
+    {
+        mode = 'a';
+    }
+    else if (strcmp(argv[1], "-A") == 0)
+    {
+        mode = 'A';
+    }
+    else if (strcmp(argv[1], "-x") == 0)
+    {
+        mode = 'x';
+    }
+    else if (strcmp(argv[1], "-d") == 0)
+    {
+        mode = 'd';
+    }
+    else
+    {
+        lmdump_print_usage();
+        return 1;
+    }
+    rc = mdb_env_create(&env);
+    if (rc) return lmdump_report_error(rc);
+
+    rc = mdb_env_open(env, argv[2], MDB_NOSUBDIR, 0644);
+    if (rc) return lmdump_report_error(rc);
+
+    rc = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
+    if (rc) return lmdump_report_error(rc);
+
+    rc = mdb_open(txn, NULL, 0, &dbi);
+    if (rc) return lmdump_report_error(rc);
+
+    rc = mdb_cursor_open(txn, dbi, &cursor);
+    if (rc) return lmdump_report_error(rc);
+
+    while ( (rc = mdb_cursor_get(cursor, &key, &data, MDB_NEXT)) == MDB_SUCCESS )
+    {
+        if (mode == 'A')
+        {
+            printf("key: %p[%d] %.*s\n",
+                key.mv_data, (int) key.mv_size, (int) key.mv_size, (char *) key.mv_data);
+        }
+        else if (mode == 'a')
+        {
+            printf("key: %p[%d] %.*s, data: %p[%d] %.*s\n",
+                key.mv_data, (int) key.mv_size, (int) key.mv_size, (char *) key.mv_data,
+                data.mv_data, (int) data.mv_size, (int) data.mv_size, (char *) data.mv_data);
+        }
+        else if (mode == 'd')
+        {
+            printf("key: %p[%d] ,data: %p[%d]\n",
+                key.mv_data,  (int) key.mv_size,
+                data.mv_data, (int) data.mv_size);
+        }
+        else if (mode == 'x')
+        {
+            printf("key: %p[%d] ", key.mv_data,  (int) key.mv_size);
+            lmdump_print_hex(key.mv_data,  (int) key.mv_size);
+            printf(" ,data: %p[%d] ", data.mv_data,  (int) data.mv_size);
+            lmdump_print_hex(data.mv_data,  (int) data.mv_size);
+            printf("\n");
+        }
+    }
+    if (rc != MDB_NOTFOUND)
+    {
+        // At this point, not found is expected, anything else is an error
+        return lmdump_report_error(rc);
+    }
+    mdb_cursor_close(cursor);
+    mdb_close(env, dbi);
+
+    mdb_txn_abort(txn);
+    mdb_env_close(env);
+
+    return 0;
+}
+
+#else
+int lmdump_main(ARG_UNUSED int argc, ARG_UNUSED char * argv[])
+{
+    printf("lmdump only implemented for LMDB.\n");
+    return 1;
+}
+#endif

--- a/cf-check/lmdump.h
+++ b/cf-check/lmdump.h
@@ -1,0 +1,8 @@
+#ifndef __LMDUMP_H__
+#define __LMDUMP_H__
+
+#include <platform.h>
+
+int lmdump_main(int argc, char * argv[]);
+
+#endif

--- a/configure.ac
+++ b/configure.ac
@@ -1715,6 +1715,7 @@ AC_CONFIG_FILES([Makefile
     libenv/Makefile
     libpromises/Makefile
     cf-agent/Makefile
+    cf-check/Makefile
     cf-promises/Makefile
     cf-execd/Makefile
     cf-key/Makefile

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -435,11 +435,11 @@ static void GetNameInfo3(EvalContext *ctx)
     long sz;
 #endif
 
-#define COMPONENTS_SIZE 14
+#define COMPONENTS_SIZE 15
     // This is used for $(sys.cf_agent), $(sys.cf_serverd) ... :
     char *components[COMPONENTS_SIZE] = { "cf-twin", "cf-agent", "cf-serverd", "cf-monitord", "cf-know",
         "cf-report", "cf-key", "cf-runagent", "cf-execd", "cf-hub",
-        "cf-promises", "cf-upgrade", "cf-net",
+        "cf-promises", "cf-upgrade", "cf-net", "cf-check",
         NULL
     };
     int have_component[COMPONENTS_SIZE];

--- a/tests/acceptance/Makefile.am
+++ b/tests/acceptance/Makefile.am
@@ -71,6 +71,7 @@ TESTS_ENVIRONMENT = env \
 	CF_SERVERD=`pwd`/../../cf-serverd/cf-serverd \
 	CF_KEY=`pwd`/../../cf-key/cf-key \
 	CF_NET=`pwd`/../../cf-net/cf-net \
+	CF_CHECK=`pwd`/../../cf-check/cf-check \
 	RPMVERCMP=`pwd`/../../ext/rpmvercmp \
 	MOCK_PACKAGE_MANAGER=`pwd`/mock_package_manager
 

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -100,6 +100,7 @@ CF_SERVERD=${CF_SERVERD:-}          ; export CF_SERVERD
 CF_EXECD=${CF_EXECD:-}              ; export CF_EXECD
 CF_KEY=${CF_KEY:-}                  ; export CF_KEY
 CF_NET=${CF_NET:-}                  ; export CF_NET
+CF_CHECK=${CF_CHECK:-}              ; export CF_CHECK
 CF_RUNAGENT=${CF_RUNAGENT:-}        ; export CF_RUNAGENT
 RPMVERCMP=${RPMVERCMP:-}            ; export RPMVERCMP
 LIBTOOL=${LIBTOOL:-}                ; export LIBTOOL
@@ -205,7 +206,7 @@ unix_seconds() {
 }
 
 usage() {
-    echo "testall [-h|--help] [-q|--quiet] [--gainroot=<command>] [--agent=<agent>] [--cfpromises=<cf-promises>] [--cfserverd=<cf-serverd>] [--cfexecd=<cf-execd>] [--cfkey=<cf-key>] [--cfnet=<cf-net>] [--bindir=<bindir>] [--tests=...] [--gdb] [--printlog] [<test> <test>...]"
+    echo "testall [-h|--help] [-q|--quiet] [--gainroot=<command>] [--agent=<agent>] [--cfpromises=<cf-promises>] [--cfserverd=<cf-serverd>] [--cfexecd=<cf-execd>] [--cfkey=<cf-key>] [--cfnet=<cf-net>] [--cfcheck=<cf-check>] [--bindir=<bindir>] [--tests=...] [--gdb] [--printlog] [<test> <test>...]"
     echo
     echo "If no test is given, all standard tests are run:"
     echo "  Tests with names of form <file>.cf are expected to run successfully"
@@ -237,6 +238,8 @@ usage() {
     echo "           and defaults to $DEFCF_KEY."
     echo " --cfnet   provides a way to specify non-default cf-net location,"
     echo "           and defaults to $DEFCF_NET."
+    echo " --cfcheck provides a way to specify non-default cf-check location,"
+    echo "           and defaults to $DEFCF_CHECK."
     echo " --cfrunagent  provides a way to specify non-default cf-runagent location,"
     echo "           and defaults to $DEFCF_RUNAGENT."
     echo " --rpmvercmp  provides a way to specify non-default rpmvercmp location,"
@@ -412,6 +415,7 @@ runtest() {
                 $LN_CMD "$CF_EXECD" "$WORKDIR/bin"
                 $LN_CMD "$CF_KEY" "$WORKDIR/bin"
                 $LN_CMD "$CF_NET" "$WORKDIR/bin"
+                $LN_CMD "$CF_CHECK" "$WORKDIR/bin"
                 $LN_CMD "$CF_RUNAGENT" "$WORKDIR/bin"
                 $LN_CMD "$RPMVERCMP" "$WORKDIR/bin"
             fi
@@ -799,6 +803,8 @@ do
             CF_KEY=${1#--cfkey=};;
         --cfnet=*)
             CF_NET=${1#--cfnet=};;
+        --cfcheck=*)
+            CF_CHECK=${1#--cfcheck=};;
         --cfrunagent=*)
             CF_RUNAGENT=${1#--cfrunagent=};;
         --rpmvercmp=*)
@@ -879,7 +885,7 @@ do
     esac
 done
 
-if [ -n "$AGENT" -o -n "$CF_PROMISES" -o -n "$CF_SERVERD" -o -n "$CF_EXECD" -o -n "$CF_KEY" -o -n "$CF_NET" -o -n "$CF_RUNAGENT" -o -n "$RPMVERCMP" ]
+if [ -n "$AGENT" -o -n "$CF_PROMISES" -o -n "$CF_SERVERD" -o -n "$CF_EXECD" -o -n "$CF_KEY" -o -n "$CF_NET" -o -n "$CF_CHECK" -o -n "$CF_RUNAGENT" -o -n "$RPMVERCMP" ]
 then
     if [ -n "$BINDIR" ]
     then
@@ -909,6 +915,7 @@ find_default_binary DEFCF_SERVERD cf-serverd
 find_default_binary DEFCF_EXECD cf-execd
 find_default_binary DEFCF_KEY cf-key
 find_default_binary DEFCF_NET cf-net
+find_default_binary DEFCF_CHECK cf-check
 find_default_binary DEFCF_RUNAGENT cf-runagent
 find_default_binary DEFRPMVERCMP rpmvercmp
 
@@ -921,11 +928,12 @@ CF_SERVERD=${CF_SERVERD:-${DEFCF_SERVERD}}
 CF_EXECD=${CF_EXECD:-${DEFCF_EXECD}}
 CF_KEY=${CF_KEY:-${DEFCF_KEY}}
 CF_NET=${CF_NET:-${DEFCF_NET}}
+CF_CHECK=${CF_CHECK:-${DEFCF_CHECK}}
 CF_RUNAGENT=${CF_RUNAGENT:-${DEFCF_RUNAGENT}}
 RPMVERCMP=${RPMVERCMP:-${DEFRPMVERCMP}}
 LIBTOOL=${LIBTOOL:-${DEFLIBTOOL}}
 
-if [ ! -x "$AGENT" -o ! -x "$CF_PROMISES" -o ! -x "$CF_SERVERD" -o ! -x "$CF_EXECD" -o ! -x "$CF_KEY" -o ! -x "$CF_NET" -o ! -x "$CF_RUNAGENT" -o ! -x "$RPMVERCMP" ]
+if [ ! -x "$AGENT" -o ! -x "$CF_PROMISES" -o ! -x "$CF_SERVERD" -o ! -x "$CF_EXECD" -o ! -x "$CF_KEY" -o ! -x "$CF_NET" -o ! -x "$CF_CHECK" -o ! -x "$CF_RUNAGENT" -o ! -x "$RPMVERCMP" ]
 then
     echo "ERROR: can't find cf-agent or other binary;"     \
          " Are you sure you're running this from OBJDIR"   \
@@ -935,9 +943,9 @@ then
     echo '$CF_SERVERD   =' "$CF_SERVERD"
     echo '$CF_EXECD     =' "$CF_EXECD"
     echo '$CF_KEY       =' "$CF_KEY"
-    echo '$CF_NET       =' "$CF_NET"
     echo '$CF_RUNAGENT  =' "$CF_RUNAGENT"
     echo '$CF_NET       =' "$CF_NET"
+    echo '$CF_CHECK     =' "$CF_CHECK"
     echo '$RPMVERCMP    =' "$RPMVERCMP"
     exit 1
 fi

--- a/tests/unit/dynamic_dependency_test.sh
+++ b/tests/unit/dynamic_dependency_test.sh
@@ -63,6 +63,9 @@ fi
 #                    v                 v                 v
 for symbol in LogSetGlobalLevel GetInterfacesInfo ConnectionInfoNew; do
     for binary in cf-*; do
+        if test "$binary" = "cf-check" ; then
+            continue
+        fi
         if test -e "$binary/.libs/$binary"; then
             LOC="$binary/.libs/$binary"
         else

--- a/travis-scripts/valgrind.sh
+++ b/travis-scripts/valgrind.sh
@@ -29,6 +29,7 @@ valgrind $VG_OPTS /var/cfengine/bin/cf-key 2>&1 | tee cf-key.txt
 valgrind $VG_OPTS /var/cfengine/bin/cf-agent -B "$(ifconfig | grep -A1 Ethernet | sed '2!d;s/.*addr:\([0-9.]*\).*/\1/')" 2>&1 | tee bootstrap.txt
 valgrind $VG_OPTS /var/cfengine/bin/cf-agent -K -f update.cf 2>&1 | tee update.txt
 valgrind $VG_OPTS /var/cfengine/bin/cf-agent -K -f promises.cf 2>&1 | tee promises.txt
+valgrind $VG_OPTS /var/cfengine/bin/cf-check lmdump -x /var/cfengine/state/cf_lock.lmdb 2>&1 | tee check.txt
 
 echo "Killing cfengine processes"
 ps aux | grep [c]f-


### PR DESCRIPTION
Corrupt local databases (LMDB) continues to be a problem.
cf-check will be used to diagnose and remediate problems
with corrupt databases. It is a standalone binary, which
doesn't evaluate policy or use the local databases, thus
it can be used in situations where the other binaries
like cf-agent would hang.

cf-check replaces our lmdb database dumper, lmdump.
`cf-check lmdump` or symlinking / renaming it to lmdump
will make cf-check have the exact same behavior as lmdump.

cf-check will include much more functionality in the future
and some of the code will be added to other binaries,
for example to do health checks of databases on startup.

Merge together:
https://github.com/cfengine/core/pull/3367
https://github.com/cfengine/enterprise/pull/456
https://github.com/cfengine/buildscripts/pull/463