### PR TITLE
CFE-2678: Global connection cache

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -267,9 +267,12 @@ int main(int argc, char *argv[])
 
     GenericAgentPostLoadInit(ctx);
     ThisAgentInit();
+    ConnCache_Init();
 
     BeginAudit();
     KeepPromises(ctx, policy, config);
+
+    ConnCache_Destroy();
 
     if (ALLCLASSESREPORT)
     {
@@ -1812,7 +1815,6 @@ static int NewTypeContext(TypeSequence type)
         break;
 
     case TYPE_SEQUENCE_FILES:
-        ConnCache_Init();
         break;
 
     case TYPE_SEQUENCE_PROCESSES:
@@ -1846,7 +1848,6 @@ static void DeleteTypeContext(EvalContext *ctx, TypeSequence type)
         break;
 
     case TYPE_SEQUENCE_FILES:
-        ConnCache_Destroy();
         break;
 
     case TYPE_SEQUENCE_PROCESSES:

--- a/libcfnet/conn_cache.c
+++ b/libcfnet/conn_cache.c
@@ -128,6 +128,22 @@ AgentConnection *ConnCache_FindIdleMarkBusy(const char *server,
             {
                 assert(svp->status == CONNCACHE_STATUS_IDLE);
 
+                // Check connection state before returning it
+                int error = 0;
+                socklen_t len = sizeof(error);
+                if (getsockopt(svp->conn->conn_info->sd, SOL_SOCKET, SO_ERROR, &error, &len) < 0)
+                {
+                    Log(LOG_LEVEL_DEBUG, "FindIdle: found connection to '%s' but could not get socket status, skipping.",
+                        server);
+                    continue;
+                }
+                if (error != 0)
+                {
+                    Log(LOG_LEVEL_DEBUG, "FindIdle: found connection to '%s' but connection is broken, skipping.",
+                        server);
+                    continue;
+                }
+
                 Log(LOG_LEVEL_VERBOSE, "FindIdle:"
                     " found connection to '%s' already open and ready.",
                     server);


### PR DESCRIPTION
Currently the connection cache is destroyed after each bundle pass. In our usage of the agent (where we can have quite a lot of file copies all in different bundles), this leads to slower execution time and an increased load on the server (with up to tens of connections created and destroyed during a single run).

This patch naively activates the connection cache at the agent run level. This appears to have been held back (https://tracker.mender.io/browse/CFE-2678) because of https://tracker.mender.io/browse/CFE-2511, and waiting for a way to avoid reusing broken connections.

I could work on this as we really want to have a working connection cache. Does the solution proposed in CFE-2511 description suits you, and would allow reusing the connection cache for a whole agent run?