### PR TITLE
Define all enum values in PromiseResult

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -394,7 +394,7 @@ static PromiseResult VerifyLineDeletions(EvalContext *ctx, const Promise *pp, Ed
             "The promised end pattern '%s' was not found when selecting region to delete in '%s'",
              a.region.select_end, edcontext->filename);
         result = PromiseResultUpdate(result, PROMISE_RESULT_INTERRUPTED);
-        return false;
+        return result;
     }
 
     snprintf(lockname, CF_BUFSIZE - 1, "deleteline-%s-%s", pp->promiser, edcontext->filename);
@@ -691,7 +691,7 @@ static PromiseResult VerifyLineInsertions(EvalContext *ctx, const Promise *pp, E
             "The promised end pattern '%s' was not found when selecting region to insert in '%s'",
              a.region.select_end, edcontext->filename);
         result = PromiseResultUpdate(result, PROMISE_RESULT_INTERRUPTED);
-        return false;
+        return result;
     }
 
     if (allow_multi_lines)

--- a/cf-agent/verify_environments.c
+++ b/cf-agent/verify_environments.c
@@ -889,7 +889,7 @@ static PromiseResult DownVirt(EvalContext *ctx, virConnectPtr vc, const Attribut
                      pp->promiser);
                 result = PromiseResultUpdate(result, PROMISE_RESULT_INTERRUPTED);
                 virDomainFree(dom);
-                return false;
+                return result;
             }
 
             cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_CHANGE, pp, a, "Virtual domain '%s' is in a crashed state, terminating",

--- a/cf-monitord/history.c
+++ b/cf-monitord/history.c
@@ -506,7 +506,7 @@ static PromiseResult NovaExtractValueFromStream(EvalContext *ctx, const char *ha
                                 else
                                 {
                                     Log(LOG_LEVEL_ERR, "Error in double conversion from string value: %s", value);
-                                    return false;
+                                    return PROMISE_RESULT_FAIL;
                                 }
                             }
                             else
@@ -514,7 +514,7 @@ static PromiseResult NovaExtractValueFromStream(EvalContext *ctx, const char *ha
                                 if (!DoubleFromString(value, &real_val))
                                 {
                                     Log(LOG_LEVEL_ERR, "Error in double conversion from string value: %s", value);
-                                    return false;
+                                    return PROMISE_RESULT_FAIL;
                                 }
                             }
 

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -117,15 +117,15 @@
 /* Auditing key */
 
 typedef enum
-{
-    PROMISE_RESULT_SKIPPED = 's',
-    PROMISE_RESULT_NOOP = 'n',
-    PROMISE_RESULT_CHANGE = 'c',
-    PROMISE_RESULT_WARN = 'w', // something wrong but nothing done
-    PROMISE_RESULT_FAIL = 'f',
-    PROMISE_RESULT_DENIED = 'd',
-    PROMISE_RESULT_TIMEOUT = 't',
-    PROMISE_RESULT_INTERRUPTED = 'i'
+{                                     // Logging of outcomes in cf-agent.c:
+    PROMISE_RESULT_SKIPPED = 's',     // <Also skipped in logging>
+    PROMISE_RESULT_NOOP = 'n',        // Kept
+    PROMISE_RESULT_CHANGE = 'c',      // Repaired
+    PROMISE_RESULT_WARN = 'w',        // Not kept
+    PROMISE_RESULT_FAIL = 'f',        // Not kept
+    PROMISE_RESULT_DENIED = 'd',      // Not kept
+    PROMISE_RESULT_TIMEOUT = 't',     // Timed out
+    PROMISE_RESULT_INTERRUPTED = 'i'  // Not kept
 } PromiseResult;
 
 /*****************************************************************************/

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -118,7 +118,7 @@
 
 typedef enum
 {
-    PROMISE_RESULT_SKIPPED,
+    PROMISE_RESULT_SKIPPED = 's',
     PROMISE_RESULT_NOOP = 'n',
     PROMISE_RESULT_CHANGE = 'c',
     PROMISE_RESULT_WARN = 'w', // something wrong but nothing done


### PR DESCRIPTION
Let's hope no code was relying on this being 0.

Reported by LGTM:
https://lgtm.com/rules/2162380048/