### PR TITLE
CFE-2889: cf-remote: File input and policy server information

### DIFF
--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -42,6 +42,10 @@ def install(
             bootstrap=bootstrap,
             version=version,
             demo=demo)
+    if demo and hub:
+        print(
+            "Your demo hub is ready: https://{}/ (Username: admin, Password: password)".format(
+                hub))
 
 
 def packages(tags=None, version=None):

--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -1,6 +1,10 @@
+import os
+
 from cf_remote.remote import get_info, print_info, install_host
 from cf_remote.packages import Releases
 from cf_remote.web import download_package
+from cf_remote.paths import cf_remote_dir
+from cf_remote.utils import save_file
 from cf_remote import log
 
 
@@ -29,6 +33,8 @@ def install(
         hub_package = package
     if not client_package:
         client_package = package
+    if bootstrap:
+        save_file(os.path.join(cf_remote_dir(), "policy_server.dat"), bootstrap + "\n")
     if hub:
         log.debug("Installing hub package on '{}'".format(hub))
         install_host(

--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -50,7 +50,7 @@ def install(
 
 def packages(tags=None, version=None):
     releases = Releases()
-    print(releases)
+    print("Available releases: {}".format(releases))
 
     release = releases.default
     if version:

--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -30,11 +30,11 @@ def install(
     if not client_package:
         client_package = package
     if hub:
-        log.debug("Installing hub package on {}".format(hub))
+        log.debug("Installing hub package on '{}'".format(hub))
         install_host(
             hub, hub=True, package=hub_package, bootstrap=bootstrap, version=version, demo=demo)
     for host in (clients or []):
-        log.debug("Installing client package on {}".format(host))
+        log.debug("Installing client package on '{}'".format(host))
         install_host(
             host,
             hub=False,

--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -2,7 +2,7 @@ import argparse
 
 from cf_remote import log
 from cf_remote import commands
-from cf_remote.utils import user_error, exit_success
+from cf_remote.utils import user_error, exit_success, expand_list_from_file, is_file_string
 from cf_remote.packages import Releases
 
 
@@ -77,6 +77,20 @@ def validate_command(command, args):
             # TODO: Find this automatically
 
 
+def file_or_comma_list(string):
+    if is_file_string(string):
+        return expand_list_from_file(string)
+    return string.split(",")
+
+
+def file_or_single_host(string):
+    assert "," not in string
+    one_list = file_or_comma_list(string)
+    if len(one_list) != 1:
+        user_error("File '{}' must contain exactly 1 hostname or IP".format(string))
+    return one_list[0]
+
+
 def validate_args(args):
     if args.version is True:  # --version with no second argument
         print_version_info()
@@ -84,11 +98,18 @@ def validate_args(args):
 
     if args.version and args.command not in ["install", "packages"]:
         user_error("Cannot specify version number in '{}' command".format(command))
+    if any(x for x in [args.hub, args.bootstrap] if "," in (x or "")):
+        user_error("--hub and --bootstrap do not support lists (cannot contain commas)")
 
     if args.hosts:
-        args.hosts = args.hosts.split(",")
+        args.hosts = file_or_comma_list(args.hosts)
     if args.clients:
-        args.clients = args.clients.split(",")
+        args.clients = file_or_comma_list(args.clients)
+    if args.bootstrap:
+        args.bootstrap = file_or_single_host(args.bootstrap)
+    if args.hub:
+        args.hub = file_or_single_host(args.hub)
+
     args.command = args.command.strip()
     if not args.command:
         user_error("Invalid or missing command")

--- a/contrib/cf-remote/cf_remote/packages.py
+++ b/contrib/cf-remote/cf_remote/packages.py
@@ -152,6 +152,8 @@ class Releases:
                 continue
             if "lts_branch" not in release and "latest_stable" not in release:
                 continue
+            if "lts_branch" in release and release["lts_branch"] not in self.supported_branches:
+                continue
             if "latestLTS" in release and release["latestLTS"] == True:
                 self.default = rel
                 rel.default = True
@@ -165,5 +167,4 @@ class Releases:
                 return Release(release)
 
     def __str__(self):
-        lines = [str(x) for x in self.releases]
-        return "\n".join(lines)
+        return ", ".join(str(x.version) for x in self.releases)

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -79,7 +79,7 @@ def print_info(data):
 
 
 def connect(host, users=None):
-    log.debug("Connecting to {}".format(host))
+    log.debug("Connecting to '{}'".format(host))
     if "@" in host:
         parts = host.split("@")
         assert len(parts) == 2
@@ -97,11 +97,11 @@ def connect(host, users=None):
             return c
         except AuthenticationException:
             continue
-    sys.exit("Could not ssh into {}".format(host))
+    sys.exit("Could not ssh into '{}'".format(host))
 
 
 def get_info(host, users=None, connection=None):
-    log.debug("Getting info about {}".format(host))
+    log.debug("Getting info about '{}'".format(host))
     if not connection:
         with connect(host, users) as c:
             return get_info(host, users, c)
@@ -139,7 +139,7 @@ def scp(file, remote, connection=None):
 
 
 def install_package(host, pkg, data):
-    print("Installing '{}' on '{}'".format(pkg, host))
+    print("Installing: '{}' on '{}'".format(pkg, host))
     with connect(host) as connection:
         if ".deb" in pkg:
             ssh_sudo(connection, "dpkg -i {}".format(pkg))

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -38,7 +38,6 @@ def ssh_sudo(connection, cmd):
 
 
 def print_info(data):
-    log.debug("JSON data from host info: \n" + pretty(data))
     output = OrderedDict()
     print()
     print(data["ssh"])
@@ -66,6 +65,8 @@ def print_info(data):
         output["CFEngine"] = agent_version
     else:
         output["CFEngine"] = "Not installed"
+
+    output["Policy server"] = data.get("policy_server")
 
     binaries = []
     if "bin" in data:
@@ -116,6 +117,7 @@ def get_info(host, users=None, connection=None):
     data["arch"] = ssh_cmd(connection, "uname -m")
     data["os_release"] = os_release(ssh_cmd(connection, "cat /etc/os-release"))
     data["agent_location"] = ssh_cmd(connection, "which cf-agent")
+    data["policy_server"] = ssh_cmd(connection, "cat /var/cfengine/policy_server.dat")
     agent_version = ssh_cmd(connection, "cf-agent --version")
     if agent_version:
         # 'CFEngine Core 3.12.1 \n CFEngine Enterprise 3.12.1'
@@ -127,6 +129,8 @@ def get_info(host, users=None, connection=None):
         path = ssh_cmd(connection, "which {}".format(bin))
         if path:
             data["bin"][bin] = path
+
+    log.debug("JSON data from host info: \n" + pretty(data))
     return data
 
 

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -102,10 +102,11 @@ def connect(host, users=None):
 
 
 def get_info(host, users=None, connection=None):
-    log.debug("Getting info about '{}'".format(host))
     if not connection:
         with connect(host, users) as c:
             return get_info(host, users, c)
+
+    log.debug("Getting info about '{}'".format(host))
 
     user, host = connection.ssh_user, connection.ssh_host
     data = OrderedDict()

--- a/contrib/cf-remote/cf_remote/utils.py
+++ b/contrib/cf-remote/cf_remote/utils.py
@@ -112,3 +112,24 @@ def column_print(data):
     for key, value in data.items():
         fill = " " * (width - len(key))
         print("{}{} : {}".format(key, fill, value))
+
+
+def is_file_string(string):
+    return string and string.startswith(("./", "~/", "/", "../"))
+
+
+def expand_list_from_file(string):
+    assert is_file_string(string)
+
+    location = os.path.expanduser(string)
+    if not os.path.exists(location):
+        user_error("Hosts file '{}' does not exist".format(location))
+    if not os.path.isfile(location):
+        user_error("'{}' is not a file".format(location))
+    if not os.access(location, os.R_OK):
+        user_error("Cannot read '{}' - Permission denied".format(location))
+
+    with open(location, "r") as f:
+        hosts = [line.strip() for line in f if line.strip()]
+
+    return hosts

--- a/contrib/cf-remote/cf_remote/utils.py
+++ b/contrib/cf-remote/cf_remote/utils.py
@@ -35,10 +35,10 @@ def exit_success():
 
 def mkdir(path):
     if not os.path.exists(path):
-        log.info("Creating directory: {}".format(path))
+        log.info("Creating directory: '{}'".format(path))
         os.makedirs(path)
     else:
-        log.debug("Directory already exists: {}".format(path))
+        log.debug("Directory already exists: '{}'".format(path))
 
 
 def ls(path):

--- a/contrib/cf-remote/cf_remote/web.py
+++ b/contrib/cf-remote/cf_remote/web.py
@@ -13,7 +13,7 @@ def get_json(url):
     filename = os.path.basename(url)
     dir = cf_remote_dir("json")
     path = os.path.join(dir, filename)
-    log.debug("Saving {} to {}".format(url, path))
+    log.debug("Saving '{}' to '{}'".format(url, path))
     write_json(path, data)
 
     return data
@@ -25,8 +25,8 @@ def download_package(url):
     mkdir(dir)
     location = os.path.join(dir, filename)
     if os.path.exists(location):
-        print("Package already downloaded: {}".format(location))
+        print("Package already downloaded: '{}'".format(location))
         return location
-    print("Downloading package: {}".format(location))
+    print("Downloading package: '{}'".format(location))
     os.system("curl --silent -L '{}' -o '{}'".format(url, location))
     return location


### PR DESCRIPTION
```
$ cf-remote install --demo --clients ./clients.txt --hub ./hub.txt --bootstrap ./bootstrap.txt 

ec2-user@34.245.0.209
OS           : rhel (fedora)
Architecture : x86_64
CFEngine     : Not installed
Binaries     : rpm, yum

Package already downloaded: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova-hub-3.12.1-1.x86_64.rpm'
Copying: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova-hub-3.12.1-1.x86_64.rpm' to '34.245.0.209'
Installing: 'cfengine-nova-hub-3.12.1-1.x86_64.rpm' on '34.245.0.209'
CFEngine 3.12.1 was successfully installed on '34.245.0.209'
Bootstrapping: '34.245.0.209' -> '172.31.33.214'
Bootstrap succesful: '34.245.0.209' -> '172.31.33.214'
Transferring def.json to hub: '34.245.0.209'
Triggering an agent run on: '34.245.0.209'
Disabling password change on hub: '34.245.0.209'
Triggering an agent run on: '34.245.0.209'

ec2-user@34.242.229.95
OS           : rhel (fedora)
Architecture : x86_64
CFEngine     : Not installed
Binaries     : rpm, yum

Package already downloaded: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova-3.12.1-1.el6.x86_64.rpm'
Copying: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova-3.12.1-1.el6.x86_64.rpm' to '34.242.229.95'
Installing: 'cfengine-nova-3.12.1-1.el6.x86_64.rpm' on '34.242.229.95'
CFEngine 3.12.1 was successfully installed on '34.242.229.95'
Bootstrapping: '34.242.229.95' -> '172.31.33.214'
Bootstrap succesful: '34.242.229.95' -> '172.31.33.214'
Triggering an agent run on: '34.242.229.95'

ec2-user@54.194.167.234
OS           : rhel (fedora)
Architecture : x86_64
CFEngine     : Not installed
Binaries     : rpm, yum

Package already downloaded: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova-3.12.1-1.el6.x86_64.rpm'
Copying: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova-3.12.1-1.el6.x86_64.rpm' to '54.194.167.234'
Installing: 'cfengine-nova-3.12.1-1.el6.x86_64.rpm' on '54.194.167.234'
CFEngine 3.12.1 was successfully installed on '54.194.167.234'
Bootstrapping: '54.194.167.234' -> '172.31.33.214'
Bootstrap succesful: '54.194.167.234' -> '172.31.33.214'
Triggering an agent run on: '54.194.167.234'

ubuntu@54.229.144.15
OS           : ubuntu (debian)
Architecture : x86_64
CFEngine     : Not installed
Binaries     : dpkg, apt

Package already downloaded: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova_3.12.1-1_amd64-debian7.deb'
Copying: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova_3.12.1-1_amd64-debian7.deb' to '54.229.144.15'
Installing: 'cfengine-nova_3.12.1-1_amd64-debian7.deb' on '54.229.144.15'
CFEngine 3.12.1 was successfully installed on '54.229.144.15'
Bootstrapping: '54.229.144.15' -> '172.31.33.214'
Bootstrap succesful: '54.229.144.15' -> '172.31.33.214'
Triggering an agent run on: '54.229.144.15'

ubuntu@52.211.145.144
OS           : ubuntu (debian)
Architecture : x86_64
CFEngine     : Not installed
Binaries     : dpkg, apt

Package already downloaded: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova_3.12.1-1_amd64-debian7.deb'
Copying: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova_3.12.1-1_amd64-debian7.deb' to '52.211.145.144'
Installing: 'cfengine-nova_3.12.1-1_amd64-debian7.deb' on '52.211.145.144'
CFEngine 3.12.1 was successfully installed on '52.211.145.144'
Bootstrapping: '52.211.145.144' -> '172.31.33.214'
Bootstrap succesful: '52.211.145.144' -> '172.31.33.214'
Triggering an agent run on: '52.211.145.144'

ubuntu@34.244.12.95
OS           : ubuntu (debian)
Architecture : x86_64
CFEngine     : Not installed
Binaries     : dpkg, apt

Package already downloaded: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova_3.12.1-1_amd64-debian7.deb'
Copying: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-nova_3.12.1-1_amd64-debian7.deb' to '34.244.12.95'
Installing: 'cfengine-nova_3.12.1-1_amd64-debian7.deb' on '34.244.12.95'
CFEngine 3.12.1 was successfully installed on '34.244.12.95'
Bootstrapping: '34.244.12.95' -> '172.31.33.214'
Bootstrap succesful: '34.244.12.95' -> '172.31.33.214'
Triggering an agent run on: '34.244.12.95'
Your demo hub is ready: https://34.245.0.209/ (Username: admin, Password: password)
```

```
$ cf-remote info -H 34.245.0.209

ec2-user@34.245.0.209
OS            : rhel (fedora)
Architecture  : x86_64
CFEngine      : 3.12.1
Policy server : 172.31.33.214
Binaries      : rpm, yum

$ 
```