### PR TITLE
CFE-2954: Augments files can now handle class expressions by appending '::'

### DIFF
--- a/tests/acceptance/00_basics/def.json/class_from_classexpression.cf
+++ b/tests/acceptance/00_basics/def.json/class_from_classexpression.cf
@@ -1,0 +1,62 @@
+# basic test of the def.json facility: augments
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+
+  meta:
+      "description" -> { "CFE-2971" }
+        string => "Test that class expressions can be used to define classes via augments";
+
+  methods:
+      "Test all expected classes defined from augments"
+        usebundle => file_make("$(sys.inputdir)/promises.cf", '
+bundle agent main
+{
+  classes:
+      "pass" and => {
+                      "augments_class_from_regex",
+                      "augments_class_from_single_class_as_regex",
+                      "augments_class_from_single_class_as_expression",
+                      "augments_class_from_classexpression_and",
+                      "augments_class_from_classexpression_not",
+                      "augments_class_from_classexpression_or",
+                      "augments_class_from_classexpression_complex",
+      };
+
+
+  reports:
+    pass::
+      "PASS: All expected classes found";
+    !pass::
+      "FAIL: Not all expected classes found";
+}
+');
+
+      "Place Augments for test"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "command"
+        string => "$(sys.cf_agent) --show-evaluated-classes=augments_classes_from_ -f $(sys.inputdir)/promises.cf|$(G.grep) PASS";
+
+  methods:
+      "PASS/FAIL"
+        usebundle => dcs_passif_output(".*PASS.*",
+                                       "",
+                                       $(command),
+                                       $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/class_from_classexpression.cf.json
+++ b/tests/acceptance/00_basics/def.json/class_from_classexpression.cf.json
@@ -1,0 +1,11 @@
+{
+    "classes": {
+        "augments_class_from_regex": [ "cfengine_\\d+" ],
+        "augments_class_from_single_class_as_regex": [ "cfengine" ],
+        "augments_class_from_single_class_as_expression": [ "cfengine::" ],
+        "augments_class_from_classexpression_and": [ "cfengine.cfengine_3::" ],
+        "augments_class_from_classexpression_not": [ "!MISSING::" ],
+        "augments_class_from_classexpression_or": [ "cfengine|cfengine_3::" ],
+        "augments_class_from_classexpression_complex": [ "(cfengine|cfengine_3).!MISSING::" ]
+    }
+}

--- a/tests/acceptance/README
+++ b/tests/acceptance/README
@@ -191,7 +191,7 @@ Handling different platforms
 ------------------------------------------------------------------------------
 
 For tests that need to be skipped on certain platforms, you can add
-special meta variables to one of the test bundles. These are the
+special meta variables to the *test* bundle. These are the
 possible variable names:
 
   - test_skip_unsupported
@@ -214,6 +214,13 @@ possible variable names:
       Suppressed failures will count as a failure, but it won't block
       the build, and is appropriate for regressions or bad test
       failures.
+
+Additinally, a *description* meta variable can be added to the test to describe
+it's funciton.
+
+  meta:
+      "description" -> { "CFE-2971" }
+        string => "Test that class expressions can be used to define classes via augments";
 
 The rule of thumb is:
 


### PR DESCRIPTION
A condition in an augments file is treated as a class expression
if it ends in `::`. Otherwise it is treated as a regular
expression.

Previously there was a bug, where the conditions in augments files
were treated as both class expressions and regular expressions.
This was ambiguous, and problematic since something like
`cfengine.nginx.enabled` as a regex would match a class called
`cfengine_nginx_enabled`, while as a class expression would match
`cfengine && nginx && enabled`.

This was fixed in 3.12.1 by treating it as a regex only.
(Documented and intended behavior).

Some users still wanted a way to use class expression, so the `::`
suffix solves the problem. For the example above, you can use this
in the augments file:

`cfengine.nginx.enabled::`

Since classes cannot end with `:`, this shouldn't be a problem,
it is not useful to have regular expressions ending with `::` in
this context.

Original commit made by @basvandervlies(bas.vandervlies@surfsara.nl).
Reworked by @olehermanse(ole@northern.tech).