### PR TITLE
CFE-3082: cf-check code cleanup, better errors, man page and other options

### DIFF
--- a/cf-check/backup.c
+++ b/cf-check/backup.c
@@ -8,7 +8,7 @@
 
 #if defined(__MINGW32__) || !defined(LMDB)
 
-int backup_main(ARG_UNUSED int argc, ARG_UNUSED char **argv)
+int backup_main(ARG_UNUSED int argc, ARG_UNUSED const char *const *const argv)
 {
     Log(LOG_LEVEL_ERR,
         "cf-check backup not available on this platform/build");
@@ -103,7 +103,7 @@ int backup_files(Seq *filenames)
     return 0;
 }
 
-int backup_main(int argc, char **argv)
+int backup_main(int argc, const char *const *const argv)
 {
     Seq *files = argv_to_lmdb_files(argc, argv);
     const int ret = backup_files(files);

--- a/cf-check/backup.c
+++ b/cf-check/backup.c
@@ -106,6 +106,11 @@ int backup_files(Seq *filenames)
 int backup_main(int argc, const char *const *const argv)
 {
     Seq *files = argv_to_lmdb_files(argc, argv);
+    if (files == NULL || SeqLength(files) == 0)
+    {
+        Log(LOG_LEVEL_ERR, "No database files to back up");
+        return -1;
+    }
     const int ret = backup_files(files);
     SeqDestroy(files);
     return ret;

--- a/cf-check/backup.c
+++ b/cf-check/backup.c
@@ -8,14 +8,14 @@
 
 #if defined(__MINGW32__) || !defined(LMDB)
 
-int backup_main(int argc, char **argv)
+int backup_main(ARG_UNUSED int argc, ARG_UNUSED char **argv)
 {
     Log(LOG_LEVEL_ERR,
         "cf-check backup not available on this platform/build");
     return 1;
 }
 
-int backup_files(Seq *filenames)
+int backup_files(ARG_UNUSED Seq *filenames)
 {
     Log(LOG_LEVEL_INFO,
         "database backup not available on this platform/build");

--- a/cf-check/backup.h
+++ b/cf-check/backup.h
@@ -4,6 +4,6 @@
 #include <sequence.h>
 
 int backup_files(Seq *filenames);
-int backup_main(int argc, char **argv);
+int backup_main(int argc, const char *const *argv);
 
 #endif

--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -36,7 +36,7 @@ static void print_help()
         "\n");
 }
 
-int main(int argc, char **argv)
+int main(int argc, const char *const *const argv)
 {
     if (StringEndsWith(argv[0], "lmdump"))
     {
@@ -57,8 +57,8 @@ int main(int argc, char **argv)
     }
 
     const int cmd_argc = argc - 1;
-    char **cmd_argv = argv + 1;
-    char *command = cmd_argv[0];
+    const char *const *const cmd_argv = argv + 1;
+    const char *const command = cmd_argv[0];
 
     if (StringSafeEqual_IgnoreCase(command, "lmdump") ||
         StringSafeEqual_IgnoreCase(command, "dump"))

--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -4,6 +4,7 @@
 #include <repair.h>
 #include <string_lib.h>
 #include <logging.h>
+#include <man.h>
 
 static void print_version()
 {
@@ -36,7 +37,54 @@ static void print_help()
         "\n");
 }
 
-int main(int argc, const char *const *const argv)
+static const char *const CF_CHECK_SHORT_DESCRIPTION =
+    "Utility for diagnosis and repair of local CFEngine databases.";
+
+static const char *const CF_CHECK_MANPAGE_LONG_DESCRIPTION =
+    "cf-check does not evaluate policy or rely on the integrity of the\n"
+    "databases. It is intended to be able to detect and repair a corrupt\n"
+    "database.";
+
+// static const Description COMMANDS[] =
+// {
+//     {"help",     "Prints general help or per topic",
+//                  "cf-check help [command]"},
+//     {"diagnose", "Assess the health of one or more database files",
+//                  "cf-check diagnose"},
+//     {"backup",   "Copy database files to a timestamped folder",
+//                  "cf-check backup"},
+//     {"repair",   "Diagnose, then backup and delete any corrupt databases",
+//                  "cf-check repair"},
+//     {"dump",     "Print the contents of a database file",
+//                  "cf-check dump -a " WORKDIR "/state/cf_lastseen.lmdb"},
+//     {NULL, NULL, NULL}
+// };
+
+static const struct option OPTIONS[] =
+{
+    {"help",        optional_argument,  0, 'h'},
+    {"manpage",     no_argument,        0, 'M'},
+    {"version",     no_argument,        0, 'V'},
+    {"debug",       no_argument,        0, 'd'},
+    {"verbose",     no_argument,        0, 'v'},
+    {"log-level",   required_argument,  0, 'g'},
+    {"inform",      no_argument,        0, 'I'},
+    {NULL,          0,                  0, '\0'}
+};
+
+static const char *const HINTS[] =
+{
+    "Print the help message",
+    "Print the man page",
+    "Output the version of the software",
+    "Enable debugging output",
+    "Enable verbose output",
+    "Specify how detailed logs should be. Possible values: 'error', 'warning', 'notice', 'info', 'verbose', 'debug'",
+    "Enable basic information output",
+    NULL
+};
+
+int main(int argc, const char *const *argv)
 {
     if (StringEndsWith(argv[0], "lmdump"))
     {
@@ -53,12 +101,71 @@ int main(int argc, const char *const *const argv)
     {
         print_help();
         Log(LOG_LEVEL_ERR, "No command given");
-        return 1;
+        return EXIT_FAILURE;
     }
 
-    const int cmd_argc = argc - 1;
-    const char *const *const cmd_argv = argv + 1;
-    const char *const command = cmd_argv[0];
+    int c = 0;
+    int start_index = 1;
+    const char *optstr = "+hMg:dvI"; // + means stop for non opt arg. :)
+    while ((c = getopt_long(argc, (char *const *) argv, optstr, OPTIONS, &start_index))
+            != -1)
+    {
+        switch (c)
+        {
+            case 'd':
+            {
+                LogSetGlobalLevel(LOG_LEVEL_DEBUG);
+                break;
+            }
+            case 'v':
+            {
+                LogSetGlobalLevel(LOG_LEVEL_VERBOSE);
+                break;
+            }
+            case 'I':
+            {
+                LogSetGlobalLevel(LOG_LEVEL_INFO);
+                break;
+            }
+            case 'g':
+            {
+                LogSetGlobalLevelArgOrExit(optarg);
+                break;
+            }
+            case 'V':
+            {
+                print_version();
+                return EXIT_SUCCESS;
+                break;
+            }
+            case 'h':
+            {
+                print_help();
+                return EXIT_SUCCESS;
+                break;
+            }
+            case 'M':
+            {
+                Writer *out = FileWriter(stdout);
+                ManPageWrite(out, "cf-check", time(NULL),
+                             CF_CHECK_SHORT_DESCRIPTION,
+                             CF_CHECK_MANPAGE_LONG_DESCRIPTION,
+                             OPTIONS, HINTS,
+                             true);
+                FileWriterDetach(out);
+                return EXIT_SUCCESS;
+                break;
+            }
+            default:
+            {
+                return EXIT_FAILURE;
+                break;
+            }
+        }
+    }
+    const char *const *const cmd_argv = argv + optind;
+    int cmd_argc = argc - optind;
+    const char *command = cmd_argv[0];
 
     if (StringSafeEqual_IgnoreCase(command, "lmdump") ||
         StringSafeEqual_IgnoreCase(command, "dump"))
@@ -78,24 +185,18 @@ int main(int argc, const char *const *const argv)
     {
         return repair_main(cmd_argc, cmd_argv);
     }
-
-    if (StringSafeEqual_IgnoreCase(command, "help") ||
-        StringSafeEqual_IgnoreCase(command, "--help") ||
-        StringSafeEqual_IgnoreCase(command, "-h"))
+    if (StringSafeEqual_IgnoreCase(command, "help"))
     {
         print_help();
-        return 0;
+        return EXIT_SUCCESS;
     }
-
-    if (StringSafeEqual_IgnoreCase(command, "version") ||
-        StringSafeEqual_IgnoreCase(command, "--version") ||
-        StringSafeEqual_IgnoreCase(command, "-V"))
+    if (StringSafeEqual_IgnoreCase(command, "version"))
     {
         print_version();
-        return 0;
+        return EXIT_SUCCESS;
     }
 
     print_help();
     Log(LOG_LEVEL_ERR, "Unrecognized command: '%s'", command);
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/cf-check/diagnose.c
+++ b/cf-check/diagnose.c
@@ -368,6 +368,11 @@ size_t diagnose_files(Seq *filenames, Seq **corrupt)
 int diagnose_main(int argc, const char *const *const argv)
 {
     Seq *files = argv_to_lmdb_files(argc, argv);
+    if (files == NULL || SeqLength(files) == 0)
+    {
+        Log(LOG_LEVEL_ERR, "No database files to diagnose");
+        return -1;
+    }
     const int ret = diagnose_files(files, NULL);
     SeqDestroy(files);
     return ret;

--- a/cf-check/diagnose.c
+++ b/cf-check/diagnose.c
@@ -4,7 +4,7 @@
 
 #if defined(__MINGW32__) || !defined(LMDB)
 
-int diagnose_main(ARG_UNUSED int argc, ARG_UNUSED char **argv)
+int diagnose_main(ARG_UNUSED int argc, ARG_UNUSED const char *const *const argv)
 {
     Log(LOG_LEVEL_ERR,
         "cf-check diagnose not available on this platform/build");
@@ -365,7 +365,7 @@ size_t diagnose_files(Seq *filenames, Seq **corrupt)
     return corruptions;
 }
 
-int diagnose_main(int argc, char **argv)
+int diagnose_main(int argc, const char *const *const argv)
 {
     Seq *files = argv_to_lmdb_files(argc, argv);
     const int ret = diagnose_files(files, NULL);

--- a/cf-check/diagnose.c
+++ b/cf-check/diagnose.c
@@ -4,14 +4,14 @@
 
 #if defined(__MINGW32__) || !defined(LMDB)
 
-int diagnose_main(int argc, char **argv)
+int diagnose_main(ARG_UNUSED int argc, ARG_UNUSED char **argv)
 {
     Log(LOG_LEVEL_ERR,
         "cf-check diagnose not available on this platform/build");
     return 1;
 }
 
-size_t diagnose_files(Seq *filenames, Seq **corrupt)
+size_t diagnose_files(ARG_UNUSED Seq *filenames, ARG_UNUSED Seq **corrupt)
 {
     Log(LOG_LEVEL_INFO,
         "database diagnosis not available on this platform/build");

--- a/cf-check/diagnose.h
+++ b/cf-check/diagnose.h
@@ -4,6 +4,6 @@
 #include <sequence.h>
 
 size_t diagnose_files(Seq *filenames, Seq **corrupt);
-int diagnose_main(int argc, char **argv);
+int diagnose_main(int argc, const char *const *argv);
 
 #endif

--- a/cf-check/lmdump.c
+++ b/cf-check/lmdump.c
@@ -126,7 +126,7 @@ int lmdump(lmdump_mode mode, const char *file)
     return 0;
 }
 
-int lmdump_main(int argc, char **argv)
+int lmdump_main(int argc, const char *const *const argv)
 {
     assert(argv != NULL);
 
@@ -149,7 +149,7 @@ int lmdump_main(int argc, char **argv)
 }
 
 #else
-int lmdump_main(ARG_UNUSED int argc, ARG_UNUSED char **argv)
+int lmdump_main(ARG_UNUSED int argc, ARG_UNUSED const char *const *const argv)
 {
     printf("lmdump only implemented for LMDB.\n");
     return 1;

--- a/cf-check/lmdump.c
+++ b/cf-check/lmdump.c
@@ -126,7 +126,7 @@ int lmdump(lmdump_mode mode, const char *file)
     return 0;
 }
 
-int lmdump_main(int argc, char * argv[])
+int lmdump_main(int argc, char **argv)
 {
     assert(argv != NULL);
 
@@ -149,7 +149,7 @@ int lmdump_main(int argc, char * argv[])
 }
 
 #else
-int lmdump_main(ARG_UNUSED int argc, ARG_UNUSED char * argv[])
+int lmdump_main(ARG_UNUSED int argc, ARG_UNUSED char **argv)
 {
     printf("lmdump only implemented for LMDB.\n");
     return 1;

--- a/cf-check/lmdump.h
+++ b/cf-check/lmdump.h
@@ -14,6 +14,6 @@ typedef enum
 
 lmdump_mode lmdump_char_to_mode(char mode);
 int lmdump(lmdump_mode mode, const char *file);
-int lmdump_main(int argc, char * argv[]);
+int lmdump_main(int argc, char **argv);
 
 #endif

--- a/cf-check/lmdump.h
+++ b/cf-check/lmdump.h
@@ -14,6 +14,6 @@ typedef enum
 
 lmdump_mode lmdump_char_to_mode(char mode);
 int lmdump(lmdump_mode mode, const char *file);
-int lmdump_main(int argc, char **argv);
+int lmdump_main(int argc, const char *const *argv);
 
 #endif

--- a/cf-check/repair.c
+++ b/cf-check/repair.c
@@ -4,7 +4,7 @@
 
 #if defined(__MINGW32__) || !defined(LMDB)
 
-int repair_main(ARG_UNUSED int argc, ARG_UNUSED char **argv)
+int repair_main(ARG_UNUSED int argc, ARG_UNUSED const char *const *const argv)
 {
     Log(LOG_LEVEL_ERR,
         "cf-check repair not available on this platform/build");
@@ -113,7 +113,7 @@ int repair_files(Seq *files)
     return 0;
 }
 
-int repair_main(int argc, char **argv)
+int repair_main(int argc, const char *const *const argv)
 {
     Seq *files = argv_to_lmdb_files(argc, argv);
     if (files == NULL)

--- a/cf-check/repair.c
+++ b/cf-check/repair.c
@@ -4,7 +4,7 @@
 
 #if defined(__MINGW32__) || !defined(LMDB)
 
-int repair_main(int argc, char **argv)
+int repair_main(ARG_UNUSED int argc, ARG_UNUSED char **argv)
 {
     Log(LOG_LEVEL_ERR,
         "cf-check repair not available on this platform/build");

--- a/cf-check/repair.h
+++ b/cf-check/repair.h
@@ -1,7 +1,7 @@
 #ifndef __REPAIR_H__
 #define __REPAIR_H__
 
-int repair_main(int argc, char **argv);
+int repair_main(int argc, const char *const *argv);
 int repair_default();
 
 #endif

--- a/cf-check/utilities.c
+++ b/cf-check/utilities.c
@@ -11,9 +11,6 @@
 Seq *default_lmdb_files()
 {
     const char *state = GetStateDir();
-    Log(LOG_LEVEL_INFO,
-        "No filenames specified, defaulting to .lmdb files in %s",
-        state);
     Seq *files = ListDir(state, ".lmdb");
     if (files == NULL)
     {
@@ -26,6 +23,9 @@ Seq *argv_to_lmdb_files(int argc, const char *const *const argv)
 {
     if (argc <= 1)
     {
+        Log(LOG_LEVEL_INFO,
+            "No filenames specified, defaulting to .lmdb files in %s",
+            GetStateDir());
         return default_lmdb_files();
     }
 

--- a/cf-check/utilities.c
+++ b/cf-check/utilities.c
@@ -22,7 +22,7 @@ Seq *default_lmdb_files()
     return files;
 }
 
-Seq *argv_to_lmdb_files(int argc, char **argv)
+Seq *argv_to_lmdb_files(int argc, const char *const *const argv)
 {
     if (argc <= 1)
     {

--- a/cf-check/utilities.h
+++ b/cf-check/utilities.h
@@ -6,8 +6,8 @@
 // These functions should be moved to libutils once cf-check is
 // implemented and backported.
 
-Seq *argv_to_seq(int argc, char **argv);
+Seq *argv_to_seq(int argc, const char *const *argv);
 Seq *default_lmdb_files();
-Seq *argv_to_lmdb_files(int argc, char **argv);
+Seq *argv_to_lmdb_files(int argc, const char *const *argv);
 
 #endif

--- a/libutils/sequence.c
+++ b/libutils/sequence.c
@@ -568,7 +568,7 @@ Seq *SeqStringDeserialize(const char *const serialized)
     return seq;
 }
 
-Seq *SeqFromArgv(int argc, char **argv)
+Seq *SeqFromArgv(int argc, const char *const *const argv)
 {
     assert(argc > 0);
     assert(argv != NULL);
@@ -577,7 +577,7 @@ Seq *SeqFromArgv(int argc, char **argv)
     Seq *args = SeqNew(argc, NULL);
     for (int i = 0; i < argc; ++i)
     {
-        SeqAppend(args, argv[i]);
+        SeqAppend(args, (void *)argv[i]); // Discards const
     }
     return args;
 }

--- a/libutils/sequence.h
+++ b/libutils/sequence.h
@@ -274,6 +274,6 @@ Seq *SeqStringDeserialize(const char *serialized);
  * Shallow copy. SeqDestroy is safe, it will not free the contents of argv.
  *
  */
-Seq *SeqFromArgv(int argc, char **argv);
+Seq *SeqFromArgv(int argc, const char *const *argv);
 
 #endif


### PR DESCRIPTION
cf-check now supports the same options as the other CFEngine
binaries; log-level, verbose, debug, manpage, version, help.

There were some error messages before, but this commit ensures that
all commands (diagnose, repair, backup) both print errors and exit
with non-zero exit code, when no db files are found.

Also clarified log messages and code comments to be more clear.
The DB check in cf-agent and cf-execd does not fail if there are
no files.