### PR TITLE
CFE-3135: cf-remote: Added --edition option to enable installing community packages

### DIFF
--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -57,7 +57,8 @@ def install(
         client_package=None,
         version=None,
         demo=False,
-        call_collect=False):
+        call_collect=False,
+        edition=None):
     assert hubs or clients
     assert not (hubs and clients and package)
     # These assertions are checked in main.py
@@ -74,7 +75,7 @@ def install(
         if type(hubs) is str:
             hubs = [hubs]
         for index, hub in enumerate(hubs):
-            log.debug("Installing hub package on '{}'".format(hub))
+            log.debug("Installing {} hub package on '{}'".format(edition, hub))
             install_host(
                 hub,
                 hub=True,
@@ -82,16 +83,18 @@ def install(
                 bootstrap=bootstrap[index % len(bootstrap)] if bootstrap else None,
                 version=version,
                 demo=demo,
-                call_collect=call_collect)
+                call_collect=call_collect,
+                edition=edition)
     for index, host in enumerate(clients or []):
-        log.debug("Installing client package on '{}'".format(host))
+        log.debug("Installing {} client package on '{}'".format(edition, host))
         install_host(
             host,
             hub=False,
             package=client_package,
             bootstrap=bootstrap[index % len(bootstrap)] if bootstrap else None,
             version=version,
-            demo=demo)
+            demo=demo,
+            edition=edition)
     if demo and hubs:
         for hub in hubs:
             print(
@@ -99,8 +102,8 @@ def install(
                 format(strip_user(hub)))
 
 
-def packages(tags=None, version=None):
-    releases = Releases()
+def packages(tags=None, version=None, edition=None):
+    releases = Releases(edition)
     print("Available releases: {}".format(releases))
 
     release = releases.default

--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -22,6 +22,7 @@ def get_args():
     ap.add_argument("--clients", "-c", help="Where to install client package", type=str)
     ap.add_argument("--hub", help="Where to install hub package", type=str)
     ap.add_argument("--bootstrap", "-B", help="cf-agent --bootstrap argument", type=str)
+    ap.add_argument("--edition", "-E", help="Enterprise or community packages", type=str)
     ap.add_argument("--package", help="Local path to package for transfer and install", type=str)
     ap.add_argument("--hub-package", help="Local path to package for --hub", type=str)
     ap.add_argument("--client-package", help="Local path to package for --clients", type=str)
@@ -52,9 +53,10 @@ def run_command_with_args(command, args):
             client_package=args.client_package,
             version=args.version,
             demo=args.demo,
-            call_collect=args.call_collect)
+            call_collect=args.call_collect,
+            edition=args.edition)
     elif command == "packages":
-        commands.packages(tags=args.args, version=args.version)
+        commands.packages(tags=args.args, version=args.version, edition=args.edition)
     elif command == "run":
         commands.run(hosts=args.hosts, command=" ".join(args.args))
     elif command == "sudo":
@@ -71,6 +73,17 @@ def validate_command(command, args):
 
     if args.bootstrap and command != "install":
         user_error("--bootstrap can only be used with install command")
+
+    if args.edition:
+        if command not in ["install", "packages"]:
+            user_error("--edition can only be used with install and packages commands")
+        args.edition = args.edition.lower()
+        if args.edition == "core":
+            args.edition = "community"
+        if args.edition not in ["enterprise", "community"]:
+            user_error("--edition must be either community or enterprise")
+    elif command in ["install", "packages"]:
+        args.edition = "enterprise"
 
     if args.call_collect and not args.demo:
         user_error("--call-collect must be used with --demo")

--- a/contrib/cf-remote/cf_remote/packages.py
+++ b/contrib/cf-remote/cf_remote/packages.py
@@ -143,8 +143,9 @@ class Release:
 
 
 class Releases:
-    def __init__(self):
-        self.url = "https://cfengine.com/release-data/enterprise/releases.json"
+    def __init__(self, edition="enterprise"):
+        assert edition in ["community", "enterprise"]
+        self.url = "https://cfengine.com/release-data/{}/releases.json".format(edition)
         self.data = get_json(self.url)
         self.supported_branches = []
         for branch in self.data["lts_branches"]:

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -158,13 +158,15 @@ def install_host(
         version=None,
         demo=False,
         call_collect=False,
-        connection=None):
+        connection=None,
+        edition=None):
     data = get_info(host, connection=connection)
     print_info(data)
 
     if not package:
         tags = []
-        tags.append("hub" if hub else "agent")
+        if edition == "enterprise":
+            tags.append("hub" if hub else "agent")
         tags.append("64" if data["arch"] in ["x86_64", "amd64"] else data["arch"])
         extension = None
         if "package_tags" in data and "msi" in data["package_tags"]:
@@ -173,7 +175,7 @@ def install_host(
             extension = ".deb"
         elif "rpm" in data["bin"]:
             extension = ".rpm"
-        releases = Releases()
+        releases = Releases(edition)
         release = releases.default
         if version:
             release = releases.pick_version(version)

--- a/contrib/cf-remote/cf_remote/utils.py
+++ b/contrib/cf-remote/cf_remote/utils.py
@@ -108,7 +108,16 @@ def parse_version(string):
         return None
     # 'CFEngine Core 3.12.1 \n CFEngine Enterprise 3.12.1'
     #                ^ split and use this part for version number
-    return string.split()[2]
+    words = string.split()
+    if len(words) < 3:
+        return None
+    version_number = words[2]
+    edition = words[1]
+    if edition == "Core":
+        edition = "Community"
+    if "Enterprise" in string:
+        edition = "Enterprise"
+    return "{} ({})".format(version_number, edition)
 
 
 def parse_systeminfo(data):


### PR DESCRIPTION
Example:

```
$ cf-remote install --hub 34.255.3.86 --bootstrap 172.31.34.185 --edition community

ubuntu@34.255.3.86
OS            : ubuntu (debian)
Architecture  : x86_64
CFEngine      : Not installed
Policy server : None
Binaries      : dpkg, apt

Package already downloaded: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-community_3.12.2-2_amd64-debian7.deb'
Copying: '/Users/olehermanse/.cfengine/cf-remote/packages/cfengine-community_3.12.2-2_amd64-debian7.deb' to '34.255.3.86'
Installing: 'cfengine-community_3.12.2-2_amd64-debian7.deb' on '34.255.3.86'
CFEngine 3.12.2 (Community) was successfully installed on '34.255.3.86'
Bootstrapping: '34.255.3.86' -> '172.31.34.185'
Bootstrap successful: '34.255.3.86' -> '172.31.34.185'
olehermanse@OHMBP ~ $ cf-remote info -H 34.255.3.86

ubuntu@34.255.3.86
OS            : ubuntu (debian)
Architecture  : x86_64
CFEngine      : 3.12.2 (Community)
Policy server : 172.31.34.185
Binaries      : dpkg, apt

$ 
```