### PR TITLE
Fix ShellCommandReturnsZero() return value in error path

### DIFF
--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -244,7 +244,7 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
         {
             if (errno != EINTR)
             {
-                return -1;
+                return false;
             }
         }
 


### PR DESCRIPTION
Returning non-zero from a function returning bool is the same as
returning true. If there is an error in the child process, the function
should return false to indicate failure.