### PR TITLE
CFE-3036: Added --no-truncate option to cf-key

### DIFF
--- a/cf-key/cf-key-functions.h
+++ b/cf-key/cf-key-functions.h
@@ -44,9 +44,7 @@ extern bool LOOKUP_HOSTS;
 
 int PrintDigest(const char *pubkey);
 void ParseKeyArg(char *keyarg, char **filename, char **ipaddr, char **username);
-bool ShowHost(const char *hostkey, const char *address,
-              bool incoming, const KeyHostSeen *quality, void *ctx);
-void ShowLastSeenHosts();
+void ShowLastSeenHosts(bool truncate);
 int RemoveKeys(const char *input, bool must_be_coherent);
 bool KeepKeyPromises(const char *public_key_file, const char *private_key_file, const int key_size);
 int ForceKeyRemoval(const char *key);


### PR DESCRIPTION
This option, when used with --show-hosts changes the formatting
of the output. Instead of padding and truncating each of the
fields, they are printed, in full, with no padding, and separated
by a single tab character. The output is not as pretty, but should
be more useful for parsing by other scripts / tooling.

**Example:**

```
root@dev core $ cf-key -s
Direction  IP                                       Name                      Last connection            Key
Outgoing   192.168.100.10                           -                         Mon Apr 15 09:34:56 2019   MD5=a9b9a2c7f9cf17a3f0a378f2c38ee587
Total Entries: 1
root@dev core $ cf-key -s --no-truncate
Direction       IP      Name    Last connection Key
Outgoing        192.168.100.10  -       Mon Apr 15 09:34:56 2019        MD5=a9b9a2c7f9cf17a3f0a378f2c38ee587
Total Entries: 1
root@dev core $ cf-key --no-truncate
Usage: cf-key [OPTIONS]

Options:
  --help        , -h       - Print the help message
  --inform      , -I       - Print basic information about key generation
  --debug       , -d       - Enable debugging output
  --verbose     , -v       - Output verbose information about the behaviour of cf-key
  --version     , -V       - Output the version of the software
  --log-level   , -g value - Specify how detailed logs should be. Possible values: 'error', 'warning', 'notice', 'info', 'verbose', 'debug'
  --output-file , -f value - Specify an alternative output file than the default.
  --key-type    , -T value - Specify a RSA key size in bits, the default value is 2048.
  --show-hosts  , -s       - Show lastseen hostnames and IP addresses
  --no-truncate , -N       - Don't truncate -s / --show-hosts output
  --remove-keys , -r value - Remove keys for specified hostname/IP/MD5/SHA (cf-key -r SHA=12345, cf-key -r MD5=12345, cf-key -r host001, cf-key -r 203.0.113.1)
  --force-removal, -x       - Force removal of keys (USE AT YOUR OWN RISK)
  --install-license, -l value - Install license file on Enterprise server (CFEngine Enterprise Only)
  --print-digest, -p value - Print digest of the specified public key
  --trust-key   , -t value - Make cf-serverd/cf-agent trust the specified public key. Argument value is of the form [[USER@]IPADDR:]FILENAME where FILENAME is the local path of the public key for client at IPADDR address.
  --color       , -C value - Enable colorized output. Possible values: 'always', 'auto', 'never'. If option is used, the default value is 'auto'
  --timestamp              - Log timestamps on each line of log output
  --numeric     , -n       - Do not lookup host names

Website: http://www.cfengine.com
This software is Copyright (C) 2008,2010-present Northern.tech AS.
   error: --no-truncate / -N option is only for --show-hosts / -s
root@dev core $ cf-key --show-hosts --no-truncate
Direction       IP      Name    Last connection Key
Outgoing        192.168.100.10  -       Mon Apr 15 09:34:56 2019        MD5=a9b9a2c7f9cf17a3f0a378f2c38ee587
Total Entries: 1
root@dev core $
```

**Ticket:** https://tracker.mender.io/browse/CFE-3036