### PR TITLE
Update man pages to remove harded 'agent' on verbose option

### DIFF
--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -105,7 +105,7 @@ static const char *const HINTS[] =
 {
     "Print the help message",
     "Enable debugging output",
-    "Output verbose information about the behaviour of the agent",
+    "Output verbose information about the behaviour of cf-execd",
     "All talk and no action mode - make no changes, only inform of promises not kept",
     "Output the version of the software",
     "Specify an alternative input file than the default. This option is overridden by FILE if supplied as argument.",

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -94,7 +94,7 @@ static const char *const HINTS[] =
     "Print the help message",
     "Print basic information about key generation",
     "Enable debugging output",
-    "Output verbose information about the behaviour of the agent",
+    "Output verbose information about the behaviour of cf-key",
     "Output the version of the software",
     "Specify how detailed logs should be. Possible values: 'error', 'warning', 'notice', 'info', 'verbose', 'debug'",
     "Specify an alternative output file than the default.",

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -96,7 +96,7 @@ static const char *const HINTS[] =
 {
     "Print the help message",
     "Enable debugging output",
-    "Output verbose information about the behaviour of the agent",
+    "Output verbose information about the behaviour of cf-monitord",
     "All talk and no action mode - make no changes, only inform of promises not kept",
     "Output the version of the software",
     "Ignore system lock",

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -102,7 +102,7 @@ static const char *const HINTS[] =
     "Print the help message",
     "Use the specified bundlesequence for verification",
     "Enable debugging output",
-    "Output verbose information about the behaviour of the agent",
+    "Output verbose information about the behaviour of cf-promises",
     "Specify how detailed logs should be. Possible values: 'error', 'warning', 'notice', 'info', 'verbose', 'debug'",
     "All talk and no action mode - make no changes, only inform of promises not kept",
     "Output the version of the software",

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -123,7 +123,7 @@ static const char *const HINTS[] =
     "Print the help message",
     "Parallelize connections (50 by default)",
     "Enable debugging output",
-    "Output verbose information about the behaviour of the agent",
+    "Output verbose information about the behaviour of cf-runagent",
     "Specify how detailed logs should be. Possible values: 'error', 'warning', 'notice', 'info', 'verbose', 'debug'",
     "All talk and no action mode - make no changes, only inform of promises not kept",
     "Output the version of the software",


### PR DESCRIPTION
I ran into this in https://support.northern.tech/hc/en-us/requests/4073

man page for cf-runagent said

-v

Output verbose information about the behaviour of the agent

but it didn't; it output verbose information about the behavior of cf-runagent.

Nick Anderson suggested I update the man pages by editing these C files,
so here you go.