### PR TITLE
CFE-3006: Moved known_dirs to libutils - 3.12.x

### DIFF
--- a/libpromises/Makefile.am
+++ b/libpromises/Makefile.am
@@ -52,109 +52,109 @@ libpromises_la_LIBADD = ../libutils/libutils.la ../libcfnet/libcfnet.la \
 	../libenv/libenv.la $(ENTERPRISE_LDADD)
 
 libpromises_la_SOURCES = \
-        cf3parse.y cf3parse.h \
-        cf3lex.l \
-        acl_tools.h acl_tools_posix.c \
-        actuator.c actuator.h \
-        assoc.c assoc.h \
-        audit.c audit.h \
-        attributes.c attributes.h \
-        bootstrap.c bootstrap.h bootstrap.inc failsafe.cf \
-        cf3.defs.h \
-        cf3.extern.h \
-        cf3globals.c \
-        chflags.c chflags.h \
-        class.c class.h \
-        constants.c \
-        conversion.c conversion.h \
-        crypto.c crypto.h \
-        dbm_api.c dbm_api.h dbm_priv.h \
-        dbm_migration.c dbm_migration.h \
-        dbm_migration_lastseen.c \
-        dbm_lmdb.c \
-        dbm_quick.c \
-        dbm_tokyocab.c \
-        extensions_template.c.pre extensions_template.h.pre \
-        enterprise_stubs.c enterprise_extension.c enterprise_extension.h \
-        eval_context.c eval_context.h \
-        evalfunction.c evalfunction.h \
-        exec_tools.c exec_tools.h \
-        expand.c expand.h \
-        extensions.c extensions.h \
-        feature.c feature.h \
-        files_copy.c files_copy.h \
-        files_hashes.c files_hashes.h \
-        files_interfaces.c files_interfaces.h \
-        files_lib.c files_lib.h \
-        files_names.c files_names.h \
-        fncall.c fncall.h \
-        generic_agent.c generic_agent.h \
-        granules.c granules.h \
-        instrumentation.c instrumentation.h \
-        item_lib.c item_lib.h \
-        iteration.c iteration.h \
-        keyring.c keyring.h\
-        known_dirs.c known_dirs.h \
-        lastseen.c lastseen.h \
-        loading.c loading.h \
-        locks.c locks.h \
-        logic_expressions.c logic_expressions.h \
-        matching.c matching.h \
-        match_scope.c match_scope.h \
-        math_eval.c math_eval.h math.pc \
-        mod_access.c mod_access.h \
-        mod_common.c mod_common.h \
-        mod_databases.c mod_databases.h \
-        mod_environ.c mod_environ.h \
-        mod_exec.c mod_exec.h \
-        mod_files.c mod_files.h \
-        mod_measurement.c mod_measurement.h \
-        mod_methods.c mod_methods.h \
-        mod_outputs.c mod_outputs.h \
-        mod_packages.c mod_packages.h \
-        mod_process.c mod_process.h \
-        mod_report.c mod_report.h \
-        mod_services.c mod_services.h \
-        mod_storage.c mod_storage.h \
-        mod_knowledge.c mod_knowledge.h \
-        mod_users.c mod_users.h \
-        modes.c \
-        monitoring_read.c monitoring_read.h \
-        mutex.c mutex.h \
-        ornaments.c ornaments.h \
-        policy.c policy.h \
-        parser.c parser.h \
-        parser_state.h \
-        patches.c \
-        pipes.h pipes.c \
-        processes_select.c processes_select.h \
-        process_lib.h process_unix_priv.h \
-        promises.c promises.h \
-        prototypes3.h \
-        rlist.c rlist.h \
-        scope.c scope.h \
-        shared_lib.c shared_lib.h \
-        signals.c signals.h \
-        sort.c sort.h \
-        storage_tools.c \
-        string_expressions.c string_expressions.h \
-        syntax.c syntax.h \
-        syslog_client.c syslog_client.h \
-        systype.c systype.h \
-        timeout.c timeout.h \
-        unix.c unix.h \
-        var_expressions.c var_expressions.h \
-        vars.c vars.h \
-        variable.c variable.h \
-        verify_classes.c verify_classes.h \
-        verify_reports.c \
-        verify_vars.c verify_vars.h \
-        cf-windows-functions.h \
-        ../cf-check/backup.c ../cf-check/backup.h \
-        ../cf-check/diagnose.c ../cf-check/diagnose.h \
-        ../cf-check/lmdump.c ../cf-check/lmdump.h \
-        ../cf-check/utilities.c ../cf-check/utilities.h \
-        ../cf-check/repair.c ../cf-check/repair.h
+	acl_tools.h acl_tools_posix.c \
+	actuator.c actuator.h \
+	assoc.c assoc.h \
+	attributes.c attributes.h \
+	audit.c audit.h \
+	bootstrap.c bootstrap.h bootstrap.inc failsafe.cf \
+	cf-windows-functions.h \
+	cf3.defs.h \
+	cf3.extern.h \
+	cf3globals.c \
+	cf3lex.l \
+	cf3parse.y cf3parse.h \
+	chflags.c chflags.h \
+	class.c class.h \
+	constants.c \
+	conversion.c conversion.h \
+	crypto.c crypto.h \
+	dbm_api.c dbm_api.h dbm_priv.h \
+	dbm_migration.c dbm_migration.h \
+	dbm_migration_lastseen.c \
+	dbm_lmdb.c \
+	dbm_quick.c \
+	dbm_tokyocab.c \
+	enterprise_stubs.c enterprise_extension.c enterprise_extension.h \
+	eval_context.c eval_context.h \
+	evalfunction.c evalfunction.h \
+	exec_tools.c exec_tools.h \
+	expand.c expand.h \
+	extensions.c extensions.h \
+	extensions_template.c.pre extensions_template.h.pre \
+	feature.c feature.h \
+	files_copy.c files_copy.h \
+	files_hashes.c files_hashes.h \
+	files_interfaces.c files_interfaces.h \
+	files_lib.c files_lib.h \
+	files_names.c files_names.h \
+	fncall.c fncall.h \
+	generic_agent.c generic_agent.h \
+	granules.c granules.h \
+	instrumentation.c instrumentation.h \
+	item_lib.c item_lib.h \
+	iteration.c iteration.h \
+	keyring.c keyring.h \
+	known_dirs.c known_dirs.h \
+	lastseen.c lastseen.h \
+	loading.c loading.h \
+	locks.c locks.h \
+	logic_expressions.c logic_expressions.h \
+	matching.c matching.h \
+	match_scope.c match_scope.h \
+	math_eval.c math_eval.h math.pc \
+	mod_access.c mod_access.h \
+	mod_common.c mod_common.h \
+	mod_databases.c mod_databases.h \
+	mod_environ.c mod_environ.h \
+	mod_exec.c mod_exec.h \
+	mod_files.c mod_files.h \
+	mod_knowledge.c mod_knowledge.h \
+	mod_measurement.c mod_measurement.h \
+	mod_methods.c mod_methods.h \
+	mod_outputs.c mod_outputs.h \
+	mod_packages.c mod_packages.h \
+	mod_process.c mod_process.h \
+	mod_report.c mod_report.h \
+	mod_services.c mod_services.h \
+	mod_storage.c mod_storage.h \
+	mod_users.c mod_users.h \
+	modes.c \
+	monitoring_read.c monitoring_read.h \
+	mutex.c mutex.h \
+	ornaments.c ornaments.h \
+	parser.c parser.h \
+	parser_state.h \
+	patches.c \
+	pipes.h pipes.c \
+	policy.c policy.h \
+	processes_select.c processes_select.h \
+	process_lib.h process_unix_priv.h \
+	promises.c promises.h \
+	prototypes3.h \
+	rlist.c rlist.h \
+	scope.c scope.h \
+	shared_lib.c shared_lib.h \
+	signals.c signals.h \
+	sort.c sort.h \
+	storage_tools.c \
+	string_expressions.c string_expressions.h \
+	syntax.c syntax.h \
+	syslog_client.c syslog_client.h \
+	systype.c systype.h \
+	timeout.c timeout.h \
+	unix.c unix.h \
+	var_expressions.c var_expressions.h \
+	variable.c variable.h \
+	vars.c vars.h \
+	verify_classes.c verify_classes.h \
+	verify_reports.c \
+	verify_vars.c verify_vars.h \
+	../cf-check/backup.c ../cf-check/backup.h \
+	../cf-check/diagnose.c ../cf-check/diagnose.h \
+	../cf-check/lmdump.c ../cf-check/lmdump.h \
+	../cf-check/repair.c ../cf-check/repair.h \
+	../cf-check/utilities.c ../cf-check/utilities.h
 
 if !NT
 

--- a/libpromises/Makefile.am
+++ b/libpromises/Makefile.am
@@ -95,7 +95,6 @@ libpromises_la_SOURCES = \
 	item_lib.c item_lib.h \
 	iteration.c iteration.h \
 	keyring.c keyring.h \
-	known_dirs.c known_dirs.h \
 	lastseen.c lastseen.h \
 	loading.c loading.h \
 	locks.c locks.h \

--- a/libpromises/cf-windows-functions.h
+++ b/libpromises/cf-windows-functions.h
@@ -70,12 +70,6 @@ int NovaWin_GetSysDir(char *sysDir, int sysDirSz);
 int NovaWin_GetProgDir(char *progDir, int progDirSz);
 int NovaWin_GetEnv(char *varName, char *varContents, int varContentsSz);
 
-const char *GetDefaultWorkDir(void);
-const char *GetDefaultLogDir(void);
-const char *GetDefaultPidDir(void);
-const char *GetDefaultMasterDir(void);
-const char *GetDefaultInputDir(void);
-
 /* win_user.c */
 
 int NovaWin_UserNameToSid(char *userName, SID *sid, DWORD sidSz, int shouldExist);

--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -29,56 +29,57 @@ AM_CPPFLAGS = $(PCRE_CPPFLAGS) $(OPENSSL_CPPFLAGS)
 AM_LDFLAGS  = $(PCRE_LDFLAGS) $(OPENSSL_LDFLAGS)
 
 libutils_la_LIBADD = ../libcompat/libcompat.la
-libutils_la_LIBS     = $(PCRE_LIBS) $(OPENSSL_LIBS)
+libutils_la_LIBS   = $(PCRE_LIBS) $(OPENSSL_LIBS)
 
 libutils_la_SOURCES = \
 	alloc.c alloc.h \
+	array_map.c array_map_priv.h \
+	bool.h \
+	buffer.c buffer.h \
+	cf-windows-functions.h \
+	cfversion.c cfversion.h \
 	cleanup.c cleanup.h \
 	compiler.h \
+	csv_writer.c csv_writer.h \
+	csv_parser.c csv_parser.h \
 	definitions.h \
 	deprecated.h \
 	dir.h dir_priv.h \
+	encode.c encode.h \
+	file_lib.c file_lib.h \
+	hash.c hash.h \
+	hash_map.c hash_map_priv.h \
 	hash_method.h \
+	ip_address.c ip_address.h \
+	json.c json.h json-priv.h \
+	json-utils.c json-utils.h \
+	json-yaml.c json-yaml.h \
+	libcrypto-compat.c libcrypto-compat.h \
+	list.c list.h \
+	logging.c logging.h logging_priv.h \
+	man.c man.h \
+	map.c map.h map_common.h \
+	misc_lib.c misc_lib.h \
+	mustache.c mustache.h \
+	passopenfile.c passopenfile.h \
 	path.c path.h \
+	pcre_include.h \
+	pcre_wrap.c pcre_wrap.h \
+	platform.h condition_macros.h \
+	printsize.h \
+	proc_keyvalue.c proc_keyvalue.h \
+	queue.c queue.h \
+	rb-tree.c rb-tree.h \
+	refcount.c refcount.h \
+	regex.c regex.h \
+	ring_buffer.c ring_buffer.h \
 	sequence.c sequence.h \
 	set.c set.h \
 	statistics.c statistics.h \
 	string_lib.c string_lib.h \
-	pcre_include.h \
-	platform.h condition_macros.h \
-	proc_keyvalue.c proc_keyvalue.h \
-	bool.h \
-	json.c json.h json-priv.h \
-	json-utils.c json-utils.h \
-	json-yaml.c json-yaml.h \
-	refcount.c refcount.h \
-	list.c list.h \
-	logging.c logging.h logging_priv.h \
-	buffer.c buffer.h \
-	ip_address.c ip_address.h \
-	map.c map.h map_common.h \
-	array_map.c array_map_priv.h \
-	hash_map.c hash_map_priv.h \
-	misc_lib.c misc_lib.h \
-	writer.c writer.h \
-	csv_writer.c csv_writer.h \
-	csv_parser.c csv_parser.h \
-	xml_writer.c xml_writer.h \
-	file_lib.c file_lib.h \
-	man.c man.h \
-	rb-tree.c rb-tree.h \
-	mustache.c mustache.h \
-	cfversion.c cfversion.h \
-	passopenfile.c passopenfile.h \
 	unicode.c unicode.h \
-	hash.c hash.h \
-	queue.c queue.h \
-	ring_buffer.c ring_buffer.h \
-	regex.c regex.h \
-	encode.c encode.h \
-	pcre_wrap.c pcre_wrap.h \
-	libcrypto-compat.c libcrypto-compat.h \
-	printsize.h
+	writer.c writer.h \
+	xml_writer.c xml_writer.h
 
 if !NT
   libutils_la_SOURCES += unix_dir.c

--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -36,7 +36,6 @@ libutils_la_SOURCES = \
 	array_map.c array_map_priv.h \
 	bool.h \
 	buffer.c buffer.h \
-	cf-windows-functions.h \
 	cfversion.c cfversion.h \
 	cleanup.c cleanup.h \
 	compiler.h \
@@ -54,6 +53,7 @@ libutils_la_SOURCES = \
 	json.c json.h json-priv.h \
 	json-utils.c json-utils.h \
 	json-yaml.c json-yaml.h \
+	known_dirs.c known_dirs.h \
 	libcrypto-compat.c libcrypto-compat.h \
 	list.c list.h \
 	logging.c logging.h logging_priv.h \

--- a/libutils/known_dirs.h
+++ b/libutils/known_dirs.h
@@ -27,7 +27,8 @@
 
 #include <platform.h>
 
-const char *GetDefaultDir_helper(char dir[PATH_MAX], const char *root_dir, const char *append_dir);
+const char *GetDefaultDir_helper(char dir[PATH_MAX], const char *root_dir,
+                                 const char *append_dir);
 
 const char *GetWorkDir(void);
 const char *GetLogDir(void);
@@ -35,5 +36,15 @@ const char *GetPidDir(void);
 const char *GetMasterDir(void);
 const char *GetInputDir(void);
 const char *GetStateDir(void);
+
+#ifdef __MINGW32__
+
+const char *GetDefaultWorkDir(void);
+const char *GetDefaultLogDir(void);
+const char *GetDefaultPidDir(void);
+const char *GetDefaultMasterDir(void);
+const char *GetDefaultInputDir(void);
+
+#endif
 
 #endif

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -52,11 +52,11 @@ libtest_la_SOURCES = cmockery.c cmockery.h schema.h test.c test.h \
 	../../libutils/alloc.c \
 	../../libpromises/patches.c \
 	../../libpromises/constants.c \
-        ../../libpromises/known_dirs.c \
-        ../../libutils/map.c \
-        ../../libutils/array_map.c \
-        ../../libutils/hash.c \
-        ../../libutils/hash_map.c
+	../../libutils/array_map.c \
+	../../libutils/known_dirs.c \
+	../../libutils/map.c \
+	../../libutils/hash.c \
+	../../libutils/hash_map.c
 
 libtest_la_LIBADD = ../../libcompat/libcompat.la
 
@@ -90,7 +90,7 @@ libdb_la_SOURCES += ../../libpromises/cf3globals.c
 endif
 libdb_la_LIBADD = libstr.la ../../libutils/libutils.la
 #libdb_la_CPPFLAGS = $(LMDB_CPPFLAGS) $(TOKYOCABINET_CPPFLAGS) $(QDBM_CPPFLAGS)
-# Make sure that source files are compiled to separate object files 
+# Make sure that source files are compiled to separate object files
 # libdb_la-file.o
 libdb_la_CFLAGS = $(AM_CFLAGS)
 


### PR DESCRIPTION
Also moved some windows-only things out from `cf-windows-functions`. `known_dirs` should not depend on something that uses `libpromises`-specific things.

Ticket: CFE-3006
Changelog: None