### PR TITLE
ENT-4814: cf-monitord fixes (log messages, tracking growing files, C code opportunistic cleanup)

### DIFF
--- a/cf-monitord/history.c
+++ b/cf-monitord/history.c
@@ -74,7 +74,7 @@ static void PutRecordForTime(CF_DB *db, time_t time, const Averages *values)
     WriteDB(db, timekey, values, sizeof(Averages));
 }
 
-static void Nova_SaveFilePosition(const char *handle, char *name, long fileptr)
+static void Nova_SaveFilePosition(const char *handle, const char *name, long fileptr)
 {
     CF_DB *dbp;
     char *key = StringConcatenate(2, handle, name);
@@ -90,7 +90,7 @@ static void Nova_SaveFilePosition(const char *handle, char *name, long fileptr)
     free(key);
 }
 
-static long Nova_RestoreFilePosition(const char *handle, char *name)
+static long Nova_RestoreFilePosition(const char *handle, const char *name)
 {
     CF_DB *dbp;
     long fileptr;

--- a/cf-monitord/history.c
+++ b/cf-monitord/history.c
@@ -470,7 +470,7 @@ static PromiseResult NovaExtractValueFromStream(EvalContext *ctx, const char *ha
 
         if (a->measure.select_line_matching && StringMatchFull(a->measure.select_line_matching, ip->name))
         {
-            Log(LOG_LEVEL_VERBOSE, " ?? Look for %s regex %s", handle, a->measure.select_line_matching);
+            Log(LOG_LEVEL_VERBOSE, "  Found regex '%s' matches line '%s'", a->measure.select_line_matching, ip->name);
             found = true;
             match = ip;
 

--- a/cf-monitord/history.c
+++ b/cf-monitord/history.c
@@ -74,33 +74,37 @@ static void PutRecordForTime(CF_DB *db, time_t time, const Averages *values)
     WriteDB(db, timekey, values, sizeof(Averages));
 }
 
-static void Nova_SaveFilePosition(char *name, long fileptr)
+static void Nova_SaveFilePosition(const char *handle, char *name, long fileptr)
 {
     CF_DB *dbp;
+    char *key = StringConcatenate(2, handle, name);
 
     if (!OpenDB(&dbp, dbid_static))
     {
         return;
     }
 
-    Log(LOG_LEVEL_VERBOSE, "Saving state for %s at %ld", name, fileptr);
-    WriteDB(dbp, name, &fileptr, sizeof(long));
+    Log(LOG_LEVEL_VERBOSE, "Saving state for %s at %ld", key, fileptr);
+    WriteDB(dbp, key, &fileptr, sizeof(long));
     CloseDB(dbp);
+    free(key);
 }
 
-static long Nova_RestoreFilePosition(char *name)
+static long Nova_RestoreFilePosition(const char *handle, char *name)
 {
     CF_DB *dbp;
     long fileptr;
+    char *key = StringConcatenate(2, handle, name);
 
     if (!OpenDB(&dbp, dbid_static))
     {
         return 0L;
     }
 
-    ReadDB(dbp, name, &fileptr, sizeof(long));
-    Log(LOG_LEVEL_VERBOSE, "Resuming state for %s at %ld", name, fileptr);
+    ReadDB(dbp, key, &fileptr, sizeof(long));
+    Log(LOG_LEVEL_VERBOSE, "Resuming state for %s at %ld", key, fileptr);
     CloseDB(dbp);
+    free(key);
     return fileptr;
 }
 
@@ -180,6 +184,7 @@ static Item *NovaReSample(EvalContext *ctx, int slot, const Attributes *attr, co
     struct timespec start;
     FILE *fin = NULL;
     mode_t maskval = 0;
+    const char *handle = PromiseGetHandle(pp);
 
     if (a.measure.stream_type && strcmp(a.measure.stream_type, "pipe") == 0)
     {
@@ -257,7 +262,7 @@ static Item *NovaReSample(EvalContext *ctx, int slot, const Attributes *attr, co
 
             if (a.measure.growing)
             {
-                filepos = Nova_RestoreFilePosition(pp->promiser);
+                filepos = Nova_RestoreFilePosition(handle, pp->promiser);
 
                 if (sb.st_size >= filepos)
                 {
@@ -356,7 +361,7 @@ static Item *NovaReSample(EvalContext *ctx, int slot, const Attributes *attr, co
             long fileptr = ftell(fin);
 
             fclose(fin);
-            Nova_SaveFilePosition(pp->promiser, fileptr);
+            Nova_SaveFilePosition(handle, pp->promiser, fileptr);
         }
         else if (a.measure.stream_type && strcmp(a.measure.stream_type, "pipe") == 0)
         {


### PR DESCRIPTION
The previous log line did not provide useful information, and made it look as if
it were still trying to determine if the line matched or not.