### PR TITLE
CFE-2768: Added function to filter CSV by class expressions

### DIFF
--- a/tests/acceptance/01_vars/02_functions/classfiltercsv_1.cf
+++ b/tests/acceptance/01_vars/02_functions/classfiltercsv_1.cf
@@ -1,0 +1,51 @@
+body common control
+{
+        inputs => { "../../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2768" }
+        string => "Test that classfiltercsv() works:
+                   - column headings
+                   - simple filtering (no duplicates after filter)
+                   - no sorting";
+
+}
+bundle agent check
+{
+  vars:
+      "data_file" string => "$(this.promise_filename).csv";
+      "d" data => classfiltercsv( $(data_file),
+                                  "true", # Data file contains column headings
+                                  0);     # Column containing class expression to filter with
+
+  classes:
+
+      # Check if Token has the value we expect
+      "Token_OK" expression => strcmp( "$(d[0][Token])", "net.ipv4.ip_forward" );
+
+      # Check if Value has the value we expect
+      "Value_OK" expression => strcmp( "$(d[0][Value])", "ANYVALUE" );
+
+      # Check if the result contains the number of records we expect.
+      "Length_OK" expression => strcmp( length( d ), 1 );
+
+  methods:
+
+      "Pass/FAIL"
+        usebundle => dcs_passif_expected( 'Token_OK,Value_OK,Length_OK', '', $(this.promise_filename) ),
+        inherit => "true";
+
+  reports:
+      DEBUG|EXTRA::
+      "Function returned:$(with)" with => string_mustache( "{{%-top-}}", d );
+
+      "supercalifragilisticexpialidociousNOTDEFINED is actually defined."
+        if => "supercalifragilisticexpialidociousNOTDEFINED";
+      "supercalifragilisticexpialidociousNOTDEFINED is not defined (as expected)"
+        unless => "supercalifragilisticexpialidociousNOTDEFINED";
+}

--- a/tests/acceptance/01_vars/02_functions/classfiltercsv_1.cf.csv
+++ b/tests/acceptance/01_vars/02_functions/classfiltercsv_1.cf.csv
@@ -1,0 +1,3 @@
+ClassExpr,Token,Value
+any,net.ipv4.ip_forward,ANYVALUE
+supercalifragilisticexpialidociousNOTDEFINED,net.ipv4.ip_forward,SHOULD_BE_FILTERED_OUT

--- a/tests/acceptance/01_vars/02_functions/classfiltercsv_2.cf
+++ b/tests/acceptance/01_vars/02_functions/classfiltercsv_2.cf
@@ -1,0 +1,51 @@
+body common control
+{
+        inputs => { "../../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2768" }
+        string => "Test that classfiltercsv() works:
+                   - no column headings
+                   - simple filtering (no duplicates after filter)
+                   - no sorting";
+
+}
+bundle agent check
+{
+  vars:
+      "data_file" string => "$(this.promise_filename).csv";
+      "d" data => classfiltercsv( $(data_file),
+                                  "false", # Data file contains column headings
+                                  0);      # Column containing class expression to filter with
+
+  classes:
+
+      # Check if Token has the value we expect
+      "Token_OK" expression => strcmp( "$(d[0][0])", "net.ipv4.ip_forward" );
+
+      # Check if Value has the value we expect
+      "Value_OK" expression => strcmp( "$(d[0][1])", "ANYVALUE" );
+
+      # Check if the result contains the number of records we expect.
+      "Length_OK" expression => strcmp( length( d ), 1 );
+
+  methods:
+
+      "Pass/FAIL"
+        usebundle => dcs_passif_expected( 'Token_OK,Value_OK,Length_OK', '', $(this.promise_filename) ),
+        inherit => "true";
+
+  reports:
+      DEBUG|EXTRA::
+      "Function returned:$(with)" with => string_mustache( "{{%-top-}}", d );
+
+      "supercalifragilisticexpialidociousNOTDEFINED is actually defined."
+        if => "supercalifragilisticexpialidociousNOTDEFINED";
+      "supercalifragilisticexpialidociousNOTDEFINED is not defined (as expected)"
+        unless => "supercalifragilisticexpialidociousNOTDEFINED";
+}

--- a/tests/acceptance/01_vars/02_functions/classfiltercsv_2.cf.csv
+++ b/tests/acceptance/01_vars/02_functions/classfiltercsv_2.cf.csv
@@ -1,0 +1,2 @@
+any,net.ipv4.ip_forward,ANYVALUE
+supercalifragilisticexpialidociousNOTDEFINED,net.ipv4.ip_forward,SHOULD_BE_FILTERED_OUT

--- a/tests/acceptance/01_vars/02_functions/classfiltercsv_3.cf
+++ b/tests/acceptance/01_vars/02_functions/classfiltercsv_3.cf
@@ -1,0 +1,52 @@
+body common control
+{
+        inputs => { "../../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2768" }
+        string => "Test that classfiltercsv() works:
+                   - column headings
+                   - simple filtering (no duplicates after filter)
+                   - sorting";
+
+}
+bundle agent check
+{
+  vars:
+      "data_file" string => "$(this.promise_filename).csv";
+      "d" data => classfiltercsv( $(data_file),
+                                  "true", # Data file contains column headings
+                                  0,      # Column containing class expression to filter with
+                                  1);     # Column to sort by (NOT IMPLEMENTED AT TIME OF TEST)
+
+  classes:
+
+      # Check if Token has the value we expect
+      "Token_OK" expression => strcmp( "$(d[0][Token])", "net.ipv4.ip_forward" );
+
+      # Check if Value has the value we expect
+      "Value_OK" expression => strcmp( "$(d[0][Value])", "ANYVALUE-sort0" );
+
+      # Check if the result contains the number of records we expect.
+      "Length_OK" expression => isgreaterthan( length( d ), 0);
+
+  methods:
+
+      "Pass/FAIL"
+        usebundle => dcs_passif_expected( 'Token_OK,Value_OK,Length_OK', '', $(this.promise_filename) ),
+        inherit => "true";
+
+  reports:
+      DEBUG|EXTRA::
+      "Function returned:$(with)" with => string_mustache( "{{%-top-}}", d );
+
+      "supercalifragilisticexpialidociousNOTDEFINED is actually defined."
+        if => "supercalifragilisticexpialidociousNOTDEFINED";
+      "supercalifragilisticexpialidociousNOTDEFINED is not defined (as expected)"
+        unless => "supercalifragilisticexpialidociousNOTDEFINED";
+}

--- a/tests/acceptance/01_vars/02_functions/classfiltercsv_3.cf.csv
+++ b/tests/acceptance/01_vars/02_functions/classfiltercsv_3.cf.csv
@@ -1,0 +1,6 @@
+ClassExpr,SORT,Token,Value
+any,1,net.ipv4.ip_forward,ANYVALUE-sort1
+any,a,net.ipv4.ip_forward,ANYVALUE-sorta
+any,A,net.ipv4.ip_forward,ANYVALUE-sortA
+supercalifragilisticexpialidociousNOTDEFINED,0,net.ipv4.ip_forward,SHOULD_BE_FILTERED_OUT
+any,0,net.ipv4.ip_forward,ANYVALUE-sort0

--- a/tests/acceptance/01_vars/02_functions/classfiltercsv_4.cf
+++ b/tests/acceptance/01_vars/02_functions/classfiltercsv_4.cf
@@ -1,0 +1,51 @@
+body common control
+{
+        inputs => { "../../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2768" }
+        string => "Test that classfiltercsv() works:
+                   - column headings
+                   - simple filtering (no duplicates after filter)
+                   - no sorting
+                   - 2 invalid rows, one that would be included, and one that would be filtered out are both ignored";
+}
+bundle agent check
+{
+  vars:
+      "data_file" string => "$(this.promise_filename).csv";
+      "d" data => classfiltercsv( $(data_file),
+                                  "true", # Data file contains column headings
+                                  0);      # Column containing class expression to filter with
+
+  classes:
+
+      # Check if Token has the value we expect
+      "Token_OK" expression => strcmp( "$(d[0][Token])", "net.ipv4.ip_forward" );
+
+      # Check if Value has the value we expect
+      "Value_OK" expression => strcmp( "$(d[0][Value])", "ANYVALUE" );
+
+      # Check if the result contains the number of records we expect.
+      "Length_OK" expression => strcmp( length( d ), 1 );
+
+  methods:
+
+      "Pass/FAIL"
+        usebundle => dcs_passif_expected( 'Token_OK,Value_OK,Length_OK', '', $(this.promise_filename) ),
+        inherit => "true";
+
+  reports:
+      DEBUG|EXTRA::
+      "Function returned:$(with)" with => string_mustache( "{{%-top-}}", d );
+
+      "supercalifragilisticexpialidociousNOTDEFINED is actually defined."
+        if => "supercalifragilisticexpialidociousNOTDEFINED";
+      "supercalifragilisticexpialidociousNOTDEFINED is not defined (as expected)"
+        unless => "supercalifragilisticexpialidociousNOTDEFINED";
+}

--- a/tests/acceptance/01_vars/02_functions/classfiltercsv_4.cf.csv
+++ b/tests/acceptance/01_vars/02_functions/classfiltercsv_4.cf.csv
@@ -1,0 +1,5 @@
+ClassExpr,Token,Value
+any,net.ipv4.ip_forward,ANYVALUE
+supercalifragilisticexpialidociousNOTDEFINED,net.ipv4.ip_forward,SHOULD_BE_FILTERED_OUT
+supercalifragilisticexpialidociousNOTDEFINED,net.ipv4.ip_forward,SHOULD,BE,FILTERED,OUT
+cfengine,net.ipv4.ip_forward,INVALID,SHOULD,BE,FILTERED,OUT

--- a/tests/acceptance/01_vars/02_functions/classfiltercsv_5.cf
+++ b/tests/acceptance/01_vars/02_functions/classfiltercsv_5.cf
@@ -1,0 +1,51 @@
+body common control
+{
+        inputs => { "../../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2768" }
+        string => "Test that classfiltercsv() works:
+                   - column headings
+                   - simple filtering (no duplicates after filter)
+                   - no sorting
+                   - empty rows";
+}
+bundle agent check
+{
+  vars:
+      "data_file" string => "$(this.promise_filename).csv";
+      "d" data => classfiltercsv( $(data_file),
+                                  "true", # Data file contains column headings
+                                  0);      # Column containing class expression to filter with
+
+  classes:
+
+      # Check if Token has the value we expect
+      "Token_OK" expression => strcmp( "$(d[0][Token])", "net.ipv4.ip_forward" );
+
+      # Check if Value has the value we expect
+      "Value_OK" expression => strcmp( "$(d[0][Value])", "ANYVALUE" );
+
+      # Check if the result contains the number of records we expect.
+      "Length_OK" expression => strcmp( length( d ), 1 );
+
+  methods:
+
+      "Pass/FAIL"
+        usebundle => dcs_passif_expected( 'Token_OK,Value_OK,Length_OK', '', $(this.promise_filename) ),
+        inherit => "true";
+
+  reports:
+      DEBUG|EXTRA::
+      "Function returned:$(with)" with => string_mustache( "{{%-top-}}", d );
+
+      "supercalifragilisticexpialidociousNOTDEFINED is actually defined."
+        if => "supercalifragilisticexpialidociousNOTDEFINED";
+      "supercalifragilisticexpialidociousNOTDEFINED is not defined (as expected)"
+        unless => "supercalifragilisticexpialidociousNOTDEFINED";
+}

--- a/tests/acceptance/01_vars/02_functions/classfiltercsv_5.cf.csv
+++ b/tests/acceptance/01_vars/02_functions/classfiltercsv_5.cf.csv
@@ -1,0 +1,7 @@
+ClassExpr,Token,Value
+
+
+any,net.ipv4.ip_forward,ANYVALUE
+
+
+supercalifragilisticexpialidociousNOTDEFINED,net.ipv4.ip_forward,SHOULD_BE_FILTERED_OUT


### PR DESCRIPTION
Will currently only filter data, does not remove duplicates and
such. Also cannot sort yet.

This is not ready to be merged, but I want feedback.

@nickanderson if you want to try it, you could check out my branch and compile it.