### PR TITLE
CFE-2882: Don't trim leading zeroes in ubuntu minor version class

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2371,13 +2371,14 @@ static int Linux_Debian_Version(EvalContext *ctx)
     else if (strcmp(os, "Ubuntu") == 0)
     {
         LinuxDebianSanitizeIssue(buffer);
-        sscanf(buffer, "%*s %[^.].%d", version, &release);
+        char minor[CF_MAXVARSIZE] = {0};
+        sscanf(buffer, "%*s %[^.].%s", version, minor);
         snprintf(buffer, CF_MAXVARSIZE, "ubuntu_%s", version);
         SetFlavor(ctx, buffer);
         EvalContextClassPutHard(ctx, "ubuntu", "inventory,attribute_name=none,source=agent");
         if (release >= 0)
         {
-            snprintf(buffer, CF_MAXVARSIZE, "ubuntu_%s_%d", version, release);
+            snprintf(buffer, CF_MAXVARSIZE, "ubuntu_%s_%s", version, minor);
             EvalContextClassPutHard(ctx, buffer, "inventory,attribute_name=none,source=agent");
         }
     }

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2312,7 +2312,10 @@ static int Linux_Debian_Version(EvalContext *ctx)
     char classname[CF_MAXVARSIZE], buffer[CF_MAXVARSIZE], os[CF_MAXVARSIZE], version[CF_MAXVARSIZE];
 
     Log(LOG_LEVEL_VERBOSE, "This appears to be a debian system.");
-    EvalContextClassPutHard(ctx, "debian", "inventory,attribute_name=none,source=agent");
+    EvalContextClassPutHard(
+        ctx,
+        "debian",
+        "inventory,attribute_name=none,source=agent,derived-from-file="DEBIAN_VERSION_FILENAME);
 
     buffer[0] = classname[0] = '\0';
 
@@ -2330,7 +2333,10 @@ static int Linux_Debian_Version(EvalContext *ctx)
     case 2:
         Log(LOG_LEVEL_VERBOSE, "This appears to be a Debian %u.%u system.", major, release);
         snprintf(classname, CF_MAXVARSIZE, "debian_%u_%u", major, release);
-        EvalContextClassPutHard(ctx, classname, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(
+            ctx,
+            classname,
+            "inventory,attribute_name=none,source=agent,derived-from-file="DEBIAN_VERSION_FILENAME);
         snprintf(classname, CF_MAXVARSIZE, "debian_%u", major);
         SetFlavor(ctx, classname);
         break;
@@ -2347,7 +2353,10 @@ static int Linux_Debian_Version(EvalContext *ctx)
         if (strlen(version) > 0)
         {
             snprintf(classname, CF_MAXVARSIZE, "debian_%s", version);
-            EvalContextClassPutHard(ctx, classname, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(
+                ctx,
+                classname,
+                "inventory,attribute_name=none,source=agent,derived-from-file="DEBIAN_VERSION_FILENAME);
         }
         break;
     }
@@ -2365,7 +2374,10 @@ static int Linux_Debian_Version(EvalContext *ctx)
         LinuxDebianSanitizeIssue(buffer);
         sscanf(buffer, "%*s %*s %[^./]", version);
         snprintf(buffer, CF_MAXVARSIZE, "debian_%s", version);
-        EvalContextClassPutHard(ctx, "debian", "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(
+            ctx,
+            "debian",
+            "inventory,attribute_name=none,source=agent,derived-from-file="DEBIAN_ISSUE_FILENAME);
         SetFlavor(ctx, buffer);
     }
     else if (strcmp(os, "Ubuntu") == 0)
@@ -2375,11 +2387,17 @@ static int Linux_Debian_Version(EvalContext *ctx)
         sscanf(buffer, "%*s %[^.].%s", version, minor);
         snprintf(buffer, CF_MAXVARSIZE, "ubuntu_%s", version);
         SetFlavor(ctx, buffer);
-        EvalContextClassPutHard(ctx, "ubuntu", "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(
+            ctx,
+            "ubuntu",
+            "inventory,attribute_name=none,source=agent,derived-from-file="DEBIAN_ISSUE_FILENAME);
         if (release >= 0)
         {
             snprintf(buffer, CF_MAXVARSIZE, "ubuntu_%s_%s", version, minor);
-            EvalContextClassPutHard(ctx, buffer, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(
+                ctx,
+                buffer,
+                "inventory,attribute_name=none,source=agent,derived-from-file="DEBIAN_ISSUE_FILENAME);
         }
     }
 

--- a/tests/acceptance/02_classes/03_os/ubuntu.cf
+++ b/tests/acceptance/02_classes/03_os/ubuntu.cf
@@ -1,0 +1,51 @@
+#######################################################
+#
+# Test ubuntu classes
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "dummy" string => "dummy";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "dummy" string => "dummy";
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+    ubuntu_18_04.ubuntu_18_4::
+     "not_ok";
+    ubuntu_16_04.ubuntu_16_4::
+     "not_ok";
+    ubuntu_14_04.ubuntu_14_4::
+     "not_ok";
+    ubuntu_12_04.ubuntu_12_4::
+     "not_ok";
+    any::
+      "ok" not => "not_ok";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
# Ubuntu 18

**Before:**
```
root@ip-172-31-45-190 core $ cf-promises --show-classes | grep -i ubuntu
linux_x86_64_4_15_0_1032_aws__34_Ubuntu_SMP_Thu_Jan_17_15_18_09_UTC_2019 source=agent,derived-from=sys.long_arch,hardclass
ubuntu                                                       inventory,attribute_name=none,source=agent,derived-from-file=/etc/os-release,hardclass
ubuntu_18                                                    inventory,attribute_name=none,source=agent,derived-from=sys.flavor,hardclass
ubuntu_18_04                                                 inventory,attribute_name=none,source=agent,derived-from-file=/etc/os-release,hardclass
ubuntu_18_4                                                  inventory,attribute_name=none,source=agent,hardclass
root@ip-172-31-45-190 core $ cf-promises --show-classes | grep -i debian
debian                                                       inventory,attribute_name=none,source=agent,hardclass
debian_buster                                                inventory,attribute_name=none,source=agent,hardclass
debian_derived                                               source=promise,inventory,attribute_name=none
root@ip-172-31-45-190 core $ 
```

**After:**
```
root@ip-172-31-45-190 core $ cf-promises --show-classes | grep -i ubuntu
linux_x86_64_4_15_0_1032_aws__34_Ubuntu_SMP_Thu_Jan_17_15_18_09_UTC_2019 source=agent,derived-from=sys.long_arch,hardclass
ubuntu                                                       inventory,attribute_name=none,source=agent,derived-from-file=/etc/os-release,hardclass
ubuntu_18                                                    inventory,attribute_name=none,source=agent,derived-from=sys.flavor,hardclass
ubuntu_18_04                                                 inventory,attribute_name=none,source=agent,derived-from-file=/etc/os-release,hardclass
root@ip-172-31-45-190 core $ cf-promises --show-classes | grep -i debian
debian                                                       inventory,attribute_name=none,source=agent,derived-from-file=/etc/debian_version,hardclass
debian_buster                                                inventory,attribute_name=none,source=agent,derived-from-file=/etc/debian_version,hardclass
debian_derived                                               source=promise,inventory,attribute_name=none
root@ip-172-31-45-190 core $ 
```