### PR TITLE
CFE-3136: Added valid commands to cf-remote help output

### DIFF
--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -32,7 +32,7 @@ def get_args():
         "--call-collect", help="Enable call collect in --demo def.json", action='store_true')
     ap.add_argument(
         "--version", "-V", help="Print or specify version", nargs="?", type=str, const=True)
-    ap.add_argument("command", help="Action to perform", type=str, nargs='?')
+    ap.add_argument("command", help="Action to perform (info|install|packages|run|sudo|scp)", type=str, nargs='?')
     ap.add_argument("args", help="Arguments", type=str, nargs='*')
 
     args = ap.parse_args()
@@ -123,7 +123,7 @@ def validate_args(args):
         args.hub = file_or_comma_list(args.hub)
 
     if not args.command:
-        user_error("Invalid or missing command")
+        user_error("Invalid or missing command. Use one of (info|install|packages|run|sudo|scp)")
     args.command = args.command.strip()
     validate_command(args.command, args)
 


### PR DESCRIPTION
Before:

```
> $ cf-remote -h
usage: cf-remote [-h] [--hosts HOSTS] [--clients CLIENTS] [--hub HUB]
                 [--bootstrap BOOTSTRAP] [--package PACKAGE]
                 [--hub-package HUB_PACKAGE] [--client-package CLIENT_PACKAGE]
                 [--log-level LOG_LEVEL] [--demo] [--call-collect]
                 [--version [VERSION]]
                 [command] [args [args ...]]

Spooky CFEngine at a distance

positional arguments:
  command               Action to perform (default: None)
  args                  Arguments (default: None)

optional arguments:
  -h, --help            show this help message and exit
  --hosts HOSTS, -H HOSTS
                        Which hosts to connect to (ssh) (default: None)
  --clients CLIENTS, -c CLIENTS
                        Where to install client package (default: None)
  --hub HUB             Where to install hub package (default: None)
  --bootstrap BOOTSTRAP, -B BOOTSTRAP
                        cf-agent --bootstrap argument (default: None)
  --package PACKAGE     Local path to package for transfer and install
                        (default: None)
  --hub-package HUB_PACKAGE
                        Local path to package for --hub (default: None)
  --client-package CLIENT_PACKAGE
                        Local path to package for --clients (default: None)
  --log-level LOG_LEVEL
                        Specify detail of logging (default: WARNING)
  --demo                Use defaults to make demos smoother (NOT secure)
                        (default: False)
  --call-collect        Enable call collect in --demo def.json (default:
                        False)
  --version [VERSION], -V [VERSION]
                        Print or specify version (default: None)
```

After:

```
> $ cf-remote -h
usage: cf-remote [-h] [--hosts HOSTS] [--clients CLIENTS] [--hub HUB]
                 [--bootstrap BOOTSTRAP] [--package PACKAGE]
                 [--hub-package HUB_PACKAGE] [--client-package CLIENT_PACKAGE]
                 [--log-level LOG_LEVEL] [--demo] [--call-collect]
                 [--version [VERSION]]
                 [command] [args [args ...]]

Spooky CFEngine at a distance

positional arguments:
  command               Action to perform (info|install|packages|run|sudo|scp)
                        (default: None)
  args                  Arguments (default: None)

optional arguments:
  -h, --help            show this help message and exit
  --hosts HOSTS, -H HOSTS
                        Which hosts to connect to (ssh) (default: None)
  --clients CLIENTS, -c CLIENTS
                        Where to install client package (default: None)
  --hub HUB             Where to install hub package (default: None)
  --bootstrap BOOTSTRAP, -B BOOTSTRAP
                        cf-agent --bootstrap argument (default: None)
  --package PACKAGE     Local path to package for transfer and install
                        (default: None)
  --hub-package HUB_PACKAGE
                        Local path to package for --hub (default: None)
  --client-package CLIENT_PACKAGE
                        Local path to package for --clients (default: None)
  --log-level LOG_LEVEL
                        Specify detail of logging (default: WARNING)
  --demo                Use defaults to make demos smoother (NOT secure)
                        (default: False)
  --call-collect        Enable call collect in --demo def.json (default:
                        False)
  --version [VERSION], -V [VERSION]
                        Print or specify version (default: None)
```