### PR TITLE
Set policy->release_id to "failsafe"/"bootstrap" when running failsafe.cf

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -170,6 +170,10 @@ Policy *SelectAndLoadPolicy(GenericAgentConfig *config, EvalContext *ctx, bool v
             GenericAgentConfigSetInputFile(config, GetInputDir(), "failsafe.cf");
             Log(LOG_LEVEL_ERR, "CFEngine failsafe.cf: %s %s", config->input_dir, config->input_file);
             policy = LoadPolicy(ctx, config);
+
+            /* running the failsafe policy, set the release_id to "failsafe" */
+            free(policy->release_id);
+            policy->release_id = xstrdup("failsafe");
         }
     }
     return policy;

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -615,15 +615,24 @@ Policy *LoadPolicy(EvalContext *ctx, GenericAgentConfig *config)
         }
     }
 
-    JsonElement *validated_doc = ReadReleaseIdFileFromInputs();
-    if (validated_doc)
+    if (config->agent_type == AGENT_TYPE_AGENT &&
+        config->agent_specific.agent.bootstrap_argument != NULL)
     {
-        const char *release_id = JsonObjectGetAsString(validated_doc, "releaseId");
-        if (release_id)
+        /* doing bootstrap, set the release_id to "bootstrap" */
+        policy->release_id = xstrdup("bootstrap");
+    }
+    else
+    {
+        JsonElement *validated_doc = ReadReleaseIdFileFromInputs();
+        if (validated_doc)
         {
-            policy->release_id = xstrdup(release_id);
+            const char *release_id = JsonObjectGetAsString(validated_doc, "releaseId");
+            if (release_id)
+            {
+                policy->release_id = xstrdup(release_id);
+            }
+            JsonDestroy(validated_doc);
         }
-        JsonDestroy(validated_doc);
     }
 
     return policy;


### PR DESCRIPTION
This makes it clear in the logs that the policy run was running
the failsafe policy to either bootstrap or try to recover.

Ticket: CFE-3031
Changelog: Title