### PR TITLE
Private keys generated by cf-key are no longer encrypted

### DIFF
--- a/cf-key/cf-key-functions.c
+++ b/cf-key/cf-key-functions.c
@@ -229,9 +229,7 @@ static bool KeepKeyPromisesRSA(RSA *pair, const char *public_key_file, const cha
 
     Log(LOG_LEVEL_VERBOSE, "Writing private key to '%s'", private_key_file);
 
-    const EVP_CIPHER *cipher = EVP_des_ede3_cbc();
-    int res = PEM_write_RSAPrivateKey(fp, pair, cipher, (void *)PRIVKEY_PASSPHRASE,
-                                 PRIVKEY_PASSPHRASE_LEN, NULL, NULL);
+    int res = PEM_write_RSAPrivateKey(fp, pair, NULL, NULL, 0, NULL, NULL);
     fclose(fp);
 
     if (res == 0)

--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -196,6 +196,8 @@ bool LoadSecretKeys(const char *const priv_key_path,
         {
             DESTROY_AND_NULL(RSA_free, *priv_key);
         }
+
+        // Can read both encrypted (old) and unencrypted(new) key files:
         *priv_key = PEM_read_RSAPrivateKey(fp, NULL, NULL, (void*) priv_passphrase);
         if (*priv_key == NULL)
         {

--- a/libpromises/crypto.h
+++ b/libpromises/crypto.h
@@ -31,6 +31,9 @@
 
 #include <logging.h>
 
+// This passphrase was used to encrypt private keys.
+// We no longer encrypt new keys, but the passphrase is kept
+// for backwards compatibility - old encrypted keys will still work.
 #define PRIVKEY_PASSPHRASE "Cfengine passphrase"
 #define PRIVKEY_PASSPHRASE_LEN 19
 


### PR DESCRIPTION
Private key files encrypted with a broken cipher and default
hard coded passphrase provide no real security, and is only an
inconvenience. Maybe it was intended to add a password prompt
later, but it's been 10 years now, and the cipher and passphrase
remain untouched. The function which reads keys still supports
both encrypted and unencrypted keys, it will decrypt if necessary.

This passphrase was introduced as part of cf-key in:
c7765f71ff04f07f497988a2a068122394da30bc