### PR TITLE
CFE-2678: Enable global connection cache

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -267,9 +267,12 @@ int main(int argc, char *argv[])
 
     GenericAgentPostLoadInit(ctx);
     ThisAgentInit();
+    ConnCache_Init();
 
     BeginAudit();
     KeepPromises(ctx, policy, config);
+
+    ConnCache_Destroy();
 
     if (ALLCLASSESREPORT)
     {
@@ -1812,7 +1815,6 @@ static int NewTypeContext(TypeSequence type)
         break;
 
     case TYPE_SEQUENCE_FILES:
-        ConnCache_Init();
         break;
 
     case TYPE_SEQUENCE_PROCESSES:
@@ -1846,7 +1848,6 @@ static void DeleteTypeContext(EvalContext *ctx, TypeSequence type)
         break;
 
     case TYPE_SEQUENCE_FILES:
-        ConnCache_Destroy();
         break;
 
     case TYPE_SEQUENCE_PROCESSES:


### PR DESCRIPTION
Currently the connection cache is destroyed after each bundle pass. In our usage of the agent (where we can have quite a lot of file copies all in different bundles), this leads to slower execution time and an increased load on the server (with up to tens of connections created and destroyed during a single run).

This patch activates the connection cache at the agent run level. This appears to have been held back (https://tracker.mender.io/browse/CFE-2678) because of https://tracker.mender.io/browse/CFE-2511, and waiting for a way to avoid reusing broken connections.

We could work on this as we would love to have a working connection cache, do you have any guidance on how you want this to be implemented?