### PR TITLE
ENT-4064: cf-check: diagnose and backup now use state directory by default

### DIFF
--- a/cf-check/Makefile.am
+++ b/cf-check/Makefile.am
@@ -24,17 +24,25 @@
 noinst_LTLIBRARIES = libcf-check.la
 
 AM_CPPFLAGS = -I$(srcdir)/../libutils \
+	$(PCRE_CPPFLAGS) \
+	$(LIBYAML_CPPFLAGS) \
 	$(LMDB_CPPFLAGS)
 
 AM_CFLAGS = \
 	$(LMDB_CFLAGS) \
+	$(PCRE_CFLAGS) \
+	$(LIBYAML_CFLAGS) \
 	$(PTHREAD_CFLAGS)
 
 AM_LDFLAGS = \
+	$(PCRE_LDFLAGS) \
+	$(LIBYAML_LDFLAGS) \
 	$(LMDB_LDFLAGS)
 
 libcf_check_la_LIBADD = ../libutils/libutils.la \
 	$(LMDB_LIBS) \
+	$(PCRE_LIBS) \
+	$(LIBYAML_LIBS) \
 	$(PTHREAD_LIBS)
 
 libcf_check_la_SOURCES = \

--- a/cf-check/backup.c
+++ b/cf-check/backup.c
@@ -58,32 +58,36 @@ const char *create_backup_dir()
     return backup_dir;
 }
 
-int backup_files(int count, char **files)
+int backup_files(Seq *filenames)
 {
-    if (count <= 0)
-    {
-        printf("Need to supply filename(s)\n");
-        return 1;
-    }
+    assert(filenames != NULL);
+    const size_t length = SeqLength(filenames);
+
+    // Attempting to back up 0 files is considered a failure:
+    assert_or_return(length > 0, 1);
 
     const char *backup_dir = create_backup_dir();
 
     printf("Backing up to '%s'\n", backup_dir);
 
-    for (int i = 0; i < count; ++i)
+    for (int i = 0; i < length; ++i)
     {
-        if (!copy_file_to_folder(files[i], backup_dir))
+        const char *file = SeqAt(filenames, i);
+        if (!copy_file_to_folder(file, backup_dir))
         {
-            printf("Copying '%s' failed\n", files[i]);
+            printf("Copying '%s' failed\n", file);
             return 1;
         }
     }
     return 0;
 }
 
-int backup_main(int count, char **argv)
+int backup_main(int argc, char **argv)
 {
-    return backup_files(count - 1, argv + 1);
+    Seq *files = argv_to_lmdb_files(argc, argv);
+    const int ret = backup_files(files);
+    SeqDestroy(files);
+    return ret;
 }
 
 #endif

--- a/cf-check/diagnose.c
+++ b/cf-check/diagnose.c
@@ -24,6 +24,8 @@ int diagnose_main(int argc, char **argv)
 #include <lmdb.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include <utilities.h>
+#include <sequence.h>
 
 #define CF_CHECK_RUN_CODES(macro)                         \
     macro(OK)                                             \
@@ -316,19 +318,15 @@ static int fork_and_diagnose(const char *path)
     return CF_CHECK_OK;
 }
 
-int diagnose_main(int argc, char **argv)
+size_t diagnose_files(Seq* filenames)
 {
-    if (argc <= 1)
+    size_t corruptions = 0;
+    const size_t length = SeqLength(filenames);
+    for (int i = 0; i < length; ++i)
     {
-        printf("Need to supply filename(s)\n");
-        return 1;
-    }
-    int corruptions = 0;
-    const int total = argc - 1;
-    for (int i = 1; i < argc; ++i)
-    {
-        const int r = fork_and_diagnose(argv[i]);
-        printf("Status of '%s': %s\n", argv[i], CF_CHECK_STRING(r));
+        const char *filename = SeqAt(filenames, i);
+        const int r = fork_and_diagnose(filename);
+        printf("Status of '%s': %s\n", filename, CF_CHECK_STRING(r));
 
         if (r != CF_CHECK_OK)
         {
@@ -337,13 +335,21 @@ int diagnose_main(int argc, char **argv)
     }
     if (corruptions == 0)
     {
-        printf("All %d databases healthy\n", total);
+        printf("All %zu databases healthy\n", length);
     }
     else
     {
-        printf("Problems detected in %d/%d databases\n", corruptions, total);
+        printf("Problems detected in %zu/%zu databases\n", corruptions, length);
     }
     return corruptions;
+}
+
+int diagnose_main(int argc, char **argv)
+{
+    Seq *files = argv_to_lmdb_files(argc, argv);
+    const int ret = diagnose_files(files);
+    SeqDestroy(files);
+    return ret;
 }
 
 #endif

--- a/cf-check/utilities.h
+++ b/cf-check/utilities.h
@@ -1,11 +1,18 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
 
+#include <sequence.h>
+
 // These functions should be moved to libutils once cf-check is
 // implemented and backported.
 
 bool copy_file(const char *src, const char *dst);
 const char *filename_part(const char *path);
 bool copy_file_to_folder(const char *src, const char *dst_dir);
+Seq *ls(const char *dir, const char *extension);
+char *join_paths_alloc(const char *dir, const char *leaf);
+Seq *argv_to_seq(int argc, char **argv);
+Seq *default_lmdb_files();
+Seq *argv_to_lmdb_files(int argc, char **argv);
 
 #endif


### PR DESCRIPTION
When no files are specified, default behavior is identical to
/var/cfengine/state/*.lmdb (expanded by shell).

This command can be used as a prototype for `cf-check repair`:

```
cf-check diagnose || ( cf-check backup && rm -f /var/cfengine/state/*.lmdb && echo "Successful repair!")
```

Example:

```
$ cf-check diagnose || ( cf-check backup && rm -f /var/cfengine/state/*.lmdb && echo "Successful repair!")
No filenames specified, defaulting to .lmdb files in /var/cfengine/state/
Status of '/var/cfengine/state/cf_state.lmdb': OK
Status of '/var/cfengine/state/history.lmdb': OK
Status of '/var/cfengine/state/packages_installed_apt_get.lmdb': OK
Status of '/var/cfengine/state/nova_measures.lmdb': OK
Status of '/var/cfengine/state/nova_static.lmdb': OK
Status of '/var/cfengine/state/packages_updates_apt_get.lmdb': OK
Status of '/var/cfengine/state/cf_observations.lmdb': OK
Status of '/var/cfengine/state/cf_lock.lmdb': OK
Status of '/var/cfengine/state/packages_installed_$(package_module_knowledge.platform_default).lmdb': OK
All 9 databases healthy
$ echo "BASDSADASDASDASDASDASDASDASDASDASD" > /var/cfengine/state/cf_lastseen.lmdb
$ cf-check diagnose || ( cf-check backup && rm -f /var/cfengine/state/*.lmdb && echo "Successful repair!")
No filenames specified, defaulting to .lmdb files in /var/cfengine/state/
Status of '/var/cfengine/state/cf_state.lmdb': OK
Status of '/var/cfengine/state/history.lmdb': OK
Status of '/var/cfengine/state/packages_installed_apt_get.lmdb': OK
Status of '/var/cfengine/state/nova_measures.lmdb': OK
Status of '/var/cfengine/state/nova_static.lmdb': OK
Status of '/var/cfengine/state/packages_updates_apt_get.lmdb': OK
Status of '/var/cfengine/state/cf_lastseen.lmdb': SYSTEM_ERROR 183 - Unknown
Status of '/var/cfengine/state/cf_observations.lmdb': OK
Status of '/var/cfengine/state/cf_lock.lmdb': OK
Status of '/var/cfengine/state/packages_installed_$(package_module_knowledge.platform_default).lmdb': OK
Problems detected in 1/10 databases
No filenames specified, defaulting to .lmdb files in /var/cfengine/state/
Backing up to '/var/cfengine/backup/1544803923/'
Copying: '/var/cfengine/state/cf_state.lmdb' -> '/var/cfengine/backup/1544803923/cf_state.lmdb'
Copying: '/var/cfengine/state/history.lmdb' -> '/var/cfengine/backup/1544803923/history.lmdb'
Copying: '/var/cfengine/state/packages_installed_apt_get.lmdb' -> '/var/cfengine/backup/1544803923/packages_installed_apt_get.lmdb'
Copying: '/var/cfengine/state/nova_measures.lmdb' -> '/var/cfengine/backup/1544803923/nova_measures.lmdb'
Copying: '/var/cfengine/state/nova_static.lmdb' -> '/var/cfengine/backup/1544803923/nova_static.lmdb'
Copying: '/var/cfengine/state/packages_updates_apt_get.lmdb' -> '/var/cfengine/backup/1544803923/packages_updates_apt_get.lmdb'
Copying: '/var/cfengine/state/cf_lastseen.lmdb' -> '/var/cfengine/backup/1544803923/cf_lastseen.lmdb'
Copying: '/var/cfengine/state/cf_observations.lmdb' -> '/var/cfengine/backup/1544803923/cf_observations.lmdb'
Copying: '/var/cfengine/state/cf_lock.lmdb' -> '/var/cfengine/backup/1544803923/cf_lock.lmdb'
Copying: '/var/cfengine/state/packages_installed_$(package_module_knowledge.platform_default).lmdb' -> '/var/cfengine/backup/1544803923/packages_installed_$(package_module_knowledge.platform_default).lmdb'
Successful repair!
$ cf-check diagnose || ( cf-check backup && rm -f /var/cfengine/state/*.lmdb && echo "Successful repair!")
No filenames specified, defaulting to .lmdb files in /var/cfengine/state/
All 0 databases healthy
$ cf-agent
$ cf-check diagnose || ( cf-check backup && rm -f /var/cfengine/state/*.lmdb && echo "Successful repair!")
No filenames specified, defaulting to .lmdb files in /var/cfengine/state/
Status of '/var/cfengine/state/cf_state.lmdb': OK
Status of '/var/cfengine/state/packages_installed_apt_get.lmdb': OK
Status of '/var/cfengine/state/nova_static.lmdb': OK
Status of '/var/cfengine/state/packages_updates_apt_get.lmdb': OK
Status of '/var/cfengine/state/cf_lock.lmdb': OK
Status of '/var/cfengine/state/packages_installed_$(package_module_knowledge.platform_default).lmdb': OK
All 6 databases healthy
```