### PR TITLE
ENT-4110: unset LD_LIBRARY_PATH and LIBPATH in init scripts

### DIFF
--- a/misc/init.d/cfengine3.in
+++ b/misc/init.d/cfengine3.in
@@ -66,6 +66,10 @@ CFENTERPRISE_INITD=$PREFIX/bin/cfengine3-nova-hub-init-d.sh
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:$PREFIX/bin
 
+# ensure that we use RPATH/loader entries from our binaries and not from the environment
+unset LIBPATH		# AIX < 5.3
+unset LD_LIBRARY_PATH
+
 # Has the package been 'removed' but not purged?
 test -f $CFEXECD || exit 0
 


### PR DESCRIPTION
Just to be safe, let's unset these to ensure that our binaries use exactly the libraries they specify internally.