### PR TITLE
CFE-646: Suppressed noisy error when directories already exist (3.12.x)

### DIFF
--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -290,7 +290,7 @@ bool MakeParentDirectory(const char *parentandchild, bool force)
             {
                 mask = umask(0);
 
-                if (mkdir(currentpath, DEFAULTMODE) == -1)
+                if (mkdir(currentpath, DEFAULTMODE) == -1 && errno != EEXIST)
                 {
                     Log(LOG_LEVEL_ERR,
                         "Unable to make directory: %s (mkdir: %s)",


### PR DESCRIPTION
Previously, cf-key (for instance) would report that it could not
create the directory, indicating that something had gone wrong.
With this commit, `mkdir()` will not log error if it just failed
because the file already exists.

Ticket: CFE-646
Changelog: None
(cherry picked from commit e9c4cca0019ef4be871d4151b5a42b154938ab5c)