### PR TITLE
clang-format: Add spaces after type casts

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,6 +14,7 @@ DerivePointerAlignment: false
 PointerAlignment: Right
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
+SpaceAfterCStyleCast: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 BreakStringLiterals: false


### PR DESCRIPTION
Correct according to our style guide.