### PR TITLE
CFE-2977: Added sys.bootstrap_id policy variable

### DIFF
--- a/libpromises/bootstrap.h
+++ b/libpromises/bootstrap.h
@@ -45,6 +45,8 @@ bool RemoveAllExistingPolicyInInputs(const char *inputdir);
 bool MasterfileExists(const char *masterdir);
 
 // BOOTSTRAP ID FUNCTIONS:
-bool CreateBootstrapIDFile(const char *workdir);
+char *CreateBootstrapIDFile(const char *workdir);
+char *ReadBootstrapIDFile(const char *workdir);
+void EvalContextSetBootstrapID(EvalContext *ctx, char *bootstrap_id);
 
 #endif

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -608,7 +608,12 @@ void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config)
 
         PolicyServerWriteFile(GetWorkDir(), bootstrap_arg);
         EvalContextSetPolicyServer(ctx, bootstrap_arg);
-        CreateBootstrapIDFile(GetWorkDir());
+        char *const bootstrap_id = CreateBootstrapIDFile(GetWorkDir());
+        if (bootstrap_id != NULL)
+        {
+            EvalContextSetBootstrapID(ctx, bootstrap_id);
+            free(bootstrap_id);
+        }
 
         /* FIXME: Why it is called here? Can't we move both invocations to before if? */
         UpdateLastPolicyUpdateTime(ctx);
@@ -621,6 +626,12 @@ void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config)
             Log(LOG_LEVEL_VERBOSE, "This agent is bootstrapped to: %s",
                 existing_policy_server);
             EvalContextSetPolicyServer(ctx, existing_policy_server);
+            char *const bootstrap_id = ReadBootstrapIDFile(GetWorkDir());
+            if (bootstrap_id != NULL)
+            {
+                EvalContextSetBootstrapID(ctx, bootstrap_id);
+                free(bootstrap_id);
+            }
             free(existing_policy_server);
             UpdateLastPolicyUpdateTime(ctx);
             if (GetAmPolicyHub())

--- a/libutils/writer.c
+++ b/libutils/writer.c
@@ -250,6 +250,8 @@ void WriterClose(Writer *writer)
 char *StringWriterClose(Writer *writer)
 // NOTE: transfer of ownership for allocated return value
 {
+    assert(writer != NULL);
+
     if (writer->type != WT_STRING)
     {
         ProgrammingError("Wrong writer type");

--- a/travis-scripts/valgrind.sh
+++ b/travis-scripts/valgrind.sh
@@ -158,6 +158,15 @@ echo "Running cf-check:"
 valgrind $VG_OPTS /var/cfengine/bin/cf-check diagnose /var/cfengine/state/*.lmdb 2>&1 | tee check.txt
 check_output check.txt
 
+echo "Checking that bootstrap ID doesn't change"
+/var/cfengine/bin/cf-agent --show-evaluated-vars | grep bootstrap_id > id_a
+/var/cfengine/bin/cf-agent -K --show-evaluated-vars | grep bootstrap_id > id_b
+cat id_a
+diff id_a id_b
+
+echo "Checking that bootstrap ID has expected length"
+[ `cat id_a | awk '{print $2}' | wc -c` -eq 41 ]
+
 print_ps
 
 echo "Checking that serverd and execd PIDs are still correct/alive:"

--- a/travis-scripts/valgrind.sh
+++ b/travis-scripts/valgrind.sh
@@ -168,7 +168,7 @@ echo "Killing valgrind cf-execd"
 kill $exec_pid
 echo "Killing valgrind cf-serverd"
 kill $server_pid
-sleep 10
+sleep 30
 
 echo "Output from cf-execd in valgrind:"
 cat execd.txt

--- a/travis-scripts/valgrind.sh
+++ b/travis-scripts/valgrind.sh
@@ -28,6 +28,8 @@ cd masterfiles
 ./autogen.sh
 make install
 
+systemctl daemon-reload
+
 function print_ps {
     set +e
     echo "CFEngine processes:"


### PR DESCRIPTION
Contains the ID from `/var/cfengine/bootstrap_id.dat`, if present.