### PR TITLE
CFE-2887: Test classes defined by module protocol are automatically canonified

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7853,6 +7853,15 @@ void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print
 
             BufferDestroy(tagbuf);
         }
+        else
+        {
+            Log(LOG_LEVEL_VERBOSE, "Automatically canonifying '%s'", content);
+            CanonifyNameInPlace(content);
+            Log(LOG_LEVEL_VERBOSE, "Automatically canonified to '%s'", content);
+            Buffer *tagbuf = StringSetToBuffer(tags, ',');
+            EvalContextClassPutSoft(ctx, content, CONTEXT_SCOPE_NAMESPACE, BufferData(tagbuf));
+            BufferDestroy(tagbuf);
+        }
         break;
     case '-':
         if (length > CF_MAXVARSIZE)
@@ -8060,10 +8069,9 @@ static bool CheckID(const char *id)
     {
         if (!CheckIDChar(*sp))
         {
-            Log(LOG_LEVEL_ERR,
+            Log(LOG_LEVEL_WARNING,
                   "Module protocol contained an illegal character '%c' in class/variable identifier '%s'.", *sp,
                   id);
-            return false;
         }
     }
 

--- a/tests/acceptance/08_commands/01_modules/classes-automatically-canonified.cf
+++ b/tests/acceptance/08_commands/01_modules/classes-automatically-canonified.cf
@@ -1,0 +1,49 @@
+body common control
+{
+        inputs => { "../../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+
+      "description"
+        string => "Test that classes defined via the module protocol are
+                   automatically canonified.";
+
+  classes:
+      "my-invalid-class"
+        expression => "any",
+        scope => "namespace";
+
+  commands:
+      "$(G.echo) +invalid-class@module"
+        module => "true";
+
+  reports:
+    (EXTRA|DEBUG).invalid_class_module::
+      "Class defined from module automatically canonified as expected";
+
+    (EXTRA|DEBUG).!invalid_class_module::
+      "Class defined from module NOT automatically canonified";
+
+    (EXTRA|DEBUG).my_invalid_class::
+      "My class was automatically canonified as expected";
+
+    (EXTRA|DEBUG).!my_invalid_class::
+      "My class was NOT automatically canonified";
+}
+bundle agent check
+{
+  classes:
+      "pass" and => { "my_invalid_class", "invalid_class_module" };
+
+  reports:
+    pass::
+      "$(this.promise_filename) Pass";
+
+    !pass::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Changelog: CFE-2877 Class names set by module protocol are automatically canonified
(cherry picked from commit dc44c8e550e756dacf318076e19460dcda97840f)