### PR TITLE
DONOTMERGE: call _exit() on SIGTERM

### DIFF
--- a/libpromises/signals.c
+++ b/libpromises/signals.c
@@ -173,6 +173,8 @@ void HandleSignalsForDaemon(int signum)
     switch (signum)
     {
     case SIGTERM:
+        _exit(0);
+        break;
     case SIGINT:
     case SIGSEGV:
     case SIGKILL:


### PR DESCRIPTION
We need to exit hard to see where the memory is allocated.