### PR TITLE
ENT-4505: Don't allow NULL pointers as strings in hashing

### DIFF
--- a/libutils/hash_map.c
+++ b/libutils/hash_map.c
@@ -65,6 +65,7 @@ HashMap *HashMapNew(MapHashFn hash_fn, MapKeyEqualFn equal_fn,
 
 static unsigned int HashMapGetBucket(const HashMap *map, const void *key)
 {
+    assert(map != NULL);
     unsigned int hash = map->hash_fn(key, 0);
     assert (ISPOW2 (map->size));
     return (hash & (map->size - 1));

--- a/libutils/map.c
+++ b/libutils/map.c
@@ -162,6 +162,7 @@ bool MapInsert(Map *map, void *key, void *value)
 {
     assert(map != NULL);
     /* MapGet() is not capable of handling NULL values. */
+    assert(key != NULL);
     assert(value != NULL);
 
     if (IsArrayMap(map))
@@ -202,6 +203,7 @@ static MapKeyValue *MapGetRaw(const Map *map, const void *key)
 bool MapHasKey(const Map *map, const void *key)
 {
     assert(map != NULL);
+    assert(key != NULL);
     return MapGetRaw(map, key) != NULL;
 }
 

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -92,9 +92,12 @@ size_t StringCopy(const char *const from, char *const to, const size_t buf_size)
 
 unsigned int StringHash(const char *str, unsigned int seed)
 {
+    assert(str != NULL);
     unsigned const char *p = (unsigned const char *) str;
     unsigned int h = seed;
-    size_t len = strlen(str);
+
+    // NULL is not allowed, but we will prevent segfault anyway:
+    size_t len = (str != NULL) ? strlen(str) : 0;
 
     /* https://en.wikipedia.org/wiki/Jenkins_hash_function#one-at-a-time */
     for (size_t i = 0; i < len; i++)

--- a/tests/unit/map_test.c
+++ b/tests/unit/map_test.c
@@ -349,10 +349,6 @@ static void test_has_key(void)
     assert_false(StringMapInsert(map, xstrdup("one"), xstrdup("first")));
     assert_true(StringMapHasKey(map, "one"));
 
-    assert_false(StringMapHasKey(map, NULL));
-    assert_false(StringMapInsert(map, NULL, xstrdup("null")));
-    assert_true(StringMapHasKey(map, NULL));
-
     StringMapDestroy(map);
 }
 


### PR DESCRIPTION
Merge together: 
https://github.com/cfengine/core/pull/3549
https://github.com/cfengine/enterprise/pull/493
https://github.com/cfengine/nova/pull/1382