### PR TITLE
cf-check: dump command now dumps DB contents to JSON5

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,4 +27,5 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 BreakBeforeBraces: Allman
+BreakBeforeBinaryOperators: NonAssignment
 ---

--- a/cf-check/Makefile.am
+++ b/cf-check/Makefile.am
@@ -51,6 +51,7 @@ libcf_check_la_SOURCES = \
 	cf-check.c \
 	diagnose.c diagnose.h \
 	lmdump.c lmdump.h \
+	dump.c dump.h \
 	utilities.c utilities.h \
 	repair.c repair.h
 

--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -45,20 +45,22 @@ static const char *const CF_CHECK_MANPAGE_LONG_DESCRIPTION =
     "databases. It is intended to be able to detect and repair a corrupt\n"
     "database.";
 
-// static const Description COMMANDS[] =
-// {
-//     {"help",     "Prints general help or per topic",
-//                  "cf-check help [command]"},
-//     {"diagnose", "Assess the health of one or more database files",
-//                  "cf-check diagnose"},
-//     {"backup",   "Copy database files to a timestamped folder",
-//                  "cf-check backup"},
-//     {"repair",   "Diagnose, then backup and delete any corrupt databases",
-//                  "cf-check repair"},
-//     {"dump",     "Print the contents of a database file",
-//                  "cf-check dump -a " WORKDIR "/state/cf_lastseen.lmdb"},
-//     {NULL, NULL, NULL}
-// };
+static const Description COMMANDS[] =
+{
+    {"help",     "Prints general help or per topic",
+                 "cf-check help [command]"},
+    {"diagnose", "Assess the health of one or more database files",
+                 "cf-check diagnose"},
+    {"backup",   "Copy database files to a timestamped folder",
+                 "cf-check backup"},
+    {"repair",   "Diagnose, then backup and delete any corrupt databases",
+                 "cf-check repair"},
+    {"dump",     "Print the contents of a database file",
+                 "cf-check dump -a " WORKDIR "/state/cf_lastseen.lmdb"},
+    {"lmdump",   "Print the contents of a database file",
+                 "cf-check lmdump -a " WORKDIR "/state/cf_lastseen.lmdb"},
+    {NULL, NULL, NULL}
+};
 
 static const struct option OPTIONS[] =
 {
@@ -83,6 +85,38 @@ static const char *const HINTS[] =
     "Enable basic information output",
     NULL
 };
+
+static int CFCheckHelpTopic(const char *topic)
+{
+    assert(topic != NULL);
+    bool found = false;
+    for (int i = 0; COMMANDS[i].name != NULL; ++i)
+    {
+        if (strcmp(COMMANDS[i].name, topic) == 0)
+        {
+            printf("Command:     %s\n", COMMANDS[i].name);
+            printf("Usage:       %s\n", COMMANDS[i].usage);
+            printf("Description: %s\n", COMMANDS[i].description);
+            found = true;
+            break;
+        }
+    }
+
+    // Add more detailed explanation here if necessary:
+    if (strcmp("help", topic) == 0)
+    {
+        printf("\nYou did it, you used the help command!\n");
+    }
+    else
+    {
+        if (!found)
+        {
+            printf("Unknown help topic: '%s'\n", topic);
+            return EXIT_FAILURE;
+        }
+    }
+    return EXIT_SUCCESS;
+}
 
 int main(int argc, const char *const *argv)
 {
@@ -187,7 +221,20 @@ int main(int argc, const char *const *argv)
     }
     if (StringSafeEqual_IgnoreCase(command, "help"))
     {
-        print_help();
+        if (cmd_argc > 2)
+        {
+            Log(LOG_LEVEL_ERR, "help takes exactly 0 or 1 arguments");
+            return EXIT_FAILURE;
+        }
+        else if (cmd_argc <= 1)
+        {
+            print_help();
+        }
+        else
+        {
+            assert(cmd_argc == 2);
+            CFCheckHelpTopic(cmd_argv[1]);
+        }
         return EXIT_SUCCESS;
     }
     if (StringSafeEqual_IgnoreCase(command, "version"))

--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -1,4 +1,5 @@
 #include <lmdump.h>
+#include <dump.h>
 #include <diagnose.h>
 #include <backup.h>
 #include <repair.h>
@@ -28,10 +29,11 @@ static void print_help()
         "\thelp - Print this help menu\n"
         "\n"
         "Usage:\n"
-        "\t$ cf-check command [options]\n"
+        "\t$ cf-check <command> [options] [file ...]\n"
         "\n"
         "Examples:\n"
-        "\t$ cf-check dump -a " WORKDIR "/state/cf_lastseen.lmdb\n"
+        "\t$ cf-check dump " WORKDIR "/state/cf_lastseen.lmdb\n"
+        "\t$ cf-check lmdump -a " WORKDIR "/state/cf_lastseen.lmdb\n"
         "\t$ cf-check diagnose\n"
         "\t$ cf-check repair\n"
         "\n");
@@ -56,8 +58,8 @@ static const Description COMMANDS[] =
     {"repair",   "Diagnose, then backup and delete any corrupt databases",
                  "cf-check repair"},
     {"dump",     "Print the contents of a database file",
-                 "cf-check dump -a " WORKDIR "/state/cf_lastseen.lmdb"},
-    {"lmdump",   "Print the contents of a database file",
+                 "cf-check dump " WORKDIR "/state/cf_lastseen.lmdb"},
+    {"lmdump",   "LMDB database dumper (deprecated)",
                  "cf-check lmdump -a " WORKDIR "/state/cf_lastseen.lmdb"},
     {NULL, NULL, NULL}
 };
@@ -201,10 +203,13 @@ int main(int argc, const char *const *argv)
     int cmd_argc = argc - optind;
     const char *command = cmd_argv[0];
 
-    if (StringSafeEqual_IgnoreCase(command, "lmdump") ||
-        StringSafeEqual_IgnoreCase(command, "dump"))
+    if (StringSafeEqual_IgnoreCase(command, "lmdump"))
     {
         return lmdump_main(cmd_argc, cmd_argv);
+    }
+    if (StringSafeEqual_IgnoreCase(command, "dump"))
+    {
+        return dump_main(cmd_argc, cmd_argv);
     }
     if (StringSafeEqual_IgnoreCase(command, "diagnose"))
     {

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -1,0 +1,207 @@
+#include <platform.h>
+#include <dump.h>
+
+#ifdef LMDB
+#include <lmdb.h>
+#include <string_lib.h>
+
+typedef enum
+{
+    DUMP_MODE_FULL,
+    DUMP_MODE_KEYS,
+    DUMP_MODE_VALUES,
+} dump_mode;
+
+static void print_usage(void)
+{
+    printf("Usage: cf-check dump FILE\n");
+    printf("Example: cf-check dump /var/cfengine/state/cf_lastseen.lmdb\n");
+}
+
+static int dump_report_error(int rc)
+{
+    printf("err(%d): %s\n", rc, mdb_strerror(rc));
+    return rc;
+}
+
+void dump_print_json_string(const char *const data, const size_t size)
+{
+    printf("\"");
+    for (size_t i = 0; i < size; ++i)
+    {
+        char byte = data[i];
+        switch (byte)
+        {
+        case '\0':
+            printf("\\0");
+            break;
+        case '\\':
+            printf("\\\\");
+            break;
+        case '\b':
+            printf("\\b");
+            break;
+        case '\f':
+            printf("\\f");
+            break;
+        case '\n':
+            printf("\\n");
+            break;
+        case '\r':
+            printf("\\r");
+            break;
+        case '\t':
+            printf("\\t");
+            break;
+        case '"':
+            printf("\\\"");
+            break;
+        default:
+            if (isprint(byte))
+            {
+                printf("%c", byte);
+            }
+            else
+            {
+                printf("\\x%2.2x", (unsigned char) byte);
+            }
+        }
+    }
+    printf("\"");
+}
+
+void dump_print_opening_bracket(const dump_mode mode)
+{
+    if (mode == DUMP_MODE_FULL)
+    {
+        printf("{\n");
+    }
+    else
+    {
+        printf("[\n");
+    }
+}
+
+void dump_print_object_line(const MDB_val key, const MDB_val value)
+{
+    printf("\t");
+    dump_print_json_string(key.mv_data, key.mv_size);
+    printf(": ");
+    dump_print_json_string(value.mv_data, value.mv_size);
+    printf(",\n");
+}
+
+void dump_print_array_line(const MDB_val value)
+{
+    printf("\t");
+    dump_print_json_string(value.mv_data, value.mv_size);
+    printf(",\n");
+}
+
+void dump_print_closing_bracket(const dump_mode mode)
+{
+    if (mode == DUMP_MODE_FULL)
+    {
+        printf("}\n");
+    }
+    else
+    {
+        printf("]\n");
+    }
+}
+
+int dump_db(const char *file, const dump_mode mode)
+{
+    assert(file != NULL);
+
+    int r;
+    MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
+    MDB_cursor *cursor;
+
+    if (0 != (r = mdb_env_create(&env))
+        || 0 != (r = mdb_env_open(env, file, MDB_NOSUBDIR | MDB_RDONLY, 0644))
+        || 0 != (r = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn))
+        || 0 != (r = mdb_open(txn, NULL, 0, &dbi))
+        || 0 != (r = mdb_cursor_open(txn, dbi, &cursor)))
+    {
+        return dump_report_error(r);
+    }
+
+    MDB_val key, value;
+    dump_print_opening_bracket(mode);
+    while ((r = mdb_cursor_get(cursor, &key, &value, MDB_NEXT)) == MDB_SUCCESS)
+    {
+        switch (mode) {
+            case DUMP_MODE_FULL:
+                dump_print_object_line(key, value);
+                break;
+            case DUMP_MODE_KEYS:
+                dump_print_array_line(key);
+                break;
+            case DUMP_MODE_VALUES:
+                dump_print_array_line(value);
+                break;
+            default:
+                debug_abort_if_reached();
+                break;
+        }
+    }
+    dump_print_closing_bracket(mode);
+
+    if (r != MDB_NOTFOUND)
+    {
+        // At this point, not found is expected, anything else is an error
+        return dump_report_error(r);
+    }
+    mdb_cursor_close(cursor);
+    mdb_close(env, dbi);
+
+    mdb_txn_abort(txn);
+    mdb_env_close(env);
+
+    return 0;
+}
+
+int dump_main(int argc, const char *const *const argv)
+{
+    assert(argv != NULL);
+    if (argc < 2 || argc > 3)
+    {
+        print_usage();
+        return EXIT_FAILURE;
+    }
+    dump_mode mode = DUMP_MODE_FULL;
+    const char *filename = argv[1];
+    if (argv[1][0] == '-')
+    {
+        if (argc != 3)
+        {
+            print_usage();
+            return EXIT_FAILURE;
+        }
+        const char *const option = argv[1];
+        filename = argv[2];
+        if (StringSafeEqual(option, "--keys")
+            || StringSafeEqual(option, "-k"))
+        {
+            mode = DUMP_MODE_KEYS;
+        }
+        else if (
+            StringSafeEqual(option, "--values")
+            || StringSafeEqual(option, "-v"))
+        {
+            mode = DUMP_MODE_VALUES;
+        }
+    }
+    return dump_db(filename, mode);
+}
+
+#else
+int dump_main(ARG_UNUSED int argc, ARG_UNUSED const char *const *const argv)
+{
+    printf("dump only implemented for LMDB.\n");
+    return 1;
+}
+#endif

--- a/cf-check/dump.h
+++ b/cf-check/dump.h
@@ -1,0 +1,6 @@
+#ifndef CF_CHECK_DUMP_H
+#define CF_CHECK_DUMP_H
+
+int dump_main(int argc, const char *const *argv);
+
+#endif


### PR DESCRIPTION
cf-check: dump command now dumps DB contents to JSON5

Example:

```
$ cf-check dump /var/cfengine/state/cf_lastseen.lmdb
{
        "a192.168.100.10\0": "MD5=efbb78408659e9e99188218a8518b7ec\0",
        "kMD5=efbb78408659e9e99188218a8518b7ec\0": "192.168.100.10\0",
        "qoMD5=efbb78408659e9e99188218a8518b7ec\0": "\0\xf6h]\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
}
```

`dump` was previously an alias for `lmdump`.

`lmdump` command, as well as symlinking `cf-check` as `lmdump`,
is still supported, for compatibility.

New functionality will be added to `dump` command.

Some code should be moved to JSON library, but I need to make
bigger changes there, so I think it's okay to merge this first.