### PR TITLE
CFE-2994: cf-check directories can now be controlled from ENV vars

### DIFF
--- a/cf-check/backup.c
+++ b/cf-check/backup.c
@@ -4,6 +4,7 @@
 #include <backup.h>
 #include <logging.h>
 #include <file_lib.h>
+#include <known_dirs.h>
 
 #if defined(__MINGW32__) || !defined(LMDB)
 
@@ -26,7 +27,15 @@ int backup_files(Seq *filenames)
 const char *create_backup_dir()
 {
     static char backup_dir[PATH_MAX];
-    const char *const backup_root = WORKDIR "/backups/";
+    static char backup_root[PATH_MAX];
+    snprintf(
+        backup_root,
+        PATH_MAX,
+        "%s%c%s%c",
+        GetWorkDir(),
+        FILE_SEPARATOR,
+        "backups",
+        FILE_SEPARATOR);
 
     if (mkdir(backup_root, 0700) != 0)
     {

--- a/cf-check/utilities.c
+++ b/cf-check/utilities.c
@@ -6,10 +6,11 @@
 #include <alloc.h>
 #include <logging.h>
 #include <file_lib.h>
+#include <known_dirs.h>
 
 Seq *default_lmdb_files()
 {
-    const char *state = WORKDIR "/state/";
+    const char *state = GetStateDir();
     Log(LOG_LEVEL_INFO,
         "No filenames specified, defaulting to .lmdb files in %s",
         state);


### PR DESCRIPTION
Should also make it respect `--with-statedir` configure option.