### PR TITLE
CFE-2983: Display an error when a function defining a variables still…

### DIFF
--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -147,6 +147,11 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
             if (res.status == FNCALL_FAILURE)
             {
                 /* We do not assign variables to failed fn calls */
+                if (EvalContextGetPass(ctx) == CF_DONEPASSES-1) {
+                    // If we still fail at last pass, make a log
+                    Log(LOG_LEVEL_VERBOSE, "While setting variable '%s' in bundle '%s', function '%s' failed - skipping",
+                                       pp->promiser, PromiseGetBundle(pp)->name, fp->name);
+                }
                 RvalDestroy(res.rval);
                 VarRefDestroy(ref);
                 return PROMISE_RESULT_NOOP;


### PR DESCRIPTION
… fails at pass3

(cherry picked from commit 7756ddd3d66e6150f876089fef38efab5d08514d)