### PR TITLE
HashPubKey(): consistency of declaration and definition

### DIFF
--- a/tests/unit/lastseen_migration_test.c
+++ b/tests/unit/lastseen_migration_test.c
@@ -276,7 +276,7 @@ char *HashPrintSafe(ARG_UNUSED char *dst, ARG_UNUSED size_t dst_size,
     fail();
 }
 
-void HashPubKey(ARG_UNUSED RSA *key,
+void HashPubKey(ARG_UNUSED const RSA *key,
                 ARG_UNUSED unsigned char digest[EVP_MAX_MD_SIZE + 1],
                 ARG_UNUSED HashMethod type)
 {


### PR DESCRIPTION
Function "HashPubKey()" has a 'const' inconsistency between its declaration and definition, causing, causing a compilation error (under "make check").