### PR TITLE
CFE-3140: An ID of rhel in os-release file will now define both rhel and redhat classes

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1141,10 +1141,21 @@ static void OSReleaseParse(EvalContext *ctx, const char *file_path)
         if (os_release_id != NULL)
         {
             CanonifyNameInPlace(os_release_id);
+
+            const char *alias = NULL;
+            if (StringSafeEqual(os_release_id, "rhel"))
+            {
+                alias = "redhat";
+            }
+
             if (os_release_version_id == NULL)
             {
                 // if VERSION_ID doesn't exist, define only one hard class:
                 EvalContextClassPutHard(ctx, os_release_id, tags);
+                if (alias != NULL)
+                {
+                    EvalContextClassPutHard(ctx, alias, tags);
+                }
             }
             else // if VERSION_ID exists set flavor and multiple hard classes:
             {
@@ -1167,6 +1178,10 @@ static void OSReleaseParse(EvalContext *ctx, const char *file_path)
                 // One of the hard classes is already set by SetFlavor
                 // but it seems excessive to try to skip this:
                 DefineVersionedHardClasses(ctx, tags, os_release_id, os_release_version_id);
+                if (alias != NULL)
+                {
+                    DefineVersionedHardClasses(ctx, tags, alias, os_release_version_id);
+                }
             }
         }
         free(os_release_version_id);


### PR DESCRIPTION
Contents of os-release on RHEL 8:

```
[ec2-user@ip-172-31-38-120 core]$ cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="8.0 (Ootpa)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="8.0"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Red Hat Enterprise Linux 8.0 (Ootpa)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:8.0:GA"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_BUGZILLA_PRODUCT_VERSION=8.0
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.0"
```

Our older platform detection code (which uses the redhat-release file) sets
the hard class `redhat`, not `rhel`. For backwards compatibility, I added an
alias, so both are defined.

**Before:**

```
[ec2-user@ip-172-31-38-120 core]$ sudo /var/cfengine/bin/cf-promises --show-classes | grep redhat
inventory_redhat_have_python_symlink                         source=promise
redhat                                                       inventory,attribute_name=none,source=agent,hardclass
redhat_pure                                                  source=promise,inventory,attribute_name=none
```

**After:**

```
[ec2-user@ip-172-31-38-120 core]$ sudo /var/cfengine/bin/cf-promises --show-classes | grep redhat
inventory_redhat_have_python_symlink                         source=promise
redhat                                                       inventory,attribute_name=none,source=agent,derived-from-file=/etc/os-release,hardclass
redhat_8                                                     inventory,attribute_name=none,source=agent,derived-from-file=/etc/os-release,hardclass
redhat_8_0                                                   inventory,attribute_name=none,source=agent,derived-from-file=/etc/os-release,hardclass
redhat_pure                                                  source=promise,inventory,attribute_name=none
```