### PR TITLE
Use proper enum constant for true in expressions (3.12)

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -470,7 +470,7 @@ static ExpressionValue EvalTokenAsClass(const char *classname, void *param)
             if (EvalContextHeapContainsHard(ctx, ref.name))
             {
                 ClassRefDestroy(ref);
-                return true;
+                return EXPRESSION_VALUE_TRUE;
             }
         }
     }
@@ -479,7 +479,7 @@ static ExpressionValue EvalTokenAsClass(const char *classname, void *param)
         if (EvalContextHeapContainsHard(ctx, ref.name))
         {
             ClassRefDestroy(ref);
-            return true;
+            return EXPRESSION_VALUE_TRUE;
         }
 
         const char *ns = EvalContextCurrentNamespace(ctx);


### PR DESCRIPTION
No change in behavior, mainly to satisfy LGTM rule.

Found by LGTM:
https://lgtm.com/rules/1508474826013/