### PR TITLE
ENT-4136: Made SetJoin and StringSetJoin optionally copy elements

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -449,8 +449,8 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 else
                 {
-                    StringSetJoin(config->heap_soft, defined_classes);
-                    free(defined_classes);
+                    StringSetJoin(config->heap_soft, defined_classes, xstrdup);
+                    StringSetDestroy(defined_classes);
                 }
             }
             break;
@@ -464,8 +464,8 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 else
                 {
-                    StringSetJoin(config->heap_negated, negated_classes);
-                    free(negated_classes);
+                    StringSetJoin(config->heap_negated, negated_classes, xstrdup);
+                    StringSetDestroy(negated_classes);
                 }
             }
             break;

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -206,8 +206,8 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 else
                 {
-                    StringSetJoin(config->heap_soft, defined_classes);
-                    free(defined_classes);
+                    StringSetJoin(config->heap_soft, defined_classes, xstrdup);
+                    StringSetDestroy(defined_classes);
                 }
             }
             break;
@@ -221,8 +221,8 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 else
                 {
-                    StringSetJoin(config->heap_negated, negated_classes);
-                    free(negated_classes);
+                    StringSetJoin(config->heap_negated, negated_classes, xstrdup);
+                    StringSetDestroy(negated_classes);
                 }
             }
             break;

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -370,8 +370,8 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 else
                 {
-                    StringSetJoin(config->heap_soft, defined_classes);
-                    free(defined_classes);
+                    StringSetJoin(config->heap_soft, defined_classes, xstrdup);
+                    StringSetDestroy(defined_classes);
                 }
             }
             break;
@@ -385,8 +385,8 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 else
                 {
-                    StringSetJoin(config->heap_negated, negated_classes);
-                    free(negated_classes);
+                    StringSetJoin(config->heap_negated, negated_classes, xstrdup);
+                    StringSetDestroy(negated_classes);
                 }
             }
             break;

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -183,8 +183,8 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 else
                 {
-                    StringSetJoin(config->heap_soft, defined_classes);
-                    free(defined_classes);
+                    StringSetJoin(config->heap_soft, defined_classes, xstrdup);
+                    StringSetDestroy(defined_classes);
                 }
             }
             break;
@@ -198,8 +198,8 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 else
                 {
-                    StringSetJoin(config->heap_negated, negated_classes);
-                    free(negated_classes);
+                    StringSetJoin(config->heap_negated, negated_classes, xstrdup);
+                    StringSetDestroy(negated_classes);
                 }
             }
             break;

--- a/libutils/set.c
+++ b/libutils/set.c
@@ -92,7 +92,7 @@ void *SetIteratorNext(SetIterator *i)
     return kv ? kv->key : NULL;
 }
 
-void SetJoin(Set *set, Set *otherset)
+void SetJoin(Set *set, Set *otherset, SetElementCopyFn copy_function)
 {
     assert(set != NULL);
     assert(otherset != NULL);
@@ -104,6 +104,10 @@ void SetJoin(Set *set, Set *otherset)
 
     for (ptr = SetIteratorNext(&si); ptr != NULL; ptr = SetIteratorNext(&si))
     {
+        if (copy_function != NULL)
+        {
+            ptr = copy_function(ptr);
+        }
         SetAdd(set, ptr);
     }
 }

--- a/libutils/set.h
+++ b/libutils/set.h
@@ -31,6 +31,7 @@
 
 typedef Map Set;
 typedef MapIterator SetIterator;
+typedef void *(*SetElementCopyFn)(const void *);
 
 Set *SetNew(MapHashFn element_hash_fn,
             MapKeyEqualFn element_equal_fn,
@@ -38,7 +39,7 @@ Set *SetNew(MapHashFn element_hash_fn,
 void SetDestroy(Set *set);
 
 void SetAdd(Set *set, void *element);
-void SetJoin(Set *set, Set *otherset);
+void SetJoin(Set *set, Set *otherset, SetElementCopyFn copy_function);
 bool SetContains(const Set *set, const void *element);
 bool SetRemove(Set *set, const void *element);
 void SetClear(Set *set);
@@ -54,12 +55,13 @@ void *SetIteratorNext(SetIterator *i);
     {                                                                   \
         Set *impl;                                                      \
     } Prefix##Set;                                                      \
+    typedef ElementType(*Prefix##CopyFn)(const ElementType);            \
                                                                         \
     typedef SetIterator Prefix##SetIterator;                            \
                                                                         \
     Prefix##Set *Prefix##SetNew(void);                                  \
     void Prefix##SetAdd(const Prefix##Set *set, ElementType element);   \
-    void Prefix##SetJoin(const Prefix##Set *set, const Prefix##Set *otherset); \
+    void Prefix##SetJoin(const Prefix##Set *set, const Prefix##Set *otherset, Prefix##CopyFn copy_function); \
     bool Prefix##SetContains(const Prefix##Set *Set, const ElementType element);  \
     bool Prefix##SetRemove(const Prefix##Set *Set, const ElementType element);  \
     void Prefix##SetClear(Prefix##Set *set);                            \
@@ -83,9 +85,9 @@ void *SetIteratorNext(SetIterator *i);
         SetAdd(set->impl, (void *)element);                             \
     }                                                                   \
                                                                         \
-    void Prefix##SetJoin(const Prefix##Set *set, const Prefix##Set *otherset) \
+    void Prefix##SetJoin(const Prefix##Set *set, const Prefix##Set *otherset, Prefix##CopyFn copy_function) \
     {                                                                   \
-        SetJoin(set->impl, otherset->impl);                             \
+        SetJoin(set->impl, otherset->impl, (SetElementCopyFn) copy_function);              \
     }                                                                   \
                                                                         \
     bool Prefix##SetContains(const Prefix##Set *set, const ElementType element)   \

--- a/tests/unit/set_test.c
+++ b/tests/unit/set_test.c
@@ -67,7 +67,8 @@ void test_stringset_join(void)
     {
         StringSet *set1 = StringSetNew();
         StringSet *set2 = StringSetNew();
-        StringSetJoin(set1, set2);
+        StringSetJoin(set1, set2, xstrdup);
+        StringSetDestroy(set2);
 
         assert_int_equal(0, StringSetSize(set1));
 
@@ -78,13 +79,12 @@ void test_stringset_join(void)
 
         BufferDestroy(buff);
         StringSetDestroy(set1);
-        StringSetDestroy(set2);
     }
 
     {
         StringSet *set = StringSetNew();
         StringSetAdd(set, xstrdup("foo"));
-        StringSetJoin(set, set);
+        StringSetJoin(set, set, xstrdup);
 
         assert_int_equal(1, StringSetSize(set));
 
@@ -102,16 +102,17 @@ void test_stringset_join(void)
         StringSet *set2 = StringSetNew();
         StringSetAdd(set1, xstrdup("foo"));
         StringSetAdd(set2, xstrdup("bar"));
-        StringSetJoin(set1, set2);
+        StringSetJoin(set1, set2, xstrdup);
+        StringSetDestroy(set2);
 
         assert_int_equal(2, StringSetSize(set1));
 
         Buffer *buff = StringSetToBuffer(set1, ',');
+        StringSetDestroy(set1);
 
         assert_true(buff);
         assert_string_equal(BufferData(buff), "foo,bar");
 
-        StringSetDestroy(set1);
         BufferDestroy(buff);
     }
 }


### PR DESCRIPTION
This fixes some small memory leaks in argument parsing
for cf-agent, cf-execd, cf-promises, and cf-serverd.
These leaks were not so serious, as they only happen
once, during startup (they don't increase over time).
It also fixes a memory leak in set_test.

This part of the code is also not performance critical,
so the extra copying should be no problem.

Before this change it was impossible to use SetJoin
without leaking memory. This is because SetJoin reused
elements from second argument, so you end up with 2 sets
with pointers to the same data. Sets only have keys, so there
is no soft destroy function.

Now, if you use the copy function parameter to SetJoin, for
example with xstrdup, both sets can be destroyed using normal
SetDestroy.

StringSetJoin could be made to always use xstrdup, however,
I like the current approach (pass by arg) better because:

1) It is the same as SetJoin
2) It is more explicit, it is more clear what this does:

   StringSetJoin(a, b, xstrdup);