### PR TITLE
CFE-2067:  Removed programming error in handling of process_count body

### DIFF
--- a/cf-agent/verify_processes.c
+++ b/cf-agent/verify_processes.c
@@ -132,6 +132,14 @@ static PromiseResult VerifyProcesses(EvalContext *ctx, const Attributes *a, cons
     return result;
 }
 
+static void ProcessCountDefineClass(EvalContext *const ctx, const Rlist *const rp)
+{
+    ClassRef ref = ClassRefParse(RlistScalarValue(rp));
+    EvalContextClassPutSoft(
+        ctx, RlistScalarValue(rp), CONTEXT_SCOPE_NAMESPACE, "source=promise");
+    ClassRefDestroy(ref);
+}
+
 static PromiseResult VerifyProcessOp(EvalContext *ctx, const Attributes *a, const Promise *pp)
 {
     bool do_signals = true;
@@ -153,9 +161,7 @@ static PromiseResult VerifyProcessOp(EvalContext *ctx, const Attributes *a, cons
             result = PromiseResultUpdate(result, PROMISE_RESULT_CHANGE);
             for (const Rlist *rp = a->process_count.out_of_range_define; rp != NULL; rp = rp->next)
             {
-                ClassRef ref = ClassRefParse(RlistScalarValue(rp));
-                EvalContextClassPutSoft(ctx, RlistScalarValue(rp), CONTEXT_SCOPE_NAMESPACE, "source=promise");
-                ClassRefDestroy(ref);
+                ProcessCountDefineClass(ctx, rp);
             }
             out_of_range = true;
         }
@@ -163,9 +169,7 @@ static PromiseResult VerifyProcessOp(EvalContext *ctx, const Attributes *a, cons
         {
             for (const Rlist *rp = a->process_count.in_range_define; rp != NULL; rp = rp->next)
             {
-                ClassRef ref = ClassRefParse(RlistScalarValue(rp));
-                EvalContextClassPutSoft(ctx, RlistScalarValue(rp), CONTEXT_SCOPE_NAMESPACE, "source=promise");
-                ClassRefDestroy(ref);
+                ProcessCountDefineClass(ctx, rp);
             }
             cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a, "Process promise for '%s' is kept", pp->promiser);
             out_of_range = false;

--- a/tests/acceptance/05_processes/01_matching/process_count_fncalls.cf
+++ b/tests/acceptance/05_processes/01_matching/process_count_fncalls.cf
@@ -1,0 +1,23 @@
+bundle agent main
+{
+  meta:
+      "description" -> { "CFE-2067" }
+        string => "Test that process_count body can have (failing) function calls";
+
+  processes:
+      # Test that this doesn't cause a crash / abort:
+      "cf-execd"
+        process_count => process_count_one("$(nosuchvar)");
+         # Error will be printed since variable won't expand, expected behavior
+
+  reports:
+      # Nothing to check, running without crashing is good enough
+      "$(this.promise_filename) Pass";
+}
+
+body process_count process_count_one(suffix)
+{
+  match_range => irange("1", "1");
+  in_range_define => { canonify("one_$(suffix)") };
+  out_of_range_define => { canonify("not_one_$(suffix)") };
+}


### PR DESCRIPTION
Previously, having a failing function call inside in_range_define
or out_of_range_define would cause a programming error when
trying to define that as a class. Fixed it by detecting the
case, printing a normal error, and skipping defining the class.