### PR TITLE
ENT-3858: Travis: Run unit tests with ASAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   include:
     - os: linux
       sudo: required
-      env: JOB_TYPE=compile_and_unit_test
+      env: JOB_TYPE=compile_and_unit_test_asan
     - os: linux
       sudo: required
       env: JOB_TYPE=valgrind_health_check

--- a/travis-scripts/script.sh
+++ b/travis-scripts/script.sh
@@ -52,6 +52,12 @@ then
     make -C tests/unit check
     make -C tests/load check
     exit
+elif [ "$JOB_TYPE" = compile_and_unit_test_asan ]
+then
+    make CFLAGS="-Werror -Wno-pointer-sign -fsanitize=address" LDFLAGS="-fsanitize=address -pthread"
+    make -C tests/unit CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address -pthread" check
+    make -C tests/load CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address -pthread" check
+    exit
 else
     make
 fi


### PR DESCRIPTION
AddressSanitizer (ASAN) adds instrumentation to binaries
to detect memory leaks, buffer overflows etc.

It is similar to valgrind, but detects other kinds of problems,
and is much more performant (but a makes it a little harder
to build).