### PR TITLE
CFE-2596: Keys in the lock database, cf_lock.lmdb, are now human-readable

### DIFF
--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -196,6 +196,7 @@ static int LmdbEnvOpen(
 {
     assert(env != NULL);  // dereferenced in lmdb (mdb_env_open)
     assert(path != NULL); // dereferenced (strlen) in lmdb (mdb_env_open)
+    assert(mdb_env_get_maxkeysize(env) == 511); // Search for 511 in locks.c
 
     /* There is a race condition in LMDB that will fail to open the database
      * environment if another process is opening it at the exact same time. This

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -210,14 +210,7 @@ static bool WriteLockData(CF_DB *dbp, const char *lock_id, LockData *lock_data)
 #ifdef LMDB
     unsigned char digest2[EVP_MAX_MD_SIZE*2 + 1];
 
-    if (!strcmp(lock_id, "CF_CRITICAL_SECTION"))
-    {
-        strcpy(digest2, lock_id);
-    }
-    else
-    {
-        GenerateMd5Hash(lock_id, digest2);
-    }
+    GenerateMd5Hash(lock_id, digest2);
 
     LOG_LOCK_ENTRY(lock_id, digest2, lock_data);
     ret = WriteDB(dbp, digest2, lock_data, sizeof(LockData));
@@ -371,14 +364,7 @@ static int RemoveLock(const char *name)
 #ifdef LMDB
     unsigned char digest2[EVP_MAX_MD_SIZE*2 + 1];
 
-    if (!strcmp(name, "CF_CRITICAL_SECTION"))
-    {
-        strcpy(digest2, name);
-    }
-    else
-    {
-        GenerateMd5Hash(name, digest2);
-    }
+    GenerateMd5Hash(name, digest2);
 
     LOG_LOCK_ENTRY(name, digest2, NULL);
     DeleteDB(dbp, digest2);


### PR DESCRIPTION
LMDB keys are limited to 511 bytes, by default. To get around
this, the keys were changed to be hashes some time ago.
This change effectively reverts that commit, making the keys
normal strings by default, and overwriting the last part with a
hash, if necessary (if the key would exceed 511 bytes).