### PR TITLE
ENT-3749: Squash ReplaceStr() and StringReplace()

### DIFF
--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -754,52 +754,6 @@ void ReplaceChar(char *in, char *out, int outSz, char from, char to)
     }
 }
 
-/* TODO replace with StringReplace. This one is pretty slow, calls strncmp
- * O(n) times even if string matches nowhere. */
-bool ReplaceStr(const char *in, char *out, int outSz, const char *from, const char *to)
-/* Replaces all occurrences of strings 'from' to 'to' in preallocated
- * string 'out'. Returns true on success, false otherwise. */
-{
-    int inSz;
-    int outCount;
-    int inCount;
-    int fromSz, toSz;
-
-    memset(out, 0, outSz);
-
-    inSz = strlen(in);
-    fromSz = strlen(from);
-    toSz = strlen(to);
-
-    inCount = 0;
-    outCount = 0;
-
-    while ((inCount < inSz) && (outCount < outSz))
-    {
-        if (strncmp(in + inCount, from, fromSz) == 0)
-        {
-            if (outCount + toSz >= outSz)
-            {
-                return false;
-            }
-
-            strcat(out, to);
-
-            inCount += fromSz;
-            outCount += toSz;
-        }
-        else
-        {
-            out[outCount] = in[inCount];
-
-            inCount++;
-            outCount++;
-        }
-    }
-
-    return true;
-}
-
 /**
  * Replace all occurrences of #find with #replace.
  *

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -803,11 +803,11 @@ bool ReplaceStr(const char *in, char *out, int outSz, const char *from, const ch
 /**
  * Replace all occurrences of #find with #replace.
  *
- * @return the length of #buf or (size_t) -1 in case of overflow, or 0
- *         if no replace took place.
+ * @return the length of #buf or -1 in case of overflow, or 0 if no replace
+ *         took place.
  */
-size_t StringReplace(char *buf, size_t buf_size,
-                     const char *find, const char *replace)
+ssize_t StringReplace(char *buf, size_t buf_size,
+                      const char *find, const char *replace)
 {
     assert(find[0] != '\0');
 
@@ -822,7 +822,7 @@ size_t StringReplace(char *buf, size_t buf_size,
     size_t buf_len = strlen(buf);
     size_t buf_idx = 0;
     char tmp[buf_size];
-    size_t tmp_len = 0;
+    ssize_t tmp_len = 0;
 
     /* Do all replacements we find. */
     do
@@ -832,7 +832,7 @@ size_t StringReplace(char *buf, size_t buf_size,
 
         if (tmp_len + prefix_len + replace_len >= buf_size)
         {
-            return (size_t) -1;
+            return -1;
         }
 
         memcpy(&tmp[tmp_len], &buf[buf_idx], prefix_len);
@@ -849,7 +849,7 @@ size_t StringReplace(char *buf, size_t buf_size,
     size_t leftover_len = buf_len - buf_idx;
     if (tmp_len + leftover_len >= buf_size)
     {
-        return (size_t) -1;
+        return -1;
     }
     memcpy(&tmp[tmp_len], &buf[buf_idx], leftover_len + 1);
     tmp_len += leftover_len;

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -110,7 +110,6 @@ char *StringSubstring(const char *source, size_t source_len, int start, int len)
 /* Allocates the result */
 char *SearchAndReplace(const char *source, const char *search, const char *replace);
 
-bool ReplaceStr(const char *in, char *out, int outSz, const char *from, const char *to);
 ssize_t StringReplace(char *buf, size_t buf_size, const char *find, const char *replace);
 
 bool IsStrIn(const char *str, const char *const strs[]);

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -111,7 +111,7 @@ char *StringSubstring(const char *source, size_t source_len, int start, int len)
 char *SearchAndReplace(const char *source, const char *search, const char *replace);
 
 bool ReplaceStr(const char *in, char *out, int outSz, const char *from, const char *to);
-size_t StringReplace(char *buf, size_t buf_size, const char *find, const char *replace);
+ssize_t StringReplace(char *buf, size_t buf_size, const char *find, const char *replace);
 
 bool IsStrIn(const char *str, const char *const strs[]);
 bool IsStrCaseIn(const char *str, const char *const strs[]);

--- a/tests/unit/string_lib_test.c
+++ b/tests/unit/string_lib_test.c
@@ -429,27 +429,33 @@ static void test_string_to_long_errors(void)
 {
     // A succesful call to StringToLong should return 0:
     long target = 0;
-    assert(StringToLong("1234",&target) == 0);
-    assert(target == 1234);
+    assert_int_equal(StringToLong("1234", &target), 0);
+    assert_int_equal(target, 1234);
 
     // Test that invalid inputs give error return code:
-    assert(StringToLong("",       &target) != 0);
-    assert(StringToLong(" ",      &target) != 0);
-    assert(StringToLong("error",  &target) != 0);
-    assert(StringToLong("-error", &target) != 0);
-    assert(StringToLong("ffff",   &target) != 0);
-    assert(StringToLong("1d",     &target) != 0);
-    assert(StringToLong("56789d", &target) != 0);
-    assert(StringToLong("9999999999999999999999999999999",&target) == ERANGE);
-    assert(StringToLong(" 999999999999999999999999999999",&target) == ERANGE);
-    assert(StringToLong("-999999999999999999999999999999",&target) == ERANGE);
+    assert_int_not_equal(StringToLong("",       &target), 0);
+    assert_int_not_equal(StringToLong(" ",      &target), 0);
+    assert_int_not_equal(StringToLong("error",  &target), 0);
+    assert_int_not_equal(StringToLong("-error", &target), 0);
+    assert_int_not_equal(StringToLong("ffff",   &target), 0);
+    assert_int_not_equal(StringToLong("1d",     &target), 0);
+    assert_int_not_equal(StringToLong("56789d", &target), 0);
+    assert_int_equal(StringToLong("9999999999999999999999999999999",
+                                  &target),
+                     ERANGE);
+    assert_int_equal(StringToLong(" 999999999999999999999999999999",
+                                  &target),
+                     ERANGE);
+    assert_int_equal(StringToLong("-999999999999999999999999999999",
+                                  &target),
+                     ERANGE);
 
     // Test that error logging function can be called:
     LogStringToLongError("-999999999999999999999999999999", "string_lib_test",
                          ERANGE);
 
     // Check that target is unmodified after errors:
-    assert(target == 1234);
+    assert_int_equal(target, 1234);
 }
 
 static void test_string_to_long_unsafe(void)


### PR DESCRIPTION
From Jira:

```
We have two functions ReplaceStr() and StringReplace() that do pretty much the same, but not exactly. We should squash them and get rid of one of them - probably the former one as it has worse performance.

Acceptance criteria:
1. Only one function for replacing strings in place used in our codebase.
2. Unit tests for the function written and passing.
```

Currently WIP, still needs tests for `StringReplace()`

Merge together:
https://github.com/cfengine/enterprise/pull/483