### PR TITLE
ENT-5038/master: Added 3 retries when starting daemons on AIX

### DIFF
--- a/misc/init.d/cfengine3.in
+++ b/misc/init.d/cfengine3.in
@@ -319,7 +319,7 @@ cf_start_daemon()
         "$daemon" "$@"
         cf_touch "$LOCKDIR/$base_daemon"
     elif [ "$AIX" = "1" ]; then
-        "$daemon" "$@" && break
+        "$daemon" "$@"
         if [ "$?" != "0" ]; then
             for retry in 1 2 3; do
                 msg="   retry $retry starting $daemon"

--- a/misc/init.d/cfengine3.in
+++ b/misc/init.d/cfengine3.in
@@ -77,6 +77,7 @@ test -f $CFEXECD || exit 0
 SUSE=0
 REDHAT=0
 DEBIAN=0
+AIX=0
 
 # SuSE
 if [ -d /var/lock/subsys ] && [ -f /usr/bin/zypper ]; then
@@ -98,6 +99,11 @@ if [ -f /etc/debian_version ] && [ -f /usr/bin/apt-get ]; then
     else
         LOCKDIR=/var/lock
     fi
+fi
+
+# AIX
+if [ -f /usr/bin/oslevel ]; then
+    AIX=1
 fi
 
 if [ -z "$LOCKDIR" ]; then
@@ -312,7 +318,17 @@ cf_start_daemon()
     elif [ "$DEBIAN" = "1" ] && [ "$SSD" = "0" ]; then
         "$daemon" "$@"
         cf_touch "$LOCKDIR/$base_daemon"
-
+    elif [ "$AIX" = "1" ]; then
+        "$daemon" "$@" && break
+        if [ "$?" != "0" ]; then
+            for retry in 1 2 3; do
+                msg="   retry $retry starting $daemon"
+                printf "$msg"
+                logger -p user.error -t "CFEngine init script" $msg
+                sleep 5
+                "$daemon" "$@" && break
+            done
+        fi
     # All others
     else
         "$daemon" "$@"


### PR DESCRIPTION
After reboot, sometimes, some daemons do not start successfully. This change adds up to 3 retries when starting daemons on AIX with a 5-second pause between retries.

Here is example output run while netcat is keeping port 5308 busy and preventing cf-serverd from starting:

```
#+begin_example
l0790p002_pub[/] > /etc/rc.d/init.d/cfengine3 start
-n Starting cf-execd...

-n Starting cf-serverd...
   error: Unable to start server
   re-try 1 starting /var/cfengine/bin/cf-serverd   error: Unable to start server
   re-try 2 starting /var/cfengine/bin/cf-serverd   error: Unable to start server
   re-try 3 starting /var/cfengine/bin/cf-serverd   error: Unable to start server

-n Starting cf-monitord...
#+end_example

```