### PR TITLE
LGTM: Detect non-bool functions which return true or false

### DIFF
--- a/.lgtm/cpp-queries/function-returns-bool-macro.qhelp
+++ b/.lgtm/cpp-queries/function-returns-bool-macro.qhelp
@@ -1,0 +1,31 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+
+<p>
+Non-bool function returns true or false macro.
+<code>true</code> and <code>false</code> macros are technically <code>int</code>, but we want type checking.
+</p>
+
+</overview>
+<recommendation>
+
+<p>
+Change the function's return type to bool or return another more appropriate constant.
+</p>
+
+</recommendation>
+<example>
+
+</example>
+<references>
+
+<li>
+  CFEngine Contribution guidelines: <a href="https://github.com/cfengine/core/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a>
+</li>
+
+</references>
+</qhelp>

--- a/.lgtm/cpp-queries/function-returns-bool-macro.ql
+++ b/.lgtm/cpp-queries/function-returns-bool-macro.ql
@@ -1,0 +1,25 @@
+/**
+ * @name Non-bool function returns true or false macro
+ * @description Functions with return type other than 'bool' should not return 'true' or 'false'.
+ *              'true' and 'false' macros are technically 'int', but we want type checking.
+ * @kind problem
+ * @problem.severity error
+ * @id cpp/function-returns-bool-macro
+ * @tags readability
+ *       correctness
+ * @precision very-high
+ */
+
+import cpp
+
+from Function f, ReturnStmt r, MacroInvocation m // Select all functions, return statements and macro invocations
+where r.getEnclosingFunction() = f               // Return statement is inside function
+  and r.hasExpr()                                // Return statement returns something (not return;)
+  and f.getType().getName() != "bool"            // Function has non-bool return type
+  and f.getType().getName() != "int"             // Ignore int functions as well, for now (old code has a lot)
+  and m.getExpr() = r.getExpr()                  // The returned value (expression) is a macro
+  and (m.getMacroName() = "true"                 // Macro is "true"
+       or m.getMacroName() = "false")            // or "false"
+select r, "Function " + f.getName() +            // Select the return statement as the alert, and print a nice message
+          " has return type " + f.getType().getName() +
+          " and returns bool (" + r.getExpr().toString()+ ")"


### PR DESCRIPTION
This custom query looks for functions with return type other than
`int` and `bool`, and alerts if they return `true` or `false`.

The severity can be reduced later, I just want to test this.
It can also be expanded to catch int functions, but then
we will have a lot of alerts.