### PR TITLE
LGTM: Boolean type checking now respects type casts

### DIFF
--- a/.lgtm/cpp-queries/bool-type-mismatch-return.ql
+++ b/.lgtm/cpp-queries/bool-type-mismatch-return.ql
@@ -15,7 +15,13 @@
 import cpp
 
 predicate isBoolExpr(Expr expression){
-  expression.getType().getName() = "bool"
+  ( // bool type and not typecast to something else
+    expression.getType().getName() = "bool"
+    and not exists(CStyleCast cast |
+      cast.getExpr() = expression
+      and cast.getType().getName() != "bool"
+    )
+  )
   or exists(MacroInvocation m |
             m.getExpr() = expression
             and (m.getMacroName() = "true"


### PR DESCRIPTION
Gets rid of at least 2 false positives. I think query needs more
work to handle all variants of type casts.