### PR TITLE
CF-2951: ps command can handle longer usernames

### DIFF
--- a/libpromises/systype.c
+++ b/libpromises/systype.c
@@ -99,7 +99,7 @@ const char *const VPSOPTS[] =
     [PLATFORM_CONTEXT_HP] = "-ef",                    /* hpux */
     [PLATFORM_CONTEXT_AIX] =  "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args",       /* aix */
     /* Note: keep in sync with GetProcessOptions()'s hack for Linux 2.4 */
-    [PLATFORM_CONTEXT_LINUX] = "-eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss:9,nlwp,stime,etime,time,args",/* linux */
+    [PLATFORM_CONTEXT_LINUX] = "-eo user:30,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss:9,nlwp,stime,etime,time,args",/* linux */
     [PLATFORM_CONTEXT_BUSYBOX] = "",                  /* linux / busybox */
     [PLATFORM_CONTEXT_SOLARIS] = "-eo user,pid,pcpu,pmem,osz,rss,tty,s,stime,time,args",                  /* solaris >= 11 */
     [PLATFORM_CONTEXT_SUN_SOLARIS] = "-eo user,pid,pcpu,pmem,osz,rss,tty,s,stime,time,args",              /* solaris < 11 */

--- a/tests/unit/mon_processes_test.c
+++ b/tests/unit/mon_processes_test.c
@@ -49,7 +49,7 @@ static bool GetSysUsers( int *userListSz, int *numRootProcs, int *numOtherProcs)
     /* SKIP on HP-UX since cf-monitord doesn't count processes correctly! */
     return false;
 #else
-    xsnprintf(cbuff, CF_BUFSIZE, "ps -eo user,pid > %s/users.txt", CFWORKDIR);
+    xsnprintf(cbuff, CF_BUFSIZE, "ps -eo user:30,pid > %s/users.txt", CFWORKDIR);
 #endif
 
     Item *userList = NULL;


### PR DESCRIPTION
Increased it to 30 chars instead of 8

Changelog: title