### PR TITLE
ENT-4752 Set tag on version specific os related class for default collection

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -721,7 +721,7 @@ static void GetNameInfo3(EvalContext *ctx)
     Log(LOG_LEVEL_VERBOSE, "Additional hard class defined as: %s", CanonifyName(workbuf));
 
     snprintf(workbuf, CF_BUFSIZE, "%s_%s", VSYSNAME.sysname, VSYSNAME.release);
-    EvalContextClassPutHard(ctx, workbuf, "source=agent,derived-from=sys.sysname,derived-from=sys.release");
+    EvalContextClassPutHard(ctx, workbuf, "inventory,attribute_name=none,source=agent,derived-from=sys.sysname,derived-from=sys.release");
 
     EvalContextClassPutHard(ctx, VSYSNAME.machine, "source=agent,derived-from=sys.machine");
     Log(LOG_LEVEL_VERBOSE, "Additional hard class defined as: %s", CanonifyName(workbuf));


### PR DESCRIPTION
Version specific classes are useful for subdividing the enterprise host tree, so
we need to tag them so that they are collected by default.

Ticket: ENT-4752
Changelog: Title