### PR TITLE
Fixed memory leak in filesexist()

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7296,6 +7296,7 @@ static FnCallResult FnCallFileSexist(EvalContext *ctx, ARG_UNUSED const Policy *
         {
             file_found = false;
         }
+        free(val);
         el = JsonIteratorNextValueByType(&iter, JSON_ELEMENT_TYPE_PRIMITIVE, true);
     }
 


### PR DESCRIPTION
Found by manually running enterprise hub agent in valgrind.

See: https://github.com/cfengine/core/pull/3463/files#r286054720