### PR TITLE
Fix style for prep section in classfiltercsv() example

### DIFF
--- a/examples/classfiltercsv.cf
+++ b/examples/classfiltercsv.cf
@@ -31,7 +31,6 @@
 #@ echo 'example_class3,1,net.ipv4.ip_forward,127.0.0.4'   >> /tmp/classfiltercsv.csv
 #@ echo 'also_undefined,0,net.ipv4.ip_forward,NOT_DEFINED'  >> /tmp/classfiltercsv.csv
 #@ sed -i 's/$/\r/' /tmp/classfiltercsv.csv
-#@
 #@ ```
 #+end_src
 


### PR DESCRIPTION
This aligns the style with that used in peerleaders() which does render
correctly in docs.