### PR TITLE
ENT-4777: Added function to trim trailing CRLF from a line of CSV data

### DIFF
--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -145,6 +145,8 @@ int StripTrailingNewline(char *str, size_t max_length);
 int Chop(char *str, size_t max_length);
 
 char *TrimWhitespace(char *s);
+size_t TrimCSVLineCRLF(char *data);
+size_t TrimCSVLineCRLFStrict(char *data);
 
 /**
  * @brief Check if a string ends with the given suffix


### PR DESCRIPTION
Will be used in reporting.