### PR TITLE
Avoid swallowing the number part of YAML string value

### DIFF
--- a/libutils/json-yaml.c
+++ b/libutils/json-yaml.c
@@ -111,7 +111,8 @@ static JsonElement* JsonParseYamlScalarValue(yaml_event_t *event)
          JSON_YAML_SCALAR_TAG_IS(tag, YAML_FLOAT_TAG)))
     {
         JsonElement *tobuild;
-        if (JSON_PARSE_OK == JsonParseAsNumber(&value, &tobuild))
+        const char *end_of_num_part = value;
+        if (JSON_PARSE_OK == JsonParseAsNumber(&end_of_num_part, &tobuild))
         {
             return tobuild;
         }

--- a/tests/acceptance/01_vars/02_functions/parseyaml_with_unquoted_values_starting_with_digits.cf
+++ b/tests/acceptance/01_vars/02_functions/parseyaml_with_unquoted_values_starting_with_digits.cf
@@ -7,9 +7,8 @@ body common control
 bundle agent test
 {
    meta:
-     "test_soft_fail"
-       string => "any",
-       meta => { "redmine7372" };
+     "description" -> { "CFE-2033" }
+       string => "Make sure parsing YAML values starting with numbers works";
 
    vars:
       "class" string => "1003_efl_test";


### PR DESCRIPTION
The JsonParseAsNumber() tries to parse the given string as a
number, *and also moves the pointer to the point it failed to
continue doing so*. To use it as a check function we need to give
it a pointer it can mangle instead of the pointer we plan to
continue using.

Ticket: CFE-2033
Changelog: Fix parsing YAML values starting with numbers
(cherry picked from commit 48619fc0f3bf1dab31c02b9425d88e8ada9e35c3)