### PR TITLE
[3.12.x] Make sure map->load is 0 at the end of HashMapClear()

### DIFF
--- a/libutils/hash_map.c
+++ b/libutils/hash_map.c
@@ -199,6 +199,7 @@ static void FreeBucketListItem(HashMap *map, BucketListItem *item)
     map->destroy_key_fn(item->value.key);
     map->destroy_value_fn(item->value.value);
     free(item);
+    map->load--;
 }
 
 /* Do not destroy value item */
@@ -211,6 +212,7 @@ static void FreeBucketListItemSoft(HashMap *map, BucketListItem *item)
 
     map->destroy_key_fn(item->value.key);
     free(item);
+    map->load--;
 }
 
 void HashMapClear(HashMap *map)
@@ -223,6 +225,7 @@ void HashMapClear(HashMap *map)
         }
         map->buckets[i] = NULL;
     }
+    assert(map->load == 0);
 }
 
 void HashMapSoftDestroy(HashMap *map)


### PR DESCRIPTION
Otherwise the size is unchanged and the map thinks it still has
all the items that were there before. The items are gone, but
when new ones are inserted, the table sooner or later hits the
threshold and grows automatically. Repeat this process of "insert
a couple hundred items, clear, repeat" multiple times and the
table grows and grows...and grows.

Let's decrement map->load everytime we remove an item and assert
that it reaches 0 when all items are removed.

Ticket: CFE-3032
Changelog: Fix growing memory footprint of daemons
(cherry picked from commit 09e5d244793d80ec6e953ae6f57f045eda30ab0d)