### PR TITLE
Acceptance tests for process handling: CFE-3025

### DIFF
--- a/libpromises/systype.c
+++ b/libpromises/systype.c
@@ -99,7 +99,8 @@ const char *const VPSOPTS[] =
     [PLATFORM_CONTEXT_HP] = "-ef",                    /* hpux */
     [PLATFORM_CONTEXT_AIX] =  "-N -eo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,stat,st=STIME,time,args",       /* aix */
     /* Note: keep in sync with GetProcessOptions()'s hack for Linux 2.4 */
-    [PLATFORM_CONTEXT_LINUX] = "-eo user:30,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss:9,nlwp,stime,etime,time,args",/* linux */
+    /* For header text "TTY" specify "tname" (not "tty" which gives header "TT") */
+    [PLATFORM_CONTEXT_LINUX] = "-eo user:30,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss:9,tname,nlwp,stime,etime,time,args",/* linux */
     [PLATFORM_CONTEXT_BUSYBOX] = "",                  /* linux / busybox */
     [PLATFORM_CONTEXT_SOLARIS] = "-eo user,pid,pcpu,pmem,osz,rss,tty,s,stime,time,args",                  /* solaris >= 11 */
     [PLATFORM_CONTEXT_SUN_SOLARIS] = "-eo user,pid,pcpu,pmem,osz,rss,tty,s,stime,time,args",              /* solaris < 11 */

--- a/tests/acceptance/05_processes/01_matching/owner.cf
+++ b/tests/acceptance/05_processes/01_matching/owner.cf
@@ -1,0 +1,87 @@
+#######################################################
+#
+# Run multiple similar tests for 'process_owner'.
+# We test both expected success and expected failure.
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "dummy" string => "dummy";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "ok_list" slist => {
+        "pass_root_1", "pass_root_2", "pass_nouser_3", "pass_nouser_4",
+        "!fail_root_1", "!fail_root_2", "!fail_nouser_3", "!fail_nouser_4"
+      };
+
+  processes:
+      ### 'root' processes:
+      # finding many processes is good
+      ".*"
+        process_select => test_select_owners("root"),
+        process_count => test_range("2", "inf", "pass_root_1", "fail_root_1");
+
+      # looking for a tiny number should fail
+      ".*"
+        process_select => test_select_owners("root"),
+        process_count => test_range("0", "1", "fail_root_2", "pass_root_2");
+
+      ### A hopefully non-existent user:
+      # finding zero processes is good
+      ".*"
+        process_select => test_select_owners("NoSuchUserWeHope"),
+        process_count => test_range("0", "0", "pass_nouser_3", "fail_nouser_3");
+
+      # looking for one or more should fail
+      ".*"
+        process_select => test_select_owners("NoSuchUserWeHope"),
+        process_count => test_range("1", "inf", "fail_nouser_4", "pass_nouser_4");
+
+}
+
+body process_count test_range(min, max, class_good, class_bad)
+{
+      match_range => irange("$(min)", "$(max)");
+      in_range_define => { "$(class_good)" };
+      out_of_range_define => { "$(class_bad)" };
+}
+
+body process_select test_select_owners(owner)
+{
+      process_owner => { "$(owner)" };
+      process_result => "process_owner";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok" and => { @(test.ok_list) };
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 30

--- a/tests/acceptance/05_processes/01_matching/tty.cf
+++ b/tests/acceptance/05_processes/01_matching/tty.cf
@@ -1,0 +1,108 @@
+#######################################################
+#
+# Basic checking of 'tty' selector.
+#
+# The name pattern of ttys varies across operating systems.
+# While the example in the documentation (e.g. "pts/[0-9]+")
+# is typical and illustrative, this basic-level test needs to be
+# reliably portable.
+#
+# The possible meta "test_skip_needs_work" would allow graceful handling
+# of platforms that have not yet been tested.  But aim to minimise
+# any reliance on this.
+#
+# It assumes that the host on which the test is being run will have at least
+# one tty connection active.  This is clearly the case if it being run
+# by a human from their command line.  But it might not be true in a
+# CI/CD environment; in such a case the meta/skip may be useful.
+#
+# Tests:
+#
+# 1.  Negative: using a highly unlikely name.
+#
+# 2.  Positive: using a known-good name pattern; allow to differ across OSes.
+#
+# David Lee, 2019
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "dummy" string => "dummy";
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "test_skip_needs_work" -> {"CFE-3025"}
+        string => "!linux.!hpux",
+        comment => "TTY-based process filtering does't work well no other platforms";
+
+  vars:
+    # Maintenance note: Aim to cover as many OSes as possible
+    # and mimimise the ".+" catch-all.
+    linux::
+      "dev_pattern" string => "(pts/[0-9]+)|(ttyS?[0-9]+)";
+    !linux::
+      "dev_pattern" string => ".+";
+
+  processes:
+      ### Expect zero processes on a tty with a highly unlikely name.
+      ".*"
+        handle => "expect_none",
+        process_select => test_select_tty("No-Such-Major/No-Such-Minor"),
+        process_count => test_range("0", "0", "pass_bad_dev", "fail_bad_dev");
+
+      ### Expect to find one or more processes on these ttys.
+      ".*"
+        handle => "expect_some",
+        process_select => test_select_tty("$(dev_pattern)"),
+        process_count => test_range("1", "inf", "pass_good_dev", "fail_good_dev");
+
+}
+
+body process_count test_range(min, max, class_good, class_bad)
+{
+      match_range => irange("$(min)", "$(max)");
+      in_range_define => { "$(class_good)" };
+      out_of_range_define => { "$(class_bad)" };
+}
+
+body process_select test_select_tty(tty_pattern)
+{
+      tty => "$(tty_pattern)";
+      process_result => "tty";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok" and => {
+        "pass_good_dev", "pass_bad_dev",
+        "!fail_good_dev", "!fail_bad_dev",
+      };
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 30


### PR DESCRIPTION
The acceptance tests had not been covering 'tty' or 'process_owner'.  The two commits here begin to fill that gap.

The 'process_owner' test is standalone.

The 'tty' test has an associated source code change.  See the comment within its commit message for more details.

See issues CFE-3025, which itself emerged from CFE-3020 and CFE-1655