### PR TITLE
Asserts and checks for TYPED_MAP_DEFINE

### DIFF
--- a/libutils/map.h
+++ b/libutils/map.h
@@ -144,53 +144,68 @@ void MapPrintStats(const Map *map, FILE *f);
                                                                         \
     bool Prefix##MapInsert(const Prefix##Map *map, KeyType key, ValueType value) \
     {                                                                   \
+        assert(map);                                                    \
         return MapInsert(map->impl, key, value);                        \
     }                                                                   \
                                                                         \
     bool Prefix##MapHasKey(const Prefix##Map *map, const KeyType key)   \
     {                                                                   \
+        assert(map);                                                    \
         return MapHasKey(map->impl, key);                               \
     }                                                                   \
                                                                         \
     ValueType Prefix##MapGet(const Prefix##Map *map, const KeyType key) \
     {                                                                   \
+        assert(map);                                                    \
         return MapGet(map->impl, key);                                  \
     }                                                                   \
                                                                         \
     bool Prefix##MapRemove(const Prefix##Map *map, const KeyType key)   \
     {                                                                   \
+        assert(map);                                                    \
         return MapRemove(map->impl, key);                               \
     }                                                                   \
                                                                         \
     void Prefix##MapClear(Prefix##Map *map)                             \
     {                                                                   \
+        assert(map);                                                    \
         MapClear(map->impl);                                            \
     }                                                                   \
                                                                         \
     size_t Prefix##MapSize(const Prefix##Map *map)                      \
     {                                                                   \
+        assert(map);                                                    \
         return MapSize(map->impl);                                      \
     }                                                                   \
                                                                         \
     void Prefix##MapDestroy(Prefix##Map *map)                           \
     {                                                                   \
-        MapDestroy(map->impl);                                          \
-        free(map);                                                      \
+        if (map != NULL)                                                \
+        {                                                               \
+          MapDestroy(map->impl);                                        \
+          free(map);                                                    \
+        }                                                               \
     }                                                                   \
                                                                         \
     void Prefix##MapSoftDestroy(Prefix##Map *map)                       \
     {                                                                   \
-        MapSoftDestroy(map->impl);                                      \
-        free(map);                                                      \
+        if (map != NULL)                                                \
+        {                                                               \
+          MapSoftDestroy(map->impl);                                    \
+          free(map);                                                    \
+        }                                                               \
     }                                                                   \
                                                                         \
     bool Prefix##MapContainsSameKeys(const Prefix##Map *map1, const Prefix##Map *map2) \
     {                                                                   \
+        assert(map1);                                                   \
+        assert(map2);                                                   \
         return MapContainsSameKeys(map1->impl, map2->impl);             \
     }                                                                   \
                                                                         \
     void Prefix##MapPrintStats(const Prefix##Map *map, FILE *f)         \
     {                                                                   \
+        assert(map);                                                    \
         return MapPrintStats(map->impl, f);                             \
     }                                                                   \
 


### PR DESCRIPTION
This macro defines a typed map with many functions. Most of these
functions dereference their 'map' argument so they should assert
it's not NULL. The two exceptions are the `Prefix##MapDestroy()`
and `Prefix##MapSoftDestroy()` functions which should do nothing
when given `NULL`.