### PR TITLE
CFE-2989: Human readable JSON5 dumping of LMDB databases

### DIFF
--- a/cf-check/Makefile.am
+++ b/cf-check/Makefile.am
@@ -51,6 +51,7 @@ libcf_check_la_SOURCES = \
 	cf-check.c \
 	diagnose.c diagnose.h \
 	lmdump.c lmdump.h \
+	db_structs.h \
 	dump.c dump.h \
 	utilities.c utilities.h \
 	repair.c repair.h

--- a/cf-check/db_structs.h
+++ b/cf-check/db_structs.h
@@ -1,0 +1,152 @@
+#ifndef CFENGINE_DB_STRUCTS_H
+#define CFENGINE_DB_STRUCTS_H
+
+// All structs needed for cf-check pretty printing
+// Structs from libutils are included normally via headers
+// Structs from libpromises are duplicated; cf-check doesn't use libpromises
+
+#include <statistics.h>
+// typedef struct
+// {
+//     double q;
+//     double expect;
+//     double var;
+//     double dq;
+// } QPoint;
+
+// Struct used for quality entries in /var/cfengine/state/cf_lastseen.lmdb:
+typedef struct
+{
+    time_t lastseen;
+    QPoint Q;
+} KeyHostSeen; // Keep in sync with lastseen.h
+
+// Struct used for lock entries in /var/cfengine/state/cf_lock.lmdb:
+typedef struct
+{
+    pid_t pid;
+    time_t time;
+    time_t process_start_time;
+} LockData; // Keep in sync with cf3.defs.h
+
+#define OBSERVABLES_APPLY(apply_macro) \
+    apply_macro(users)                 \
+    apply_macro(rootprocs)             \
+    apply_macro(otherprocs)            \
+    apply_macro(diskfree)              \
+    apply_macro(loadavg)               \
+    apply_macro(netbiosns_in)          \
+    apply_macro(netbiosns_out)         \
+    apply_macro(netbiosdgm_in)         \
+    apply_macro(netbiosdgm_out)        \
+    apply_macro(netbiosssn_in)         \
+    apply_macro(netbiosssn_out)        \
+    apply_macro(imap_in)               \
+    apply_macro(imap_out)              \
+    apply_macro(cfengine_in)           \
+    apply_macro(cfengine_out)          \
+    apply_macro(nfsd_in)               \
+    apply_macro(nfsd_out)              \
+    apply_macro(smtp_in)               \
+    apply_macro(smtp_out)              \
+    apply_macro(www_in)                \
+    apply_macro(www_out)               \
+    apply_macro(ftp_in)                \
+    apply_macro(ftp_out)               \
+    apply_macro(ssh_in)                \
+    apply_macro(ssh_out)               \
+    apply_macro(wwws_in)               \
+    apply_macro(wwws_out)              \
+    apply_macro(icmp_in)               \
+    apply_macro(icmp_out)              \
+    apply_macro(udp_in)                \
+    apply_macro(udp_out)               \
+    apply_macro(dns_in)                \
+    apply_macro(dns_out)               \
+    apply_macro(tcpsyn_in)             \
+    apply_macro(tcpsyn_out)            \
+    apply_macro(tcpack_in)             \
+    apply_macro(tcpack_out)            \
+    apply_macro(tcpfin_in)             \
+    apply_macro(tcpfin_out)            \
+    apply_macro(tcpmisc_in)            \
+    apply_macro(tcpmisc_out)           \
+    apply_macro(webaccess)             \
+    apply_macro(weberrors)             \
+    apply_macro(syslog)                \
+    apply_macro(messages)              \
+    apply_macro(temp0)                 \
+    apply_macro(temp1)                 \
+    apply_macro(temp2)                 \
+    apply_macro(temp3)                 \
+    apply_macro(cpuall)                \
+    apply_macro(cpu0)                  \
+    apply_macro(cpu1)                  \
+    apply_macro(cpu2)                  \
+    apply_macro(cpu3)                  \
+    apply_macro(microsoft_ds_in)       \
+    apply_macro(microsoft_ds_out)      \
+    apply_macro(www_alt_in)            \
+    apply_macro(www_alt_out)           \
+    apply_macro(imaps_in)              \
+    apply_macro(imaps_out)             \
+    apply_macro(ldap_in)               \
+    apply_macro(ldap_out)              \
+    apply_macro(ldaps_in)              \
+    apply_macro(ldaps_out)             \
+    apply_macro(mongo_in)              \
+    apply_macro(mongo_out)             \
+    apply_macro(mysql_in)              \
+    apply_macro(mysql_out)             \
+    apply_macro(postgresql_in)         \
+    apply_macro(postgresql_out)        \
+    apply_macro(ipp_in)                \
+    apply_macro(ipp_out)               \
+    apply_macro(spare)
+
+// Macros to apply to each element:
+
+// Double # useful for creating an identifier, expands to ob_postgresql_in,
+#define GENERATE_OB_ENUM(OB_NAME) ob_##OB_NAME,
+// Single # useful for creating string literals, expands to: "postgresql_in",
+#define GENERATE_OB_STRING(OB_NAME) #OB_NAME,
+
+// Use apply macro to generate enum and string array
+
+typedef enum Observable
+{
+    OBSERVABLES_APPLY(GENERATE_OB_ENUM) observables_max
+} Observable;
+
+static const char *const observable_strings[] =
+{
+    OBSERVABLES_APPLY(GENERATE_OB_STRING) NULL
+};
+
+// Not the actual count, just the room we set aside in struct (and LMDB):
+#define CF_OBSERVABLES 100
+
+typedef struct Averages
+{
+    time_t last_seen;
+    QPoint Q[CF_OBSERVABLES];
+} Averages; // Keep in sync with cf3.defs.h
+
+typedef enum
+{
+    CONTEXT_STATE_POLICY_RESET,                    /* Policy when trying to add already defined persistent states */
+    CONTEXT_STATE_POLICY_PRESERVE
+} PersistentClassPolicy; // Keep in sync with cf3.defs.h
+
+typedef struct
+{
+    unsigned int expires;
+    PersistentClassPolicy policy;
+    char tags[]; // variable length, must be zero terminated
+} PersistentClassInfo; // Keep in sync with cf3.defs.h
+// Note that tags array does not increase the sizeof() this struct
+// It allows us to index bytes after the policy variable (plus padding)
+// As far as C is concerned, tags can be zero length,
+// we do however require that it is at least 1 (NUL) byte
+
+#endif

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -7,7 +7,7 @@
 
 typedef enum
 {
-    DUMP_MODE_FULL,
+    DUMP_MODE_SIMPLE,
     DUMP_MODE_KEYS,
     DUMP_MODE_VALUES,
 } dump_mode;
@@ -72,7 +72,7 @@ void dump_print_json_string(const char *const data, const size_t size)
 
 void dump_print_opening_bracket(const dump_mode mode)
 {
-    if (mode == DUMP_MODE_FULL)
+    if (mode == DUMP_MODE_SIMPLE)
     {
         printf("{\n");
     }
@@ -100,7 +100,7 @@ void dump_print_array_line(const MDB_val value)
 
 void dump_print_closing_bracket(const dump_mode mode)
 {
-    if (mode == DUMP_MODE_FULL)
+    if (mode == DUMP_MODE_SIMPLE)
     {
         printf("}\n");
     }
@@ -134,7 +134,7 @@ int dump_db(const char *file, const dump_mode mode)
     while ((r = mdb_cursor_get(cursor, &key, &value, MDB_NEXT)) == MDB_SUCCESS)
     {
         switch (mode) {
-            case DUMP_MODE_FULL:
+            case DUMP_MODE_SIMPLE:
                 dump_print_object_line(key, value);
                 break;
             case DUMP_MODE_KEYS:
@@ -172,7 +172,7 @@ int dump_main(int argc, const char *const *const argv)
         print_usage();
         return EXIT_FAILURE;
     }
-    dump_mode mode = DUMP_MODE_FULL;
+    dump_mode mode = DUMP_MODE_SIMPLE;
     const char *filename = argv[1];
     if (argv[1][0] == '-')
     {

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -10,9 +10,9 @@
 
 typedef enum
 {
-    DUMP_NICE, // Print strings in a nice way, and file specific structs
+    DUMP_NICE,     // Print strings in a nice way, and file specific structs
     DUMP_PORTABLE, // Portable and unambiguous, structs and raw strings
-    DUMP_SIMPLE, // Fallback mode for arbitrary / unrecognized data
+    DUMP_SIMPLE,   // Fallback mode for arbitrary / unrecognized data
     DUMP_KEYS,
     DUMP_VALUES,
 } dump_mode;
@@ -126,7 +126,8 @@ static void print_struct_lock_data(
         JsonElement *json = JsonObjectCreate(3);
         JsonObjectAppendInteger(json, "pid", pid);
         JsonObjectAppendInteger(json, "time", time);
-        JsonObjectAppendInteger(json, "process_start_time", process_start_time);
+        JsonObjectAppendInteger(
+            json, "process_start_time", process_start_time);
 
         Writer *w = FileWriter(stdout);
         JsonWriteCompact(w, json);
@@ -369,21 +370,22 @@ static int dump_db(const char *file, const dump_mode mode)
     print_opening_bracket(mode);
     while ((r = mdb_cursor_get(cursor, &key, &value, MDB_NEXT)) == MDB_SUCCESS)
     {
-        switch (mode) {
-            case DUMP_NICE:
-            case DUMP_PORTABLE:
-            case DUMP_SIMPLE:
-                print_line_key_value(key, value, file, strip_strings, structs);
-                break;
-            case DUMP_KEYS:
-                print_line_array_element(key, strip_strings);
-                break;
-            case DUMP_VALUES:
-                print_line_array_element(value, strip_strings);
-                break;
-            default:
-                debug_abort_if_reached();
-                break;
+        switch (mode)
+        {
+        case DUMP_NICE:
+        case DUMP_PORTABLE:
+        case DUMP_SIMPLE:
+            print_line_key_value(key, value, file, strip_strings, structs);
+            break;
+        case DUMP_KEYS:
+            print_line_array_element(key, strip_strings);
+            break;
+        case DUMP_VALUES:
+            print_line_array_element(value, strip_strings);
+            break;
+        default:
+            debug_abort_if_reached();
+            break;
         }
     }
     print_closing_bracket(mode);

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -5,9 +5,11 @@
 #include <lmdb.h>
 #include <string_lib.h>
 #include <json.h>
+#include <db_structs.h>
 
 typedef enum
 {
+    DUMP_MODE_NICE, // Customized printing of structs based on file name
     DUMP_MODE_SIMPLE,
     DUMP_MODE_KEYS,
     DUMP_MODE_VALUES,
@@ -41,7 +43,7 @@ void dump_print_json_string(const char *const data, const size_t size)
 
 void dump_print_opening_bracket(const dump_mode mode)
 {
-    if (mode == DUMP_MODE_SIMPLE)
+    if (mode == DUMP_MODE_SIMPLE || mode == DUMP_MODE_NICE)
     {
         printf("{\n");
     }
@@ -60,6 +62,214 @@ void dump_print_object_line(const MDB_val key, const MDB_val value)
     printf(",\n");
 }
 
+void nice_print_lastseen_quality(const MDB_val value)
+{
+    assert(sizeof(KeyHostSeen) == value.mv_size);
+    if (sizeof(KeyHostSeen) != value.mv_size)
+    {
+        // Fall back to simple printing in release builds:
+        dump_print_json_string(value.mv_data, value.mv_size);
+    }
+    else
+    {
+        // TODO: improve names of struct members in QPoint and KeyHostSeen
+        const KeyHostSeen *const quality = value.mv_data;
+        const time_t lastseen = quality->lastseen;
+        const QPoint Q = quality->Q;
+
+        JsonElement *q_json = JsonObjectCreate(4);
+        JsonObjectAppendReal(q_json, "q", Q.q);
+        JsonObjectAppendReal(q_json, "expect", Q.expect);
+        JsonObjectAppendReal(q_json, "var", Q.var);
+        JsonObjectAppendReal(q_json, "dq", Q.dq);
+
+        JsonElement *top_json = JsonObjectCreate(2);
+        JsonObjectAppendInteger(top_json, "lastseen", lastseen);
+        JsonObjectAppendObject(top_json, "Q", q_json);
+
+        Writer *w = FileWriter(stdout);
+        JsonWriteCompact(w, top_json);
+        FileWriterDetach(w);
+        JsonDestroy(top_json);
+    }
+}
+
+void nice_print_lock_data(const MDB_val value)
+{
+    assert(sizeof(LockData) == value.mv_size);
+    if (sizeof(LockData) != value.mv_size)
+    {
+        // Fall back to simple printing in release builds:
+        dump_print_json_string(value.mv_data, value.mv_size);
+    }
+    else
+    {
+        // TODO: improve names of struct members in LockData
+        const LockData *const lock = value.mv_data;
+        const pid_t pid = lock->pid;
+        const time_t time = lock->time;
+        const time_t process_start_time = lock->process_start_time;
+
+        JsonElement *json = JsonObjectCreate(3);
+        JsonObjectAppendInteger(json, "pid", pid);
+        JsonObjectAppendInteger(json, "time", time);
+        JsonObjectAppendInteger(json, "process_start_time", process_start_time);
+
+        Writer *w = FileWriter(stdout);
+        JsonWriteCompact(w, json);
+        FileWriterDetach(w);
+        JsonDestroy(json);
+    }
+}
+
+void nice_print_averages(const MDB_val value)
+{
+    assert(sizeof(Averages) == value.mv_size);
+    if (sizeof(Averages) != value.mv_size)
+    {
+        // Fall back to simple printing in release builds:
+        dump_print_json_string(value.mv_data, value.mv_size);
+    }
+    else
+    {
+        // TODO: clean up Averages
+        const Averages *const averages = value.mv_data;
+        const time_t last_seen = averages->last_seen;
+
+        JsonElement *all_observables = JsonObjectCreate(observables_max);
+        assert(observables_max <= CF_OBSERVABLES);
+
+        for (Observable i = 0; i < observables_max; ++i)
+        {
+            JsonElement *observable = JsonObjectCreate(4);
+            QPoint Q = averages->Q[i];
+            const char *const name = observable_strings[i];
+
+            JsonObjectAppendReal(observable, "q", Q.q);
+            JsonObjectAppendReal(observable, "expect", Q.expect);
+            JsonObjectAppendReal(observable, "var", Q.var);
+            JsonObjectAppendReal(observable, "dq", Q.dq);
+            JsonObjectAppendObject(all_observables, name, observable);
+        }
+
+        JsonElement *top_json = JsonObjectCreate(2);
+        JsonObjectAppendInteger(top_json, "last_seen", last_seen);
+        JsonObjectAppendObject(top_json, "Q", all_observables);
+
+        Writer *w = FileWriter(stdout);
+        JsonWriteCompact(w, top_json);
+        FileWriterDetach(w);
+        JsonDestroy(top_json);
+    }
+}
+
+void nice_print_persistent_class(const MDB_val value)
+{
+    // Value from db should always be bigger than sizeof struct
+    // Since tags is not counted in sizeof. `tags` is variable size,
+    // and should be at least size 1 (NUL byte) for data to make sense.
+    assert(value.mv_size > sizeof(PersistentClassInfo));
+    if (value.mv_size <= sizeof(PersistentClassInfo))
+    {
+        // Fall back to simple printing in release builds:
+        dump_print_json_string(value.mv_data, value.mv_size);
+    }
+    else
+    {
+        const PersistentClassInfo *const class_info = value.mv_data;
+        const unsigned int expires = class_info->expires;
+        const PersistentClassPolicy policy = class_info->policy;
+        const char *policy_str;
+        switch (policy)
+        {
+        case CONTEXT_STATE_POLICY_RESET:
+            policy_str = "RESET";
+            break;
+        case CONTEXT_STATE_POLICY_PRESERVE:
+            policy_str = "PRESERVE";
+            break;
+        default:
+            debug_abort_if_reached();
+            policy_str = "INTERNAL ERROR";
+            break;
+        }
+
+        const char *const tags = class_info->tags;
+        assert(tags > (char *) class_info);
+
+        const size_t offset = (tags - (char *) class_info);
+        const size_t offset_no_padding =
+            (sizeof(unsigned int) + sizeof(PersistentClassPolicy));
+        assert(offset >= offset_no_padding);
+
+        assert(value.mv_size > offset);
+        const size_t str_size = value.mv_size - offset;
+        assert(str_size > 0);
+        if (memchr(tags, '\0', str_size) == NULL)
+        {
+            // String is not terminated, abort or fall back to default:
+            debug_abort_if_reached();
+            dump_print_json_string(value.mv_data, value.mv_size);
+            return;
+        }
+
+        // At this point, it should be safe to strdup(tags)
+
+        JsonElement *top_json = JsonObjectCreate(2);
+        JsonObjectAppendInteger(top_json, "expires", expires);
+        JsonObjectAppendString(top_json, "policy", policy_str);
+        JsonObjectAppendString(top_json, "tags", tags);
+
+        Writer *w = FileWriter(stdout);
+        JsonWriteCompact(w, top_json);
+        FileWriterDetach(w);
+        JsonDestroy(top_json);
+    }
+}
+
+void dump_print_object_line_nice(
+    const MDB_val key, const MDB_val value, const char *file)
+{
+    printf("\t");
+    dump_print_json_string(key.mv_data, key.mv_size);
+    printf(": ");
+    if (StringEndsWith(file, "cf_lastseen.lmdb")
+        && StringStartsWith(key.mv_data, "q"))
+    {
+        nice_print_lastseen_quality(value);
+    }
+    else if (StringEndsWith(file, "cf_lock.lmdb"))
+    {
+        nice_print_lock_data(value);
+    }
+    else if (StringEndsWith(file, "cf_observations.lmdb"))
+    {
+        if (StringSafeEqual(key.mv_data, "DATABASE_AGE"))
+        {
+            assert(sizeof(double) == value.mv_size);
+            const double *const age = value.mv_data;
+            printf("%f", *age);
+        }
+        else
+        {
+            nice_print_averages(value);
+        }
+    }
+    else if (StringEndsWith(file, "history.lmdb"))
+    {
+        nice_print_averages(value);
+    }
+    else if (StringEndsWith(file, "cf_state.lmdb"))
+    {
+        nice_print_persistent_class(value);
+    }
+    else
+    {
+        dump_print_json_string(value.mv_data, value.mv_size);
+    }
+    printf(",\n");
+}
+
 void dump_print_array_line(const MDB_val value)
 {
     printf("\t");
@@ -69,7 +279,7 @@ void dump_print_array_line(const MDB_val value)
 
 void dump_print_closing_bracket(const dump_mode mode)
 {
-    if (mode == DUMP_MODE_SIMPLE)
+    if (mode == DUMP_MODE_SIMPLE || mode == DUMP_MODE_NICE)
     {
         printf("}\n");
     }
@@ -112,6 +322,9 @@ int dump_db(const char *file, const dump_mode mode)
             case DUMP_MODE_VALUES:
                 dump_print_array_line(value);
                 break;
+            case DUMP_MODE_NICE:
+                dump_print_object_line_nice(key, value, file);
+                break;
             default:
                 debug_abort_if_reached();
                 break;
@@ -141,7 +354,7 @@ int dump_main(int argc, const char *const *const argv)
         print_usage();
         return EXIT_FAILURE;
     }
-    dump_mode mode = DUMP_MODE_SIMPLE;
+    dump_mode mode = DUMP_MODE_NICE;
     const char *filename = argv[1];
     if (argv[1][0] == '-')
     {
@@ -162,6 +375,18 @@ int dump_main(int argc, const char *const *const argv)
             || StringSafeEqual(option, "-v"))
         {
             mode = DUMP_MODE_VALUES;
+        }
+        else if (
+            StringSafeEqual(option, "--nice")
+            || StringSafeEqual(option, "-n"))
+        {
+            mode = DUMP_MODE_NICE;
+        }
+        else if (
+            StringSafeEqual(option, "--simple")
+            || StringSafeEqual(option, "-s"))
+        {
+            mode = DUMP_MODE_SIMPLE;
         }
     }
     return dump_db(filename, mode);

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -10,11 +10,11 @@
 
 typedef enum
 {
-    DUMP_MODE_NICE, // Print strings in a nice way, and file specific structs
-    DUMP_MODE_PORTABLE, // Portable and unambiguous, structs and raw strings
-    DUMP_MODE_SIMPLE, // Fallback mode for arbitrary / unrecognized data
-    DUMP_MODE_KEYS,
-    DUMP_MODE_VALUES,
+    DUMP_NICE, // Print strings in a nice way, and file specific structs
+    DUMP_PORTABLE, // Portable and unambiguous, structs and raw strings
+    DUMP_SIMPLE, // Fallback mode for arbitrary / unrecognized data
+    DUMP_KEYS,
+    DUMP_VALUES,
 } dump_mode;
 
 static void print_usage(void)
@@ -23,13 +23,13 @@ static void print_usage(void)
     printf("Example: cf-check dump /var/cfengine/state/cf_lastseen.lmdb\n");
 }
 
-static int dump_report_error(int rc)
+static int dump_report_error(const int rc)
 {
     printf("err(%d): %s\n", rc, mdb_strerror(rc));
     return rc;
 }
 
-void dump_print_json_string(
+static void print_json_string(
     const char *const data, size_t size, const bool strip_strings)
 {
     assert(data != NULL);
@@ -47,21 +47,21 @@ void dump_print_json_string(
 
     if (strip_strings)
     {
-        const size_t length = strnlen(data, size);
+        const size_t len = strnlen(data, size);
 
         // Unfortunately, the packages_installed_apt_get.lmdb database
         // has unterminated strings:
-        assert((size == 1) || data[size -1] == '\n' || (length == (size - 1)));
+        assert((size == 1) || (len == (size - 1)) || (data[size - 1] == '\n'));
 
-        // Most of what we store are C strings
-        // except 1 byte '0' or '1', and some structs
-        // So in nice mode, we try to default to printing C strings in a nice way
-        // This means it can be ambiguous (we chop off the NUL byte sometimes)
-        // Use --simple for correct, unambiguous, uglier output
-        if (size > 1 && length == (size - 1))
+        // Most of what we store are C strings except 1 byte '0' or '1',
+        // and some structs. So in nice mode, we try to default to printing
+        // C strings in a nice way. This means it can be ambiguous (we chop
+        // off the NUL byte sometimes). Use --simple for correct, unambiguous,
+        // uglier output.
+        if (size > 1 && len == (size - 1))
         {
             // Looks like a normal string, let's remove NUL byte (nice mode)
-            size = length;
+            size = len;
         }
     }
 
@@ -73,25 +73,14 @@ void dump_print_json_string(
     printf("\"");
 }
 
-void dump_print_opening_bracket(const dump_mode mode)
-{
-    if (mode == DUMP_MODE_VALUES || mode == DUMP_MODE_KEYS)
-    {
-        printf("[\n");
-    }
-    else
-    {
-        printf("{\n");
-    }
-}
-
-void print_lastseen_quality(const MDB_val value, const bool strip_strings)
+static void print_struct_lastseen_quality(
+    const MDB_val value, const bool strip_strings)
 {
     assert(sizeof(KeyHostSeen) == value.mv_size);
     if (sizeof(KeyHostSeen) != value.mv_size)
     {
         // Fall back to simple printing in release builds:
-        dump_print_json_string(value.mv_data, value.mv_size, strip_strings);
+        print_json_string(value.mv_data, value.mv_size, strip_strings);
     }
     else
     {
@@ -117,13 +106,14 @@ void print_lastseen_quality(const MDB_val value, const bool strip_strings)
     }
 }
 
-void print_lock_data(const MDB_val value, const bool strip_strings)
+static void print_struct_lock_data(
+    const MDB_val value, const bool strip_strings)
 {
     assert(sizeof(LockData) == value.mv_size);
     if (sizeof(LockData) != value.mv_size)
     {
         // Fall back to simple printing in release builds:
-        dump_print_json_string(value.mv_data, value.mv_size, strip_strings);
+        print_json_string(value.mv_data, value.mv_size, strip_strings);
     }
     else
     {
@@ -146,13 +136,14 @@ void print_lock_data(const MDB_val value, const bool strip_strings)
 }
 
 // Used to print values in /var/cfengine/state/cf_observations.lmdb:
-void print_averages(const MDB_val value, const bool strip_strings)
+static void print_struct_averages(
+    const MDB_val value, const bool strip_strings)
 {
     assert(sizeof(Averages) == value.mv_size);
     if (sizeof(Averages) != value.mv_size)
     {
         // Fall back to simple printing in release builds:
-        dump_print_json_string(value.mv_data, value.mv_size, strip_strings);
+        print_json_string(value.mv_data, value.mv_size, strip_strings);
     }
     else
     {
@@ -187,7 +178,8 @@ void print_averages(const MDB_val value, const bool strip_strings)
     }
 }
 
-void print_persistent_class(const MDB_val value, const bool strip_strings)
+static void print_struct_persistent_class(
+    const MDB_val value, const bool strip_strings)
 {
     // Value from db should always be bigger than sizeof struct
     // Since tags is not counted in sizeof. `tags` is variable size,
@@ -196,7 +188,7 @@ void print_persistent_class(const MDB_val value, const bool strip_strings)
     if (value.mv_size <= sizeof(PersistentClassInfo))
     {
         // Fall back to simple printing in release builds:
-        dump_print_json_string(value.mv_data, value.mv_size, strip_strings);
+        print_json_string(value.mv_data, value.mv_size, strip_strings);
     }
     else
     {
@@ -233,7 +225,7 @@ void print_persistent_class(const MDB_val value, const bool strip_strings)
         {
             // String is not terminated, abort or fall back to default:
             debug_abort_if_reached();
-            dump_print_json_string(value.mv_data, value.mv_size, strip_strings);
+            print_json_string(value.mv_data, value.mv_size, strip_strings);
             return;
         }
 
@@ -251,7 +243,7 @@ void print_persistent_class(const MDB_val value, const bool strip_strings)
     }
 }
 
-void dump_print_value(
+static void print_struct_or_string(
     const MDB_val key,
     const MDB_val value,
     const char *const file,
@@ -264,11 +256,11 @@ void dump_print_value(
         if (StringEndsWith(file, "cf_lastseen.lmdb")
             && StringStartsWith(key.mv_data, "q"))
         {
-            print_lastseen_quality(value, strip_strings);
+            print_struct_lastseen_quality(value, strip_strings);
         }
         else if (StringEndsWith(file, "cf_lock.lmdb"))
         {
-            print_lock_data(value, strip_strings);
+            print_struct_lock_data(value, strip_strings);
         }
         else if (StringEndsWith(file, "cf_observations.lmdb"))
         {
@@ -280,16 +272,16 @@ void dump_print_value(
             }
             else
             {
-                print_averages(value, strip_strings);
+                print_struct_averages(value, strip_strings);
             }
         }
         else if (StringEndsWith(file, "history.lmdb"))
         {
-            print_averages(value, strip_strings);
+            print_struct_averages(value, strip_strings);
         }
         else if (StringEndsWith(file, "cf_state.lmdb"))
         {
-            print_persistent_class(value, strip_strings);
+            print_struct_persistent_class(value, strip_strings);
         }
         else
         {
@@ -300,11 +292,11 @@ void dump_print_value(
     const bool was_printed = (structs && !fallback);
     if (!was_printed)
     {
-        dump_print_json_string(value.mv_data, value.mv_size, strip_strings);
+        print_json_string(value.mv_data, value.mv_size, strip_strings);
     }
 }
 
-void dump_print_object_line(
+static void print_line_key_value(
     const MDB_val key,
     const MDB_val value,
     const char *const file,
@@ -312,22 +304,35 @@ void dump_print_object_line(
     const bool structs)
 {
     printf("\t");
-    dump_print_json_string(key.mv_data, key.mv_size, strip_strings);
+    print_json_string(key.mv_data, key.mv_size, strip_strings);
     printf(": ");
-    dump_print_value(key, value, file, strip_strings, structs);
+    print_struct_or_string(key, value, file, strip_strings, structs);
     printf(",\n");
 }
 
-void dump_print_array_line(const MDB_val value, const bool strip_strings)
+static void print_line_array_element(
+    const MDB_val value, const bool strip_strings)
 {
     printf("\t");
-    dump_print_json_string(value.mv_data, value.mv_size, strip_strings);
+    print_json_string(value.mv_data, value.mv_size, strip_strings);
     printf(",\n");
 }
 
-void dump_print_closing_bracket(const dump_mode mode)
+static void print_opening_bracket(const dump_mode mode)
 {
-    if (mode == DUMP_MODE_KEYS || mode == DUMP_MODE_VALUES)
+    if (mode == DUMP_VALUES || mode == DUMP_KEYS)
+    {
+        printf("[\n");
+    }
+    else
+    {
+        printf("{\n");
+    }
+}
+
+static void print_closing_bracket(const dump_mode mode)
+{
+    if (mode == DUMP_KEYS || mode == DUMP_VALUES)
     {
         printf("]\n");
     }
@@ -337,13 +342,13 @@ void dump_print_closing_bracket(const dump_mode mode)
     }
 }
 
-int dump_db(const char *file, const dump_mode mode)
+static int dump_db(const char *file, const dump_mode mode)
 {
     assert(file != NULL);
 
-    const bool strip_strings = ((mode == DUMP_MODE_NICE) ? true : false);
+    const bool strip_strings = ((mode == DUMP_NICE) ? true : false);
     const bool structs =
-        ((mode == DUMP_MODE_NICE || mode == DUMP_MODE_PORTABLE) ? true : false);
+        ((mode == DUMP_NICE || mode == DUMP_PORTABLE) ? true : false);
 
     int r;
     MDB_env *env;
@@ -361,28 +366,27 @@ int dump_db(const char *file, const dump_mode mode)
     }
 
     MDB_val key, value;
-    dump_print_opening_bracket(mode);
+    print_opening_bracket(mode);
     while ((r = mdb_cursor_get(cursor, &key, &value, MDB_NEXT)) == MDB_SUCCESS)
     {
         switch (mode) {
-            case DUMP_MODE_NICE:
-            case DUMP_MODE_PORTABLE:
-            case DUMP_MODE_SIMPLE:
-                dump_print_object_line(key, value, file, strip_strings, structs);
+            case DUMP_NICE:
+            case DUMP_PORTABLE:
+            case DUMP_SIMPLE:
+                print_line_key_value(key, value, file, strip_strings, structs);
                 break;
-            case DUMP_MODE_KEYS:
-                dump_print_array_line(key, strip_strings);
+            case DUMP_KEYS:
+                print_line_array_element(key, strip_strings);
                 break;
-            case DUMP_MODE_VALUES:
-                dump_print_array_line(value, strip_strings);
-                break;
+            case DUMP_VALUES:
+                print_line_array_element(value, strip_strings);
                 break;
             default:
                 debug_abort_if_reached();
                 break;
         }
     }
-    dump_print_closing_bracket(mode);
+    print_closing_bracket(mode);
 
     if (r != MDB_NOTFOUND)
     {
@@ -398,7 +402,7 @@ int dump_db(const char *file, const dump_mode mode)
     return 0;
 }
 
-int dump_dbs(Seq *const files, const dump_mode mode)
+static int dump_dbs(Seq *const files, const dump_mode mode)
 {
     assert(files != NULL);
     const size_t length = SeqLength(files);
@@ -454,7 +458,7 @@ int dump_main(int argc, const char *const *const argv)
     assert(argv != NULL);
     assert(argc >= 1);
 
-    dump_mode mode = DUMP_MODE_NICE;
+    dump_mode mode = DUMP_NICE;
     const char *const *filenames = argv + 1;
     size_t filenames_len = argc - 1;
     if (filenames_len > 0 && filenames[0] != NULL && filenames[0][0] == '-')
@@ -466,23 +470,23 @@ int dump_main(int argc, const char *const *const argv)
 
         if (matches_option(option, "--keys", "-k"))
         {
-            mode = DUMP_MODE_KEYS;
+            mode = DUMP_KEYS;
         }
         else if (matches_option(option, "--values", "-v"))
         {
-            mode = DUMP_MODE_VALUES;
+            mode = DUMP_VALUES;
         }
         else if (matches_option(option, "--nice", "-n"))
         {
-            mode = DUMP_MODE_NICE;
+            mode = DUMP_NICE;
         }
         else if (matches_option(option, "--simple", "-s"))
         {
-            mode = DUMP_MODE_SIMPLE;
+            mode = DUMP_SIMPLE;
         }
         else if (matches_option(option, "--portable", "-p"))
         {
-            mode = DUMP_MODE_PORTABLE;
+            mode = DUMP_PORTABLE;
         }
         else
         {

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -4,6 +4,7 @@
 #ifdef LMDB
 #include <lmdb.h>
 #include <string_lib.h>
+#include <json.h>
 
 typedef enum
 {
@@ -27,46 +28,14 @@ static int dump_report_error(int rc)
 void dump_print_json_string(const char *const data, const size_t size)
 {
     printf("\"");
-    for (size_t i = 0; i < size; ++i)
-    {
-        char byte = data[i];
-        switch (byte)
-        {
-        case '\0':
-            printf("\\0");
-            break;
-        case '\\':
-            printf("\\\\");
-            break;
-        case '\b':
-            printf("\\b");
-            break;
-        case '\f':
-            printf("\\f");
-            break;
-        case '\n':
-            printf("\\n");
-            break;
-        case '\r':
-            printf("\\r");
-            break;
-        case '\t':
-            printf("\\t");
-            break;
-        case '"':
-            printf("\\\"");
-            break;
-        default:
-            if (isprint(byte))
-            {
-                printf("%c", byte);
-            }
-            else
-            {
-                printf("\\x%2.2x", (unsigned char) byte);
-            }
-        }
-    }
+
+    Slice unescaped_data = {.data = (void *) data, .size = size};
+    // TODO: should probably change Slice in libntech to take (const void *)
+    // TODO: Expose Json5EscapeDataWriter and use it instead
+    char *escaped_data = Json5EscapeData(unescaped_data);
+    printf("%s", escaped_data);
+    free(escaped_data);
+
     printf("\"");
 }
 

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -41,6 +41,27 @@ void dump_print_json_string(const char *const data, const size_t size)
     printf("\"");
 }
 
+void dump_print_json_string_nice(const char *const data, size_t size)
+{
+    assert(data != NULL);
+    assert(strnlen(data, size) == (size - 1));
+
+    printf("\"");
+
+    if (strnlen(data, size) == (size - 1))
+    {
+        // Looks like a normal string, let's remove NUL byte (nice mode)
+        size -= 1;
+    }
+
+    Slice unescaped_data = {.data = (void *) data, .size = size};
+    char *escaped_data = Json5EscapeData(unescaped_data);
+    printf("%s", escaped_data);
+    free(escaped_data);
+
+    printf("\"");
+}
+
 void dump_print_opening_bracket(const dump_mode mode)
 {
     if (mode == DUMP_MODE_SIMPLE || mode == DUMP_MODE_NICE)
@@ -231,7 +252,7 @@ void dump_print_object_line_nice(
     const MDB_val key, const MDB_val value, const char *file)
 {
     printf("\t");
-    dump_print_json_string(key.mv_data, key.mv_size);
+    dump_print_json_string_nice(key.mv_data, key.mv_size);
     printf(": ");
     if (StringEndsWith(file, "cf_lastseen.lmdb")
         && StringStartsWith(key.mv_data, "q"))
@@ -265,7 +286,7 @@ void dump_print_object_line_nice(
     }
     else
     {
-        dump_print_json_string(value.mv_data, value.mv_size);
+        dump_print_json_string_nice(value.mv_data, value.mv_size);
     }
     printf(",\n");
 }

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -467,11 +467,18 @@ int dump_main(int argc, const char *const *const argv)
         {
             mode = DUMP_MODE_SIMPLE;
         }
+        else
+        {
+            print_usage();
+            printf("Unrecognized option: '%s'\n", option);
+            return 1;
+        }
     }
 
     if (filenames_len > 0 && filenames[0] != NULL && filenames[0][0] == '-')
     {
         print_usage();
+        printf("Only one option supported!\n");
         return 1;
     }
 

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -346,6 +346,31 @@ int dump_db(const char *file, const dump_mode mode)
     return 0;
 }
 
+static bool matches_option(
+    const char *const supplied,
+    const char *const longopt,
+    const char *const shortopt)
+{
+    assert(supplied != NULL);
+    assert(shortopt != NULL);
+    assert(longopt != NULL);
+    assert(strlen(shortopt) == 2);
+    assert(strlen(longopt) >= 3);
+    assert(shortopt[0] == '-' && shortopt[1] != '-');
+    assert(longopt[0] == '-' && longopt[1] == '-' && longopt[2] != '-');
+
+    const size_t length = strlen(supplied);
+    if (length <= 1)
+    {
+        return false;
+    }
+    else if (length == 2)
+    {
+        return StringSafeEqual(supplied, shortopt);
+    }
+    return StringSafeEqualN_IgnoreCase(supplied, longopt, length);
+}
+
 int dump_main(int argc, const char *const *const argv)
 {
     assert(argv != NULL);
@@ -365,26 +390,19 @@ int dump_main(int argc, const char *const *const argv)
         }
         const char *const option = argv[1];
         filename = argv[2];
-        if (StringSafeEqual(option, "--keys")
-            || StringSafeEqual(option, "-k"))
+        if (matches_option(option, "--keys", "-k"))
         {
             mode = DUMP_MODE_KEYS;
         }
-        else if (
-            StringSafeEqual(option, "--values")
-            || StringSafeEqual(option, "-v"))
+        else if (matches_option(option, "--values", "-v"))
         {
             mode = DUMP_MODE_VALUES;
         }
-        else if (
-            StringSafeEqual(option, "--nice")
-            || StringSafeEqual(option, "-n"))
+        else if (matches_option(option, "--nice", "-n"))
         {
             mode = DUMP_MODE_NICE;
         }
-        else if (
-            StringSafeEqual(option, "--simple")
-            || StringSafeEqual(option, "-s"))
+        else if (matches_option(option, "--simple", "-s"))
         {
             mode = DUMP_MODE_SIMPLE;
         }


### PR DESCRIPTION
cf-check can use our knowledge of what these databases contain (structs), as well as the JSON code in libntech, to print the information in a readable way. Here's a comparison:

**mdb_dump:**

```
root@dev core $ mdb_dump -np /var/cfengine/state/cf_lastseen.lmdb
VERSION=3
format=print
type=btree
mapsize=104857600
maxreaders=126
db_pagesize=4096
HEADER=END
 a192.168.100.10\00
 MD5=0924931c0116d2640e609bfbb424dc18\00
 kMD5=0924931c0116d2640e609bfbb424dc18\00
 192.168.100.10\00
 qoMD5=0924931c0116d2640e609bfbb424dc18\00
 \cd\96z]\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00
DATA=END
root@dev core $
```

**lmdump:**

```
root@dev core $ lmdump -a /var/cfengine/state/cf_lastseen.lmdb
key: 0x7f3bc38abf34[16] a192.168.100.10, data: 0x7f3bc38abf44[37] MD5=0924931c0116d2640e609bfbb424dc18
key: 0x7f3bc38abf72[38] kMD5=0924931c0116d2640e609bfbb424dc18, data: 0x7f3bc38abf98[15] 192.168.100.10
key: 0x7f3bc38abfb0[39] qoMD5=0924931c0116d2640e609bfbb424dc18, data: 0x7f3bc38abfd7[40] ͖z]
root@dev core $
```

**cf-check dump:**

```
root@dev core $ cf-check dump /var/cfengine/state/cf_lastseen.lmdb
{
        "a192.168.100.10": "MD5=0924931c0116d2640e609bfbb424dc18",
        "kMD5=0924931c0116d2640e609bfbb424dc18": "192.168.100.10",
        "qoMD5=0924931c0116d2640e609bfbb424dc18": {"Q":{"dq":0.0000,"expect":0.0000,"q":0.0000,"var":0.0000},"lastseen":1568315085},
}
root@dev core $
```

**Using json5 and jq to pretty-print "normal" JSON:**

```
root@dev core $ cf-check dump /var/cfengine/state/cf_lastseen.lmdb | json5 | jq
{
  "a192.168.100.10": "MD5=0924931c0116d2640e609bfbb424dc18",
  "kMD5=0924931c0116d2640e609bfbb424dc18": "192.168.100.10",
  "qoMD5=0924931c0116d2640e609bfbb424dc18": {
    "Q": {
      "dq": 0,
      "expect": 0,
      "q": 0,
      "var": 0
    },
    "lastseen": 1568315085
  }
}
root@dev core $
```