### PR TITLE
CFE-2689: Fixed bug and error message in unless attribute

### DIFF
--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -31,6 +31,7 @@
 #include <set.h>
 #include <sequence.h>
 #include <var_expressions.h>
+#include <logic_expressions.h>
 #include <scope.h>
 #include <variable.h>
 #include <class.h>
@@ -208,7 +209,11 @@ Seq *EvalContextResolveBodyExpression(const EvalContext *ctx, const Policy *poli
 
 /* - Parsing/evaluating expressions - */
 void ValidateClassSyntax(const char *str);
-bool IsDefinedClass(const EvalContext *ctx, const char *context);
+ExpressionValue CheckClassExpression(const EvalContext *ctx, const char *context);
+static inline bool IsDefinedClass(const EvalContext *ctx, const char *context)
+{
+    return (CheckClassExpression(ctx, context) == EXPRESSION_VALUE_TRUE);
+}
 StringSet *ClassesMatching(const EvalContext *ctx, ClassTableIterator *iter, const char* regex, const Rlist *tags, bool first_only);
 
 bool EvalProcessResult(const char *process_result, StringSet *proc_attr);

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -491,7 +491,7 @@ static bool EvaluateConstraintIteration(EvalContext *ctx, const Constraint *cp, 
   @brief Helper function to determine whether the Rval of ifvarclass/if/unless is defined.
   If the Rval is a function, call that function.
 */
-static bool IsVarClassDefined(const EvalContext *ctx, const Constraint *cp, Promise *pcopy)
+static ExpressionValue CheckVarClassExpression(const EvalContext *ctx, const Constraint *cp, Promise *pcopy)
 {
     assert(ctx);
     assert(cp);
@@ -506,7 +506,7 @@ static bool IsVarClassDefined(const EvalContext *ctx, const Constraint *cp, Prom
     Rval final;
     if (!EvaluateConstraintIteration((EvalContext*)ctx, cp, &final))
     {
-        return false;
+        return EXPRESSION_VALUE_ERROR;
     }
 
     char *classes = NULL;
@@ -525,18 +525,23 @@ static bool IsVarClassDefined(const EvalContext *ctx, const Constraint *cp, Prom
         break;
     }
 
-    if (!classes)
+    if (classes == NULL)
     {
-        return false;
+        return EXPRESSION_VALUE_ERROR;
     }
     // sanity check for unexpanded variables
     if (strchr(classes, '$') || strchr(classes, '@'))
     {
         Log(LOG_LEVEL_DEBUG, "Class expression did not evaluate");
-        return false;
+        return EXPRESSION_VALUE_ERROR;
     }
 
-    return IsDefinedClass(ctx, classes);
+    return CheckClassExpression(ctx, classes);
+}
+
+static bool IsVarClassDefined(const EvalContext *ctx, const Constraint *cp, Promise *pcopy)
+{
+    return (CheckVarClassExpression(ctx, cp, pcopy) == EXPRESSION_VALUE_TRUE);
 }
 
 /* Expands "$(this.promiser)" comment if present. Writes the result to pp. */

--- a/tests/acceptance/00_basics/04_bundles/unless_bug.cf
+++ b/tests/acceptance/00_basics/04_bundles/unless_bug.cf
@@ -11,10 +11,6 @@ bundle agent test
       "description" -> { "CFE-2698" }
         string => "This test shows a bug in unless which should be fixed";
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "CFE-2698" };
-
   vars:
     any::
       "target_variable"


### PR DESCRIPTION
**Bug fix:**

`unless_bug.cf`:

```
bundle agent test
{
  meta:
    any::
      "description" -> { "CFE-2698" }
        string => "This test shows a bug in unless which should be fixed";

  vars:
    any::
      "target_variable"
        string => "value";

      "vars_promise_which_should_be_skipped"
        string => "value",
        unless => isvariable( $(variable_defined_later) );

      # If you move this variable up, the test will pass,
      # the order shouldn't matter here, this is a bug
      "variable_defined_later"
        string => "target_variable";
}
```

**Change in error message:**

Before:

```
$ cf-agent unless_illegal.x.cf -D AUTO -K
   error: unless_illegal.x.cf:0:0: In attribute 'unless', Function does not return the required type. Given attribute value 'isvariable("$(no_such_variable)")'
   error: Fatal CFEngine error: Cannot continue
$ echo $?
1
```

After:

```
$ cf-agent unless_illegal.x.cf -D AUTO -K
R: test description: This test ensures that unresolved function calls in unless are illegal
   error: Fatal CFEngine error: Unresolved function call in vars promise 'vars_promise_which_should_error', the constraint 'unless => isvariable("$(no_such_variable)")' might have unexpanded variables
$ echo $?
1
```


**Internal details:**

To fully understand this, you have to consider the multiple
evaluation passes. Variables may not be available in the
first pass. So, for 3-pass evaluation, a promise using `if`
might look like this:

```
SKIP -> SKIP -> False (don't run promise)
```

We want the equivalent `unless` to behave like this:

```
SKIP -> SKIP -> False (DO run promise)
```

However, It would previously invert the SKIP outcome like this:

```
False (RUN Promise) -> ???? -> ????
```

(Question marks because it doesn't matter, the promise was
already evaluated at this point).

There was also a misleading error message for unless, which
prompted the issue. When the agent tries to explain what
went wrong when evaluating this promise.

The internal functions involved here have to properly
distinguish between true, false, and error/skip. i.e. don't
invert the error.