### PR TITLE
NetBSD ps output gets truncated

### DIFF
--- a/libpromises/systype.c
+++ b/libpromises/systype.c
@@ -108,11 +108,11 @@ const char *const VPSOPTS[] =
 #else
     [PLATFORM_CONTEXT_FREEBSD] = "auxw",              /* freebsd 9.2 and older*/
 #endif
-    [PLATFORM_CONTEXT_NETBSD] = "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,start,time,args",   /* netbsd */
+    [PLATFORM_CONTEXT_NETBSD] = "-axwwo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,nlwp,start,time,args",   /* netbsd */
     [PLATFORM_CONTEXT_CRAYOS] = "-elyf",              /* cray */
     [PLATFORM_CONTEXT_WINDOWS_NT] = "-aW",            /* NT */
     [PLATFORM_CONTEXT_SYSTEMV] = "-ef",               /* Unixware */
-    [PLATFORM_CONTEXT_OPENBSD] = "-axo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,start,time,args",       /* openbsd */
+    [PLATFORM_CONTEXT_OPENBSD] = "-axwwo user,pid,ppid,pgid,pcpu,pmem,vsz,ni,rss,start,time,args",       /* openbsd */
     [PLATFORM_CONTEXT_CFSCO] = "-ef",                 /* sco */
     [PLATFORM_CONTEXT_DARWIN] = "auxw",               /* darwin */
     [PLATFORM_CONTEXT_QNX] = "-elyf",                 /* qnx */


### PR DESCRIPTION
* `ps -axo`: truncates the ouptut of ps at the width of terminal.
* `ps -axwwo`: displays the full length of the command and args

Without this patch cf-agent --bootstrap fails with 80 column
terminals, and success with wider terminals. Error message:

```
cf-agent[29746]: CFEngine(agent)  Bootstrapping failed, cf-execd is not running
```

From the `man ps` page of NetBSD (https://netbsd.gw.com/cgi-bin/man-cgi?ps+1):

```
     -w           Use 132 columns to display information instead of the
                  default, which is your window size.  If the -w option is
                  specified more than once, ps will use as many columns as
                  necessary without regard to your window size.
```

Reading the ps man page of OpenBSD seems to have the same problem:

https://man.openbsd.org/ps