### PR TITLE
ENT-4064: help and version commands in cf-check

### DIFF
--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -2,6 +2,29 @@
 #include <diagnose.h>
 #include <string_lib.h>
 
+static void print_help()
+{
+    printf(
+        "\n"
+        "cf-check:\n"
+        "\tUtility for diagnosis and repair of local CFEngine databases.\n"
+        "\tThis BETA version of the tool is for testing purposes only.\n"
+        "\n"
+        "Commands:\n"
+        "\tdump - Print the contents of a database file\n"
+        "\tdiagnose - Assess the health of one or more database files\n"
+        "\thelp - Print this help menu\n"
+        "\n"
+        "Usage:\n"
+        "\t$ cf-check command [options]\n"
+        "\n"
+        "Examples:\n"
+        "\t$ cf-check dump -a /var/cfengine/state/cf_lastseen.lmdb\n"
+        "\t$ cf-check diagnose /var/cfengine/state/*.lmdb\n"
+        "\n"
+    );
+}
+
 int main(int argc, char **argv)
 {
     if (StringEndsWith(argv[0], "lmdump"))
@@ -12,7 +35,8 @@ int main(int argc, char **argv)
 
     if (argc < 2)
     {
-        printf("Need to supply a command, for example 'cf-check lmdump'\n");
+        print_help();
+        printf("No command given.\n");
         return 1;
     }
 
@@ -30,6 +54,15 @@ int main(int argc, char **argv)
         return diagnose_main(cmd_argc, cmd_argv);
     }
 
+    if (StringSafeEqual_IgnoreCase(command, "help") ||
+        StringSafeEqual_IgnoreCase(command, "--help") ||
+        StringSafeEqual_IgnoreCase(command, "-h"))
+    {
+        print_help();
+        return 0;
+    }
+
+    print_help();
     printf("Unrecognized command: '%s'\n", command);
     return 1;
 }

--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -20,11 +20,11 @@ int main(int argc, char **argv)
     char **cmd_argv = argv + 1;
     char *command = cmd_argv[0];
 
-    if (StringSafeEqual(command, "lmdump"))
+    if (StringSafeEqual_IgnoreCase(command, "lmdump"))
     {
         return lmdump_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual(command, "diagnose"))
+    if (StringSafeEqual_IgnoreCase(command, "diagnose"))
     {
         return diagnose_main(cmd_argc, cmd_argv);
     }

--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -2,6 +2,11 @@
 #include <diagnose.h>
 #include <string_lib.h>
 
+static void print_version()
+{
+    printf("cf-check BETA version %s\n", VERSION);
+}
+
 static void print_help()
 {
     printf(
@@ -13,6 +18,7 @@ static void print_help()
         "Commands:\n"
         "\tdump - Print the contents of a database file\n"
         "\tdiagnose - Assess the health of one or more database files\n"
+        "\tversion - Print version information\n"
         "\thelp - Print this help menu\n"
         "\n"
         "Usage:\n"
@@ -59,6 +65,14 @@ int main(int argc, char **argv)
         StringSafeEqual_IgnoreCase(command, "-h"))
     {
         print_help();
+        return 0;
+    }
+
+    if (StringSafeEqual_IgnoreCase(command, "version") ||
+        StringSafeEqual_IgnoreCase(command, "--version") ||
+        StringSafeEqual_IgnoreCase(command, "-V"))
+    {
+        print_version();
         return 0;
     }
 

--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -20,7 +20,8 @@ int main(int argc, char **argv)
     char **cmd_argv = argv + 1;
     char *command = cmd_argv[0];
 
-    if (StringSafeEqual_IgnoreCase(command, "lmdump"))
+    if (StringSafeEqual_IgnoreCase(command, "lmdump") ||
+        StringSafeEqual_IgnoreCase(command, "dump"))
     {
         return lmdump_main(cmd_argc, cmd_argv);
     }


### PR DESCRIPTION
Example:
```
root@dev core $ cf-check

cf-check:
        Utility for diagnosis and repair of local CFEngine databases.
        This BETA version of the tool is for testing purposes only.

Commands:
        dump - Print the contents of a database file
        diagnose - Assess the health of one or more database files
        version - Print version information
        help - Print this help menu

Usage:
        $ cf-check command [options]

Examples:
        $ cf-check dump -a /var/cfengine/state/cf_lastseen.lmdb
        $ cf-check diagnose /var/cfengine/state/*.lmdb

No command given.
root@dev core $ cf-check version
cf-check BETA version 3.13.0a.9f1942a
root@dev core $ cf-check -V
cf-check BETA version 3.13.0a.9f1942a
root@dev core $ cf-check dump -a /var/cfengine/state/cf_lastseen.lmdb
key: 0x7f356a0f0f34[16] a192.168.100.10, data: 0x7f356a0f0f44[37] MD5=4e0ea665461330cc5b40a4001727ff4e
key: 0x7f356a0f0f72[38] kMD5=4e0ea665461330cc5b40a4001727ff4e, data: 0x7f356a0f0f98[15] 192.168.100.10
key: 0x7f356a0f0fb0[39] qoMD5=4e0ea665461330cc5b40a4001727ff4e, data: 0x7f356a0f0fd7[40] [
root@dev core $ cf-check diagnose /var/cfengine/state/*.lmdb
Status of '/var/cfengine/state/cf_lastseen.lmdb': OK
Status of '/var/cfengine/state/cf_lock.lmdb': OK
Status of '/var/cfengine/state/cf_observations.lmdb': OK
Status of '/var/cfengine/state/cf_state.lmdb': OK
Status of '/var/cfengine/state/history.lmdb': OK
Status of '/var/cfengine/state/nova_measures.lmdb': OK
Status of '/var/cfengine/state/nova_static.lmdb': OK
Status of '/var/cfengine/state/packages_installed_apt_get.lmdb': OK
Status of '/var/cfengine/state/packages_installed_$(package_module_knowledge.platform_default).lmdb': OK
Status of '/var/cfengine/state/packages_updates_apt_get.lmdb': OK
All 10 databases healthy
root@dev core $
```