### PR TITLE
[3.12.x] Retry SSL_accept() if WANT_READ or WANT_WRITE is indicated

### DIFF
--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -46,6 +46,7 @@
 
 static SSL_CTX *SSLSERVERCONTEXT = NULL;
 
+#define MAX_ACCEPT_RETRIES 5
 
 /**
  * @param[in]  priv_key private key to use (or %NULL to use the global PRIVKEY)
@@ -470,7 +471,25 @@ bool BasicServerTLSSessionEstablish(ServerConnectionState *conn, SSL_CTX *ssl_ct
     /* Now we are letting OpenSSL take over the open socket. */
     SSL_set_fd(ssl, ConnectionInfoSocket(conn->conn_info));
 
-    int ret = SSL_accept(ssl);
+    int remaining_tries = MAX_ACCEPT_RETRIES;
+    int ret = -1;
+    bool should_retry = true;
+    while ((ret < 0) && should_retry)
+    {
+        ret = SSL_accept(ssl);
+        if (ret < 0)
+        {
+            int code = TLSLogError(ssl, LOG_LEVEL_VERBOSE, "SSL accept failed", ret);
+            should_retry = ((remaining_tries > 0) &&
+                            ((code == SSL_ERROR_WANT_READ) || (code == SSL_ERROR_WANT_WRITE)));
+
+        }
+        if ((ret < 0) && should_retry)
+        {
+            sleep(1);
+            remaining_tries--;
+        }
+    }
     if (ret <= 0)
     {
         TLSLogError(ssl, LOG_LEVEL_ERR,


### PR DESCRIPTION
SSL_accept() may fail with SSL_get_error() returning
SSL_ERROR_WANT_READ or WANT_WRITE in some cases. That doesn't
indicate a fatal error in SSL connection establishing, but rather
a potentially temporary problem which could be fixed by a
retry. And that's exactly what we should do.

See man:SSL_accept(3) for details.

This is a follow-up for ca691fe91ecea6fe7f091ce5680ad7f0a1a020ce
which did the same for SSL_connect, SSL_read and SSL_write.

Ticket: CFE-3066
Changelog: cf-serverd now tries to accept connection multiple times
(cherry picked from commit 03bd0698a9fd330b72a1068ea023345b445d3cd0)