### PR TITLE
CFE-3008 Message about invalid class characters from module protocol moved to VERBOSE (3.7.x)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7217,7 +7217,7 @@ static bool CheckID(const char *id)
     {
         if (!isalnum((int) *sp) && (*sp != '.') && (*sp != '-') && (*sp != '_') && (*sp != '[') && (*sp != ']'))
         {
-            Log(LOG_LEVEL_WARNING,
+            Log(LOG_LEVEL_VERBOSE,
                   "Module protocol contained an illegal character '%c' in class/variable identifier '%s'.", *sp,
                   id);
         }


### PR DESCRIPTION
In CFE-2887 the module protocol began automatically canonifying classes
that were defined in order to align with the behaviour of policy. This
change moves a warning about the class containing invalid characters to
VERBOSE as to align with policy.

(cherry picked from commit 829afc3d3b786cc3b5d8c469f1023d589b9dc33c)