### PR TITLE
cf-remote: Reuse SSH connections and other fixes (Digital Ocean Compatibility)

### DIFF
--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -11,7 +11,7 @@ from cf_remote import log
 def info(hosts, users=None):
     assert hosts
     for host in hosts:
-        data = get_info(host, users)
+        data = get_info(host, users=users)
         print_info(data)
 
 

--- a/contrib/cf-remote/cf_remote/demo.py
+++ b/contrib/cf-remote/cf_remote/demo.py
@@ -4,17 +4,17 @@ import json
 from cf_remote import log
 from cf_remote.paths import cf_remote_dir
 from cf_remote.utils import save_file
-import cf_remote.remote as remote
+from cf_remote.ssh import scp, connect, ssh_sudo
 
 
 def agent_run(host):
     print("Triggering an agent run on: '{}'".format(host))
-    with remote.connect(host) as connection:
+    with connect(host) as connection:
         command = "/var/cfengine/bin/cf-agent -Kf update.cf"
-        output = remote.ssh_sudo(connection, command)
+        output = ssh_sudo(connection, command)
         log.debug(output)
         command = "/var/cfengine/bin/cf-agent -K"
-        output = remote.ssh_sudo(connection, command)
+        output = ssh_sudo(connection, command)
         log.debug(output)
 
 
@@ -54,6 +54,6 @@ def install_def_json(host):
     data = json.dumps(def_json(), indent=2)
     path = os.path.join(cf_remote_dir("json"), "def.json")
     save_file(path, data)
-    remote.scp(path, host)
-    with remote.connect(host) as connection:
+    scp(path, host)
+    with connect(host) as connection:
         connection.sudo("cp def.json /var/cfengine/masterfiles/def.json")

--- a/contrib/cf-remote/cf_remote/demo.py
+++ b/contrib/cf-remote/cf_remote/demo.py
@@ -4,14 +4,11 @@ import json
 from cf_remote import log
 from cf_remote.paths import cf_remote_dir
 from cf_remote.utils import save_file
-from cf_remote.ssh import scp, connect, ssh_sudo
+from cf_remote.ssh import scp, ssh_sudo, auto_connect
 
 
-def agent_run(host, connection=None):
-    if not connection:
-        with connect(host) as connection:
-            return agent_run(host, connection)
-
+@auto_connect
+def agent_run(host, *, connection=None):
     print("Triggering an agent run on: '{}'".format(host))
     command = "/var/cfengine/bin/cf-agent -Kf update.cf"
     output = ssh_sudo(connection, command)
@@ -52,11 +49,8 @@ def def_json():
     }
 
 
-def install_def_json(host, connection=None):
-    if not connection:
-        with connect(host) as connection:
-            return install_def_json(host, connection)
-
+@auto_connect
+def install_def_json(host, *, connection=None):
     print("Transferring def.json to hub: '{}'".format(host))
     data = json.dumps(def_json(), indent=2)
     path = os.path.join(cf_remote_dir("json"), "def.json")

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -3,50 +3,13 @@ import sys
 from os.path import basename
 from collections import OrderedDict
 
-import fabric
-from paramiko.ssh_exception import AuthenticationException
-from invoke.exceptions import UnexpectedExit
-
 from cf_remote.utils import os_release, column_print, pretty, user_error
+from cf_remote.ssh import connect, ssh_sudo, ssh_cmd, scp
 from cf_remote import log
 from cf_remote.web import download_package
 from cf_remote.packages import Releases
 
 import cf_remote.demo as demo_lib
-
-
-def ssh_cmd(connection, cmd, errors=False):
-    try:
-        log.debug("Running over SSH: '{}'".format(cmd))
-        result = connection.run(cmd, hide=True)
-        output = result.stdout.strip()
-        log.debug("'{}' -> '{}'".format(cmd, output))
-        return output
-    except UnexpectedExit as e:
-        msg = "Non-sudo command unexpectedly exited: '{}'".format(cmd)
-        if errors:
-            print(e)
-            log.error(msg)
-        else:
-            log.debug(msg)
-        return None
-
-
-def ssh_sudo(connection, cmd, errors=False):
-    try:
-        log.debug("Running(sudo) over SSH: '{}'".format(cmd))
-        result = connection.run('sudo bash -c "{}"'.format(cmd.replace('"', r'\"')), hide=True)
-        output = result.stdout.strip()
-        log.debug("'{}' -> '{}'".format(cmd, output))
-        return output
-    except UnexpectedExit as e:
-        msg = "Sudo command unexpectedly exited: '{}'".format(cmd)
-        if errors:
-            print(e)
-            log.error(msg)
-        else:
-            log.debug(msg)
-        return None
 
 
 def print_info(data):
@@ -89,28 +52,6 @@ def print_info(data):
 
     column_print(output)
     print()
-
-
-def connect(host, users=None):
-    log.debug("Connecting to '{}'".format(host))
-    if "@" in host:
-        parts = host.split("@")
-        assert len(parts) == 2
-        host = parts[1]
-        if not users:
-            users = [parts[0]]
-    if not users:
-        users = ["ubuntu", "ec2-user", "centos", "vagrant", "root"]
-    for user in users:
-        try:
-            c = fabric.Connection(host=host, user=user)
-            c.ssh_user = user
-            c.ssh_host = host
-            c.run("whoami", hide=True)
-            return c
-        except AuthenticationException:
-            continue
-    sys.exit("Could not ssh into '{}'".format(host))
 
 
 def transfer_file(host, file, users=None, connection=None):
@@ -162,15 +103,6 @@ def get_info(host, users=None, connection=None):
 
     log.debug("JSON data from host info: \n" + pretty(data))
     return data
-
-
-def scp(file, remote, connection=None):
-    if not connection:
-        with connect(remote) as connection:
-            scp(file, remote, connection)
-    else:
-        print("Copying: '{}' to '{}'".format(file, remote))
-        connection.put(file)
 
 
 def install_package(host, pkg, data):

--- a/contrib/cf-remote/cf_remote/ssh.py
+++ b/contrib/cf-remote/cf_remote/ssh.py
@@ -37,6 +37,7 @@ def scp(file, remote, connection=None):
 
 
 def ssh_cmd(connection, cmd, errors=False):
+    assert connection
     try:
         log.debug("Running over SSH: '{}'".format(cmd))
         result = connection.run(cmd, hide=True)
@@ -54,6 +55,7 @@ def ssh_cmd(connection, cmd, errors=False):
 
 
 def ssh_sudo(connection, cmd, errors=False):
+    assert connection
     try:
         log.debug("Running(sudo) over SSH: '{}'".format(cmd))
         result = connection.run('sudo bash -c "{}"'.format(cmd.replace('"', r'\"')), hide=True)

--- a/contrib/cf-remote/cf_remote/ssh.py
+++ b/contrib/cf-remote/cf_remote/ssh.py
@@ -1,0 +1,70 @@
+import fabric
+from paramiko.ssh_exception import AuthenticationException
+from invoke.exceptions import UnexpectedExit
+
+from cf_remote import log
+
+
+def connect(host, users=None):
+    log.debug("Connecting to '{}'".format(host))
+    if "@" in host:
+        parts = host.split("@")
+        assert len(parts) == 2
+        host = parts[1]
+        if not users:
+            users = [parts[0]]
+    if not users:
+        users = ["ubuntu", "ec2-user", "centos", "vagrant", "root"]
+    for user in users:
+        try:
+            c = fabric.Connection(host=host, user=user)
+            c.ssh_user = user
+            c.ssh_host = host
+            c.run("whoami", hide=True)
+            return c
+        except AuthenticationException:
+            continue
+    sys.exit("Could not ssh into '{}'".format(host))
+
+
+def scp(file, remote, connection=None):
+    if not connection:
+        with connect(remote) as connection:
+            scp(file, remote, connection)
+    else:
+        print("Copying: '{}' to '{}'".format(file, remote))
+        connection.put(file)
+
+
+def ssh_cmd(connection, cmd, errors=False):
+    try:
+        log.debug("Running over SSH: '{}'".format(cmd))
+        result = connection.run(cmd, hide=True)
+        output = result.stdout.strip()
+        log.debug("'{}' -> '{}'".format(cmd, output))
+        return output
+    except UnexpectedExit as e:
+        msg = "Non-sudo command unexpectedly exited: '{}'".format(cmd)
+        if errors:
+            print(e)
+            log.error(msg)
+        else:
+            log.debug(msg)
+        return None
+
+
+def ssh_sudo(connection, cmd, errors=False):
+    try:
+        log.debug("Running(sudo) over SSH: '{}'".format(cmd))
+        result = connection.run('sudo bash -c "{}"'.format(cmd.replace('"', r'\"')), hide=True)
+        output = result.stdout.strip()
+        log.debug("'{}' -> '{}'".format(cmd, output))
+        return output
+    except UnexpectedExit as e:
+        msg = "Sudo command unexpectedly exited: '{}'".format(cmd)
+        if errors:
+            print(e)
+            log.error(msg)
+        else:
+            log.debug(msg)
+        return None

--- a/contrib/cf-remote/cf_remote/ssh.py
+++ b/contrib/cf-remote/cf_remote/ssh.py
@@ -27,6 +27,22 @@ def connect(host, users=None):
     sys.exit("Could not ssh into '{}'".format(host))
 
 
+# Decorator to make a function automatically connect
+# Requires that first positional argument is host
+# and connection should be a keyword argument with default None
+# Uses a context manager (with) to ensure connections are closed
+def auto_connect(func):
+    def connect_wrapper(host, *args, **kwargs):
+        if not kwargs.get("connection"):
+            with connect(host, users=kwargs.get("users")) as connection:
+                assert connection
+                kwargs["connection"] = connection
+                return func(host, *args, **kwargs)
+        return func(host, *args, **kwargs)
+
+    return connect_wrapper
+
+
 def scp(file, remote, connection=None):
     if not connection:
         with connect(remote) as connection:


### PR DESCRIPTION
The main reason why `install` wasn't working in Digital Ocean was that it opened a lot of SSH connections to the same host. This pull request fixes that and some other problems highlighted by LGTM code analysis.