### PR TITLE
ENT-4885: Moved platform.h include in sequence

### DIFF
--- a/libutils/sequence.c
+++ b/libutils/sequence.c
@@ -22,7 +22,7 @@
   included file COSL.txt.
 */
 
-
+#include <platform.h>
 #include <sequence.h>
 #include <alloc.h>
 #include <string_lib.h>

--- a/libutils/sequence.h
+++ b/libutils/sequence.h
@@ -25,7 +25,10 @@
 #ifndef CFENGINE_SEQUENCE_H
 #define CFENGINE_SEQUENCE_H
 
-#include <platform.h>
+#include <stddef.h>    // size_t
+#include <sys/types.h> // ssize_t
+#include <assert.h>    // assert()
+#include <stdio.h>     // FILE
 
 /**
   @brief Sequence data-structure.


### PR DESCRIPTION
Makes it easier to reuse without adding many dependencies.
Ideally, config.h (platform.h) should be included in c files,
not headers.