### PR TITLE
Attributes structs are now initialized using a macro

### DIFF
--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -44,7 +44,7 @@ void ClearFilesAttributes(Attributes *whom)
 
 Attributes GetFilesAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
 // default for file copy
 
@@ -115,7 +115,7 @@ Attributes GetFilesAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetReportsAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.transaction = GetTransactionConstraints(ctx, pp);
     attr.classes = GetClassDefinitionConstraints(ctx, pp);
@@ -128,7 +128,7 @@ Attributes GetReportsAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetEnvironmentsAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.transaction = GetTransactionConstraints(ctx, pp);
     attr.classes = GetClassDefinitionConstraints(ctx, pp);
@@ -141,7 +141,7 @@ Attributes GetEnvironmentsAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetServicesAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.transaction = GetTransactionConstraints(ctx, pp);
     attr.classes = GetClassDefinitionConstraints(ctx, pp);
@@ -155,7 +155,7 @@ Attributes GetServicesAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetPackageAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.transaction = GetTransactionConstraints(ctx, pp);
     attr.classes = GetClassDefinitionConstraints(ctx, pp);
@@ -201,7 +201,7 @@ static User GetUserConstraints(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetUserAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.havebundle = PromiseBundleOrBodyConstraintExists(ctx, "home_bundle", pp);
 
@@ -217,7 +217,7 @@ Attributes GetUserAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetDatabaseAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.transaction = GetTransactionConstraints(ctx, pp);
     attr.classes = GetClassDefinitionConstraints(ctx, pp);
@@ -229,7 +229,7 @@ Attributes GetDatabaseAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetClassContextAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes a = { {0} };
+    Attributes a = ZeroAttributes;
 
     a.transaction = GetTransactionConstraints(ctx, pp);
     a.classes = GetClassDefinitionConstraints(ctx, pp);
@@ -242,7 +242,7 @@ Attributes GetClassContextAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetExecAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.contain = GetExecContainConstraints(ctx, pp);
     attr.havecontain = PromiseGetConstraintAsBoolean(ctx, "contain", pp);
@@ -266,7 +266,7 @@ Attributes GetExecAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetProcessAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.signals = PromiseGetConstraintAsList(ctx, "signals", pp);
     attr.process_stop = PromiseGetConstraintAsRval(pp, "process_stop", RVAL_TYPE_SCALAR);
@@ -292,7 +292,7 @@ Attributes GetProcessAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetStorageAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.mount = GetMountConstraints(ctx, pp);
     attr.volume = GetVolumeConstraints(ctx, pp);
@@ -319,7 +319,7 @@ Attributes GetStorageAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetMethodAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.havebundle = PromiseBundleOrBodyConstraintExists(ctx, "usebundle", pp);
 
@@ -338,7 +338,7 @@ Attributes GetMethodAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetMeasurementAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.measure = GetMeasurementConstraint(ctx, pp);
 
@@ -1409,7 +1409,7 @@ ProcessCount GetMatchesConstraints(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetInsertionAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.havelocation = PromiseGetConstraintAsBoolean(ctx, "location", pp);
     attr.location = GetLocationAttributes(pp);
@@ -1466,7 +1466,7 @@ EditLocation GetLocationAttributes(const Promise *pp)
 
 Attributes GetDeletionAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.not_matching = PromiseGetConstraintAsBoolean(ctx, "not_matching", pp);
 
@@ -1493,7 +1493,7 @@ Attributes GetDeletionAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetColumnAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.havecolumn = PromiseGetConstraintAsBoolean(ctx, "edit_field", pp);
     attr.column = GetColumnConstraints(ctx, pp);
@@ -1516,7 +1516,7 @@ Attributes GetColumnAttributes(const EvalContext *ctx, const Promise *pp)
 
 Attributes GetReplaceAttributes(const EvalContext *ctx, const Promise *pp)
 {
-    Attributes attr = { {0} };
+    Attributes attr = ZeroAttributes;
 
     attr.havereplace = PromiseGetConstraintAsBoolean(ctx, "replace_patterns", pp);
     attr.replace = GetReplaceConstraints(pp);

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1583,6 +1583,87 @@ typedef struct
     Rlist *insert_match;
 } Attributes;
 
+#define ZeroAttributes {\
+    .select = {0},\
+    .perms = {0},\
+    .copy = {0},\
+    .delete = {0},\
+    .rename = {0},\
+    .change = {0},\
+    .link = {0},\
+    .edits = {0},\
+    .packages = {0},\
+    .new_packages = {0},\
+    .context = {0},\
+    .measure = {0},\
+    .acl = {0},\
+    .database = {0},\
+    .service = {0},\
+    .users = {0},\
+    .env = {0},\
+    .transformer = NULL,\
+    .pathtype = NULL,\
+    .file_type = NULL,\
+    .repository = NULL,\
+    .edit_template = NULL,\
+    .edit_template_string = NULL,\
+    .template_method = NULL,\
+    .template_data = NULL,\
+    .touch = 0,\
+    .create = 0,\
+    .move_obstructions = 0,\
+    .inherit = 0,\
+    .recursion = { 0 },\
+    .transaction = { 0 },\
+    .classes = { 0 },\
+    .contain = { 0 },\
+    .args = NULL,\
+    .arglist = NULL,\
+    .module = 0,\
+    .signals = NULL,\
+    .process_stop = NULL,\
+    .restart_class = NULL,\
+    .process_count = { 0 },\
+    .process_select = { 0 },\
+    .report = { 0 },\
+    .mount = { 0 },\
+    .volume = { 0 },\
+    .havedepthsearch = 0,\
+    .haveselect = 0,\
+    .haverename = 0,\
+    .havedelete = 0,\
+    .haveperms = 0,\
+    .havechange = 0,\
+    .havecopy = 0,\
+    .havelink = 0,\
+    .haveeditline = 0,\
+    .haveeditxml = 0,\
+    .haveedit = 0,\
+    .havecontain = 0,\
+    .haveclasses = 0,\
+    .havetrans = 0,\
+    .haveprocess_count = 0,\
+    .havemount = 0,\
+    .havevolume = 0,\
+    .havebundle = 0,\
+    .havepackages = 0,\
+    .region = { 0 },\
+    .location = { 0 },\
+    .column = { 0 },\
+    .replace = { 0 },\
+    .xml = { 0 },\
+    .haveregion = 0,\
+    .havelocation = 0,\
+    .havecolumn = 0,\
+    .havereplace = 0,\
+    .haveinsertselect = 0,\
+    .havedeleteselect = 0,\
+    .line_select = { 0 },\
+    .sourcetype = NULL,\
+    .expandvars = 0,\
+    .not_matching = 0,\
+    .insert_match = NULL\
+}
 
 /*************************************************************************/
 /* common macros                                                         */

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -125,7 +125,7 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
 
 //    opts.drop_undefined = true;         /* always remove @{unresolved_list} */
 
-    Attributes a = { {0} };
+    Attributes a = ZeroAttributes;
     // More consideration needs to be given to using these
     //a.transaction = GetTransactionConstraints(pp);
 


### PR DESCRIPTION
The normal way of initializing a struct to zeroes is:

```
Attributes a = { 0 };
```

* If the struct has only simple types (int, enum, pointers), this
  works well.
* If the struct has other structs inside (not pointers to structs)
  it still works, compilers seem to 0 out everything correctly.
  * It does however trigger some warnings when compiling with
    `-Wextra`.

These warnings are useful in other scenarios, like here:

```
return (FnCallResult) { FNCALL_FAILURE, { 0 } };
```

Ensuring that you specify correct number of initial values,
and use `{` for structs, and don't use `{` for integers or
pointers. A kind of type checking, if you will.

Thus, to satisfy this warning, I added a macro for the
`Attributes` struct. It should be noted that this struct is the
only one which needs the special treatment (a macro). Most
structs are much simpler than this one.

There are a couple of other ways to do this:

* Initialize using memset
  * Would also zero out the struct padding
  * A function call seems hacky/unnecessary
* Initialize using a global static const
  * Static variables are always zero initialized
  * Also seems unnecessary

Changelog: None
Ticket: None
Signed-off-by: Ole Herman Schumacher Elgesem <ole@northern.tech>