### PR TITLE
[3.12.x] Fix disabling TLS 1.0

### DIFF
--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -74,7 +74,7 @@ enum tls_version {
 #endif
 
 static const char *const tls_version_strings[TLS_LAST + 1] = {"1.0", "1.1", "1.2", "1.3"};
-static unsigned int tls_disable_flags[TLS_LAST + 1] = {0, SSL_OP_NO_TLSv1_1, SSL_OP_NO_TLSv1_2, SSL_OP_NO_TLSv1_3};
+static unsigned int tls_disable_flags[TLS_LAST + 1] = {SSL_OP_NO_TLSv1, SSL_OP_NO_TLSv1_1, SSL_OP_NO_TLSv1_2, SSL_OP_NO_TLSv1_3};
 
 int CONNECTIONINFO_SSL_IDX = -1;
 


### PR DESCRIPTION
There is a flag for disabling TLS 1.0, we shouldn't just use 0.

Ticket: CFE-3068
Changelog: Title
(cherry picked from commit 9862f3928c204d7f3defc6a3dc8d3e1ee3f08819)