### PR TITLE
CFE-2983: Display an error when a function defining a variables still fails at last pass

### DIFF
--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -212,6 +212,11 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
             if (res.status == FNCALL_FAILURE)
             {
                 /* We do not assign variables to failed fn calls */
+                if (EvalContextGetPass(ctx) == CF_DONEPASSES-1) {
+                    // If we still fail at last pass, make a log
+                    Log(LOG_LEVEL_VERBOSE, "While setting variable '%s' in bundle '%s', function '%s' failed - skipping",
+                                       pp->promiser, PromiseGetBundle(pp)->name, fp->name);
+                }
                 RvalDestroy(res.rval);
                 VarRefDestroy(ref);
                 return PROMISE_RESULT_NOOP;


### PR DESCRIPTION
When used with `string_template` (see https://tracker.mender.io/browse/CFE-2983), the message is displayed twice as the function is called twice, I don't know why or how to avoid it.
Do you have any idea on how to display this log only once?

We could maybe add a debug message to state when a function is skipped during previous passes, as it can help debug a function that succeeds later than expected, what do you think about it?