### PR TITLE
ENT-4863: Set create permissions of monitord files in state directory to 0600

### DIFF
--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -42,6 +42,7 @@
 #include <exec_tools.h>
 #include <generic_agent.h> // WritePID
 #include <files_lib.h>
+#include <file_lib.h> // SetUmask()
 #include <unix.h>
 #include <verify_measurements.h>
 #include <verify_classes.h>
@@ -548,7 +549,9 @@ static void PublishEnvironment(Item *classes)
 {
     unlink(ENVFILE_NEW);
 
+    const mode_t old_umask = SetUmask(0077);
     FILE *fp = safe_fopen(ENVFILE_NEW, "a");
+    RestoreUmask(old_umask);
     if (fp == NULL)
     {
         return;

--- a/cf-monitord/mon_network.c
+++ b/cf-monitord/mon_network.c
@@ -30,6 +30,7 @@
 #include <files_names.h>
 #include <files_interfaces.h>
 #include <files_lib.h>
+#include <file_lib.h> // SetUmask()
 #include <pipes.h>
 #include <known_dirs.h>
 
@@ -429,7 +430,9 @@ void MonNetworkGatherData(double *cf_this)
         }
 
         SetNetworkEntropyClasses(CanonifyName(ECGSOCKS[i].name), "in", in[i]);
+        const mode_t old_umask = SetUmask(0077);
         RawSaveItemList(in[i], vbuff, NewLineMode_Unix);
+        RestoreUmask(old_umask);
         DeleteItemList(in[i]);
         Log(LOG_LEVEL_DEBUG, "Saved in netstat data in '%s'", vbuff);
     }
@@ -454,7 +457,9 @@ void MonNetworkGatherData(double *cf_this)
         }
 
         SetNetworkEntropyClasses(CanonifyName(ECGSOCKS[i].name), "out", out[i]);
+        const mode_t old_umask = SetUmask(0077);
         RawSaveItemList(out[i], vbuff, NewLineMode_Unix);
+        RestoreUmask(old_umask);
         Log(LOG_LEVEL_DEBUG, "Saved out netstat data in '%s'", vbuff);
         DeleteItemList(out[i]);
     }

--- a/cf-monitord/mon_processes.c
+++ b/cf-monitord/mon_processes.c
@@ -27,6 +27,7 @@
 #include <mon.h>
 #include <item_lib.h>
 #include <files_interfaces.h>
+#include <file_lib.h> // SetUmask()
 #include <pipes.h>
 #include <systype.h>
 #include <known_dirs.h>
@@ -61,7 +62,9 @@ void MonProcessesGatherData(double *cf_this)
     xsnprintf(vbuff, sizeof(vbuff), "%s/cf_users", GetStateDir());
     MapName(vbuff);
 
+    const mode_t old_umask = SetUmask(0077);
     RawSaveItemList(userList, vbuff, NewLineMode_Unix);
+    RestoreUmask(old_umask);
     DeleteItemList(userList);
 
     Log(LOG_LEVEL_VERBOSE, "(Users,root,other) = (%d,%d,%d)",


### PR DESCRIPTION
0600 matches the permissions enforced by policy.
Affected files:

 * `cf_incoming`
 * `cf_outgoing`
 * `cf_users`
 * `env_data`