### PR TITLE
ENT-4313: Introduce function to clean up logging contexts (3.12)

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1007,11 +1007,13 @@ void EvalContextDestroy(EvalContext *ctx)
         free(ctx->launch_directory);
         free(ctx->entry_point);
 
+        // Freeing logging context doesn't belong here...
         {
             LoggingPrivContext *pctx = LoggingPrivGetContext();
             free(pctx);
             LoggingPrivSetContext(NULL);
         }
+        LoggingFreeCurrentThreadContext();
 
         EvalContextDeleteIpAddresses(ctx);
 

--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -66,6 +66,19 @@ LoggingContext *GetCurrentThreadContext(void)
     return lctx;
 }
 
+void LoggingFreeCurrentThreadContext(void)
+{
+    pthread_once(&log_context_init_once, &LoggingInitializeOnce);
+    LoggingContext *lctx = pthread_getspecific(log_context_key);
+    if (lctx == NULL)
+    {
+        return;
+    }
+    // lctx->pctx is usually stack allocated and shouldn't be freed
+    FREE_AND_NULL(lctx);
+    pthread_setspecific(log_context_key, NULL);
+}
+
 void LoggingSetAgentType(const char *type)
 {
     strlcpy(AgentType, type, sizeof(AgentType));

--- a/libutils/logging.h
+++ b/libutils/logging.h
@@ -92,6 +92,7 @@ LogLevel LogLevelFromString(const char *level);
 bool LoggingFormatTimestamp(char dest[64], size_t n, struct tm *timestamp);
 
 LoggingContext *GetCurrentThreadContext(void);
+void LoggingFreeCurrentThreadContext(void);
 
 void Log(LogLevel level, const char *fmt, ...) FUNC_ATTR_PRINTF(2, 3);
 void LogDebug(enum LogModule mod, const char *fmt, ...) FUNC_ATTR_PRINTF(2, 3);


### PR DESCRIPTION
This can be used to eliminate potential small memory leaks
in multi-threaded programs, like cf-hub and cf-serverd.