### PR TITLE
ENT-3725: Added a new C macro, assert_or_return

### DIFF
--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -43,7 +43,7 @@ libutils_la_SOURCES = \
 	statistics.c statistics.h \
 	string_lib.c string_lib.h \
 	pcre_include.h \
-	platform.h \
+	platform.h condition_macros.h \
 	proc_keyvalue.c proc_keyvalue.h \
 	bool.h \
 	json.c json.h json-priv.h \

--- a/libutils/condition_macros.h
+++ b/libutils/condition_macros.h
@@ -1,0 +1,20 @@
+#ifndef __CONDITION_MACROS_H__
+#define __CONDITION_MACROS_H__
+
+#include <assert.h>
+
+// Used when you want to assert a precondtion (catch programmer mistake)
+// but also want to handle the error if it ever happens in a release build.
+// This is mainly for tightening existing functions used in many places
+// New functions should usually choose one or the other (handle error or asssert)
+#ifndef assert_or_return
+#define assert_or_return(expr, val) { \
+    assert(expr);                     \
+    if (!(expr))                      \
+    {                                 \
+        return val;                   \
+    }                                 \
+}
+#endif
+
+#endif

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -1025,7 +1025,7 @@ struct timespec
 #  define SUNOS_5
 # endif
 
-
+#include <condition_macros.h>
 
 /* Must be always the last one! */
 #include <deprecated.h>


### PR DESCRIPTION
A small part of: https://tracker.mender.io/browse/ENT-3725