### PR TITLE
Add users support for FreeBSD

### DIFF
--- a/cf-agent/Makefile.am
+++ b/cf-agent/Makefile.am
@@ -54,6 +54,10 @@ AM_LDFLAGS = \
 	$(LIBXML2_LDFLAGS) \
 	$(PAM_LDFLAGS)
 
+if FREEBSD
+    AM_LDFLAGS += -lutil
+endif
+
 libcf_agent_la_LIBADD = ../libpromises/libpromises.la \
 	$(OPENSSL_LIBS) \
 	$(PCRE_LIBS) \

--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -1542,7 +1542,14 @@ static bool DoModifyUser (const char *puser, const User *u, const struct passwd 
     assert(u != NULL);
     char cmd[CF_BUFSIZE];
 
+#ifdef HAVE_PW
+    strcpy (cmd, PW);
+    StringAppend(cmd, " usermod -n \"", sizeof(cmd));
+    StringAppend(cmd, puser, sizeof(cmd));
+    StringAppend(cmd, "\" ", sizeof(cmd));
+#else
     strcpy (cmd, USERMOD);
+#endif
 
     if (CFUSR_CHECKBIT (changemap, i_uid) != 0)
     {
@@ -1592,9 +1599,10 @@ static bool DoModifyUser (const char *puser, const User *u, const struct passwd 
         StringAppend(cmd, u->shell, sizeof(cmd));
         StringAppend(cmd, "\"", sizeof(cmd));
     }
-
+#ifndef HAVE_PW
     StringAppend(cmd, " ", sizeof(cmd));
     StringAppend(cmd, puser, sizeof(cmd));
+#endif
 
     if (CFUSR_CHECKBIT (changemap, i_password) != 0)
     {
@@ -1671,7 +1679,14 @@ static bool DoModifyUser (const char *puser, const User *u, const struct passwd 
         if (CFUSR_CHECKBIT (changemap, i_groups) != 0)
         {
             // Set real group list (see -G comment earlier).
+#ifdef HAVE_PW
+            strcpy (cmd, PW);
+            StringAppend(cmd, " usermod -n \"", sizeof(cmd));
+            StringAppend(cmd, puser, sizeof(cmd));
+            StringAppend(cmd, "\" ", sizeof(cmd));
+#else
             strcpy(cmd, USERMOD);
+#endif
             StringAppend(cmd, " -G \"", sizeof(cmd));
             char sep[2] = { '\0', '\0' };
             for (Rlist *i = u->groups_secondary; i; i = i->next)
@@ -1680,8 +1695,12 @@ static bool DoModifyUser (const char *puser, const User *u, const struct passwd 
                 StringAppend(cmd, RvalScalarValue(i->val), sizeof(cmd));
                 sep[0] = ',';
             }
+#ifdef HAVE_PW
+            StringAppend(cmd, "\"", sizeof(cmd));
+#else
             StringAppend(cmd, "\" ", sizeof(cmd));
             StringAppend(cmd, puser, sizeof(cmd));
+#endif
             if (!ExecuteUserCommand(puser, cmd, sizeof(cmd), "modifying", "Modifying"))
             {
                 return false;

--- a/configure.ac
+++ b/configure.ac
@@ -905,6 +905,24 @@ AS_IF([test "x$USERADD" != x && \
       [have_userprogs=no]
 )
 
+dnl FreeBSD
+CF3_PATH_ROOT_PROG([CHPASS], [chpass], [], [/usr/bin:$PATH])
+AS_IF([test "x$CHPASS" != "x"],
+      [AC_DEFINE(HAVE_CHPASS, 1, [Define if chpass tool is present])]
+      [AC_DEFINE_UNQUOTED(CHPASS, ["$CHPASS"], [Path to chpass tool])]
+     )
+
+CF3_PATH_ROOT_PROG([PW], [pw], [], [/usr/sbin:$PATH])
+AS_IF([test "x$PW" != "x"],
+      [AC_DEFINE(HAVE_PW, 1, [Define if pw tool is present])]
+      [AC_DEFINE_UNQUOTED(PW, ["$PW"], [Path to pw tool])]
+     )
+
+AS_IF([test "x$CHPASS" != x && \
+       test "x$PW" != x],
+      [have_userprogs=yes],
+      [have_userprogs=no]
+)
 
 AC_ARG_WITH([pam], AS_HELP_STRING([--with-pam], [Compile with PAM support]))
 AS_IF([test x$with_pam != xno],
@@ -929,15 +947,29 @@ AS_IF([test x$with_pam != xno],
         [have_pam=no]
   )
   AC_CHECK_FUNCS(fgetpwent fgetgrent)
-  AS_IF([test "x$have_pam" = "xyes" && \
-      test "x$have_userprogs" = "xyes" && \
-      test "x$ac_cv_func_fgetpwent" = "xyes" && \
-      test "x$ac_cv_func_fgetgrent" = "xyes"],
-  [
-      users_promises_ok=yes
-  ],[
-      users_promises_ok=no
-  ])
+  AS_IF([test "x$ac_cv_func_fgetpwent" = "xyes" && \
+         test "x$ac_cv_func_fgetgrent" = "xyes"],
+         [have_fgetpwent_fgetgrent=yes]
+         [AC_DEFINE(HAVE_FGETPWENT_FGETGRENT, 1, [Define if fgetpwent and fgetgrent functions are present])],
+         [have_fgetpwent_fgetgrent=no]
+     )
+
+  AS_CASE(["$target_os"],
+     [freebsd*],
+     [
+        AS_IF([test "x$have_pam" = "xyes" && \
+               test "x$have_userprogs" = "xyes"],
+              [users_promises_ok=yes],
+              [users_promises_ok=no])
+     ],
+     [
+        AS_IF([test "x$have_pam" = "xyes" && \
+               test "x$have_userprogs" = "xyes"
+               test "x$ac_cv_func_fgetpwent" = "xyes" && \
+               test "x$ac_cv_func_fgetgrent" = "xyes"],
+              [users_promises_ok=yes],
+              [users_promises_ok=no])
+     ])
 ], [
   users_promises_ok=no
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -1316,6 +1316,7 @@ case "$target_os" in
         AC_CHECK_LIB(nss_nis, yp_get_default_domain)
         ;;
    freebsd*|dragonfly*)
+     AM_CONDITIONAL([FREEBSD], true)
         ;;
    netbsd*)
         ;;


### PR DESCRIPTION
Add users support for FreeBSD.

Use pw insread of useradd and usermod, user chpass instead of chpasswd, use rmuser instead of userdel. 

Implement fgetpwent() and fgetgrent() for FreeBSD.

Needs to be tested as I have only tested some cases myself for my personal needs.