### PR TITLE
CFE-3036: Added --no-truncate option to cf-key (3.12)

### DIFF
--- a/cf-key/cf-key-functions.h
+++ b/cf-key/cf-key-functions.h
@@ -44,9 +44,7 @@ extern bool LOOKUP_HOSTS;
 
 int PrintDigest(const char *pubkey);
 void ParseKeyArg(char *keyarg, char **filename, char **ipaddr, char **username);
-bool ShowHost(const char *hostkey, const char *address,
-              bool incoming, const KeyHostSeen *quality, void *ctx);
-void ShowLastSeenHosts();
+void ShowLastSeenHosts(bool truncate);
 int RemoveKeys(const char *input, bool must_be_coherent);
 bool KeepKeyPromises(const char *public_key_file, const char *private_key_file, const int key_size);
 int ForceKeyRemoval(const char *key);


### PR DESCRIPTION
This option, when used with --show-hosts changes the formatting
of the output. Instead of padding and truncating each of the
fields, they are printed, in full, with no padding, and separated
by a single tab character. The output is not as pretty, but should
be more useful for parsing by other scripts / tooling.