### PR TITLE
ENT-4921: Removed stime_range and ttime_range constraints from promise hash

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -606,7 +606,7 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt,
     Rlist *rp;
     FnCall *fp;
 
-    char *noRvalHash[] = { "mtime", "atime", "ctime", NULL };
+    char *noRvalHash[] = { "mtime", "atime", "ctime", "stime_range", "ttime_range", NULL };
     int doHash;
 
     md = HashDigestFromId(type);


### PR DESCRIPTION
This may be causing reporting failures in some cases.

Changelog: title
Ticket: ENT-4921