### PR TITLE
Fix determine_version.py to deal with the 3.12.2-2 re-release

### DIFF
--- a/misc/determine-version.py
+++ b/misc/determine-version.py
@@ -167,14 +167,19 @@ except IndexError:                          # command returned no output
 # Find the most recent tag reachable from this commit.
 git = subprocess.Popen(["git", "describe", "--tags", "--abbrev=0", REV],
                        stdout=subprocess.PIPE)
-recent_tag = git.stdout.readlines()[0].decode().strip()
-verbose_print("recent_tag = %s" % recent_tag)
+recent_tag_random = git.stdout.readlines()[0].decode().strip()
 
 # Find the revision corresponding to the tag
-git = subprocess.Popen(["git", "rev-parse", recent_tag + "^{}"],
+git = subprocess.Popen(["git", "rev-parse", recent_tag_random + "^{}"],
                        stdout=subprocess.PIPE)
 recent_rev = git.stdout.readlines()[0].decode().strip()
 verbose_print("recent_rev = %s" % recent_rev)
+
+# Find the shortest (nicest) tag for the given revision
+git = subprocess.Popen(["git", "tag", "--points-at", recent_rev],
+                       stdout=subprocess.PIPE)
+recent_tag = git.stdout.readlines()[0].decode().strip()
+verbose_print("recent_tag = %s" % recent_tag)
 
 # Find its version, if any.
 recent_version = extract_version_components(recent_tag)

--- a/misc/determine-version.py
+++ b/misc/determine-version.py
@@ -231,7 +231,7 @@ else:
 verbose_print("all_tags   =", all_tags)
 
 
-if len(all_tags) == 0:
+if len(all_tags) == 0 or (not in_master_branch):
     # No tags besides the most recent one were found, so this is a new
     # patch version. So "increase" the patch version:
 


### PR DESCRIPTION
Merge together:
https://github.com/cfengine/enterprise/pull/522
https://github.com/cfengine/nova/pull/1430
https://github.com/cfengine/masterfiles/pull/1413