### PR TITLE
Only use 'cmp_to_key' in determine_version if it exists

### DIFF
--- a/misc/determine-version.py
+++ b/misc/determine-version.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 import os
 from os.path import basename
-from functools import cmp_to_key
+try:
+    from functools import cmp_to_key
+except ImportError:
+    cmp_to_key = None
 
 try:
     DEVNULL = subprocess.DEVNULL
@@ -221,7 +224,10 @@ for tag in git_tag_list.stdout.readlines():
         continue
     all_tags.append(match)
 
-all_tags = sorted(all_tags, key=cmp_to_key(version_cmp), reverse=True)
+if cmp_to_key is None:
+    all_tags = sorted(all_tags, cmp=version_cmp, reverse=True)
+else:
+    all_tags = sorted(all_tags, key=cmp_to_key(version_cmp), reverse=True)
 verbose_print("all_tags   =", all_tags)
 
 


### PR DESCRIPTION
Otherwise do things the old way using 'cmp=' because if
'cmp_to_key' doesn't exist, we are running an old version of
Python which supports 'cmp='.

This fixes running determine_version.py on CentOS 6 which has
Python 2.6.