### PR TITLE
CFE-3023: Retry SSL_read on SSL_ERROR_WANT_READ

### DIFF
--- a/libcfnet/tls_client.c
+++ b/libcfnet/tls_client.c
@@ -310,7 +310,19 @@ int TLSTry(ConnectionInfo *conn_info)
     /* Initiate the TLS handshake over the already open TCP socket. */
     SSL_set_fd(conn_info->ssl, conn_info->sd);
 
-    int ret = SSL_connect(conn_info->ssl);
+    do
+      {
+        ret = SSL_connect(conn_info->ssl);
+        if (ret < 0)
+          {
+            code = TLSLogError(conn_info->ssl, LOG_LEVEL_ERR,
+                               "Attempted to establish TLS connection", ret);
+            if (code == SSL_ERROR_WANT_READ)
+              {
+                sleep(1);
+              }
+          }
+      } while( ret < 0 && code == SSL_ERROR_WANT_READ && (tries++ < 10) );
     if (ret <= 0)
     {
         TLSLogError(conn_info->ssl, LOG_LEVEL_ERR,

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -726,17 +726,17 @@ int TLSRecv(SSL *ssl, char *buffer, int toget)
 
     int received,tries = 0,code=0;
     do
-      {
+    {
         received = SSL_read(ssl, buffer, toget);
         if (received < 0)
-          {
+        {
             code = TLSLogError(ssl, LOG_LEVEL_ERR, "SSL_read", received);
             if (code == SSL_ERROR_WANT_READ)
-              {
+            {
                 sleep(1);
-              }
-          }
-      } while( received < 0 && code == SSL_ERROR_WANT_READ && (tries++ < 10) );
+            }
+        }
+    } while (received < 0 && code == SSL_ERROR_WANT_READ && (tries++ < 10));
 
     if (received < 0)
     {


### PR DESCRIPTION
Changelog: Title

When the client gets SSL_ERROR_WANT_READ, we should re-try instead of shutting
down the whole session.