### PR TITLE
[3.10.x] CFE-2478: Allow forward slash character in module protocol commands

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7955,7 +7955,8 @@ static FnCallResult FnCallCFEngineCallers(EvalContext *ctx, ARG_UNUSED const Pol
 
 static bool CheckIDChar(const char ch)
 {
-    return isalnum((int) ch) || (ch == '.') || (ch == '-') || (ch == '_') || (ch == '[') || (ch == ']');
+    return isalnum((int) ch) || (ch == '.') || (ch == '-') || (ch == '_') ||
+                                (ch == '[') || (ch == ']') || (ch == '/');
 }
 
 static bool CheckID(const char *id)

--- a/tests/acceptance/08_commands/01_modules/module-array-allows-slash.cf
+++ b/tests/acceptance/08_commands/01_modules/module-array-allows-slash.cf
@@ -8,11 +8,8 @@ body common control
 bundle agent test
 {
   meta:
-      "description" string => "Test that arrays defined by modules can contain slashes just like classic arrays.";
-
-      "test_soft_fail"
-        string => "any",
-        meta => { "CFE-2478" };
+      "description" -> { "CFE-2768" }
+        string => "Test that arrays defined by modules can contain slashes just like classic arrays.";
 
   commands:
 
@@ -48,7 +45,7 @@ bundle agent check
 {
   vars:
     # Construct strings from the array values for comparison and test pass/fail
-    "expected" string => "array_value array_path_key_value another_array_path_key_value";
+    "expected" string => "array_key_value array_path_key_value another_array_path_key_value";
     "actual" string => "$(echo.array[key]) $(echo.array[/path/key]) $(test.array[/path/key])";
 
   methods:


### PR DESCRIPTION
Previously, the function only allowed alphanumerical and
characters `_`, `.`, `-`, `[` and `]`. Forward slash is not used
for anything in module protocol commands, and is therefore added. Also
reenabled the test for slashes in module commands.

Ticket: CFE-2478
Changelog: Title