### PR TITLE
Do not increment version after alpha/beta release

### DIFF
--- a/misc/determine-version.py
+++ b/misc/determine-version.py
@@ -254,7 +254,15 @@ else:
     # (3.x) versions. But since those are not reachable from here, we
     # have branched off again, i.e. we need a new *minor* (3.x)
     # version. So find the newest minor version and increase it.
-    final_print("%s.%d.0a.%s" % (all_tags[0][0], int(all_tags[0][1]) + 1, abbrev_rev))
+
+    # Unless the newest minor version is an alpha or beta release which
+    # should not trigger minor version incrementing (we are yet to
+    # release the final version of that minor release).
+    # A tag in all_tags is like: ('3', '15', '0', 'b1-build2')
+    if all_tags[0][3].startswith(("a", "b")):
+        final_print("%s.%d.0a.%s" % (all_tags[0][0], int(all_tags[0][1]), abbrev_rev))
+    else:
+        final_print("%s.%d.0a.%s" % (all_tags[0][0], int(all_tags[0][1]) + 1, abbrev_rev))
 
 
 sys.exit(0)


### PR DESCRIPTION
After releasing say 3.15.0 beta, we don't want to start building
3.16.0 packages, 3.15.0 is still yet to be released.

Merge together:
https://github.com/cfengine/core/pull/3837
https://github.com/cfengine/enterprise/pull/545
https://github.com/cfengine/nova/pull/1517
https://github.com/cfengine/masterfiles/pull/1505