### PR TITLE
CFE-3134: Fixed crash when no command supplied for cf-remote

### DIFF
--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -122,9 +122,9 @@ def validate_args(args):
     if args.hub:
         args.hub = file_or_comma_list(args.hub)
 
-    args.command = args.command.strip()
     if not args.command:
         user_error("Invalid or missing command")
+    args.command = args.command.strip()
     validate_command(args.command, args)
 
 


### PR DESCRIPTION
Before:

```
> $ cf-remote -H $(hostname)
Traceback (most recent call last):
  File "/home/nickanderson/bin/cf-remote", line 11, in <module>
    main()
  File "/home/nickanderson/Northern.Tech/CFEngine/core/contrib/cf-remote/cf_remote/main.py", line 133, in main
    validate_args(args)
  File "/home/nickanderson/Northern.Tech/CFEngine/core/contrib/cf-remote/cf_remote/main.py", line 125, in validate_args
    args.command = args.command.strip()
```

After:

```
> $ cf-remote -H $(hostname)
cf-remote: Invalid or missing command
```