### PR TITLE
Prevented buffer overflow when policy variable names are longer than 1024 bytes (3.12)

### DIFF
--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -53,11 +53,11 @@ static const char *const POLICY_ERROR_VARS_CONSTRAINT_DUPLICATE_TYPE =
     "Variable contains existing data type contstraint %s, tried to "
     "redefine with %s";
 static const char *const POLICY_ERROR_VARS_PROMISER_NUMERICAL =
-    "Variable promises cannot have a purely numerical promiser (name)";
-static const char *const POLICY_ERROR_VARS_PROMISER_RESERVED =
-    "Variable promise is using a reserved name";
+    "Variable promises cannot have a purely numerical name (promiser)";
+static const char *const POLICY_ERROR_VARS_PROMISER_INVALID =
+    "Variable promise is using an invalid name (promiser)";
 static const char *const POLICY_ERROR_CLASSES_PROMISER_NUMERICAL =
-    "Classes promises cannot have a purely numerical promiser (name)";
+    "Classes promises cannot have a purely numerical name (promiser)";
 
 static bool ActionCheck(const Body *body, Seq *errors)
 {
@@ -168,7 +168,7 @@ static bool VarsParseTreeCheck(const Promise *pp, Seq *errors)
     if (!CheckParseVariableName(pp->promiser))
     {
         SeqAppend(errors, PolicyErrorNew(POLICY_ELEMENT_TYPE_PROMISE, pp,
-                                         POLICY_ERROR_VARS_PROMISER_RESERVED));
+                                         POLICY_ERROR_VARS_PROMISER_INVALID));
         success = false;
     }
 

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -836,6 +836,7 @@ int CheckParseVariableName(const char *name)
     }
 
     scopeid[0] = '\0';
+    vlval[0] = '\0';
 
     if (strchr(name, '.'))
     {

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -843,10 +843,6 @@ int CheckParseVariableName(const char *name)
         return false;
     }
 
-    char scopeid[CF_MAXVARSIZE], vlval[CF_MAXVARSIZE];
-    scopeid[0] = '\0';
-    vlval[0] = '\0';
-
     int count = 0, level = 0;
 
     const char *const first_dot = strchr(name, '.');
@@ -889,9 +885,7 @@ int CheckParseVariableName(const char *name)
         if (count == 1)
         {
             // Check that there is something before and after first dot:
-            sscanf(name, "%[^.].%s", scopeid, vlval);
-
-            if (scopeid[0] == '\0' || vlval[0] == '\0')
+            if (name[0] == '.' || first_dot[1] == '\0')
             {
                 return false;
             }

--- a/tests/unit/syntax_test.c
+++ b/tests/unit/syntax_test.c
@@ -109,6 +109,54 @@ static void test_typecheck_null_rval(void)
     assert_int_equal(SYNTAX_TYPE_MATCH_ERROR_GOT_NULL, err);
 }
 
+static void test_check_parse_variable_name(void)
+{
+    // Test was added after function
+    // It shows what it actually does (not what was intended)
+
+    // Allowed variable "names":
+    assert_true(CheckParseVariableName("a"));
+    assert_true(CheckParseVariableName("myvar"));
+    assert_true(CheckParseVariableName("SuperCaliFragilisticExpialidocius"));
+    assert_true(CheckParseVariableName("a.b"));
+    assert_true(CheckParseVariableName("a[b]"));
+    assert_true(CheckParseVariableName("a[b.c]"));
+    assert_true(CheckParseVariableName("a[b.c.d]"));
+    assert_true(CheckParseVariableName("a.b[c.d.e]"));
+    assert_true(CheckParseVariableName("a.b[c.d.e]"));
+    assert_true(CheckParseVariableName("Namespace.var[$(ns.expand)]"));
+
+    // Not allowed:
+    assert_false(CheckParseVariableName("a.b.c"));
+    assert_false(CheckParseVariableName("abc.def.ghi"));
+    assert_false(CheckParseVariableName(".a"));
+    assert_false(CheckParseVariableName("a."));
+    assert_false(CheckParseVariableName(".abc"));
+    assert_false(CheckParseVariableName("abc."));
+
+    // Reserved:
+    assert_false(CheckParseVariableName("promiser"));
+    assert_false(CheckParseVariableName("handle"));
+    assert_false(CheckParseVariableName("promise_filename"));
+    assert_false(CheckParseVariableName("promise_dirname"));
+    assert_false(CheckParseVariableName("promise_linenumber"));
+    assert_false(CheckParseVariableName("this"));
+
+    // Edge cases, allowed:
+    assert_true(CheckParseVariableName(""));
+    assert_true(CheckParseVariableName(" "));
+    assert_true(CheckParseVariableName("    "));
+    assert_true(CheckParseVariableName("\t"));
+    assert_true(CheckParseVariableName("a["));
+    assert_true(CheckParseVariableName("a.["));
+
+    // Edge cases, not allowed:
+    assert_false(CheckParseVariableName("."));
+    assert_false(CheckParseVariableName("..."));
+    assert_false(CheckParseVariableName(".[]"));
+    assert_false(CheckParseVariableName(".[][]"));
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -130,6 +178,7 @@ int main()
 
         unit_test(test_copy_from_servers),
         unit_test(test_typecheck_null_rval),
+        unit_test(test_check_parse_variable_name),
     };
 
     return run_tests(tests);


### PR DESCRIPTION
Cherry-picks from https://github.com/cfengine/core/pull/3807

Merge-conflict: bool-correctness fixes not in 3.12.x