### PR TITLE
CFE-2478: Allow forward slash character in module protocol commands

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -8087,7 +8087,8 @@ static FnCallResult FnCallCFEngineCallers(EvalContext *ctx, ARG_UNUSED const Pol
 
 static bool CheckIDChar(const char ch)
 {
-    return isalnum((int) ch) || (ch == '.') || (ch == '-') || (ch == '_') || (ch == '[') || (ch == ']');
+    return isalnum((int) ch) || (ch == '.') || (ch == '-') || (ch == '_') ||
+                                (ch == '[') || (ch == ']') || (ch == '/');
 }
 
 static bool CheckID(const char *id)


### PR DESCRIPTION
Previously, the function only allowed alphanumerical and
characters `_`, `.`, `-`, `[` and `]`. Forward slash is not used
for anything in module protocol commands, and is therefore added.

Ticket: CFE-2478
Changelog: Title

This is a tiny change.
Will also create PR for documentation.