### PR TITLE
ENT-4497: Fixed inconsistent NULL checks (3.12)

### DIFF
--- a/cf-agent/verify_databases.c
+++ b/cf-agent/verify_databases.c
@@ -477,6 +477,13 @@ static int ValidateRegistryPromiser(char *key, const Promise *pp)
 
     strlcpy(root_key, key, CF_MAXVARSIZE );
     sp = strchr(root_key, '\\');
+    if (sp == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Cannot locate '\\' in '%s'", root_key);
+        Log(LOG_LEVEL_ERR, "Failed validating registry promiser");
+        PromiseRef(LOG_LEVEL_ERR, pp);
+        return false;
+    }
     *sp = '\0';
 
     for (i = 0; valid[i] != NULL; i++)

--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -1209,6 +1209,11 @@ static bool DoCreateUser(const char *puser, User u, enum cfopaction action,
         if (a->havebundle)
         {
             const Constraint *method_attrib = PromiseGetConstraint(pp, "home_bundle");
+            if (method_attrib == NULL)
+            {
+                Log(LOG_LEVEL_ERR, "Cannot create user (home_bundle not found)");
+                return false;
+            }
             VerifyMethod(ctx, method_attrib->rval, *a, pp);
         }
 

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -67,6 +67,11 @@ Rlist *NewExpArgs(EvalContext *ctx, const Policy *policy, const FnCall *fp, cons
     }
 
     const FnCallType *fn = FnCallTypeGet(fp->name);
+    if (fn == NULL)
+    {
+        FatalError(ctx, "Function call '%s' has unknown type", fp->name);
+    }
+    else
     {
         int len = RlistLen(fp->args);
 
@@ -251,6 +256,10 @@ static FnCallResult CallFunction(EvalContext *ctx, const Policy *policy, const F
 {
     const Rlist *rp = fp->args;
     const FnCallType *fncall_type = FnCallTypeGet(fp->name);
+    if (fncall_type == NULL)
+    {
+        FatalError(ctx, "Function call '%s' has unknown type", fp->name);
+    }
 
     int argnum = 0;
     for (argnum = 0; rp != NULL && fncall_type->args[argnum].pattern != NULL; argnum++)

--- a/libpromises/known_dirs.c
+++ b/libpromises/known_dirs.c
@@ -56,6 +56,11 @@ const char *GetDefaultDir_helper(char dir[PATH_MAX], const char *root_dir, const
         {
             struct passwd *mpw = getpwuid(getuid());
 
+            if (mpw == NULL)
+            {
+                return NULL;
+            }
+
             if ( append_dir == NULL )
             {
                 if (snprintf(dir, PATH_MAX, "%s/.cfagent", mpw->pw_dir) >= PATH_MAX)


### PR DESCRIPTION
In all cases, if the functions would return
NULL previously it would result in undefined
behavior / crashes (deref NULL pointer). So
logging errors and/or stopping agent should
be safe changes.

Reported by LGTM:
https://lgtm.com/rules/2151900540/