### PR TITLE
Replaced uses of localtime with the safer localtime_r (3.12)

### DIFF
--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -717,7 +717,11 @@ static void MailResult(const ExecConfig *config, const char *file)
     free(existing_policy_server);
 
 #if defined __linux__ || defined __NetBSD__ || defined __FreeBSD__ || defined __OpenBSD__
-    strftime(vbuff, CF_BUFSIZE, "Date: %a, %d %b %Y %H:%M:%S %z\r\n", localtime(&now));
+    {
+        struct tm tm_value;
+        struct tm *const tm_pointer = localtime_r(&now, &tm_value);
+        strftime(vbuff, CF_BUFSIZE, "Date: %a, %d %b %Y %H:%M:%S %z\r\n", tm_pointer);
+    }
     send(sd, vbuff, strlen(vbuff), 0);
 #endif
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -6377,16 +6377,16 @@ static FnCallResult FnCallStrftime(ARG_UNUSED EvalContext *ctx,
     // this will be a problem on 32-bit systems...
     const time_t when = IntFromString(RlistScalarValue(finalargs->next->next));
 
-    struct tm tm;
+    struct tm tm_value;
     struct tm *tm_pointer;
 
     if (strcmp("gmtime", mode) == 0)
     {
-        tm_pointer = gmtime_r(&when, &tm);
+        tm_pointer = gmtime_r(&when, &tm_value);
     }
     else
     {
-        tm_pointer = localtime(&when);
+        tm_pointer = localtime_r(&when, &tm_value);
     }
 
     char buffer[CF_BUFSIZE];


### PR DESCRIPTION
Reported by LGTM:
https://lgtm.com/rules/2154840805/