### PR TITLE
fix bogus success message for 'cfe_internal' package

### DIFF
--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -2706,15 +2706,17 @@ static bool ExecuteSchedule(EvalContext *ctx, const PackageManager *schedule, Pa
                     EvalContextStackPushPromiseFrame(ctx, ppi);
                     if (EvalContextStackPushPromiseIterationFrame(ctx, NULL))
                     {
-                        if (ExecPackageCommand(ctx, command_string, verify, true, &a, ppi, &result))
+                        bool ok = ExecPackageCommand(ctx, command_string, verify, true, &a, ppi, &result);
+
+                        if (StringSafeEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
+                        {
+                            Log(LOG_LEVEL_DEBUG, "ExecuteSchedule: Ignoring outcome for special package '%s'", pi->name);
+                        }
+                        else if (ok)
                         {
                             Log(LOG_LEVEL_VERBOSE,
                                 "Package schedule execution ok for '%s' (outcome cannot be promised by cf-agent)",
                                   pi->name);
-                        }
-                        else if (strncmp(pi->name, PACKAGE_IGNORED_CFE_INTERNAL, strlen(PACKAGE_IGNORED_CFE_INTERNAL)) == 0)
-                        {
-                            Log(LOG_LEVEL_DEBUG, "ExecuteSchedule: Ignoring outcome for special package '%s'", pi->name);
                         }
                         else
                         {
@@ -2771,15 +2773,15 @@ static bool ExecuteSchedule(EvalContext *ctx, const PackageManager *schedule, Pa
 
                         for (const PackageItem *pi = pm->pack_list; pi != NULL; pi = pi->next)
                         {
-                            if (ok)
+                            if (StringSafeEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
+                            {
+                                Log(LOG_LEVEL_DEBUG, "ExecuteSchedule: Ignoring outcome for special package '%s'", pi->name);
+                            }
+                            else if (ok)
                             {
                                 Log(LOG_LEVEL_VERBOSE,
                                     "Bulk package schedule execution ok for '%s' (outcome cannot be promised by cf-agent)",
                                       pi->name);
-                            }
-                            else if (strncmp(pi->name, PACKAGE_IGNORED_CFE_INTERNAL, strlen(PACKAGE_IGNORED_CFE_INTERNAL)) == 0)
-                            {
-                                Log(LOG_LEVEL_DEBUG, "ExecuteSchedule: Ignoring outcome for special package '%s'", pi->name);
                             }
                             else
                             {
@@ -2957,15 +2959,17 @@ static bool ExecutePatch(EvalContext *ctx, const PackageManager *schedule, Packa
                     EvalContextStackPushPromiseFrame(ctx, pp);
                     if (EvalContextStackPushPromiseIterationFrame(ctx, NULL))
                     {
-                        if (ExecPackageCommand(ctx, command_string, false, true, &a, pp, &result))
+                        bool ok = ExecPackageCommand(ctx, command_string, false, true, &a, pp, &result);
+
+                        if (StringSafeEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
+                        {
+                            Log(LOG_LEVEL_DEBUG, "ExecutePatch: Ignoring outcome for special package '%s'", pi->name);
+                        }
+                        else if (ok)
                         {
                             Log(LOG_LEVEL_VERBOSE,
                                 "Package schedule execution ok for '%s' (outcome cannot be promised by cf-agent)",
                                   pi->name);
-                        }
-                        else if (strncmp(pi->name, PACKAGE_IGNORED_CFE_INTERNAL, strlen(PACKAGE_IGNORED_CFE_INTERNAL)) == 0)
-                        {
-                            Log(LOG_LEVEL_DEBUG, "ExecutePatch: Ignoring outcome for special package '%s'", pi->name);
                         }
                         else
                         {
@@ -3000,15 +3004,15 @@ static bool ExecutePatch(EvalContext *ctx, const PackageManager *schedule, Packa
 
                     for (const PackageItem *pi = pm->patch_list; pi != NULL; pi = pi->next)
                     {
-                        if (ok)
+                        if (StringSafeEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
+                        {
+                            Log(LOG_LEVEL_DEBUG, "ExecutePatch: Ignoring outcome for special package '%s'", pi->name);
+                        }
+                        else if (ok)
                         {
                             Log(LOG_LEVEL_VERBOSE,
                                 "Bulk package schedule execution ok for '%s' (outcome cannot be promised by cf-agent)",
                                   pi->name);
-                        }
-                        else if (strncmp(pi->name, PACKAGE_IGNORED_CFE_INTERNAL, strlen(PACKAGE_IGNORED_CFE_INTERNAL)) == 0)
-                        {
-                            Log(LOG_LEVEL_DEBUG, "ExecutePatch: Ignoring outcome for special package '%s'", pi->name);
                         }
                         else
                         {


### PR DESCRIPTION
Commit 9cd859620825 ("Fix cfe_internal packages to avoid return code
check.") had ExecPackageCommand() skip the return code verification to
avoid noise in the log for a command that is expected to fail.  This
results in ExecPackageCommand() indicating success, though, which leads
to the completely bogus message:

```
  verbose: Package schedule execution ok for 'cfe_internal_non_existing_package' (outcome cannot be promised by cf-agent)
```

Decide if we want to ignore the package before looking at the status
code to restore the intended behavior.

Also, clean up the package name check by wrapping it in a macro.  Note
that passing the result of strlen(3) to strncmp(3) is no different than
simply calling strcmp(3), so just do the latter.