### PR TITLE
Switched to top level config.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ stamp-h1
 /libutils/config.h
 /libutils/config.h.in
 /libutils/config.post.h
+/config.h
+/config.h.in
+/config.post.h
 
 # examples
 /examples/cfengine_stdlib.cf

--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ AC_DEFINE_UNQUOTED(ABS_TOP_SRCDIR,
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
-AC_CONFIG_HEADERS([libutils/config.h])
+AC_CONFIG_HEADERS([config.h])
 
 dnl Libtool madness
 
@@ -1741,7 +1741,7 @@ dnl ######################################################################
 AC_CONFIG_FILES([Makefile
     libcompat/Makefile
     libutils/Makefile
-    libutils/config.post.h
+    config.post.h
     libcfnet/Makefile
     libenv/Makefile
     libpromises/Makefile


### PR DESCRIPTION
It should be separate from libutils, because you want to include
headers from libutils without using this config.h. Probably
necessary for libntech.