### PR TITLE
[3.10.x] Respect windows newlines when splitting data in PipeReadData()

### DIFF
--- a/libpromises/pipes.c
+++ b/libpromises/pipes.c
@@ -159,7 +159,14 @@ Rlist *PipeReadData(const IOData *io, int pipe_timeout_secs, int pipe_terminatio
     }
 
     char *read_string = BufferClose(data);
-    Rlist *response_lines = RlistFromSplitString(read_string, '\n');
+
+#ifdef __MINGW32__
+    bool detect_crlf = true;
+#else
+    bool detect_crlf = false;
+#endif
+
+    Rlist *response_lines = RlistFromStringSplitLines(read_string, detect_crlf);
     free(read_string);
 
     return response_lines;

--- a/libpromises/rlist.h
+++ b/libpromises/rlist.h
@@ -89,6 +89,7 @@ Rlist *RlistAppend(Rlist **start, const void *item, RvalType type);
 Rlist *RlistAppendAllTypes(Rlist **start, const void *item, RvalType type, bool all_types);
 
 Rlist *RlistFromSplitString(const char *string, char sep);
+Rlist *RlistFromStringSplitLines(const char *string, bool detect_crlf);
 Rlist *RlistFromSplitRegex(const char *string, const char *regex, size_t max_entries, bool allow_blanks);
 Rlist *RlistFromRegexSplitNoOverflow(const char *string, const char *regex, int max);
 Rlist *RlistFromContainer(const JsonElement *container);


### PR DESCRIPTION
This needs to do different things on Windows and UNIX-like systems.

Add a function to split string on newlines to do so because it is
not trivial because the "\r\n" 2-byte sequence
represents a newline on Windows.

Ticket: ENT-3716
Changelog: None
(cherry picked from commit aad945ff22e2f84cb601810db9df409f06aca8da)