### PR TITLE
LGTM: Detect non-bool functions which return bool variable

### DIFF
--- a/.lgtm/cpp-queries/function-returns-bool-variable.qhelp
+++ b/.lgtm/cpp-queries/function-returns-bool-variable.qhelp
@@ -1,0 +1,36 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+
+<p>
+Non-bool function returns boolean variable.
+This can be the result of copy-pasted code, which should have been modified.
+In old-school C, there was no boolean type and it was normal to return boolean values as <code>int</code>.
+We prefer to use <code>bool</code> return type for functions which have 2 return values (<code>true</code> or <code>false</code>).
+Note that <code>true</code> and <code>false</code> are macros with type <code>int</code>.
+We have a <a href="https://lgtm.com/rules/1508474826013/">separate query</a> to detect those cases.
+</p>
+
+</overview>
+<recommendation>
+
+<p>
+Change the functions return type to <code>bool</code> or change the type of the returned value.
+(Adding a typecast is rarely the correct solution).
+</p>
+
+</recommendation>
+<example>
+
+</example>
+<references>
+
+<li>
+CFEngine Contribution guidelines: <a href="https://github.com/cfengine/core/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a>
+</li>
+
+</references>
+</qhelp>

--- a/.lgtm/cpp-queries/function-returns-bool-variable.ql
+++ b/.lgtm/cpp-queries/function-returns-bool-variable.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Non-bool function returns bool type variable
+ * @description Functions with return type other than 'bool' should not return 'bool'.
+ * @kind problem
+ * @problem.severity error
+ * @id cpp/function-returns-bool-variable
+ * @tags readability
+ *       correctness
+ * @precision very-high
+ */
+
+import cpp
+
+from Function f, ReturnStmt r                    // Select all functions and return statements
+where r.getEnclosingFunction() = f               // Return statement is inside function
+  and r.hasExpr()                                // Return statement returns something (not return;)
+  and r.getExpr().getType().toString() = "bool"  // Returns a boolean variable (or something with type bool)
+  and f.getType().getName() != "bool"            // Function has non-bool return type
+select r, "Function " + f.getName() +            // Select the return statement as the alert, and print a nice message
+          " has return type " + f.getType().getName() +
+          " and returns bool (" + r.getExpr().toString() + ")"


### PR DESCRIPTION
Since logical expressions and `true`/`false` macros are `int`
type, this query only detects functions which return a `bool`
variable (or a value typecast to `bool`).