### PR TITLE
cf-check: Improve portability of --no-fork mode

### DIFF
--- a/cf-check/diagnose.c
+++ b/cf-check/diagnose.c
@@ -303,9 +303,8 @@ static int diagnose(const char *path, bool temporary_redirect)
         freopen("/dev/null", "w", stdout);
         ret = lmdump(LMDUMP_VALUES_ASCII, path);
 
-        char buf[32];
-        snprintf(buf, sizeof(buf), "/dev/fd/%d", saved_stdout);
-        freopen(buf, "w", stdout);
+        fflush(stdout);
+        dup2(saved_stdout, STDOUT_FILENO);
     }
     else
     {


### PR DESCRIPTION
cf-check now works as before when you don't add `--no-fork`, and when you do, it uses `fflush` and `dup2` for the redirection, instead of `/dev/fd`. Both the new and old approach was tested and work on OS X and Ubuntu 18.04.