### PR TITLE
Allow sourcing the init script from state restore

### DIFF
--- a/misc/init.d/cfengine3.in
+++ b/misc/init.d/cfengine3.in
@@ -677,7 +677,9 @@ case "$1" in
         $0 start
         ;;
     *)
-        echo "Usage: $0 {start|stop|status|restart|reload|force-reload}" >&2
-        exit 1
+        if [ "x$CALLED_FROM_STATE_RESTORE" != "x1" ]; then
+          echo "Usage: $0 {start|stop|status|restart|reload|force-reload}" >&2
+          exit 1
+        fi
         ;;
 esac


### PR DESCRIPTION
This way we can use the functions from the init script in the
state restoration process where we need to start daemons.

Ticket: ENT-4313