### PR TITLE
CFE-3001: Moved common definitions to libutils - 3.10.x

### DIFF
--- a/libcfnet/cfnet.h
+++ b/libcfnet/cfnet.h
@@ -28,18 +28,13 @@
 
 
 #include <platform.h>
+#include <definitions.h>                        /* CF_BUFSIZE, CF_SMALLBUF */
 
 
 /* Only set with DetermineCfenginePort() and from cf-serverd */
 extern char CFENGINE_PORT_STR[16];                     /* GLOBAL_P GLOBAL_E */
 extern int CFENGINE_PORT;                              /* GLOBAL_P GLOBAL_E */
 
-
-/* max size of plaintext in one transaction, see
-   net.c:SendTransaction(), leave space for encryption padding
-   (assuming max 64*8 = 512-bit cipher block size). */
-#define CF_BUFSIZE 4096
-#define CF_SMALLBUF 128
 
 #define CF_MAX_IP_LEN 64                    /* max IPv4/IPv6 address length */
 #define CF_MAX_PORT_LEN 6

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -35,7 +35,8 @@
 #include <sequence.h>
 #include <logging.h>
 
-#include <cfnet.h>                       /* ProtocolVersion, CF_BUFSIZE etc */
+#include <definitions.h>                 /* CF_MAXVARSIZE, CF_BUFSIZE etc   */
+#include <cfnet.h>                       /* ProtocolVersion, etc */
 #include <misc_lib.h>                    /* xsnprintf, ProgrammingError etc */
 
 /*******************************************************************/
@@ -59,13 +60,6 @@
 /* Various defines                                                 */
 /*******************************************************************/
 
-#define CF_MAXSIZE 102400000
-#define CF_BILLION 1000000000L
-#define CF_EXPANDSIZE (2*CF_BUFSIZE)
-#define CF_BUFFERMARGIN 128
-#define CF_BLOWFISHSIZE 16
-#define CF_MAXVARSIZE 1024
-#define CF_MAXSIDSIZE 2048      /* Windows only: Max size (bytes) of security identifiers */
 #define CF_MAXFRAGMENT 19       /* abbreviate long promise names to 2*MAXFRAGMENT+3 */
 #define CF_NONCELEN (CF_BUFSIZE/16)
 #define CF_MAXLINKSIZE 256

--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -35,6 +35,7 @@ libutils_la_SOURCES = \
 	alloc.c alloc.h \
 	atexit.c atexit.h \
 	compiler.h \
+	definitions.h \
 	deprecated.h \
 	dir.h dir_priv.h \
 	hashes.c hashes.h hash_method.h \

--- a/libutils/definitions.h
+++ b/libutils/definitions.h
@@ -1,0 +1,47 @@
+/*
+   Copyright 2019 Northern.tech AS
+
+   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#ifndef CFENGINE_DEFINITIONS_H
+#define CFENGINE_DEFINITIONS_H
+
+/*****************************************************************************
+ * Size related defines							     *
+ *****************************************************************************/
+#define CF_MAXSIZE  102400000
+#define CF_BILLION 1000000000L
+
+#define CF_BLOWFISHSIZE    16
+#define CF_BUFFERMARGIN   128
+#define CF_MAXVARSIZE    1024
+#define CF_MAXSIDSIZE    2048      /* Windows only: Max size (bytes) of
+                                     security identifiers */
+
+/* Max size of plaintext in one transaction, see net.c:SendTransaction(),
+   leave space for encryption padding (assuming max 64*8 = 512-bit cipher
+   block size). */
+#define CF_SMALLBUF     128
+#define CF_BUFSIZE     4096
+#define CF_EXPANDSIZE (2 * CF_BUFSIZE)
+
+#endif // CFENGINE_DEFINITIONS_H


### PR DESCRIPTION
Currently moved only size-related definitions that we'd like to use in `libutils`.

Ticket: CFE-3001
Changelog: None