### PR TITLE
CFE-1968: Unresolved function calls in process_select body are now skipped

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -493,6 +493,30 @@ static bool KillLockHolder(const char *lock)
     }
 }
 
+static void RvalDigestUpdate(EVP_MD_CTX *context, Rlist *rp)
+{
+    assert(context != NULL);
+    assert(rp != NULL);
+
+    switch (rp->val.type)
+    {
+    case RVAL_TYPE_SCALAR:
+        EVP_DigestUpdate(context, RlistScalarValue(rp),
+                         strlen(RlistScalarValue(rp)));
+        break;
+
+    case RVAL_TYPE_FNCALL:
+        // TODO: This should be recursive and not just hash the function name
+        EVP_DigestUpdate(context, RlistFnCallValue(rp)->name,
+                         strlen(RlistFnCallValue(rp)->name));
+        break;
+
+    default:
+        ProgrammingError("Unhandled case in switch");
+        break;
+    }
+}
+
 void PromiseRuntimeHash(const Promise *pp, const char *salt,
                         unsigned char digest[EVP_MAX_MD_SIZE + 1],
                         HashMethod type)
@@ -594,22 +618,7 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt,
             case RVAL_TYPE_LIST:
                 for (rp = cp->rval.item; rp != NULL; rp = rp->next)
                 {
-                    switch (rp->val.type)
-                    {
-                    case RVAL_TYPE_SCALAR:
-                        EVP_DigestUpdate(context, RlistScalarValue(rp),
-                                         strlen(RlistScalarValue(rp)));
-                        break;
-
-                    case RVAL_TYPE_FNCALL:
-                        EVP_DigestUpdate(context, RlistFnCallValue(rp)->name,
-                                         strlen(RlistFnCallValue(rp)->name));
-                        break;
-
-                    default:
-                        ProgrammingError("Unhandled case in switch");
-                        break;
-                    }
+                    RvalDigestUpdate(context, rp);
                 }
                 break;
 
@@ -623,22 +632,7 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt,
 
                 for (rp = fp->args; rp != NULL; rp = rp->next)
                 {
-                    switch (rp->val.type)
-                    {
-                    case RVAL_TYPE_SCALAR:
-                        EVP_DigestUpdate(context, RlistScalarValue(rp),
-                                         strlen(RlistScalarValue(rp)));
-                        break;
-
-                    case RVAL_TYPE_FNCALL:
-                        EVP_DigestUpdate(context, RlistFnCallValue(rp)->name,
-                                         strlen(RlistFnCallValue(rp)->name));
-                        break;
-
-                    default:
-                        ProgrammingError("Unhandled case in switch");
-                        break;
-                    }
+                    RvalDigestUpdate(context, rp);
                 }
                 break;
 

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -594,8 +594,22 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt,
             case RVAL_TYPE_LIST:
                 for (rp = cp->rval.item; rp != NULL; rp = rp->next)
                 {
-                    EVP_DigestUpdate(context, RlistScalarValue(rp),
-                                     strlen(RlistScalarValue(rp)));
+                    switch (rp->val.type)
+                    {
+                    case RVAL_TYPE_SCALAR:
+                        EVP_DigestUpdate(context, RlistScalarValue(rp),
+                                         strlen(RlistScalarValue(rp)));
+                        break;
+
+                    case RVAL_TYPE_FNCALL:
+                        EVP_DigestUpdate(context, RlistFnCallValue(rp)->name,
+                                         strlen(RlistFnCallValue(rp)->name));
+                        break;
+
+                    default:
+                        ProgrammingError("Unhandled case in switch");
+                        break;
+                    }
                 }
                 break;
 

--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -181,7 +181,13 @@ static bool SelectProcess(const char *procentry,
 
     for (rp = a->owner; rp != NULL; rp = rp->next)
     {
-        if (SelectProcRegexMatch("USER", "UID", RlistScalarValue(rp), true, names, column))
+        if (rp->val.type == RVAL_TYPE_FNCALL)
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Function call '%s' in process_select body was not resolved, skipping",
+                RlistFnCallValue(rp)->name);
+        }
+        else if (SelectProcRegexMatch("USER", "UID", RlistScalarValue(rp), true, names, column))
         {
             StringSetAdd(process_select_attributes, xstrdup("process_owner"));
             break;

--- a/libpromises/rlist.h
+++ b/libpromises/rlist.h
@@ -28,6 +28,7 @@
 #include <cf3.defs.h>
 #include <writer.h>
 #include <json.h>
+#include <fncall.h>
 
 /* NOTE: an empty Rlist is simply NULL. */
 struct Rlist_

--- a/tests/acceptance/05_processes/01_matching/process_select_fncalls.cf
+++ b/tests/acceptance/05_processes/01_matching/process_select_fncalls.cf
@@ -1,0 +1,93 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-1968" }
+        string => "Test that process_select body can have (failing) function calls";
+  vars:
+    "canonified_uid"
+        string => canonify(getuid("nosuchuser"));
+
+  processes:
+    any::
+      "cf-agent"
+        process_select => by_owner_no_fncall("nosuchuser", "$(canonified_uid)"),
+        process_count => proc_found_one_or_more("nosuchuser_no_fncall");
+      "cf-agent"
+        process_select => by_owner("nosuchuser"),
+        process_count => proc_found_one_or_more("nosuchuser");
+      "nosuchproc"
+        process_count => proc_found_one_or_more("nosuchproc");
+      "cf-agent"
+        process_count => proc_found_one_or_more("agent");
+      ".*"
+        process_select => by_owner("root"),
+        process_count => proc_found_one_or_more("root");
+}
+
+body process_count proc_found_one_or_more(prefix)
+# defines _found / _not_found if there are 1 or more / 0 matches, respectively
+{
+      in_range_define => { "$(prefix)_found" };
+      out_of_range_define => { "$(prefix)_not_found" };
+      match_range => irange(1,"inf");
+}
+
+body process_select by_owner(u)
+# @brief Select processes owned by user `u`
+# @param u The name of the user
+#
+# Matches processes against the given username and the given username's uid
+# in case only uid is visible in process list.
+#
+# @note: if getuid fails (because there is no user) the canonify call will
+#        not resolve, and that part of the list will be skipped.
+{
+      process_owner => { "$(u)", canonify(getuid("$(u)")) };
+      process_result => "process_owner";
+}
+
+body process_select by_owner_no_fncall(u, cgu)
+# Compare behavior to this backwards compatible body
+{
+      process_owner => { "$(u)", "$(cgu)" };
+      process_result => "process_owner";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok"
+        and => {
+            "!nosuchuser_no_fncall_found", "nosuchuser_no_fncall_not_found",
+            "!nosuchuser_found", "nosuchuser_not_found",
+            "!nosuchproc_found", "nosuchproc_not_found",
+             "agent_found", "!agent_not_found",
+             "root_found", "!root_not_found"
+        };
+
+  reports:
+    DEBUG.agent_found::
+      "ok - found agent";
+    DEBUG.nosuchproc_found::
+      "not ok - found nosuchproc";
+    DEBUG.nosuchuser_found::
+      "not ok - found nosuchuser";
+    DEBUG.root_found::
+      "ok - found root!";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Function calls which always fail, like getuid("nosuchuser"), are
never resolved. Previously this would cause a programming error,
since the body is expected to have a list of strings, not
unresolved function calls.
    
The function calls are silently skipped (with a verbose message)
as this matches the behavior of calling the functions in a vars
promise, and using that as a body parameter.