### PR TITLE
cf-remote: Better command output and error handling

### DIFF
--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from cf_remote.remote import get_info, print_info, install_host, run_command, transfer_file
 from cf_remote.packages import Releases
@@ -20,8 +21,7 @@ def run(hosts, command, users=None, sudo=False):
     for host in hosts:
         lines = run_command(host=host, command=command, users=users, sudo=sudo)
         if lines is None:
-            print("Failed on host: '{}'".format(host))
-            continue
+            sys.exit("Command: '{}'\nFailed on host: '{}'".format(command, host))
         host_colon = (host + ":").ljust(16)
         if lines == "":
             print("{} '{}'".format(host_colon, command))

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -104,9 +104,11 @@ def install_package(host, pkg, data, *, connection=None):
 
     print("Installing: '{}' on '{}'".format(pkg, host))
     if ".deb" in pkg:
-        ssh_sudo(connection, "dpkg -i {}".format(pkg))
+        output = ssh_sudo(connection, "dpkg -i {}".format(pkg))
     else:
-        ssh_sudo(connection, "rpm -i {}".format(pkg))
+        output = ssh_sudo(connection, "rpm -i {}".format(pkg))
+    if output is None:
+        sys.exit("Installation failed on '{}'".format(host))
 
 
 @auto_connect
@@ -115,6 +117,8 @@ def bootstrap_host(host, policy_server, *, connection=None):
     print("Bootstrapping: '{}' -> '{}'".format(host, policy_server))
     command = "/var/cfengine/bin/cf-agent --bootstrap {}".format(policy_server)
     output = ssh_sudo(connection, command)
+    if output is None:
+        sys.exit("Bootstrap failed on '{}'".format(host))
     if output and "completed successfully" in output:
         print("Bootstrap succesful: '{}' -> '{}'".format(host, policy_server))
     else:

--- a/contrib/cf-remote/cf_remote/ssh.py
+++ b/contrib/cf-remote/cf_remote/ssh.py
@@ -57,7 +57,7 @@ def ssh_cmd(connection, cmd, errors=False):
     try:
         log.debug("Running over SSH: '{}'".format(cmd))
         result = connection.run(cmd, hide=True)
-        output = result.stdout.strip()
+        output = result.stdout.strip("\n")
         log.debug("'{}' -> '{}'".format(cmd, output))
         return output
     except UnexpectedExit as e:
@@ -75,7 +75,7 @@ def ssh_sudo(connection, cmd, errors=False):
     try:
         log.debug("Running(sudo) over SSH: '{}'".format(cmd))
         result = connection.run('sudo bash -c "{}"'.format(cmd.replace('"', r'\"')), hide=True)
-        output = result.stdout.strip()
+        output = result.stdout.strip("\n")
         log.debug("'{}' -> '{}'".format(cmd, output))
         return output
     except UnexpectedExit as e:

--- a/contrib/cf-remote/cf_remote/ssh.py
+++ b/contrib/cf-remote/cf_remote/ssh.py
@@ -66,6 +66,7 @@ def ssh_cmd(connection, cmd, errors=False):
             print(e)
             log.error(msg)
         else:
+            log.debug(str(e))
             log.debug(msg)
         return None
 
@@ -84,5 +85,6 @@ def ssh_sudo(connection, cmd, errors=False):
             print(e)
             log.error(msg)
         else:
+            log.debug(str(e))
             log.debug(msg)
         return None


### PR DESCRIPTION
This preserves formatting on the first line,
for example in cf-agent output.