### PR TITLE
[3.12.x] Fix potentially unitialized 'script_exec_opts' of a package module

### DIFF
--- a/cf-agent/package_module.c
+++ b/cf-agent/package_module.c
@@ -501,8 +501,9 @@ static void GetPackageModuleExecInfo(const PackageModuleBody *package_module, ch
 
         if (strchr(package_module->interpreter, ' ') == NULL)
         {
-            /* no spaces in the 'interpreter' string, easy! */
+            /* No spaces in the 'interpreter' string, easy! Just interpreter path given, no opts. */
             *exec_path = xstrdup(package_module->interpreter);
+            *script_exec_opts = NULL;
         }
         else
         {


### PR DESCRIPTION
If a package module has an interpreter specified, it can either
be just a path to the interpreter executable or it can also
provide options for the intepreter. If there are no such options,
'package_module->script_exec_opts' has to be NULL because we
later rely on that.

Changelog: None
(cherry picked from commit 54bd7b7bd08cb9252cccc1cd334fdd89e928ba10)