### PR TITLE
CFE-3023: Retry SSL_read on SSL_ERROR_WANT_READ (3.10)

### DIFF
--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -685,7 +685,20 @@ int TLSRecv(SSL *ssl, char *buffer, int toget)
     assert(toget < CF_BUFSIZE);
     assert_SSLIsBlocking(ssl);
 
-    int received = SSL_read(ssl, buffer, toget);
+    int received,tries = 0,code=0;
+    do
+      {
+        received = SSL_read(ssl, buffer, toget);
+        if (received < 0)
+          {
+            code = TLSLogError(ssl, LOG_LEVEL_ERR, "SSL_read", received);
+            if (code == SSL_ERROR_WANT_READ)
+              {
+                sleep(1);
+              }
+          }
+      } while( received < 0 && code == SSL_ERROR_WANT_READ && (tries++ < 10) );
+
     if (received < 0)
     {
         int errcode = TLSLogError(ssl, LOG_LEVEL_ERR, "SSL_read", received);


### PR DESCRIPTION
Changelog: Title

When the client gets SSL_ERROR_WANT_READ, we should re-try instead of shutting
down the whole session.

(cherry picked from commit c72d1c65eef399faa2a5b5cc65fe95f48bcac3a5)