### PR TITLE
CFE-3087: New functions Get and StatGet for protocol

### DIFF
--- a/cf-net/cf-net.c
+++ b/cf-net/cf-net.c
@@ -695,17 +695,9 @@ static void *CFNetGetFile(void *arg)
         return NULL;
     }
 
-    struct stat sb;
-    data->ret = cf_remote_stat(conn, true, data->remote_file, &sb, "file");
-    if (data->ret != 0)
-    {
-        printf("Could not stat: '%s'\n", data->remote_file);
-    }
-    else
-    {
-        bool ok = CopyRegularFileNet(data->remote_file, data->local_file, sb.st_size, true, conn);
-        data->ret = ok ? 0 : -1;
-    }
+    bool ok = ProtocolStatGet(conn, data->remote_file,
+                               data->local_file, 0644);
+    data->ret = ok ? 0 : -1;
     CFNetDisconnect(conn);
     return NULL;
 }

--- a/libcfnet/protocol.c
+++ b/libcfnet/protocol.c
@@ -28,6 +28,7 @@
 #include <client_protocol.h>
 #include <definitions.h>
 #include <net.h>
+#include <stat_cache.h>
 #include <string_lib.h>
 #include <tls_generic.h>
 
@@ -87,4 +88,123 @@ Seq *ProtocolOpenDir(AgentConnection *conn, const char *path)
     }
 
     return seq;
+}
+
+bool ProtocolGet(AgentConnection *conn, const char *remote_path,
+                 const char *local_path, const uint32_t file_size, int perms)
+{
+    assert(conn != NULL);
+    assert(remote_path != NULL);
+    assert(local_path != NULL);
+    assert(file_size != 0);
+
+    perms = (perms == 0) ? CF_PERMS_DEFAULT : perms;
+
+    unlink(local_path);
+    FILE *file_ptr = safe_fopen_create_perms(local_path, "wx", perms);
+    if (file_ptr == NULL)
+    {
+        Log(LOG_LEVEL_WARNING, "Failed to open file %s (fopen: %s)",
+            local_path, GetErrorStr());
+        return false;
+    }
+
+    char buf[CF_MSGSIZE] = {0};
+    int to_send = snprintf(buf, CF_MSGSIZE, "GET %d %s",
+                           CF_MSGSIZE, remote_path);
+
+
+    int ret = SendTransaction(conn->conn_info, buf, to_send, CF_DONE);
+    if (ret == -1)
+    {
+        Log(LOG_LEVEL_WARNING, "Failed to send request for remote file %s:%s",
+            conn->this_server, remote_path);
+        unlink(local_path);
+        fclose(file_ptr);
+        return false;
+    }
+
+    char cfchangedstr[sizeof(CF_CHANGEDSTR1 CF_CHANGEDSTR2)];
+    snprintf(cfchangedstr, sizeof(cfchangedstr), "%s%s",
+             CF_CHANGEDSTR1, CF_CHANGEDSTR2);
+
+    bool success = true;
+    uint32_t received_bytes = 0;
+    while (received_bytes < file_size)
+    {
+        int len = TLSRecv(conn->conn_info->ssl, buf, CF_MSGSIZE);
+        if (len == -1)
+        {
+            Log(LOG_LEVEL_WARNING, "Failed to GET file %s:%s",
+                conn->this_server, remote_path);
+            success = false;
+            break;
+        }
+        else if (len > CF_MSGSIZE)
+        {
+            Log(LOG_LEVEL_WARNING,
+                "Incorrect length of incoming packet "
+                "while retrieving %s:%s, %d > %d",
+                conn->this_server, remote_path, len, CF_MSGSIZE);
+            success = false;
+            break;
+        }
+
+        if (BadProtoReply(buf))
+        {
+            Log(LOG_LEVEL_ERR,
+                "Error from server while retrieving file %s:%s: %s",
+                conn->this_server, remote_path, buf);
+            success = false;
+            break;
+        }
+
+        if (StringSafeEqualN(buf, cfchangedstr, sizeof(cfchangedstr) - 1))
+        {
+            Log(LOG_LEVEL_ERR,
+                "Remote file %s:%s changed during file transfer",
+                conn->this_server, remote_path);
+            success = false;
+            break;
+        }
+
+        ret = fwrite(buf, sizeof(char), len, file_ptr);
+        if (ret < 0)
+        {
+            Log(LOG_LEVEL_ERR,
+                "Failed to write during retrieval of file %s:%s (fwrite: %s)",
+                conn->this_server, remote_path, GetErrorStr());
+            success = false;
+            break;
+        }
+
+        received_bytes += len;
+    }
+
+    if (!success)
+    {
+        unlink(local_path);
+    }
+
+    fclose(file_ptr);
+    return success;
+}
+
+bool ProtocolStatGet(AgentConnection *conn, const char *remote_path,
+                     const char *local_path, int perms)
+{
+    assert(conn != NULL);
+    assert(remote_path != NULL);
+
+    struct stat sb;
+    int ret = cf_remote_stat(conn, false, remote_path, &sb, "file");
+    if (ret == -1)
+    {
+        Log(LOG_LEVEL_ERR,
+            "%s: Failed to stat remote file %s:%s",
+            __func__, conn->this_server, remote_path);
+        return false;
+    }
+
+    return ProtocolGet(conn, remote_path, local_path, sb.st_size, perms);
 }

--- a/libcfnet/protocol.h
+++ b/libcfnet/protocol.h
@@ -64,4 +64,55 @@
  */
 Seq *ProtocolOpenDir(AgentConnection *conn, const char *path);
 
+/**
+ * Receives a file from a remote host.
+ *
+ * The server will use "/var/cfengine" as working directory if absolute path
+ * is not specified. The client will send a request that looks like this:
+ *      `GET <buf_size> <remote_path>`
+ *
+ * `buf_size` is the local buffer size: how much of the file to receive in
+ * each transaction. It should be aligned to block size (which is usually
+ * 4096), but currently the protocol only allows _exactly_ 4095 bytes per
+ * transaction.
+ *
+ * The function shall fail if connection is not established, or if the server
+ * gives a bad response (denoted by a message preceded by "BAD").
+ *
+ * @param [in] conn         The connection to use
+ * @param [in] remote_path  Path on remote host
+ * @param [in] local_path   Path of received file
+ * @param [in] file_size    Size of file to get
+ * @param [in] perms        Permissions of local file
+ * @return True if file was successfully transferred, false otherwise
+ *
+ * Example (for printing each directory entry):
+ * @code
+ *     AgentConnection *conn = ServerConnection("127.0.0.1", "666", ...);
+ *     bool got_file = ProtocolGet(conn, "masterfiles/update.cf",
+ *                                 "update.cf", CF_MSGSIZE, 0644);
+ *     if (got_file)
+ *     {
+ *        struct stat sb;
+ *        stat("update.cf", &sb);
+ *        printf("This file is %ld big!\n", sb.st_size);
+ *     }
+ * @endcode
+ *
+ * In the protocol, this will look like this on the server side:
+ *     Received: GET masterfiles/update.cf
+ *     Translated to: GET /var/cfengine/masterfiles/update.cf
+ */
+bool ProtocolGet(AgentConnection *conn, const char *remote_path,
+                 const char *local_path, const uint32_t file_size, int perms);
+
+
+/**
+ * Receives a file from a remote host, see documentation for #ProtocolGet
+ *
+ * This funtion will first stat the remote path before attempting to receive
+ * it.
+ */
+bool ProtocolStatGet(AgentConnection *conn, const char *remote_path,
+                     const char *local_path, int perms);
 #endif


### PR DESCRIPTION
Added functions `Get` and `StatGet`, where the latter just stats the file before calling the former function with the correct file size. `Get` uses `GET <block_size> <remote_path>` to retrieve a file.

Ticket: CFE-3087