### PR TITLE
libntech: Removed bool.h in favor of stdbool.h

### DIFF
--- a/libpromises/logic_expressions.c
+++ b/libpromises/logic_expressions.c
@@ -25,7 +25,7 @@
 #include <platform.h>
 
 #include <cf3.defs.h>
-#include <bool.h>
+#include <stdbool.h>
 #include <logic_expressions.h>
 #include <misc_lib.h>
 

--- a/libpromises/logic_expressions.h
+++ b/libpromises/logic_expressions.h
@@ -25,8 +25,8 @@
 #ifndef CFENGINE_LOGIC_EXPRESSIONS_H
 #define CFENGINE_LOGIC_EXPRESSIONS_H
 
-# include <bool.h>
-# include <string_expressions.h>
+#include <stdbool.h>
+#include <string_expressions.h>
 
 /*
    Logic expressions grammar:

--- a/libpromises/string_expressions.c
+++ b/libpromises/string_expressions.c
@@ -24,7 +24,7 @@
 
 #include <cf3.defs.h>
 
-#include <bool.h>
+#include <stdbool.h>
 #include <string_expressions.h>
 #include <misc_lib.h>
 


### PR DESCRIPTION
This PR brings libntech submodule up to date (with master HEAD) and fixes some necessary includes, since `bool.h` was removed.