### PR TITLE
CFE-3137: cf-remote: Use whoami username first if none specified

### DIFF
--- a/contrib/cf-remote/cf_remote/ssh.py
+++ b/contrib/cf-remote/cf_remote/ssh.py
@@ -4,6 +4,7 @@ from paramiko.ssh_exception import AuthenticationException
 from invoke.exceptions import UnexpectedExit
 
 from cf_remote import log
+from cf_remote.utils import whoami
 
 
 def connect(host, users=None):
@@ -16,6 +17,10 @@ def connect(host, users=None):
             users = [parts[0]]
     if not users:
         users = ["Administrator", "ubuntu", "ec2-user", "centos", "vagrant", "root"]
+        # Similar to ssh, try own username first,
+        # some systems will lock us out if we have too many failed attempts.
+        if whoami() not in users:
+            users = [whoami()] + users
     for user in users:
         try:
             log.debug("Attempting ssh: {}@{}".format(user, host))

--- a/contrib/cf-remote/cf_remote/utils.py
+++ b/contrib/cf-remote/cf_remote/utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import getpass
 from collections import OrderedDict
 from cf_remote import log
 from datetime import datetime
@@ -161,3 +162,7 @@ def strip_user(host):
     if idx != -1:
         return host[(idx + 1):]
     return host
+
+
+def whoami():
+    return getpass.getuser()


### PR DESCRIPTION
Example:

```
$ cf-remote info -H ci.cfengine.com

olehermanse@ci.cfengine.com
OS            : ubuntu (debian)
Architecture  : x86_64
CFEngine      : 3.12.0
Policy server : 172.30.0.100
Binaries      : dpkg, apt

$
```