### PR TITLE
ENT-4601: Switched perms of various temporary files in state to 0600 (3.12)

### DIFF
--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -25,6 +25,7 @@
 #include <file_lib.h>
 #include <misc_lib.h>
 #include <dir.h>
+#include <logging.h>
 
 #include <alloc.h>
 #include <libgen.h>
@@ -462,6 +463,18 @@ Seq *ListDir(const char *dir, const char *extension)
     DirClose(dirh);
 
     return contents;
+}
+
+mode_t SetUmask(mode_t new_mask)
+{
+    const mode_t old_mask = umask(0077);
+    Log(LOG_LEVEL_DEBUG, "Set umask to 0077, was %o", old_mask);
+    return old_mask;
+}
+void RestoreUmask(mode_t old_mask)
+{
+    umask(old_mask);
+    Log(LOG_LEVEL_DEBUG, "Restored umask to %o", old_mask);
 }
 
 /**

--- a/libutils/file_lib.h
+++ b/libutils/file_lib.h
@@ -101,6 +101,10 @@ char *MapNameCopy(const char *s);
 char *MapNameForward(char *s);
 
 Seq *ListDir(const char *dir, const char *extension);
+
+mode_t SetUmask(mode_t new_mask);
+void RestoreUmask(mode_t old_mask);
+
 int safe_open(const char *pathname, int flags, ...);
 FILE *safe_fopen(const char *path, const char *mode);
 


### PR DESCRIPTION
These files were created with 0644 permissions, and then
repaired in policy. However, since they are deleted / recreated
periodically, it causes INFO noise. Safer and better user
experience to create them with restricted permissions to
begin with.

Affected files:

* `$(sys.statedir)/cf_procs`
* `$(sys.statedir)/cf_rootprocs`
* `$(sys.statedir)/cf_otherprocs`

(cherry picked from commit 461dc7019ab5acebabc341143838a2307d9b92db)

Merge together:
https://github.com/cfengine/core/pull/3657
https://github.com/cfengine/enterprise/pull/516
https://github.com/cfengine/masterfiles/pull/1390