### PR TITLE
CFE-3006: Moved known_dirs to libutils - 3.10.x

### DIFF
--- a/libpromises/Makefile.am
+++ b/libpromises/Makefile.am
@@ -51,35 +51,36 @@ libpromises_la_LIBADD = ../libutils/libutils.la ../libcfnet/libcfnet.la \
 	../libenv/libenv.la $(ENTERPRISE_LDADD)
 
 libpromises_la_SOURCES = \
-        cf3parse.y cf3parse.h \
-        cf3lex.l \
         acl_tools.h acl_tools_posix.c \
         actuator.c actuator.h \
         assoc.c assoc.h \
-        audit.c audit.h \
         attributes.c attributes.h \
+        audit.c audit.h \
         bootstrap.c bootstrap.h bootstrap.inc failsafe.cf \
+        cf-windows-functions.h
         cf3.defs.h \
         cf3.extern.h \
         cf3globals.c \
+        cf3lex.l \
+        cf3parse.y cf3parse.h \
         chflags.c chflags.h \
         class.c class.h \
         constants.c \
         conversion.c conversion.h \
         crypto.c crypto.h \
         dbm_api.c dbm_api.h dbm_priv.h \
+        dbm_lmdb.c \
         dbm_migration.c dbm_migration.h \
         dbm_migration_lastseen.c \
-        dbm_lmdb.c \
         dbm_quick.c \
         dbm_tokyocab.c \
-        extensions_template.c.pre extensions_template.h.pre \
         enterprise_stubs.c enterprise_extension.c enterprise_extension.h \
         eval_context.c eval_context.h \
         evalfunction.c evalfunction.h \
         exec_tools.c exec_tools.h \
         expand.c expand.h \
         extensions.c extensions.h \
+        extensions_template.c.pre extensions_template.h.pre \
         feature.c feature.h \
         files_copy.c files_copy.h \
         files_hashes.c files_hashes.h \
@@ -106,6 +107,7 @@ libpromises_la_SOURCES = \
         mod_environ.c mod_environ.h \
         mod_exec.c mod_exec.h \
         mod_files.c mod_files.h \
+        mod_knowledge.c mod_knowledge.h \
         mod_measurement.c mod_measurement.h \
         mod_methods.c mod_methods.h \
         mod_outputs.c mod_outputs.h \
@@ -114,7 +116,6 @@ libpromises_la_SOURCES = \
         mod_report.c mod_report.h \
         mod_services.c mod_services.h \
         mod_storage.c mod_storage.h \
-        mod_knowledge.c mod_knowledge.h \
         mod_users.c mod_users.h \
         modes.c \
         mutex.c mutex.h \
@@ -125,8 +126,8 @@ libpromises_la_SOURCES = \
         parser_state.h \
         patches.c \
         pipes.h pipes.c \
-        processes_select.c processes_select.h \
         process_lib.h process_unix_priv.h \
+        processes_select.c processes_select.h \
         promises.c promises.h \
         prototypes3.h \
         rlist.c rlist.h \
@@ -147,7 +148,6 @@ libpromises_la_SOURCES = \
         verify_classes.c verify_classes.h \
         verify_reports.c \
         verify_vars.c verify_vars.h \
-        cf-windows-functions.h
 
 if !NT
 

--- a/libpromises/Makefile.am
+++ b/libpromises/Makefile.am
@@ -94,7 +94,6 @@ libpromises_la_SOURCES = \
         item_lib.c item_lib.h \
         iteration.c iteration.h \
         keyring.c keyring.h\
-        known_dirs.c known_dirs.h \
         lastseen.c lastseen.h \
         loading.c loading.h \
         locks.c locks.h \

--- a/libpromises/cf-windows-functions.h
+++ b/libpromises/cf-windows-functions.h
@@ -70,12 +70,6 @@ int NovaWin_GetSysDir(char *sysDir, int sysDirSz);
 int NovaWin_GetProgDir(char *progDir, int progDirSz);
 int NovaWin_GetEnv(char *varName, char *varContents, int varContentsSz);
 
-const char *GetDefaultWorkDir(void);
-const char *GetDefaultLogDir(void);
-const char *GetDefaultPidDir(void);
-const char *GetDefaultMasterDir(void);
-const char *GetDefaultInputDir(void);
-
 /* win_user.c */
 
 int NovaWin_UserNameToSid(char *userName, SID *sid, DWORD sidSz, int shouldExist);

--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -53,6 +53,7 @@ libutils_la_SOURCES = \
 	json.c json.h json-priv.h \
 	json-utils.c json-utils.h \
 	json-yaml.c json-yaml.h \
+	known_dirs.c known_dirs.h \
 	list.c list.h \
 	logging.c logging.h logging_priv.h \
 	man.c man.h \

--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -33,49 +33,50 @@ libutils_la_LIBS     = $(PCRE_LIBS) $(OPENSSL_LIBS)
 
 libutils_la_SOURCES = \
 	alloc.c alloc.h \
+	array_map.c array_map_priv.h \
 	atexit.c atexit.h \
+	bool.h \
+	buffer.c buffer.h \
+	cfversion.c cfversion.h \
 	compiler.h \
+	csv_writer.c csv_writer.h \
+	csv_parser.c csv_parser.h \
+	definitions.h \
 	deprecated.h \
 	dir.h dir_priv.h \
+	encode.c encode.h \
+	file_lib.c file_lib.h \
+	hash.c hash.h \
 	hashes.c hashes.h hash_method.h \
+	hash_map.c hash_map_priv.h \
+	ip_address.c ip_address.h \
+	json.c json.h json-priv.h \
+	json-utils.c json-utils.h \
+	json-yaml.c json-yaml.h \
+	list.c list.h \
+	logging.c logging.h logging_priv.h \
+	man.c man.h \
+	map.c map.h map_common.h \
+	misc_lib.c misc_lib.h \
+	mustache.c mustache.h \
+	passopenfile.c passopenfile.h \
+	pcre_include.h \
+	pcre_wrap.c pcre_wrap.h \
+	platform.h condition_macros.h \
+	printsize.h \
+	proc_keyvalue.c proc_keyvalue.h \
+	queue.c queue.h \
+	rb-tree.c rb-tree.h \
+	refcount.c refcount.h \
+	regex.c regex.h \
+	ring_buffer.c ring_buffer.h \
 	sequence.c sequence.h \
 	set.c set.h \
 	statistics.c statistics.h \
 	string_lib.c string_lib.h \
-	pcre_include.h \
-	platform.h condition_macros.h \
-	proc_keyvalue.c proc_keyvalue.h \
-	bool.h \
-	json.c json.h json-priv.h \
-	json-utils.c json-utils.h \
-	json-yaml.c json-yaml.h \
-	refcount.c refcount.h \
-	list.c list.h \
-	logging.c logging.h logging_priv.h \
-	buffer.c buffer.h \
-	ip_address.c ip_address.h \
-	map.c map.h map_common.h \
-	array_map.c array_map_priv.h \
-	hash_map.c hash_map_priv.h \
-	misc_lib.c misc_lib.h \
-	writer.c writer.h \
-	csv_writer.c csv_writer.h \
-	csv_parser.c csv_parser.h \
-	xml_writer.c xml_writer.h \
-	file_lib.c file_lib.h \
-	man.c man.h \
-	rb-tree.c rb-tree.h \
-	mustache.c mustache.h \
-	cfversion.c cfversion.h \
-	passopenfile.c passopenfile.h \
 	unicode.c unicode.h \
-	hash.c hash.h \
-	queue.c queue.h \
-	ring_buffer.c ring_buffer.h \
-	regex.c regex.h \
-	encode.c encode.h \
-	pcre_wrap.c pcre_wrap.h \
-	printsize.h
+	writer.c writer.h \
+	xml_writer.c xml_writer.h
 
 if !NT
   libutils_la_SOURCES += unix_dir.c

--- a/libutils/known_dirs.c
+++ b/libutils/known_dirs.c
@@ -23,10 +23,10 @@
 */
 
 #include <known_dirs.h>
-#include <cf3.defs.h>
+#include <definitions.h>
 #include <file_lib.h>
 
-#include <cf-windows-functions.h>
+static char OVERRIDE_BINDIR[PATH_MAX] = {0};
 
 #if defined(__CYGWIN__) || defined(__ANDROID__)
 
@@ -34,7 +34,7 @@
 static const char *GetDefault##FUNC##Dir(void)      \
 {                                                   \
     return GLOBAL;                                  \
-}                                                   \
+}
 
 /* getpwuid() on Android returns /data,
  * so use compile-time default instead */
@@ -48,11 +48,14 @@ GET_DEFAULT_DIRECTORY_DEFINE(State, STATEDIR)
 
 #elif !defined(__MINGW32__)
 
-const char *GetDefaultDir_helper(char dir[PATH_MAX], const char *root_dir, const char *append_dir)
+const char *GetDefaultDir_helper(char *dir, const char *root_dir,
+                                 const char *append_dir)
 {
+    assert(dir != NULL);
+
     if (getuid() > 0)
     {
-        if (!*dir)
+        if (dir[0] == '\0')
         {
             struct passwd *mpw = getpwuid(getuid());
 
@@ -63,14 +66,16 @@ const char *GetDefaultDir_helper(char dir[PATH_MAX], const char *root_dir, const
 
             if ( append_dir == NULL )
             {
-                if (snprintf(dir, PATH_MAX, "%s/.cfagent", mpw->pw_dir) >= PATH_MAX)
+                if (snprintf(dir, PATH_MAX, "%s/.cfagent",
+                             mpw->pw_dir) >= PATH_MAX)
                 {
                     return NULL;
                 }
             }
             else
             {
-                if (snprintf(dir, PATH_MAX, "%s/.cfagent/%s", mpw->pw_dir, append_dir) >= PATH_MAX)
+                if (snprintf(dir, PATH_MAX, "%s/.cfagent/%s",
+                             mpw->pw_dir, append_dir) >= PATH_MAX)
                 {
                     return NULL;
                 }
@@ -91,7 +96,7 @@ const char *GetDefault##FUNC##Dir(void)                             \
 {                                                                   \
     static char STATIC##dir[PATH_MAX]; /* GLOBAL_C */               \
     return GetDefaultDir_helper(STATIC##dir, GLOBAL, FOLDER);       \
-}                                                                   \
+}
 
 GET_DEFAULT_DIRECTORY_DEFINE(Work, work, WORKDIR, NULL)
 GET_DEFAULT_DIRECTORY_DEFINE(Log, log, LOGDIR, "log")
@@ -107,6 +112,31 @@ const char *GetWorkDir(void)
     const char *workdir = getenv("CFENGINE_TEST_OVERRIDE_WORKDIR");
 
     return workdir == NULL ? GetDefaultWorkDir() : workdir;
+}
+
+const char *GetBinDir(void)
+{
+    const char *workdir = getenv("CFENGINE_TEST_OVERRIDE_WORKDIR");
+
+    if (workdir == NULL)
+    {
+#ifdef __MINGW32__
+        /* Compile-time default bindir doesn't work on windows because during
+         * the build /var/cfengine/bin is used and only when the package is
+         * created, things are shuffled around */
+        snprintf(OVERRIDE_BINDIR, PATH_MAX, "%s%cbin",
+                 GetDefaultWorkDir(), FILE_SEPARATOR);
+        return OVERRIDE_BINDIR;
+#else
+        return GetDefaultBinDir();
+#endif
+    }
+    else
+    {
+        snprintf(OVERRIDE_BINDIR, PATH_MAX, "%s%cbin",
+                 workdir, FILE_SEPARATOR);
+        return OVERRIDE_BINDIR;
+    }
 }
 
 const char *GetLogDir(void)
@@ -135,7 +165,7 @@ const char *GetPidDir(void)
     }                                                                \
     else if (strcmp(GLOBAL##DIR, "default") == 0 )                   \
     {                                                                \
-        snprintf(workbuf, CF_BUFSIZE, "%s/" #FOLDER, GetWorkDir()); \
+        snprintf(workbuf, CF_BUFSIZE, "%s/" #FOLDER, GetWorkDir());  \
     }                                                                \
     else /* VAR##dir defined at compile-time */                      \
     {                                                                \
@@ -143,8 +173,11 @@ const char *GetPidDir(void)
     }                                                                \
                                                                      \
     return MapName(workbuf);                                         \
-}                                                                    \
+}
 
-const char *GetInputDir(void) GET_DIRECTORY_DEFINE_FUNC_BODY(Input, input, INPUT, inputs)
-const char *GetMasterDir(void) GET_DIRECTORY_DEFINE_FUNC_BODY(Master, master, MASTER, masterfiles)
-const char *GetStateDir(void) GET_DIRECTORY_DEFINE_FUNC_BODY(State, state, STATE, state)
+const char *GetInputDir(void)
+    GET_DIRECTORY_DEFINE_FUNC_BODY(Input, input, INPUT, inputs)
+const char *GetMasterDir(void)
+    GET_DIRECTORY_DEFINE_FUNC_BODY(Master, master, MASTER, masterfiles)
+const char *GetStateDir(void)
+    GET_DIRECTORY_DEFINE_FUNC_BODY(State, state, STATE, state)

--- a/libutils/known_dirs.h
+++ b/libutils/known_dirs.h
@@ -27,7 +27,8 @@
 
 #include <platform.h>
 
-const char *GetDefaultDir_helper(char dir[PATH_MAX], const char *root_dir, const char *append_dir);
+const char *GetDefaultDir_helper(char dir[PATH_MAX], const char *root_dir,
+                                 const char *append_dir);
 
 const char *GetWorkDir(void);
 const char *GetLogDir(void);
@@ -35,5 +36,15 @@ const char *GetPidDir(void);
 const char *GetMasterDir(void);
 const char *GetInputDir(void);
 const char *GetStateDir(void);
+
+#ifdef __MINGW32__
+
+const char *GetDefaultWorkDir(void);
+const char *GetDefaultLogDir(void);
+const char *GetDefaultPidDir(void);
+const char *GetDefaultMasterDir(void);
+const char *GetDefaultInputDir(void);
+
+#endif
 
 #endif

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -52,11 +52,11 @@ libtest_la_SOURCES = cmockery.c cmockery.h schema.h test.c test.h \
 	../../libutils/alloc.c \
 	../../libpromises/patches.c \
 	../../libpromises/constants.c \
-        ../../libpromises/known_dirs.c \
-        ../../libutils/map.c \
-        ../../libutils/array_map.c \
-        ../../libutils/hash.c \
-        ../../libutils/hash_map.c
+	../../libutils/known_dirs.c \
+	../../libutils/map.c \
+	../../libutils/array_map.c \
+	../../libutils/hash.c \
+	../../libutils/hash_map.c
 
 libtest_la_LIBADD = ../../libcompat/libcompat.la
 


### PR DESCRIPTION
Also moved some windows-only things out from `cf-windows-functions`. `known_dirs` should not depend on something that uses `libpromises`-specific things.

Ticket: CFE-3006
Changelog: None

Blocked by: #3580