### PR TITLE
Add colorization to cf-diag.sh

### DIFF
--- a/contrib/cf-diag/cf-diag.sh
+++ b/contrib/cf-diag/cf-diag.sh
@@ -34,11 +34,15 @@ outcome() {
 }
 
 succeed() {
+  [ -t 1 ] && printf '\e[0;32m'
   outcome ok "$@"
+  [ -t 1 ] && printf '\e[0m'
 }
 
 fail() {
+  [ -t 1 ] && printf '\e[0;31m'
   outcome 'not ok' "$@"
+  [ -t 1 ] && printf '\e[0m'
 }
 
 bail() {


### PR DESCRIPTION
Add colorization to cf-diag to make it easier for operators to find and fix problems.

It only colorizes the output if stdout is pointing to a tty.

We could have gotten fancier and added an option to force color regardless, but I don't think that's necessary.

This change was made by @mikeweilgart, I am just forwarding it upstream.