### PR TITLE
TLS 1.3 support

### DIFF
--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -100,27 +100,22 @@ bool ServerTLSInitialize(RSA *priv_key, RSA *pub_key, SSL_CTX **ssl_ctx)
      * CFEngine is not a web server so it does not need to support many
      * ciphers. It only allows a safe but very common subset by default,
      * extensible via "allowciphers" in body server control. By default
-     * it allows:
+     * the server side allows:
      *
      *     AES256-GCM-SHA384: most high-grade RSA-based cipher from TLSv1.2
      *     AES256-SHA: most backwards compatible but high-grade, from SSLv3
+     *     TLS_AES_256_GCM_SHA384: most high-grade RSA-based cipher from TLSv1.3
+     *
+     * Client side is using the OpenSSL's defaults by default.
      */
     const char *cipher_list = SERVER_ACCESS.allowciphers;
     if (cipher_list == NULL)
     {
-        cipher_list ="AES256-GCM-SHA384:AES256-SHA";
+        cipher_list = "AES256-GCM-SHA384:AES256-SHA:TLS_AES_256_GCM_SHA384";
     }
 
-    Log(LOG_LEVEL_VERBOSE,
-        "Setting cipher list for incoming TLS connections to: %s",
-        cipher_list);
-
-    ret = SSL_CTX_set_cipher_list(*ssl_ctx, cipher_list);
-    if (ret != 1)
+    if (!TLSSetCipherList(*ssl_ctx, cipher_list))
     {
-        Log(LOG_LEVEL_ERR,
-            "No valid ciphers in cipher list: %s",
-            cipher_list);
         goto err;
     }
 

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -111,7 +111,11 @@ bool ServerTLSInitialize(RSA *priv_key, RSA *pub_key, SSL_CTX **ssl_ctx)
     const char *cipher_list = SERVER_ACCESS.allowciphers;
     if (cipher_list == NULL)
     {
+#ifdef SSL_OP_NO_TLSv1_3        /* defined if TLS 1.3 is supported */
         cipher_list = "AES256-GCM-SHA384:AES256-SHA:TLS_AES_256_GCM_SHA384";
+#else
+        cipher_list = "AES256-GCM-SHA384:AES256-SHA";
+#endif
     }
 
     if (!TLSSetCipherList(*ssl_ctx, cipher_list))

--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -259,7 +259,7 @@ static bool SetMaxOpenFiles(int n)
         Log(LOG_LEVEL_INFO, "Failed setting max open files limit"
             " (setrlimit(NOFILE, %d): %s)", n, GetErrorStr());
         Log(LOG_LEVEL_INFO,
-            "Please ensure that 'nofile' ulimit is at least 2x maxconnections");
+            "Please ensure that 'nofile' ulimit is at least 5x maxconnections");
         return false;
     }
     else
@@ -355,7 +355,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
                                                    + EnterpriseGetMaxCfHubProcesses() + 10);
 
                 /* Set RLIMIT_NOFILE to be enough for all threads. */
-                SetMaxOpenFiles(CFD_MAXPROCESSES * 2 + 10);
+                SetMaxOpenFiles(CFD_MAXPROCESSES * 5 + 10);
             }
             else if (IsControlBody(SERVER_CONTROL_CALL_COLLECT_INTERVAL))
             {

--- a/configure.ac
+++ b/configure.ac
@@ -466,6 +466,19 @@ CF3_WITH_LIBRARY(openssl, [
       test "x$ac_cv_lib_crypto_RSA_generate_key" = "xno" ; then
       AC_MSG_ERROR(Cannot find OpenSSL)
    fi
+
+   AC_CHECK_DECL([SSL_OP_NO_TLSv1_1],
+    [AC_DEFINE([HAVE_TLS_1_1], [1], [Define if TLS 1.1 is supported by OpenSSL])],
+    [], [[#include <openssl/ssl.h>]]
+    )
+   AC_CHECK_DECL([SSL_OP_NO_TLSv1_2],
+    [AC_DEFINE([HAVE_TLS_1_2], [1], [Define if TLS 1.2 is supported by OpenSSL])],
+    [], [[#include <openssl/ssl.h>]]
+    )
+   AC_CHECK_DECL([SSL_OP_NO_TLSv1_3],
+    [AC_DEFINE([HAVE_TLS_1_3], [1], [Define if TLS 1.3 is supported by OpenSSL])],
+    [], [[#include <openssl/ssl.h>]]
+    )
 ])
 
 dnl PCRE

--- a/libcfnet/tls_client.c
+++ b/libcfnet/tls_client.c
@@ -102,20 +102,9 @@ bool TLSClientInitialize(const char *tls_min_version,
 
     TLSSetDefaultOptions(SSLCLIENTCONTEXT, tls_min_version);
 
-    if (ciphers != NULL)
+    if (!TLSSetCipherList(SSLCLIENTCONTEXT, ciphers))
     {
-        Log(LOG_LEVEL_VERBOSE,
-            "Setting cipher list for outgoing TLS connections to: %s",
-            ciphers);
-
-        ret = SSL_CTX_set_cipher_list(SSLCLIENTCONTEXT, ciphers);
-        if (ret != 1)
-        {
-            Log(LOG_LEVEL_ERR,
-                "No valid ciphers in cipher list: %s",
-                ciphers);
-            goto err2;
-        }
+        goto err2;
     }
 
     /* Create cert into memory and load it into SSL context. */

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -855,9 +855,12 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
                 " however because of old OpenSSL version it is set to: %s",
                 min_version, compiletime_min_version);
         }
+        else
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Setting minimum acceptable TLS version: 1.1");
+        }
         options |= SSL_OP_NO_TLSv1;
-        Log(LOG_LEVEL_VERBOSE,
-            "Setting minimum acceptable TLS version: 1.1");
 
     }
     else if (StringSafeEqual(min_version, "1.2"))
@@ -869,9 +872,12 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
                 " however because of old OpenSSL version it is set to: %s",
                 min_version, compiletime_min_version);
         }
+        else
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Setting minimum acceptable TLS version: 1.2");
+        }
         options |= SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1;
-        Log(LOG_LEVEL_VERBOSE,
-            "Setting minimum acceptable TLS version: 1.2");
     }
     else if (StringSafeEqual(min_version, "1.3"))
     {
@@ -883,9 +889,12 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
                 " however because of old OpenSSL version it is set to: %s",
                 min_version, compiletime_min_version);
         }
+        else
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Setting minimum acceptable TLS version: 1.3");
+        }
         options |= SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2;
-        Log(LOG_LEVEL_VERBOSE,
-            "Setting minimum acceptable TLS version: 1.3");
     }
     else
     {

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -840,16 +840,16 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
     long options = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
 
     if (min_version == NULL
-        || strcmp(min_version, "1")   == 0
-        || strcmp(min_version, "1.0") == 0)
+        || StringSafeEqual(min_version, "1")
+        || StringSafeEqual(min_version, "1.0"))
     {
         /* Do nothing, that's our default setting */
         Log(LOG_LEVEL_VERBOSE,
             "Setting minimum acceptable TLS version: 1.0");
     }
-    else if (strcmp(min_version, "1.1") == 0)
+    else if (StringSafeEqual(min_version, "1.1"))
     {
-        if (strcmp(compiletime_min_version, "1.0") == 0)
+        if (StringSafeEqual(compiletime_min_version, "1.0"))
         {
             Log(LOG_LEVEL_WARNING, "Minimum requested TLS version is %s,"
                 " however because of old OpenSSL version it is set to: %s",
@@ -860,10 +860,10 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
             "Setting minimum acceptable TLS version: 1.1");
 
     }
-    else if (strcmp(min_version, "1.2") == 0)
+    else if (StringSafeEqual(min_version, "1.2"))
     {
-        if (strcmp(compiletime_min_version, "1.0") == 0 ||
-            strcmp(compiletime_min_version, "1.1") == 0)
+        if (StringSafeEqual(compiletime_min_version, "1.0") ||
+            StringSafeEqual(compiletime_min_version, "1.1"))
         {
             Log(LOG_LEVEL_WARNING, "Minimum requested TLS version is %s,"
                 " however because of old OpenSSL version it is set to: %s",
@@ -873,11 +873,11 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
         Log(LOG_LEVEL_VERBOSE,
             "Setting minimum acceptable TLS version: 1.2");
     }
-    else if (strcmp(min_version, "1.3") == 0)
+    else if (StringSafeEqual(min_version, "1.3"))
     {
-        if (strcmp(compiletime_min_version, "1.0") == 0 ||
-            strcmp(compiletime_min_version, "1.1") == 0 ||
-            strcmp(compiletime_min_version, "1.2") == 0)
+        if (StringSafeEqual(compiletime_min_version, "1.0") ||
+            StringSafeEqual(compiletime_min_version, "1.1") ||
+            StringSafeEqual(compiletime_min_version, "1.2"))
         {
             Log(LOG_LEVEL_WARNING, "Minimum requested TLS version is %s,"
                 " however because of old OpenSSL version it is set to: %s",

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -819,17 +819,21 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
     }
 #endif
 
-    const char *compiletime_min_version = "1.2";
+    const char *compiletime_min_version = "1.3";
 
-#ifndef  SSL_OP_NO_TLSv1_1
+#ifndef  SSL_OP_NO_TLSv1_2
+#   define SSL_OP_NO_TLSv1_2 0x0                                /* nop */
+    compiletime_min_version = "1.2";
+
+# ifndef  SSL_OP_NO_TLSv1_1
 #   define SSL_OP_NO_TLSv1_1 0x0                                /* nop */
     compiletime_min_version = "1.1";
 
-# ifndef  SSL_OP_NO_TLSv1
+#  ifndef  SSL_OP_NO_TLSv1
 #   define SSL_OP_NO_TLSv1 0x0                                  /* nop */
     compiletime_min_version = "1.0";
+#  endif
 # endif
-
 #endif
 
     /* In any case use only TLS v1 or later. */
@@ -868,6 +872,20 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
         options |= SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1;
         Log(LOG_LEVEL_VERBOSE,
             "Setting minimum acceptable TLS version: 1.2");
+    }
+    else if (strcmp(min_version, "1.3") == 0)
+    {
+        if (strcmp(compiletime_min_version, "1.0") == 0 ||
+            strcmp(compiletime_min_version, "1.1") == 0 ||
+            strcmp(compiletime_min_version, "1.2") == 0)
+        {
+            Log(LOG_LEVEL_WARNING, "Minimum requested TLS version is %s,"
+                " however because of old OpenSSL version it is set to: %s",
+                min_version, compiletime_min_version);
+        }
+        options |= SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2;
+        Log(LOG_LEVEL_VERBOSE,
+            "Setting minimum acceptable TLS version: 1.3");
     }
     else
     {

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -51,7 +51,6 @@ enum tls_version {
 /* determine the highest TLS version supported by the available/used version of
  * OpenSSL */
 #if defined(SSL_OP_NO_TLSv1_3)
-#define HAVE_TLS_1_3
 #define TLS_HIGHEST_SUPPORTED TLS_1_3
 #elif defined(SSL_OP_NO_TLSv1_2)
 #define TLS_HIGHEST_SUPPORTED TLS_1_2

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -974,6 +974,7 @@ bool TLSSetCipherList(SSL_CTX *ssl_ctx, const char *cipher_list)
         }
     }
 
+#ifdef SSL_OP_NO_TLSv1_3        /* defined if TLS 1.3 is supported */
     if (cipher_suites_len != 0) /* TLS >= 1.3 ciphers */
     {
         int ret = SSL_CTX_set_ciphersuites(ssl_ctx, cipher_suites);
@@ -994,6 +995,14 @@ bool TLSSetCipherList(SSL_CTX *ssl_ctx, const char *cipher_list)
             cipher_list);
         SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_TLSv1_3);
     }
+#else
+    if (cipher_suites_len != 0)
+    {
+        Log(LOG_LEVEL_WARNING,
+            "Ignoring requested TLS 1.3 ciphersuites '%s', TLS 1.3 not supported",
+            cipher_suites);
+    }
+#endif
 
     return true;
 }

--- a/libcfnet/tls_generic.h
+++ b/libcfnet/tls_generic.h
@@ -47,5 +47,6 @@ int TLSRecv(SSL *ssl, char *buffer, int toget);
 int TLSRecvLines(SSL *ssl, char *buf, size_t buf_size);
 void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version);
 const char *TLSErrorString(intmax_t errcode);
+bool TLSSetCipherList(SSL_CTX *ssl_ctx, const char *cipher_list);
 
 #endif

--- a/libpromises/feature.c
+++ b/libpromises/feature.c
@@ -14,6 +14,17 @@ static const char* features[] = {
 #ifdef HAVE_LIBCURL
     "curl",
 #endif
+    "tls_1_0",                  /* we require versions of OpenSSL that support
+                                 * at least TLS 1.0 */
+#ifdef HAVE_TLS_1_1
+    "tls_1_1",
+#endif
+#ifdef HAVE_TLS_1_2
+    "tls_1_2",
+#endif
+#ifdef HAVE_TLS_1_3
+    "tls_1_3",
+#endif
     "def_json_preparse",
     NULL
 };


### PR DESCRIPTION
Merge together:
https://github.com/cfengine/buildscripts/pull/454

This requires OpenSSL 1.1.1 so it only has a chance to compile and pass tests when combined with https://github.com/cfengine/buildscripts/pull/454.