### PR TITLE
ENT-4395: Increased verbosity of AcquireLock permission error

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -486,8 +486,8 @@ static bool KillLockHolder(const char *lock)
         else
         {
             Log(LOG_LEVEL_ERR,
-                "Failed to kill process with PID %jd",
-                (intmax_t) lock_data.pid);
+                "Failed to kill process with PID: %jd (kill: %s)",
+                (intmax_t) lock_data.pid, GetErrorStr());
             return false;
         }
     }


### PR DESCRIPTION
Added a `GetErrorStr()` call to distinguish between programming
errors (EINVAL) and permission errors (EPERM) for `kill()`.

Ticket: ENT-4395
Changelog: Title

Should be cherry-picked, though I am unsure if it needs a changelog entry.