### PR TITLE
CFE-2918: Introduced wrappers for setenv and putenv which don't leak (3.12)

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -355,7 +355,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
 
         case 'w':
             Log(LOG_LEVEL_INFO, "Setting workdir to '%s'", optarg);
-            putenv(StringConcatenate(2, "CFENGINE_TEST_OVERRIDE_WORKDIR=", optarg));
+            setenv_wrapper("CFENGINE_TEST_OVERRIDE_WORKDIR", optarg, 1);
             break;
 
         case 'f':
@@ -963,13 +963,8 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
 
             if (strcmp(cp->lval, CFA_CONTROLBODY[AGENT_CONTROL_CHILDLIBPATH].lval) == 0)
             {
-                char output[CF_BUFSIZE];
-
-                snprintf(output, CF_BUFSIZE, "Setting LD_LIBRARY_PATH to '%s'", (const char *)value);
-                if (putenv(xstrdup(output)) == 0)
-                {
-                    Log(LOG_LEVEL_VERBOSE, "Setting '%s'", output);
-                }
+                Log(LOG_LEVEL_VERBOSE, "Setting 'LD_LIBRARY_PATH=%s'", (const char *)value);
+                setenv_wrapper("LD_LIBRARY_PATH", value, 1);
                 continue;
             }
 
@@ -1130,7 +1125,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
                 for (const Rlist *rp = value; rp != NULL; rp = rp->next)
                 {
                     assert(strchr(RlistScalarValue(rp), '=')); /* Valid for putenv() */
-                    if (putenv(xstrdup(RlistScalarValue(rp))) != 0)
+                    if (putenv_wrapper(RlistScalarValue(rp)) != 0)
                     {
                         Log(LOG_LEVEL_ERR, "Failed to set environment variable '%s'. (putenv: %s)",
                             RlistScalarValue(rp), GetErrorStr());

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -174,7 +174,6 @@ int main(int argc, char *argv[])
     GenericAgentFinalize(ctx, config);
     ExecConfigDestroy(exec_config);
     ExecdConfigDestroy(execd_config);
-
     return 0;
 }
 
@@ -186,7 +185,6 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
 {
     extern char *optarg;
     int c;
-    char ld_library_path[CF_BUFSIZE];
 
     GenericAgentConfig *config = GenericAgentConfigNewDefault(AGENT_TYPE_EXECUTOR, GetTTYInteractive());
 
@@ -260,10 +258,11 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
             break;
 
         case 'L':
-            snprintf(ld_library_path, CF_BUFSIZE - 1, "LD_LIBRARY_PATH=%s", optarg);
-            putenv(xstrdup(ld_library_path));
-            break;
-
+            {
+                Log(LOG_LEVEL_VERBOSE, "Setting 'LD_LIBRARY_PATH=%s'", optarg);
+                setenv_wrapper("LD_LIBRARY_PATH", optarg, 1);
+                break;
+            }
         case 'W':
             WINSERVICE = false;
             break;

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -279,7 +279,7 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
 
         case 'w':
             Log(LOG_LEVEL_INFO, "Setting workdir to '%s'", optarg);
-            putenv(StringConcatenate(2, "CFENGINE_TEST_OVERRIDE_WORKDIR=", optarg));
+            putenv_wrapper(StringConcatenate(2, "CFENGINE_TEST_OVERRIDE_WORKDIR=", optarg));
             break;
 
         case 'c':

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -223,10 +223,8 @@ GenericAgentConfig *CheckOpts(int argc, char **argv)
 
         case 'L':
         {
-            static char ld_library_path[CF_BUFSIZE]; /* GLOBAL_A */
             Log(LOG_LEVEL_VERBOSE, "Setting LD_LIBRARY_PATH to '%s'", optarg);
-            snprintf(ld_library_path, CF_BUFSIZE - 1, "LD_LIBRARY_PATH=%s", optarg);
-            putenv(ld_library_path);
+            setenv_wrapper("LD_LIBRARY_PATH", optarg, 1);
             break;
         }
 

--- a/cf-serverd/cf-serverd.c
+++ b/cf-serverd/cf-serverd.c
@@ -80,6 +80,5 @@ int main(int argc, char *argv[])
         GenericAgentFinalize(ctx, config);
         CleanReportBookFilterSet();
     }
-
     return 0;
 }

--- a/libutils/deprecated.h
+++ b/libutils/deprecated.h
@@ -41,10 +41,6 @@
 int sprintf(char *str, const char *format, ...) \
     FUNC_DEPRECATED("Try snprintf() or xsnprintf() or xasprintf()");
 
-int setenv(const char *name, const char *value, int overwrite) \
-    FUNC_DEPRECATED("Always use putenv() in place of non-portable setenv()!");
-
-
 #endif  /* __linux__ && __GLIBC__ */
 
 

--- a/libutils/misc_lib.h
+++ b/libutils/misc_lib.h
@@ -102,5 +102,7 @@ void __UnexpectedError(const char *file, int lineno, const char *format, ...) \
 void xclock_gettime(clockid_t clk_id, struct timespec *ts);
 void xsnprintf(char *str, size_t str_size, const char *format, ...);
 
+int setenv_wrapper(const char *name, const char *value, int overwrite);
+int putenv_wrapper(const char *str);
 
 #endif

--- a/tests/unit/misc_lib_test.c
+++ b/tests/unit/misc_lib_test.c
@@ -1,6 +1,7 @@
 #include <test.h>
 
 #include <misc_lib.h>
+#include <alloc.h>
 
 
 static void test_unsigned_modulus(void)
@@ -190,6 +191,41 @@ static void test_ISPOW2(void)
     assert_false(ISPOW2(0xFFFFFFFF));
 }
 
+static void test_putenv_wrapper(void)
+{
+    assert_true(getenv("UNIT_TEST_VAR") == NULL);
+
+    putenv_wrapper("UNIT_TEST_VAR=VALUE");
+    assert_true(getenv("UNIT_TEST_VAR") != NULL);
+    assert_string_equal(getenv("UNIT_TEST_VAR"), "VALUE");
+
+    putenv_wrapper("UNIT_TEST_VAR=NEW_VALUE");
+    assert_true(getenv("UNIT_TEST_VAR") != NULL);
+    assert_string_equal(getenv("UNIT_TEST_VAR"), "NEW_VALUE");
+
+    unsetenv("UNIT_TEST_VAR");
+    assert_true(getenv("UNIT_TEST_VAR") == NULL);
+}
+
+static void test_setenv_wrapper(void)
+{
+    assert_true(getenv("UNIT_TEST_VAR") == NULL);
+
+    setenv_wrapper("UNIT_TEST_VAR", "VALUE", 0);
+    assert_true(getenv("UNIT_TEST_VAR") != NULL);
+    assert_string_equal(getenv("UNIT_TEST_VAR"), "VALUE");
+
+    setenv_wrapper("UNIT_TEST_VAR", "NEW_VALUE", 1);
+    assert_true(getenv("UNIT_TEST_VAR") != NULL);
+    assert_string_equal(getenv("UNIT_TEST_VAR"), "NEW_VALUE");
+
+    setenv_wrapper("UNIT_TEST_VAR", "NO_OVERWRITE", 0);
+    assert_true(getenv("UNIT_TEST_VAR") != NULL);
+    assert_string_equal(getenv("UNIT_TEST_VAR"), "NEW_VALUE");
+
+    unsetenv("UNIT_TEST_VAR");
+    assert_true(getenv("UNIT_TEST_VAR") == NULL);
+}
 
 int main()
 {
@@ -202,6 +238,8 @@ int main()
         unit_test(test_upper_power_of_two),
         unit_test(test_rand_ISPOW2),
         unit_test(test_ISPOW2),
+        unit_test(test_putenv_wrapper),
+        unit_test(test_setenv_wrapper),
     };
 
     return run_tests(tests);


### PR DESCRIPTION
They still leak on exotic platforms which don't support
setenv. Fixing this is much more difficult than it seems.

Fixed one conflict in includes while cherry-picking.