### PR TITLE
Tidied mailmap entries

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,22 +1,50 @@
-Bishwa Shrestha <bishwa.shrestha@cfengine.com> <a10008@cflu-10008.(none)>
-Carlos Manuel Duclos Vergara <carlos.duclos@cfengine.com>
-Carlos Manuel Duclos Vergara <carlos.duclos@cfengine.com> <carlosduclosv@yahoo.com>
-Carlos Manuel Duclos Vergara <carlos.duclos@cfengine.com> <carlos.duclos@gmail.com>
-Michael V. Pelletier <mvpel@yahoo.com>
-Diego Zamboni <diego.zamboni@cfengine.com> <diego@zzamboni.org>
-Maciej Mrowiec <maciej.mrowiec@cfengine.com>
-Michael Clelland <michael.clelland@cfengine.com>
-Maciej Patucha <maciej.patucha@cfengine.com>
 <maciej.patucha@cfengine.com> <a10019@cflu-10019.(none)>
 <maciej.patucha@cfengine.com> <maciejpatucha@cfengine.com>
-Mikhail Gusarov <mikhail.gusarov@cfengine.com> <dottedmag@dottedmag.net>
-Sigurd Teigen <sigurd.teigen@cfengine.com> <sigurd.teigen@gmail.com>
-Geir Nygård <geir.nygard@cfengine.com>
-Mark Burgess <mark@cfengine.com>
+Aleksey Tsalolikhin <aleksey@verticalsysadmin.com> Aleksey Tsalolikhin <aleksey@verticalsysadmin.com>
+Aleksey Tsalolikhin <aleksey@verticalsysadmin.com> Aleksey Tsalolikhin <at433m@att.com>
+Aleksey Tsalolikhin <aleksey@verticalsysadmin.com> Aleksey Tsalolikhin <atsaloli.tech@gmail.com>
+Aleksey Tsalolikhin <aleksey@verticalsysadmin.com> Aleksey Tsalolikhin <atsaloli@directv.com>
+Alexis Mousset <alexis.mousset@normation.com> Alexis Mousset <alexis.mousset@rudder.io>
 Bas van der Vlies <basv@sara.nl> <root@test3.irc.sara.nl.irc.sara.nl>
-Chris Dituri <csdituri@gmail.com> chris.dituri
+Bishwa Shrestha <bishwa.shrestha@cfengine.com> <a10008@cflu-10008.(none)>
+Carlos Manuel Duclos Vergara <carlos.duclos@cfengine.com>
+Carlos Manuel Duclos Vergara <carlos.duclos@cfengine.com> <carlos.duclos@gmail.com>
+Carlos Manuel Duclos Vergara <carlos.duclos@cfengine.com> <carlosduclosv@yahoo.com>
 Chris Dituri <csdituri@gmail.com> chris dituri
-Ole Herman S. Elgesem <ole@northern.tech> <ole.elgesem@northern.tech> <ole.elgesem@cfengine.com>
-Vratislav Podzimek <vratislav.podzimek@northern.tech> <vratislav.podzimek@cfengine.com>
-Craig Comstock <craig.comstock@northern.tech> <craig.comstock@cfengine.com>
+Chris Dituri <csdituri@gmail.com> chris.dituri
+Craig Comstock <craig.comstock@northern.tech> <craig.comstock@cfengine.com> <craig@unreasonablefarm.org>
+Craig Comstock <craig.comstock@northern.tech> Craig Comstock <craig@unreasonablefarm.org>
+Craig Comstock <craig.comstock@northern.tech> craigcomstock <craig.comstock@northern.tech>
+Craig Comstock <craig.comstock@northern.tech> craigcomstock <craig@unreasonablefarm.org>
+Diego Zamboni <diego.zamboni@cfengine.com> <diego@zzamboni.org>
+Geir Nygård <geir.nygard@cfengine.com>
 John D. "Trix" Farrar <trix@basement.net> <trix@doyle.basement.net> <trixfarrar@gmail.com>
+Karl Hole Totland <karl.totland@northern.tech> Karl Hole Totland <karlhto@ifi.uio.no>
+Karl Hole Totland <karl.totland@northern.tech> Karl Hole Totland <karlhto@student.matnat.uio.no>
+Kristian Amlie <kristian.amlie@cfengine.com> Kristian Amlie <kacf@users.noreply.github.com>
+Kristian Amlie <kristian.amlie@cfengine.com> Kristian Amlie <kristian.amlie@northern.tech>
+Kristian Amlie <kristian.amlie@cfengine.com> kacfengine <kristian.amlie@cfengine.com>
+Maciej Mrowiec <maciej.mrowiec@cfengine.com> Maciej Mrowiec <mrowiec.maciej@gmail.com>
+Maciej Patucha <maciej.patucha@cfengine.com>
+Marcin Pasinski <marcin.pasinski@cfengine.com> Marcin Pasinski <marcin.pasinski@mender.io>
+Marcin Pasinski <marcin.pasinski@cfengine.com> pasinskim <marcin.pasinski@cfengine.com>
+Marcin Pasinski <marcin.pasinski@cfengine.com> pasinskim <pasinskim@users.noreply.github.com>
+Mark Burgess <mark@cfengine.com>
+Michael Clelland <michael.clelland@cfengine.com>
+Michael V. Pelletier <mvpel@yahoo.com>
+Mike Weilgart <mweilgart@directv.com> Mike Weilgart <mikeweilgart@gmail.com>
+Mike Weilgart <mweilgart@directv.com> mikeweilgart <mike.weilgart@verticalsysadmin.com>
+Mike Weilgart <mweilgart@directv.com> mikeweilgart <mikeweilgart@gmail.com>
+Mikhail Gusarov <mikhail.gusarov@cfengine.com> <dottedmag@dottedmag.net>
+Ole Herman Schumacher Elgesem <ole@northern.tech> <ole@cfengine.com> <ole.elgesem@cfengine.com> <olehermanse@users.noreply.github.com>
+Ole Herman Schumacher Elgesem <ole@northern.tech> Ole Herman S. Elgesem <ole@northern.tech>
+Ole Herman Schumacher Elgesem <ole@northern.tech> Ole Herman Schumacher Elgesem <ole.elgesem@cfengine.com>
+Ole Herman Schumacher Elgesem <ole@northern.tech> Ole Herman Schumacher Elgesem <ole.elgesem@northern.tech>
+Ole Herman Schumacher Elgesem <ole@northern.tech> Ole Herman Schumacher Elgesem <olehermanse@users.noreply.github.com>
+Sigurd Teigen <sigurd.teigen@cfengine.com> <sigurd.teigen@gmail.com>
+Vratislav Podzimek <vratislav.podzimek@northern.tech> <vratislav.podzimek@cfengine.com>
+Vratislav Podzimek <vratislav.podzimek@northern.tech> Vratislav Podzimek <v.podzimek@mykolab.com>
+Vratislav Podzimek <vratislav.podzimek@northern.tech> Vratislav Podzimek <vpodzime@users.noreply.github.com>
+jeffali <hichame.jeffali@cfengine.com> hicham <hicham@debbie01.debbie>
+jeffali <hichame.jeffali@cfengine.com> hicham <hicham@debbie2.debbie>
+jeffali <hichame.jeffali@cfengine.com> hicham <hichame.jeffali@cfengine.com>


### PR DESCRIPTION
Fixed mappings for Maciej, Vratislav, Craig, Ole, Krl, Kristian, Hichame,
Aleksey, Mike, Alexis, and Marcin to deduplicate authorship.

The mail address with the most commits was used as the primary.