### PR TITLE
Log an error if reading registry value failed in registryvalue()

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -5465,13 +5465,15 @@ static FnCallResult FnCallRegistryValue(ARG_UNUSED EvalContext *ctx, ARG_UNUSED 
 {
     char buffer[CF_BUFSIZE] = "";
 
-    if (GetRegistryValue(RlistScalarValue(finalargs),
-                         RlistScalarValue(finalargs->next),
-                         buffer, sizeof(buffer)))
+    const char *const key = RlistScalarValue(finalargs);
+    const char *const value = RlistScalarValue(finalargs->next);
+    if (GetRegistryValue(key, value, buffer, sizeof(buffer)))
     {
         return FnReturn(buffer);
     }
 
+    Log(LOG_LEVEL_ERR, "Could not read existing registry data for key '%s' and value '%s'.",
+        key, value);
     return FnFailure();
 }
 


### PR DESCRIPTION
Failing to read a registry value in the registryvalue() function
is an error.

Ticket: CFE-2568
Changelog: None

Note: This compensates the change of behavior introduced in
      cfengine/enterprise@268a4d8169.

Merge together:
https://github.com/cfengine/enterprise/pull/492