### PR TITLE
SetUmask function now correctly applies the given umask (3.10)

### DIFF
--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -331,8 +331,8 @@ void switch_symlink_hook();
 
 mode_t SetUmask(mode_t new_mask)
 {
-    const mode_t old_mask = umask(0077);
-    Log(LOG_LEVEL_DEBUG, "Set umask to 0077, was %o", old_mask);
+    const mode_t old_mask = umask(new_mask);
+    Log(LOG_LEVEL_DEBUG, "Set umask to %o, was %o", new_mask, old_mask);
     return old_mask;
 }
 void RestoreUmask(mode_t old_mask)


### PR DESCRIPTION
My mistake. Luckily, it was only ever used with 0077 anyway,
so no change in behavior.