### PR TITLE
CFE-3140: redhat_8 and redhat_8_0 are now defined on RHEL 8

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1733,6 +1733,7 @@ static int Linux_Fedora_Version(EvalContext *ctx)
 static int Linux_Redhat_Version(EvalContext *ctx)
 {
 #define REDHAT_ID "Red Hat Linux"
+#define REDHAT_ENT_ID "Red Hat Enterprise Linux"
 #define REDHAT_AS_ID "Red Hat Enterprise Linux AS"
 #define REDHAT_AS21_ID "Red Hat Linux Advanced Server"
 #define REDHAT_ES_ID "Red Hat Enterprise Linux ES"
@@ -1754,6 +1755,7 @@ static int Linux_Redhat_Version(EvalContext *ctx)
 /* We are looking for one of the following strings...
  *
  * Red Hat Linux release 6.2 (Zoot)
+ * Red Hat Enterprise Linux release 8.0 (Ootpa)
  * Red Hat Linux Advanced Server release 2.1AS (Pensacola)
  * Red Hat Enterprise Linux AS release 3 (Taroon)
  * Red Hat Enterprise Linux WS release 3 (Taroon)
@@ -1821,6 +1823,10 @@ static int Linux_Redhat_Version(EvalContext *ctx)
         edition = "cn";
     }
     else if (!strncmp(relstring, REDHAT_ID, strlen(REDHAT_ID)))
+    {
+        vendor = "redhat";
+    }
+    else if (!strncmp(relstring, REDHAT_ENT_ID, strlen(REDHAT_ENT_ID)))
     {
         vendor = "redhat";
     }

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1769,7 +1769,7 @@ static int Linux_Redhat_Version(EvalContext *ctx)
 #define RH_REL_FILENAME "/etc/redhat-release"
 
     Log(LOG_LEVEL_VERBOSE, "This appears to be a redhat (or redhat-based) system.");
-    EvalContextClassPutHard(ctx, "redhat", "inventory,attribute_name=none,source=agent");
+    EvalContextClassPutHard(ctx, "redhat", "inventory,attribute_name=none,source=agent,derived-from-file="RH_REL_FILENAME);
 
     /* Grab the first line from the file and then close it. */
     char relstring[CF_MAXVARSIZE];
@@ -1914,24 +1914,24 @@ static int Linux_Redhat_Version(EvalContext *ctx)
     {
         classbuf[0] = '\0';
         strcat(classbuf, vendor);
-        EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent,derived-from-file="RH_REL_FILENAME);
         strcat(classbuf, "_");
 
         if (strcmp(edition, "") != 0)
         {
             strcat(classbuf, edition);
-            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent,derived-from-file="RH_REL_FILENAME);
             strcat(classbuf, "_");
         }
 
         strcat(classbuf, strmajor);
-        EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent,derived-from-file="RH_REL_FILENAME);
 
         if (minor != -2)
         {
             strcat(classbuf, "_");
             strcat(classbuf, strminor);
-            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent,derived-from-file="RH_REL_FILENAME);
         }
     }
 
@@ -1940,7 +1940,7 @@ static int Linux_Redhat_Version(EvalContext *ctx)
     {
         classbuf[0] = '\0';
         strcat(classbuf, vendor);
-        EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent,derived-from-file="RH_REL_FILENAME);
         strcat(classbuf, "_");
 
         strcat(classbuf, strmajor);
@@ -1951,7 +1951,7 @@ static int Linux_Redhat_Version(EvalContext *ctx)
         {
             strcat(classbuf, "_");
             strcat(classbuf, strminor);
-            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent,derived-from-file="RH_REL_FILENAME);
         }
     }
 


### PR DESCRIPTION
The format of the /etc/redhat-release file was changed:

```
Red Hat Linux release 6.2 (Zoot)
Red Hat Enterprise Linux release 8.0 (Ootpa)
```

(Our code didn't expect the Enterprise part).

**Before:**

```
[ec2-user@ip-172-31-38-120 core]$ sudo /var/cfengine/bin/cf-promises --show-classes | grep redhat
inventory_redhat_have_python_symlink                         source=promise                          
redhat                                                       inventory,attribute_name=none,source=agent,hardclass
redhat_pure                                                  source=promise,inventory,attribute_name=none
```

**After:**

```
[ec2-user@ip-172-31-38-120 core]$ /var/cfengine/bin/cf-promises --show-classes | grep redhat
inventory_redhat_have_python_symlink                         source=promise
redhat                                                       inventory,attribute_name=none,source=agent,derived-from-file=/etc/redhat-release,hardclass
redhat_8                                                     inventory,attribute_name=none,source=agent,derived-from-file=/etc/redhat-release,hardclass
redhat_8_0                                                   inventory,attribute_name=none,source=agent,derived-from-file=/etc/redhat-release,hardclass
redhat_pure                                                  source=promise,inventory,attribute_name=none
```