### PR TITLE
 cf-remote: Only exclude hosts in call collect mode

### DIFF
--- a/contrib/cf-remote/cf_remote/demo.py
+++ b/contrib/cf-remote/cf_remote/demo.py
@@ -37,7 +37,6 @@ def def_json(call_collect=False):
             "cfengine_internal_purge_policies": ["any"]
         },
         "vars": {
-            "control_hub_exclude_hosts": ["0.0.0.0/0"],
             "acl": ["0.0.0.0/0",
                     "::/0"],
             "default_data_select_host_monitoring_include": [".*"],
@@ -50,6 +49,7 @@ def def_json(call_collect=False):
         d["classes"]["client_initiated_reporting_enabled"] = ["any"]
         d["vars"]["control_server_call_collect_interval"] = "1"
         d["vars"]["mpf_access_rules_collect_calls_admit_ips"] = ["0.0.0.0/0"]
+        d["vars"]["control_hub_exclude_hosts"] = ["0.0.0.0/0"]
 
     return d
 

--- a/contrib/cf-remote/cf_remote/demo.py
+++ b/contrib/cf-remote/cf_remote/demo.py
@@ -23,8 +23,8 @@ def disable_password_dialog(host):
     api = "https://{}/api/user/admin".format(host)
     d = json.dumps({"password": "password"})
     creds = "admin:admin"
-    c = "curl -X POST  -k {} -u {}  -H 'Content-Type: application/json' -d '{}'".format(
-        api, creds, d)
+    header = "Content-Type: application/json"
+    c = "curl -X POST  -k {} -u {}  -H '{}' -d '{}'".format(api, creds, header, d)
     log.debug(c)
     os.system(c)
 
@@ -38,7 +38,8 @@ def def_json(call_collect=False):
         },
         "vars": {
             "control_hub_exclude_hosts": ["0.0.0.0/0"],
-            "acl": ["0.0.0.0/0", "::/0"],
+            "acl": ["0.0.0.0/0",
+                    "::/0"],
             "default_data_select_host_monitoring_include": [".*"],
             "default_data_select_policy_hub_monitoring_include": [".*"],
             "control_executor_splaytime": "1"


### PR DESCRIPTION
This caused all hosts to be excluded from reporting
when running in --demo mode without --call-collect.