### PR TITLE
Revert "ENT-4064: cf-check: diagnose and backup now use state directory by default"

### DIFF
--- a/cf-check/Makefile.am
+++ b/cf-check/Makefile.am
@@ -24,25 +24,17 @@
 noinst_LTLIBRARIES = libcf-check.la
 
 AM_CPPFLAGS = -I$(srcdir)/../libutils \
-	$(PCRE_CPPFLAGS) \
-	$(LIBYAML_CPPFLAGS) \
 	$(LMDB_CPPFLAGS)
 
 AM_CFLAGS = \
 	$(LMDB_CFLAGS) \
-	$(PCRE_CFLAGS) \
-	$(LIBYAML_CFLAGS) \
 	$(PTHREAD_CFLAGS)
 
 AM_LDFLAGS = \
-	$(PCRE_LDFLAGS) \
-	$(LIBYAML_LDFLAGS) \
 	$(LMDB_LDFLAGS)
 
 libcf_check_la_LIBADD = ../libutils/libutils.la \
 	$(LMDB_LIBS) \
-	$(PCRE_LIBS) \
-	$(LIBYAML_LIBS) \
 	$(PTHREAD_LIBS)
 
 libcf_check_la_SOURCES = \

--- a/cf-check/backup.c
+++ b/cf-check/backup.c
@@ -58,36 +58,32 @@ const char *create_backup_dir()
     return backup_dir;
 }
 
-int backup_files(Seq *filenames)
+int backup_files(int count, char **files)
 {
-    assert(filenames != NULL);
-    const size_t length = SeqLength(filenames);
-
-    // Attempting to back up 0 files is considered a failure:
-    assert_or_return(length > 0, 1);
+    if (count <= 0)
+    {
+        printf("Need to supply filename(s)\n");
+        return 1;
+    }
 
     const char *backup_dir = create_backup_dir();
 
     printf("Backing up to '%s'\n", backup_dir);
 
-    for (int i = 0; i < length; ++i)
+    for (int i = 0; i < count; ++i)
     {
-        const char *file = SeqAt(filenames, i);
-        if (!copy_file_to_folder(file, backup_dir))
+        if (!copy_file_to_folder(files[i], backup_dir))
         {
-            printf("Copying '%s' failed\n", file);
+            printf("Copying '%s' failed\n", files[i]);
             return 1;
         }
     }
     return 0;
 }
 
-int backup_main(int argc, char **argv)
+int backup_main(int count, char **argv)
 {
-    Seq *files = argv_to_lmdb_files(argc, argv);
-    const int ret = backup_files(files);
-    SeqDestroy(files);
-    return ret;
+    return backup_files(count - 1, argv + 1);
 }
 
 #endif

--- a/cf-check/diagnose.c
+++ b/cf-check/diagnose.c
@@ -24,8 +24,6 @@ int diagnose_main(int argc, char **argv)
 #include <lmdb.h>
 #include <sys/wait.h>
 #include <signal.h>
-#include <utilities.h>
-#include <sequence.h>
 
 #define CF_CHECK_RUN_CODES(macro)                         \
     macro(OK)                                             \
@@ -318,15 +316,19 @@ static int fork_and_diagnose(const char *path)
     return CF_CHECK_OK;
 }
 
-size_t diagnose_files(Seq* filenames)
+int diagnose_main(int argc, char **argv)
 {
-    size_t corruptions = 0;
-    const size_t length = SeqLength(filenames);
-    for (int i = 0; i < length; ++i)
+    if (argc <= 1)
     {
-        const char *filename = SeqAt(filenames, i);
-        const int r = fork_and_diagnose(filename);
-        printf("Status of '%s': %s\n", filename, CF_CHECK_STRING(r));
+        printf("Need to supply filename(s)\n");
+        return 1;
+    }
+    int corruptions = 0;
+    const int total = argc - 1;
+    for (int i = 1; i < argc; ++i)
+    {
+        const int r = fork_and_diagnose(argv[i]);
+        printf("Status of '%s': %s\n", argv[i], CF_CHECK_STRING(r));
 
         if (r != CF_CHECK_OK)
         {
@@ -335,21 +337,13 @@ size_t diagnose_files(Seq* filenames)
     }
     if (corruptions == 0)
     {
-        printf("All %zu databases healthy\n", length);
+        printf("All %d databases healthy\n", total);
     }
     else
     {
-        printf("Problems detected in %zu/%zu databases\n", corruptions, length);
+        printf("Problems detected in %d/%d databases\n", corruptions, total);
     }
     return corruptions;
-}
-
-int diagnose_main(int argc, char **argv)
-{
-    Seq *files = argv_to_lmdb_files(argc, argv);
-    const int ret = diagnose_files(files);
-    SeqDestroy(files);
-    return ret;
 }
 
 #endif

--- a/cf-check/utilities.c
+++ b/cf-check/utilities.c
@@ -1,9 +1,5 @@
 #include <platform.h>
 #include <utilities.h>
-#include <dir.h>
-#include <sequence.h>
-#include <string_lib.h>
-#include <alloc.h>
 
 bool copy_file(const char *src, const char *dst)
 {
@@ -124,74 +120,4 @@ bool copy_file_to_folder(const char *src, const char *dst_dir)
     }
 
     return true;
-}
-
-Seq *argv_to_seq(int argc, char **argv)
-{
-    assert(argc > 0);
-    assert(argv != NULL);
-    assert(argv[0] != NULL);
-
-    Seq *args = SeqNew(argc, NULL);
-    for(int i = 0; i < argc; ++i)
-    {
-        SeqAppend(args, argv[i]);
-    }
-    return args;
-}
-
-char *join_paths_alloc(const char *dir, const char *leaf)
-{
-    if (StringEndsWith(dir, "/"))
-    {
-        return StringConcatenate(2, dir, leaf);
-    }
-    return StringConcatenate(3, dir, "/", leaf);
-}
-
-Seq *ls(const char *dir, const char *extension)
-{
-    Dir *dirh = DirOpen(dir);
-    if (dirh == NULL)
-    {
-        return NULL;
-    }
-
-    Seq *contents = SeqNew(10, free);
-
-    const struct dirent *dirp;
-
-    while ((dirp = DirRead(dirh)) != NULL)
-    {
-        const char *name = dirp->d_name;
-        if (extension == NULL || StringEndsWithCase(name, extension, true))
-        {
-            SeqAppend(contents, join_paths_alloc(dir, name));
-        }
-    }
-    DirClose(dirh);
-
-    return contents;
-}
-
-Seq *default_lmdb_files()
-{
-    const char *state = "/var/cfengine/state/";
-    printf("No filenames specified, defaulting to .lmdb files in %s\n", state);
-    Seq *files = ls(state, ".lmdb");
-    if (files == NULL)
-    {
-        printf("Could not open %s\n", state);
-    }
-    return files;
-}
-
-Seq *argv_to_lmdb_files(int argc, char **argv)
-{
-    if (argc <= 1)
-    {
-        return default_lmdb_files();
-    }
-
-    return argv_to_seq(argc - 1, argv + 1);
 }

--- a/cf-check/utilities.h
+++ b/cf-check/utilities.h
@@ -1,18 +1,11 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
 
-#include <sequence.h>
-
 // These functions should be moved to libutils once cf-check is
 // implemented and backported.
 
 bool copy_file(const char *src, const char *dst);
 const char *filename_part(const char *path);
 bool copy_file_to_folder(const char *src, const char *dst_dir);
-Seq *ls(const char *dir, const char *extension);
-char *join_paths_alloc(const char *dir, const char *leaf);
-Seq *argv_to_seq(int argc, char **argv);
-Seq *default_lmdb_files();
-Seq *argv_to_lmdb_files(int argc, char **argv);
 
 #endif


### PR DESCRIPTION
Reverts cfengine/core#3469