### PR TITLE
cf-remote: --hub and --bootstrap now accept more than one IP/hostname

### DIFF
--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -16,7 +16,7 @@ def info(hosts, users=None):
 
 
 def install(
-        hub,
+        hubs,
         clients,
         *,
         bootstrap=None,
@@ -25,8 +25,8 @@ def install(
         client_package=None,
         version=None,
         demo=False):
-    assert hub or clients
-    assert not (hub and clients and package)
+    assert hubs or clients
+    assert not (hubs and clients and package)
     # These assertions are checked in main.py
 
     if not hub_package:
@@ -34,24 +34,35 @@ def install(
     if not client_package:
         client_package = package
     if bootstrap:
-        save_file(os.path.join(cf_remote_dir(), "policy_server.dat"), bootstrap + "\n")
-    if hub:
-        log.debug("Installing hub package on '{}'".format(hub))
-        install_host(
-            hub, hub=True, package=hub_package, bootstrap=bootstrap, version=version, demo=demo)
-    for host in (clients or []):
+        if type(bootstrap) is str:
+            bootstrap = [bootstrap]
+        save_file(os.path.join(cf_remote_dir(), "policy_server.dat"), "\n".join(bootstrap + [""]))
+    if hubs:
+        if type(hubs) is str:
+            hubs = [hubs]
+        for index, hub in enumerate(hubs):
+            log.debug("Installing hub package on '{}'".format(hub))
+            install_host(
+                hub,
+                hub=True,
+                package=hub_package,
+                bootstrap=bootstrap[index % len(bootstrap)],
+                version=version,
+                demo=demo)
+    for index, host in enumerate(clients or []):
         log.debug("Installing client package on '{}'".format(host))
         install_host(
             host,
             hub=False,
             package=client_package,
-            bootstrap=bootstrap,
+            bootstrap=bootstrap[index % len(bootstrap)],
             version=version,
             demo=demo)
-    if demo and hub:
-        print(
-            "Your demo hub is ready: https://{}/ (Username: admin, Password: password)".format(
-                hub))
+    if demo and hubs:
+        for hub in hubs:
+            print(
+                "Your demo hub is ready: https://{}/ (Username: admin, Password: password)".
+                format(hub))
 
 
 def packages(tags=None, version=None):

--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -98,17 +98,15 @@ def validate_args(args):
 
     if args.version and args.command not in ["install", "packages"]:
         user_error("Cannot specify version number in '{}' command".format(command))
-    if any(x for x in [args.hub, args.bootstrap] if "," in (x or "")):
-        user_error("--hub and --bootstrap do not support lists (cannot contain commas)")
 
     if args.hosts:
         args.hosts = file_or_comma_list(args.hosts)
     if args.clients:
         args.clients = file_or_comma_list(args.clients)
     if args.bootstrap:
-        args.bootstrap = file_or_single_host(args.bootstrap)
+        args.bootstrap = file_or_comma_list(args.bootstrap)
     if args.hub:
-        args.hub = file_or_single_host(args.hub)
+        args.hub = file_or_comma_list(args.hub)
 
     args.command = args.command.strip()
     if not args.command:


### PR DESCRIPTION
Useful if you want to install multiple hubs in one command.
This is a more niche use case, so I won't change the name or
description of the options. (99% of users will want 1 hub and 1
bootstrap IP).