### PR TITLE
ENT-4601: Switched perms of various temporary files in state to 0600

### DIFF
--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -34,6 +34,7 @@
 #include <string_lib.h>                                         /* Chop */
 #include <regex.h> /* CompileRegex,StringMatchWithPrecompiledRegex,StringMatchFull */
 #include <item_lib.h>
+#include <file_lib.h>   // SetUmask(), RestoreUmask()
 #include <pipes.h>
 #include <files_interfaces.h>
 #include <rlist.h>
@@ -1657,7 +1658,13 @@ int LoadProcessTable()
     const char* const statedir = GetStateDir();
 
     snprintf(vbuff, CF_MAXVARSIZE, "%s%ccf_procs", statedir, FILE_SEPARATOR);
-    RawSaveItemList(PROCESSTABLE, vbuff, NewLineMode_Unix);
+
+    // TODO: Change safe_fopen() to default to 0600, then remove this.
+    {
+        const mode_t old_umask = SetUmask(0077);
+        RawSaveItemList(PROCESSTABLE, vbuff, NewLineMode_Unix);
+        RestoreUmask(old_umask);
+    }
 
 # ifdef HAVE_GETZONEID
     if (global_zone) /* pidlist and rootpidlist are empty if we're not in the global zone */
@@ -1696,6 +1703,9 @@ int LoadProcessTable()
         PrependItem(&rootprocs, otherprocs->name, NULL);
     }
 
+    // TODO: Change safe_fopen() to default to 0600, then remove this.
+    const mode_t old_umask = SetUmask(0077);
+
     snprintf(vbuff, CF_MAXVARSIZE, "%s%ccf_rootprocs", statedir, FILE_SEPARATOR);
     RawSaveItemList(rootprocs, vbuff, NewLineMode_Unix);
     DeleteItemList(rootprocs);
@@ -1703,6 +1713,8 @@ int LoadProcessTable()
     snprintf(vbuff, CF_MAXVARSIZE, "%s%ccf_otherprocs", statedir, FILE_SEPARATOR);
     RawSaveItemList(otherprocs, vbuff, NewLineMode_Unix);
     DeleteItemList(otherprocs);
+
+    RestoreUmask(old_umask);
 
     free(vbuff);
     return true;

--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -25,6 +25,7 @@
 #include <file_lib.h>
 #include <misc_lib.h>
 #include <dir.h>
+#include <logging.h>
 
 #include <alloc.h>
 #include <libgen.h>
@@ -462,6 +463,18 @@ Seq *ListDir(const char *dir, const char *extension)
     DirClose(dirh);
 
     return contents;
+}
+
+mode_t SetUmask(mode_t new_mask)
+{
+    const mode_t old_mask = umask(0077);
+    Log(LOG_LEVEL_DEBUG, "Set umask to 0077, was %o", old_mask);
+    return old_mask;
+}
+void RestoreUmask(mode_t old_mask)
+{
+    umask(old_mask);
+    Log(LOG_LEVEL_DEBUG, "Restored umask to %o", old_mask);
 }
 
 /**

--- a/libutils/file_lib.h
+++ b/libutils/file_lib.h
@@ -101,6 +101,10 @@ char *MapNameCopy(const char *s);
 char *MapNameForward(char *s);
 
 Seq *ListDir(const char *dir, const char *extension);
+
+mode_t SetUmask(mode_t new_mask);
+void RestoreUmask(mode_t old_mask);
+
 int safe_open(const char *pathname, int flags, ...);
 FILE *safe_fopen(const char *path, const char *mode);
 


### PR DESCRIPTION
These files were created with 0644 permissions, and then
repaired in policy. However, since they are deleted / recreated
periodically, it causes INFO noise. Safer and better user
experience to create them with restricted permissions to
begin with.

Affected files:

* `$(sys.statedir)/cf_procs`
* `$(sys.statedir)/cf_rootprocs`
* `$(sys.statedir)/cf_otherprocs`

Merge together:
https://github.com/cfengine/core/pull/3649
https://github.com/cfengine/enterprise/pull/510
https://github.com/cfengine/masterfiles/pull/1389