### PR TITLE
Split SAX1 from SAX2 (XML API)

### DIFF
--- a/tests/acceptance/xml-c14nize.c
+++ b/tests/acceptance/xml-c14nize.c
@@ -6,6 +6,9 @@
 
 static bool xmlC14nizeFile(const char *filename)
 {
+
+#ifdef LIBXML_SAX1_ENABLED
+
     xmlDocPtr doc = xmlParseFile(filename);
 
     if (doc == NULL)
@@ -36,6 +39,14 @@ static bool xmlC14nizeFile(const char *filename)
 
     xmlFreeDoc(doc);
     return true;
+
+#else
+    xmlDocPtr doc = xmlReadFile(filename, NULL, 0);
+    // agenda
+    xmlFreeDoc(doc);
+    return true;
+#endif
+
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION

```
xml-c14nize.c:9:21: error: implicit declaration of function 'xmlParseFile' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    xmlDocPtr doc = xmlParseFile(filename);
                    ^
xml-c14nize.c:9:15: warning: incompatible integer to pointer conversion initializing 'xmlDocPtr' (aka 'struct _xmlDoc *') with an expression of type 'int' [-Wint-conversion]
    xmlDocPtr doc = xmlParseFile(filename);
              ^     ~~~~~~~~~~~~~~~~~~~~~~
xml-c14nize.c:17:30: error: implicit declaration of function 'xmlOutputBufferCreateFile' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    xmlOutputBufferPtr out = xmlOutputBufferCreateFile(stdout, NULL);
                             ^
xml-c14nize.c:17:24: warning: incompatible integer to pointer conversion initializing 'xmlOutputBufferPtr' (aka 'struct _xmlOutputBuffer *') with an expression of type 'int' [-Wint-conversion]
    xmlOutputBufferPtr out = xmlOutputBufferCreateFile(stdout, NULL);
                       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
xml-c14nize.c:25:9: error: implicit declaration of function 'xmlC14NDocSaveTo' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    if (xmlC14NDocSaveTo(doc, NULL, XML_C14N_1_0, 0, true, out) < 0)
        ^
xml-c14nize.c:25:37: error: use of undeclared identifier 'XML_C14N_1_0'
    if (xmlC14NDocSaveTo(doc, NULL, XML_C14N_1_0, 0, true, out) < 0)
                                    ^
xml-c14nize.c:31:9: error: implicit declaration of function 'xmlOutputBufferClose' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    if (xmlOutputBufferClose(out) < 0)
        ^
```