### PR TITLE
Fix AIX inverse process selection test

### DIFF
--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -795,21 +795,6 @@ Solaris 9:
                     }
                 }
             }
-            else if (strcmp(names[field], "TIME") == 0)
-            {
-                // Check for processes with no TIME reported.
-                for (int pos = start[field]; pos <= end[field] && pos < linelen && !skip; pos++)
-                {
-                    if ((pos == start[field] || isspace(line[pos - 1])) /* first or after space */
-                        && (line[pos] == '-')
-                        && (isspace(line[pos + 1]) || line[pos + 1] == '\0')) /* space or end follows */
-                    {
-                        LogDebug(LOG_MOD_PS, "Detected process with no TIME reported, "
-                                 "skipping parsing of empty ps fields.");
-                        skip = true;
-                    }
-                }
-            }
         }
     }
 

--- a/tests/acceptance/05_processes/01_matching/inverse_ttime_inverse_found.cf
+++ b/tests/acceptance/05_processes/01_matching/inverse_ttime_inverse_found.cf
@@ -36,9 +36,15 @@ bundle agent test
 
 body process_count test_range
 {
-      in_range_define => { "none_found" };
-      out_of_range_define => { "some_found" };
-      match_range => irange(0,0);
+        in_range_define => { "none_found" };
+        out_of_range_define => { "some_found" };
+
+    aix::
+        # Allow one process with CPU time not between 0 seconds and 99 years on
+        # AIX because a process with TIME '-' sometimes appears there.
+        match_range => irange(0, 1);
+    !aix::
+        match_range => irange(0, 0);
 }
 
 body process_select test_select_high_users


### PR DESCRIPTION
Fixing the rather weird test seems to be a better idea than changing our super-complex `ps` output parsing code.