### PR TITLE
CFE-3030: Run daemon-reload after installing systemd files

### DIFF
--- a/misc/Makefile.am
+++ b/misc/Makefile.am
@@ -28,7 +28,7 @@ systemd_DATA  += systemd/cf-postgres.service
 systemd_DATA  += systemd/cf-runalerts.service
 systemd_DATA  += systemd/cf-serverd.service
 
-install-data-local:
+install-data-hook:
 	-systemctl daemon-reload
 
 endif


### PR DESCRIPTION
Only relevant for make install from sources (not packages).