### PR TITLE
Prevented buffer overflows in cf-monitord data parsing (3.12)

### DIFF
--- a/cf-monitord/mon_cpu.c
+++ b/cf-monitord/mon_cpu.c
@@ -62,8 +62,8 @@ void MonCPUGatherData(double *cf_this)
         {
             break;
         }
-
-        if (sscanf(buf, "%s%ld%ld%ld%ld%ld%ld%ld", cpuname, &userticks, &niceticks, &systemticks, &idle, &iowait, &irq,
+        assert(CF_MAXVARSIZE == 1024);
+        if (sscanf(buf, "%1023s%ld%ld%ld%ld%ld%ld%ld", cpuname, &userticks, &niceticks, &systemticks, &idle, &iowait, &irq,
                &softirq) != 8)
         {
             Log(LOG_LEVEL_VERBOSE, "Could not scan /proc/stat line: %60s", buf);

--- a/cf-monitord/mon_network_sniffer.c
+++ b/cf-monitord/mon_network_sniffer.c
@@ -251,10 +251,12 @@ static void AnalyzeArrival(Item *ip_addresses, long iteration, char *arrival, do
     {
         arr++;
     }
-
     if ((strstr(arrival, "proto TCP")) || (strstr(arrival, "ack")))
     {
-        sscanf(arr, "%s %*c %s %c ", src, dest, &flag);
+        assert(sizeof(src) == CF_BUFSIZE);
+        assert(sizeof(dest) == CF_BUFSIZE);
+        assert(CF_BUFSIZE == 4096);
+        sscanf(arr, "%4095s %*c %4095s %c ", src, dest, &flag);
         DePort(src);
         DePort(dest);
         isme_dest = IsInterfaceAddress(ip_addresses, dest);
@@ -308,7 +310,10 @@ static void AnalyzeArrival(Item *ip_addresses, long iteration, char *arrival, do
     }
     else if (strstr(arrival, ".53"))
     {
-        sscanf(arr, "%s %*c %s %c ", src, dest, &flag);
+        assert(sizeof(src) == CF_BUFSIZE);
+        assert(sizeof(dest) == CF_BUFSIZE);
+        assert(CF_BUFSIZE == 4096);
+        sscanf(arr, "%4095s %*c %4095s %c ", src, dest, &flag);
         DePort(src);
         DePort(dest);
         isme_dest = IsInterfaceAddress(ip_addresses, dest);
@@ -328,7 +333,10 @@ static void AnalyzeArrival(Item *ip_addresses, long iteration, char *arrival, do
     }
     else if (strstr(arrival, "proto UDP"))
     {
-        sscanf(arr, "%s %*c %s %c ", src, dest, &flag);
+        assert(sizeof(src) == CF_BUFSIZE);
+        assert(sizeof(dest) == CF_BUFSIZE);
+        assert(CF_BUFSIZE == 4096);
+        sscanf(arr, "%4095s %*c %4095s %c ", src, dest, &flag);
         DePort(src);
         DePort(dest);
         isme_dest = IsInterfaceAddress(ip_addresses, dest);
@@ -348,7 +356,10 @@ static void AnalyzeArrival(Item *ip_addresses, long iteration, char *arrival, do
     }
     else if (strstr(arrival, "proto ICMP"))
     {
-        sscanf(arr, "%s %*c %s %c ", src, dest, &flag);
+        assert(sizeof(src) == CF_BUFSIZE);
+        assert(sizeof(dest) == CF_BUFSIZE);
+        assert(CF_BUFSIZE == 4096);
+        sscanf(arr, "%4095s %*c %4095s %c ", src, dest, &flag);
         DePort(src);
         DePort(dest);
         isme_dest = IsInterfaceAddress(ip_addresses, dest);
@@ -374,8 +385,9 @@ static void AnalyzeArrival(Item *ip_addresses, long iteration, char *arrival, do
         cf_this[ob_tcpmisc_in]++;
 
         /* Here we don't know what source will be, but .... */
-
-        sscanf(arrival, "%s", src);
+        assert(sizeof(src) == CF_BUFSIZE);
+        assert(CF_BUFSIZE == 4096);
+        sscanf(arrival, "%4095s", src);
 
         if (!isdigit((int) *src))
         {


### PR DESCRIPTION
cf-monitord parses data from tcpdump and /proc.
This commit ensures that the data doesn't overflow the
buffers used.

Reported by LGTM:
https://lgtm.com/rules/2158250570/