### PR TITLE
Change /var/cfengine/backup/ to backups/ (3.12)

### DIFF
--- a/cf-check/backup.c
+++ b/cf-check/backup.c
@@ -26,7 +26,7 @@ int backup_files(Seq *filenames)
 const char *create_backup_dir()
 {
     static char backup_dir[PATH_MAX];
-    const char *const backup_root = "/var/cfengine/backup/";
+    const char *const backup_root = "/var/cfengine/backups/";
 
     if (mkdir(backup_root, 0700) != 0)
     {


### PR DESCRIPTION
The default location for file backups by agent file promises
is /var/cfengine/backups/.  It would be nicer not to have
both backup/ and backups/ (confusing).

(cherry picked from commit c0990bf9242c3e956e726df22fce8f62deb41c71)