### PR TITLE
ENT-4406: Network protocol v3 - cookie

### DIFF
--- a/cf-serverd/cf-serverd-enterprise-stubs.c
+++ b/cf-serverd/cf-serverd-enterprise-stubs.c
@@ -58,6 +58,11 @@ ENTERPRISE_FUNC_1ARG_DEFINE_STUB(bool, ReceiveCollectCall, ARG_UNUSED ServerConn
     return false;
 }
 
+ENTERPRISE_FUNC_1ARG_DEFINE_STUB(bool, ReturnCookies, ARG_UNUSED ServerConnectionState *, conn)
+{
+    return false;
+}
+
 ENTERPRISE_FUNC_3ARG_DEFINE_STUB(bool, ReturnQueryData, ARG_UNUSED ServerConnectionState *, conn, ARG_UNUSED char *, menu, ARG_UNUSED int, encrypt)
 {
     return false;

--- a/cf-serverd/cf-serverd-enterprise-stubs.h
+++ b/cf-serverd/cf-serverd-enterprise-stubs.h
@@ -40,6 +40,7 @@ ENTERPRISE_FUNC_5ARG_DECLARE(int, SetServerListenState, EvalContext *, ctx, size
 typedef void (*ServerEntryPointFunction)(EvalContext *ctx, char *ipaddr, ConnectionInfo *info);
 ENTERPRISE_FUNC_1ARG_DECLARE(bool, ReceiveCollectCall, ServerConnectionState *, conn);
 
+ENTERPRISE_FUNC_1ARG_DECLARE(bool, ReturnCookies, ServerConnectionState *, conn);
 ENTERPRISE_FUNC_3ARG_DECLARE(bool, ReturnQueryData, ServerConnectionState *, conn, char *, menu, int, encrypt);
 ENTERPRISE_FUNC_2ARG_DECLARE(bool, CFTestD_ReturnQueryData, ServerConnectionState *, conn, char *, menu);
 

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -1063,10 +1063,12 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
             goto protocol_error;
         }
 
-        if (acl_CheckExact(query_acl, name,
-                           conn->ipaddr, conn->revdns,
-                           KeyPrintableHash(ConnectionInfoKey(conn->conn_info)))
-            == false)
+        const char *hostkey = KeyPrintableHash(
+            ConnectionInfoKey(conn->conn_info));
+        const bool access_to_query = acl_CheckExact(
+            query_acl, name, conn->ipaddr, conn->revdns, hostkey);
+
+        if (!access_to_query)
         {
             Log(LOG_LEVEL_INFO, "access denied to query: %s", query);
             RefuseAccess(conn, recvbuffer);
@@ -1086,10 +1088,13 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
         {
             goto protocol_error;
         }
-        if (acl_CheckExact(query_acl, "delta",
-                           conn->ipaddr, conn->revdns,
-                           KeyPrintableHash(ConnectionInfoKey(conn->conn_info)))
-            == false)
+
+        const char *hostkey = KeyPrintableHash(
+            ConnectionInfoKey(conn->conn_info));
+        const bool access_to_query_delta = acl_CheckExact(
+            query_acl, "delta", conn->ipaddr, conn->revdns, hostkey);
+
+        if (!access_to_query_delta)
         {
             Log(LOG_LEVEL_INFO, "access denied to cookie query: %s", recvbuffer);
             RefuseAccess(conn, recvbuffer);

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -25,6 +25,7 @@
 
 #include <server_tls.h>
 #include <server_common.h>
+#include <protocol.h> // ParseProtocolVersionNetwork()
 
 #include <openssl/err.h>                                   /* ERR_get_error */
 
@@ -311,9 +312,8 @@ bool ServerIdentificationDialog(ConnectionInfo *conn_info,
         return false;
     }
 
-    int version_received = -1;
-    ret = sscanf(input, "CFE_v%d", &version_received);
-    if (ret != 1)
+    ProtocolVersion version_received = ParseProtocolVersionNetwork(input);
+    if (version_received <= CF_PROTOCOL_UNDEFINED)
     {
         Log(LOG_LEVEL_NOTICE,
             "Protocol version negotiation failed! Received: %s",

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -216,6 +216,8 @@ void ServerTLSDeInitialize(RSA **priv_key, RSA **pub_key, SSL_CTX **ssl_ctx)
  */
 bool ServerTLSPeek(ConnectionInfo *conn_info)
 {
+    assert(conn_info != NULL);
+
     assert(SSLSERVERCONTEXT != NULL);
     assert(PRIVKEY != NULL);
     assert(PUBKEY  != NULL);

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -639,6 +639,8 @@ ProtocolCommandNew GetCommandNew(char *str)
  */
 bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
 {
+    assert(conn != NULL);
+
     /* The CF_BUFEXT extra space is there to ensure we're not *reading* out of
      * bounds in commands that carry extra binary arguments, like MD5. */
     char recvbuffer[CF_BUFSIZE + CF_BUFEXT] = { 0 };

--- a/cf-serverd/server_tls.h
+++ b/cf-serverd/server_tls.h
@@ -45,6 +45,7 @@ typedef enum
     PROTOCOL_COMMAND_CONTEXT,
     PROTOCOL_COMMAND_QUERY,
     PROTOCOL_COMMAND_CALL_ME_BACK,
+    PROTOCOL_COMMAND_COOKIE,
     PROTOCOL_COMMAND_BAD
 } ProtocolCommandNew;
 
@@ -60,6 +61,7 @@ static const char *const PROTOCOL_NEW[PROTOCOL_COMMAND_BAD + 1] =
     "CONTEXT",
     "QUERY",
     "SCALLBACK",
+    "COOKIE",
     NULL
 };
 

--- a/cf-testd/cf-testd.c
+++ b/cf-testd/cf-testd.c
@@ -371,6 +371,15 @@ static bool CFTestD_BusyLoop(
     // See BusyWithNewProtocol() in server_tls.c for how to add other commands
     switch (GetCommandNew(recvbuffer))
     {
+    case PROTOCOL_COMMAND_COOKIE:
+    {
+        const char response[] = "COOKIES 0 0";
+        const size_t size = sizeof(response) - 1;
+        SendTransaction(conn->conn_info, response, size, CF_DONE);
+
+        return true;
+        break;
+    }
     case PROTOCOL_COMMAND_QUERY:
     {
         char query[256], name[128];

--- a/libcfnet/Makefile.am
+++ b/libcfnet/Makefile.am
@@ -41,6 +41,7 @@ libcfnet_la_SOURCES = \
 	net.c net.h \
 	policy_server.c policy_server.h \
 	protocol.c protocol.h \
+	protocol_version.c protocol_version.h \
 	server_code.c server_code.h \
 	stat_cache.c stat_cache.h \
 	tls_client.c tls_client.h \

--- a/libcfnet/README.md
+++ b/libcfnet/README.md
@@ -1,0 +1,61 @@
+# libcfnet - CFEngine Network protocol
+
+Generally, details about the protocol are explained in comments / code.
+However, some explanations don't naturally fit in one part / file of the codebase.
+So, they are provided here.
+
+
+## Network protocol versioning
+
+
+### Protocol versions
+
+Names of protocol versions:
+
+1. `"classic"` - Legacy, pre-TLS, protocol. Not enabled or allowed by default.
+2. `"tls"` - TLS Protocol using OpenSSL. Encrypted and 2-way authentication.
+3. `"cookie"` - TLS Protocol with cookie command for duplicate host detection.
+
+Wanted protocol version can be specified from policy:
+
+```
+body copy_from protocol_latest
+{
+  protocol_version => "latest";
+}
+```
+
+Additionally, numbers can also be used:
+
+```
+body copy_from protocol_three
+{
+  protocol_version => "3";
+}
+```
+
+
+### Version negotiation
+
+Client side (`cf-agent`, `cf-hub`, `cf-runagent`, `cf-net`) uses `ServerConnection()` function to connect to a server.
+Server side (`cf-serverd`, `cf-testd`) uses `ServerTLSPeek()` to check if the connection is TLS or not, distinguishing version 1 and 2.
+Protocol version 1 is not allowed by default, but can be allowed using `allowlegacyconnects`.
+Version negotiation then happens inside `ServerIdentificationDialog()` (server side) and `ServerConnection()` (client side).
+Client requests a wanted version, by sending a version string, for example:
+
+```
+CFE_v3
+```
+
+The version requested is usually the latest supported, unless specified in policy (`body copy_from`).
+Then, the server responds with the highest supported version (but not higher than the requested version).
+For a 3.12 server, this would be:
+
+```
+CFE_v2
+```
+
+Both server and client will then set `conn_info->protocol` to `2`, and use protocol version 2.
+There is currently no way to require a specific version number (only allow / disallow version 1).
+This is because version 2 and 3 are practically identical.
+Downgrade from version 3 to 2 happens seamlessly, but crucially, it doesn't downgrade to version 1 inside the TLS code.

--- a/libcfnet/cfnet.h
+++ b/libcfnet/cfnet.h
@@ -29,7 +29,7 @@
 
 #include <platform.h>
 #include <definitions.h>                        /* CF_BUFSIZE, CF_SMALLBUF */
-
+#include <protocol_version.h> // ProtocolVersion
 
 /* Only set with DetermineCfenginePort() and from cf-serverd */
 extern char CFENGINE_PORT_STR[16];                     /* GLOBAL_P GLOBAL_E */
@@ -50,37 +50,6 @@ extern int CFENGINE_PORT;                              /* GLOBAL_P GLOBAL_E */
 #define CF_PROTO_OFFSET 16
 #define CF_INBAND_OFFSET 8
 #define CF_MSGSIZE (CF_BUFSIZE - CF_INBAND_OFFSET)
-
-
-/**
-  Available protocol versions. When connection is initialised ProtocolVersion
-  is 0, i.e. undefined. It is after the call to ServerConnection() that
-  protocol version is decided, according to body copy_from and body common
-  control. All protocol numbers are numbered incrementally starting from 1.
- */
-typedef enum
-{
-    CF_PROTOCOL_UNDEFINED = 0,
-    CF_PROTOCOL_CLASSIC = 1,
-    /* --- Greater versions use TLS as secure communications layer --- */
-    CF_PROTOCOL_TLS = 2
-} ProtocolVersion;
-
-/* We use CF_PROTOCOL_LATEST as the default for new connections. */
-#define CF_PROTOCOL_LATEST CF_PROTOCOL_TLS
-
-static inline const char *ProtocolVersionString(const ProtocolVersion p)
-{
-    switch (p)
-    {
-    case CF_PROTOCOL_TLS:
-        return "tls";
-    case CF_PROTOCOL_CLASSIC:
-        return "classic";
-    default:
-        return "undefined";
-    }
-}
 
 typedef struct
 {

--- a/libcfnet/cfnet.h
+++ b/libcfnet/cfnet.h
@@ -72,7 +72,7 @@ typedef enum
 static const char * const PROTOCOL_VERSION_STRING[CF_PROTOCOL_LATEST + 1] = {
     "undefined",
     "classic",
-    "latest"
+    "tls",
 };
 
 typedef struct

--- a/libcfnet/cfnet.h
+++ b/libcfnet/cfnet.h
@@ -69,11 +69,18 @@ typedef enum
 /* We use CF_PROTOCOL_LATEST as the default for new connections. */
 #define CF_PROTOCOL_LATEST CF_PROTOCOL_TLS
 
-static const char * const PROTOCOL_VERSION_STRING[CF_PROTOCOL_LATEST + 1] = {
-    "undefined",
-    "classic",
-    "tls",
-};
+static inline const char *ProtocolVersionString(const ProtocolVersion p)
+{
+    switch (p)
+    {
+    case CF_PROTOCOL_TLS:
+        return "tls";
+    case CF_PROTOCOL_CLASSIC:
+        return "classic";
+    default:
+        return "undefined";
+    }
+}
 
 typedef struct
 {

--- a/libcfnet/client_protocol.c
+++ b/libcfnet/client_protocol.c
@@ -62,6 +62,8 @@ void SetSkipIdentify(bool enabled)
 
 bool IdentifyAgent(ConnectionInfo *conn_info)
 {
+    assert(conn_info != NULL);
+
     char uname[CF_BUFSIZE], sendbuff[CF_BUFSIZE];
     char dnsname[CF_MAXVARSIZE], localip[CF_MAX_IP_LEN];
     int ret;

--- a/libcfnet/connection_info.c
+++ b/libcfnet/connection_info.c
@@ -54,12 +54,16 @@ void ConnectionInfoDestroy(ConnectionInfo **info)
 
 ProtocolVersion ConnectionInfoProtocolVersion(const ConnectionInfo *info)
 {
+    assert(info != NULL);
+
     return info ? info->protocol : CF_PROTOCOL_UNDEFINED;
 }
 
 void ConnectionInfoSetProtocolVersion(ConnectionInfo *info, ProtocolVersion version)
 {
-    if (!info)
+    assert(info != NULL);
+
+    if (info ==  NULL)
     {
         return;
     }
@@ -77,12 +81,16 @@ void ConnectionInfoSetProtocolVersion(ConnectionInfo *info, ProtocolVersion vers
 
 int ConnectionInfoSocket(const ConnectionInfo *info)
 {
+    assert(info != NULL);
+
     return info ? info->sd : -1;
 }
 
 void ConnectionInfoSetSocket(ConnectionInfo *info, int s)
 {
-    if (!info)
+    assert(info != NULL);
+
+    if (info == NULL)
     {
         return;
     }
@@ -91,12 +99,16 @@ void ConnectionInfoSetSocket(ConnectionInfo *info, int s)
 
 SSL *ConnectionInfoSSL(const ConnectionInfo *info)
 {
+    assert(info != NULL);
+
     return info ? info->ssl : NULL;
 }
 
 void ConnectionInfoSetSSL(ConnectionInfo *info, SSL *ssl)
 {
-    if (!info)
+    assert(info != NULL);
+
+    if (info == NULL)
     {
         return;
     }
@@ -105,13 +117,17 @@ void ConnectionInfoSetSSL(ConnectionInfo *info, SSL *ssl)
 
 const Key *ConnectionInfoKey(const ConnectionInfo *info)
 {
+    assert(info != NULL);
+
     const Key *key = info ? info->remote_key : NULL;
     return key;
 }
 
 void ConnectionInfoSetKey(ConnectionInfo *info, Key *key)
 {
-    if (!info)
+    assert(info != NULL);
+
+    if (info == NULL)
     {
         return;
     }
@@ -129,7 +145,9 @@ void ConnectionInfoSetKey(ConnectionInfo *info, Key *key)
 
 const unsigned char *ConnectionInfoBinaryKeyHash(ConnectionInfo *info, unsigned int *length)
 {
-    if (!info)
+    assert(info != NULL);
+
+    if (info == NULL)
     {
         return NULL;
     }
@@ -145,5 +163,7 @@ const unsigned char *ConnectionInfoBinaryKeyHash(ConnectionInfo *info, unsigned 
 
 const char *ConnectionInfoPrintableKeyHash(ConnectionInfo *info)
 {
+    assert(info != NULL);
+
     return info ? KeyPrintableHash(info->remote_key) : NULL;
 }

--- a/libcfnet/net.c
+++ b/libcfnet/net.c
@@ -31,6 +31,7 @@
 #include <logging.h>
 #include <misc_lib.h>
 #include <cf3.defs.h>
+#include <protocol.h>
 
 
 /* TODO remove libpromises dependency. */
@@ -88,7 +89,7 @@ int SendTransaction(ConnectionInfo *conn_info,
     LogRaw(LOG_LEVEL_DEBUG, "SendTransaction data: ",
            work + CF_INBAND_OFFSET, len);
 
-    switch(conn_info->protocol)
+    switch (ProtocolClassicOrTLS(conn_info->protocol))
     {
 
     case CF_PROTOCOL_CLASSIC:
@@ -151,7 +152,7 @@ int ReceiveTransaction(ConnectionInfo *conn_info, char *buffer, int *more)
     int ret;
 
     /* Get control channel. */
-    switch(conn_info->protocol)
+    switch (ProtocolClassicOrTLS(conn_info->protocol))
     {
     case CF_PROTOCOL_CLASSIC:
         ret = RecvSocketStream(conn_info->sd, proto, CF_INBAND_OFFSET);
@@ -244,7 +245,7 @@ int ReceiveTransaction(ConnectionInfo *conn_info, char *buffer, int *more)
     }
 
     /* Get data. */
-    switch(conn_info->protocol)
+    switch (ProtocolClassicOrTLS(conn_info->protocol))
     {
     case CF_PROTOCOL_CLASSIC:
         ret = RecvSocketStream(conn_info->sd, buffer, len);

--- a/libcfnet/protocol.c
+++ b/libcfnet/protocol.c
@@ -31,6 +31,46 @@
 #include <string_lib.h>
 #include <tls_generic.h>
 
+ProtocolVersion ParseProtocolVersionNetwork(const char *const s)
+{
+    int version;
+    const int ret = sscanf(s, "CFE_v%d", &version);
+    if (ret != 1 || version <= CF_PROTOCOL_UNDEFINED)
+    {
+        return CF_PROTOCOL_UNDEFINED;
+    }
+    // Note that `version` may be above CF_PROTOCOL_LATEST, if the other side
+    // supports a newer protocol
+    return version;
+}
+
+ProtocolVersion ParseProtocolVersionPolicy(const char *const s)
+{
+    if (s == NULL ||
+        strcmp(s, "0") == 0 ||
+        strcmp(s, "undefined") == 0)
+    {
+        return CF_PROTOCOL_UNDEFINED;
+    }
+    if (strcmp(s, "1") == 0 ||
+        strcmp(s, "classic") == 0)
+    {
+        return CF_PROTOCOL_CLASSIC;
+    }
+    else if (strcmp(s, "2") == 0)
+    {
+        return CF_PROTOCOL_TLS;
+    }
+    else if (strcmp(s, "latest") == 0)
+    {
+        return CF_PROTOCOL_LATEST;
+    }
+    else
+    {
+        return CF_PROTOCOL_UNDEFINED;
+    }
+}
+
 Seq *ProtocolOpenDir(AgentConnection *conn, const char *path)
 {
     assert(conn != NULL);

--- a/libcfnet/protocol.c
+++ b/libcfnet/protocol.c
@@ -31,43 +31,6 @@
 #include <string_lib.h>
 #include <tls_generic.h>
 
-ProtocolVersion ParseProtocolVersionNetwork(const char *const s)
-{
-    int version;
-    const int ret = sscanf(s, "CFE_v%d", &version);
-    if (ret != 1 || version <= CF_PROTOCOL_UNDEFINED)
-    {
-        return CF_PROTOCOL_UNDEFINED;
-    }
-    // Note that `version` may be above CF_PROTOCOL_LATEST, if the other side
-    // supports a newer protocol
-    return version;
-}
-
-ProtocolVersion ParseProtocolVersionPolicy(const char *const s)
-{
-    if ((s == NULL) || (strcmp(s, "0") == 0) || (strcmp(s, "undefined") == 0))
-    {
-        return CF_PROTOCOL_UNDEFINED;
-    }
-    if ((strcmp(s, "1") == 0) || (strcmp(s, "classic") == 0))
-    {
-        return CF_PROTOCOL_CLASSIC;
-    }
-    else if ((strcmp(s, "2") == 0) || (strcmp(s, "tls") == 0))
-    {
-        return CF_PROTOCOL_TLS;
-    }
-    else if (strcmp(s, "latest") == 0)
-    {
-        return CF_PROTOCOL_LATEST;
-    }
-    else
-    {
-        return CF_PROTOCOL_UNDEFINED;
-    }
-}
-
 Seq *ProtocolOpenDir(AgentConnection *conn, const char *path)
 {
     assert(conn != NULL);

--- a/libcfnet/protocol.c
+++ b/libcfnet/protocol.c
@@ -46,18 +46,15 @@ ProtocolVersion ParseProtocolVersionNetwork(const char *const s)
 
 ProtocolVersion ParseProtocolVersionPolicy(const char *const s)
 {
-    if (s == NULL ||
-        strcmp(s, "0") == 0 ||
-        strcmp(s, "undefined") == 0)
+    if ((s == NULL) || (strcmp(s, "0") == 0) || (strcmp(s, "undefined") == 0))
     {
         return CF_PROTOCOL_UNDEFINED;
     }
-    if (strcmp(s, "1") == 0 ||
-        strcmp(s, "classic") == 0)
+    if ((strcmp(s, "1") == 0) || (strcmp(s, "classic") == 0))
     {
         return CF_PROTOCOL_CLASSIC;
     }
-    else if (strcmp(s, "2") == 0)
+    else if ((strcmp(s, "2") == 0) || (strcmp(s, "tls") == 0))
     {
         return CF_PROTOCOL_TLS;
     }

--- a/libcfnet/protocol.h
+++ b/libcfnet/protocol.h
@@ -27,62 +27,7 @@
 
 #include <cfnet.h>
 #include <sequence.h>
-
-static inline bool ProtocolIsKnown(const ProtocolVersion p)
-{
-    return ((p > CF_PROTOCOL_UNDEFINED) && (p <= CF_PROTOCOL_LATEST));
-}
-
-static inline bool ProtocolIsTLS(const ProtocolVersion p)
-{
-    return ((p >= CF_PROTOCOL_TLS) && (p <= CF_PROTOCOL_LATEST));
-}
-
-static inline bool ProtocolIsTooNew(const ProtocolVersion p)
-{
-    return (p > CF_PROTOCOL_LATEST);
-}
-
-static inline bool ProtocolIsUndefined(const ProtocolVersion p)
-{
-    return (p <= CF_PROTOCOL_UNDEFINED);
-}
-
-static inline bool ProtocolIsClassic(const ProtocolVersion p)
-{
-    return (p == CF_PROTOCOL_CLASSIC);
-}
-
-/**
- * Returns CF_PROTOCOL_TLS or CF_PROTOCOL_CLASSIC (or CF_PROTOCOL_UNDEFINED)
- * Maps all versions using TLS to CF_PROTOCOL_TLS for convenience
- * in switch statements.
- */
-static inline ProtocolVersion ProtocolClassicOrTLS(const ProtocolVersion p)
-{
-    if (ProtocolIsTLS(p))
-    {
-        return CF_PROTOCOL_TLS;
-    }
-    if (ProtocolIsClassic(p))
-    {
-        return CF_PROTOCOL_CLASSIC;
-    }
-    return CF_PROTOCOL_UNDEFINED;
-}
-
-/**
- * Parses the version string sent over network to enum, e.g. "CFE_v1" -> 1
- */
-ProtocolVersion ParseProtocolVersionNetwork(const char *s);
-
-/**
- * Parses the version string set in policy to enum, e.g. "classic" -> 1
- */
-ProtocolVersion ParseProtocolVersionPolicy(const char *s);
-
-// Old name for compatibility (enterprise), TODO remove:
-#define ProtocolVersionParse ParseProtocolVersionPolicy
+#include <protocol_version.h> // ProtocolVersion
 
 /**
  * Receives a directory listing from a remote host.

--- a/libcfnet/protocol.h
+++ b/libcfnet/protocol.h
@@ -29,6 +29,19 @@
 #include <sequence.h>
 
 /**
+ * Parses the version string sent over network to enum, e.g. "CFE_v1" -> 1
+ */
+ProtocolVersion ParseProtocolVersionNetwork(const char *s);
+
+/**
+ * Parses the version string set in policy to enum, e.g. "classic" -> 1
+ */
+ProtocolVersion ParseProtocolVersionPolicy(const char *s);
+
+// Old name for compatibility (enterprise), TODO remove:
+#define ProtocolVersionParse ParseProtocolVersionPolicy
+
+/**
  * Receives a directory listing from a remote host.
  *
  * The server will use "/var/cfengine" as working directory if absolute path

--- a/libcfnet/protocol.h
+++ b/libcfnet/protocol.h
@@ -28,6 +28,49 @@
 #include <cfnet.h>
 #include <sequence.h>
 
+static inline bool ProtocolIsKnown(const ProtocolVersion p)
+{
+    return ((p > CF_PROTOCOL_UNDEFINED) && (p <= CF_PROTOCOL_LATEST));
+}
+
+static inline bool ProtocolIsTLS(const ProtocolVersion p)
+{
+    return ((p >= CF_PROTOCOL_TLS) && (p <= CF_PROTOCOL_LATEST));
+}
+
+static inline bool ProtocolIsTooNew(const ProtocolVersion p)
+{
+    return (p > CF_PROTOCOL_LATEST);
+}
+
+static inline bool ProtocolIsUndefined(const ProtocolVersion p)
+{
+    return (p <= CF_PROTOCOL_UNDEFINED);
+}
+
+static inline bool ProtocolIsClassic(const ProtocolVersion p)
+{
+    return (p == CF_PROTOCOL_CLASSIC);
+}
+
+/**
+ * Returns CF_PROTOCOL_TLS or CF_PROTOCOL_CLASSIC (or CF_PROTOCOL_UNDEFINED)
+ * Maps all versions using TLS to CF_PROTOCOL_TLS for convenience
+ * in switch statements.
+ */
+static inline ProtocolVersion ProtocolClassicOrTLS(const ProtocolVersion p)
+{
+    if (ProtocolIsTLS(p))
+    {
+        return CF_PROTOCOL_TLS;
+    }
+    if (ProtocolIsClassic(p))
+    {
+        return CF_PROTOCOL_CLASSIC;
+    }
+    return CF_PROTOCOL_UNDEFINED;
+}
+
 /**
  * Parses the version string sent over network to enum, e.g. "CFE_v1" -> 1
  */

--- a/libcfnet/protocol_version.c
+++ b/libcfnet/protocol_version.c
@@ -1,5 +1,6 @@
 #include <platform.h>
 #include <protocol_version.h>
+#include <string_lib.h>
 
 ProtocolVersion ParseProtocolVersionNetwork(const char *const s)
 {
@@ -16,19 +17,19 @@ ProtocolVersion ParseProtocolVersionNetwork(const char *const s)
 
 ProtocolVersion ParseProtocolVersionPolicy(const char *const s)
 {
-    if ((s == NULL) || (strcmp(s, "0") == 0) || (strcmp(s, "undefined") == 0))
+    if ((s == NULL) || StringSafeEqual(s, "0") || StringSafeEqual(s, "undefined"))
     {
         return CF_PROTOCOL_UNDEFINED;
     }
-    if ((strcmp(s, "1") == 0) || (strcmp(s, "classic") == 0))
+    if (StringSafeEqual(s, "1") || StringSafeEqual(s, "classic"))
     {
         return CF_PROTOCOL_CLASSIC;
     }
-    else if ((strcmp(s, "2") == 0) || (strcmp(s, "tls") == 0))
+    else if (StringSafeEqual(s, "2") || StringSafeEqual(s, "tls"))
     {
         return CF_PROTOCOL_TLS;
     }
-    else if (strcmp(s, "latest") == 0)
+    else if (StringSafeEqual(s, "latest"))
     {
         return CF_PROTOCOL_LATEST;
     }

--- a/libcfnet/protocol_version.c
+++ b/libcfnet/protocol_version.c
@@ -1,0 +1,39 @@
+#include <platform.h>
+#include <protocol_version.h>
+
+ProtocolVersion ParseProtocolVersionNetwork(const char *const s)
+{
+    int version;
+    const int ret = sscanf(s, "CFE_v%d", &version);
+    if (ret != 1 || version <= CF_PROTOCOL_UNDEFINED)
+    {
+        return CF_PROTOCOL_UNDEFINED;
+    }
+    // Note that `version` may be above CF_PROTOCOL_LATEST, if the other side
+    // supports a newer protocol
+    return version;
+}
+
+ProtocolVersion ParseProtocolVersionPolicy(const char *const s)
+{
+    if ((s == NULL) || (strcmp(s, "0") == 0) || (strcmp(s, "undefined") == 0))
+    {
+        return CF_PROTOCOL_UNDEFINED;
+    }
+    if ((strcmp(s, "1") == 0) || (strcmp(s, "classic") == 0))
+    {
+        return CF_PROTOCOL_CLASSIC;
+    }
+    else if ((strcmp(s, "2") == 0) || (strcmp(s, "tls") == 0))
+    {
+        return CF_PROTOCOL_TLS;
+    }
+    else if (strcmp(s, "latest") == 0)
+    {
+        return CF_PROTOCOL_LATEST;
+    }
+    else
+    {
+        return CF_PROTOCOL_UNDEFINED;
+    }
+}

--- a/libcfnet/protocol_version.h
+++ b/libcfnet/protocol_version.h
@@ -37,16 +37,19 @@ typedef enum
     CF_PROTOCOL_UNDEFINED = 0,
     CF_PROTOCOL_CLASSIC = 1,
     /* --- Greater versions use TLS as secure communications layer --- */
-    CF_PROTOCOL_TLS = 2
+    CF_PROTOCOL_TLS = 2,
+    CF_PROTOCOL_COOKIE = 3,
 } ProtocolVersion;
 
 /* We use CF_PROTOCOL_LATEST as the default for new connections. */
-#define CF_PROTOCOL_LATEST CF_PROTOCOL_TLS
+#define CF_PROTOCOL_LATEST CF_PROTOCOL_COOKIE
 
 static inline const char *ProtocolVersionString(const ProtocolVersion p)
 {
     switch (p)
     {
+    case CF_PROTOCOL_COOKIE:
+        return "cookie";
     case CF_PROTOCOL_TLS:
         return "tls";
     case CF_PROTOCOL_CLASSIC:

--- a/libcfnet/protocol_version.h
+++ b/libcfnet/protocol_version.h
@@ -1,0 +1,115 @@
+/*
+   Copyright 2019 Northern.tech AS
+
+   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; version 3.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+
+#ifndef CFENGINE_PROTOCOL_VERSION_H
+#define CFENGINE_PROTOCOL_VERSION_H
+
+/**
+  Available protocol versions. When connection is initialised ProtocolVersion
+  is 0, i.e. undefined. It is after the call to ServerConnection() that
+  protocol version is decided, according to body copy_from and body common
+  control. All protocol numbers are numbered incrementally starting from 1.
+ */
+typedef enum
+{
+    CF_PROTOCOL_UNDEFINED = 0,
+    CF_PROTOCOL_CLASSIC = 1,
+    /* --- Greater versions use TLS as secure communications layer --- */
+    CF_PROTOCOL_TLS = 2
+} ProtocolVersion;
+
+/* We use CF_PROTOCOL_LATEST as the default for new connections. */
+#define CF_PROTOCOL_LATEST CF_PROTOCOL_TLS
+
+static inline const char *ProtocolVersionString(const ProtocolVersion p)
+{
+    switch (p)
+    {
+    case CF_PROTOCOL_TLS:
+        return "tls";
+    case CF_PROTOCOL_CLASSIC:
+        return "classic";
+    default:
+        return "undefined";
+    }
+}
+
+static inline bool ProtocolIsKnown(const ProtocolVersion p)
+{
+    return ((p > CF_PROTOCOL_UNDEFINED) && (p <= CF_PROTOCOL_LATEST));
+}
+
+static inline bool ProtocolIsTLS(const ProtocolVersion p)
+{
+    return ((p >= CF_PROTOCOL_TLS) && (p <= CF_PROTOCOL_LATEST));
+}
+
+static inline bool ProtocolIsTooNew(const ProtocolVersion p)
+{
+    return (p > CF_PROTOCOL_LATEST);
+}
+
+static inline bool ProtocolIsUndefined(const ProtocolVersion p)
+{
+    return (p <= CF_PROTOCOL_UNDEFINED);
+}
+
+static inline bool ProtocolIsClassic(const ProtocolVersion p)
+{
+    return (p == CF_PROTOCOL_CLASSIC);
+}
+
+/**
+ * Returns CF_PROTOCOL_TLS or CF_PROTOCOL_CLASSIC (or CF_PROTOCOL_UNDEFINED)
+ * Maps all versions using TLS to CF_PROTOCOL_TLS for convenience
+ * in switch statements.
+ */
+static inline ProtocolVersion ProtocolClassicOrTLS(const ProtocolVersion p)
+{
+    if (ProtocolIsTLS(p))
+    {
+        return CF_PROTOCOL_TLS;
+    }
+    if (ProtocolIsClassic(p))
+    {
+        return CF_PROTOCOL_CLASSIC;
+    }
+    return CF_PROTOCOL_UNDEFINED;
+}
+
+/**
+ * Parses the version string sent over network to enum, e.g. "CFE_v1" -> 1
+ */
+ProtocolVersion ParseProtocolVersionNetwork(const char *s);
+
+/**
+ * Parses the version string set in policy to enum, e.g. "classic" -> 1
+ */
+ProtocolVersion ParseProtocolVersionPolicy(const char *s);
+
+// Old name for compatibility (enterprise), TODO remove:
+#define ProtocolVersionParse ParseProtocolVersionPolicy
+
+#endif // CFENGINE_PROTOCOL_VERSION_H

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -928,8 +928,7 @@ FileCopy GetCopyConstraints(const EvalContext *ctx, const Promise *pp)
     if (protocol_version != NULL)
     {
         ProtocolVersion parsed = ParseProtocolVersionPolicy(protocol_version);
-        if ((parsed > CF_PROTOCOL_UNDEFINED)
-            && (parsed <= CF_PROTOCOL_LATEST))
+        if (ProtocolIsKnown(parsed))
         {
             f.protocol_version = parsed;
         }

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -30,6 +30,7 @@
 #include <logging.h>
 #include <chflags.h>
 #include <audit.h>
+#include <protocol.h> // ParseProtocolVersionPolicy()
 
 #define CF_DEFINECLASSES "classes"
 #define CF_TRANSACTION   "action"
@@ -926,15 +927,11 @@ FileCopy GetCopyConstraints(const EvalContext *ctx, const Promise *pp)
     f.protocol_version = CF_PROTOCOL_UNDEFINED;
     if (protocol_version != NULL)
     {
-        if (strcmp(protocol_version, "1") == 0 ||
-            strcmp(protocol_version, "classic") == 0)
+        ProtocolVersion parsed = ParseProtocolVersionPolicy(protocol_version);
+        if ((parsed > CF_PROTOCOL_UNDEFINED)
+            && (parsed <= CF_PROTOCOL_LATEST))
         {
-            f.protocol_version = CF_PROTOCOL_CLASSIC;
-        }
-        else if (strcmp(protocol_version, "2") == 0 ||
-                 strcmp(protocol_version, "latest") == 0)
-        {
-            f.protocol_version = CF_PROTOCOL_TLS;
+            f.protocol_version = parsed;
         }
     }
 

--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -93,6 +93,7 @@ static pthread_once_t db_shutdown_once = PTHREAD_ONCE_INIT; /* GLOBAL_T */
 
 /******************************************************************************/
 
+// Only append to the end, keep in sync with dbid enum in dbm_api.h
 static const char *const DB_PATHS_STATEDIR[] = {
     [dbid_classes] = "cf_classes",
     [dbid_variables] = "cf_variables",
@@ -116,7 +117,8 @@ static const char *const DB_PATHS_STATEDIR[] = {
     [dbid_agent_execution] = "nova_agent_execution",
     [dbid_bundles] = "bundles",
     [dbid_packages_installed] = "packages_installed",
-    [dbid_packages_updates] = "packages_updates"
+    [dbid_packages_updates] = "packages_updates",
+    [dbid_cookies] = "nova_cookies",
 };
 
 /*

--- a/libpromises/dbm_api.h
+++ b/libpromises/dbm_api.h
@@ -30,6 +30,7 @@
 
 #include <map.h>
 
+// Only append to the end, keep in sync with DB_PATHS_STATEDIR array
 typedef enum
 {
     dbid_classes,   // Deprecated
@@ -55,6 +56,7 @@ typedef enum
     dbid_bundles,   // Deprecated
     dbid_packages_installed, //new package promise installed packages list
     dbid_packages_updates,   //new package promise list of available updates
+    dbid_cookies, // Enterprise reporting cookies for duplicate host detection
 
     dbid_max
 } dbid;

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -734,33 +734,6 @@ void BundleResolve(EvalContext *ctx, const Bundle *bundle)
     BundleResolvePromiseType(ctx, bundle, "vars", VerifyVarPromise);
 }
 
-ProtocolVersion ProtocolVersionParse(const char *s)
-{
-    if (s == NULL ||
-        strcmp(s, "0") == 0 ||
-        strcmp(s, "undefined") == 0)
-    {
-        return CF_PROTOCOL_UNDEFINED;
-    }
-    if (strcmp(s, "1") == 0 ||
-        strcmp(s, "classic") == 0)
-    {
-        return CF_PROTOCOL_CLASSIC;
-    }
-    else if (strcmp(s, "2") == 0)
-    {
-        return CF_PROTOCOL_TLS;
-    }
-    else if (strcmp(s, "latest") == 0)
-    {
-        return CF_PROTOCOL_LATEST;
-    }
-    else
-    {
-        return CF_PROTOCOL_UNDEFINED;
-    }
-}
-
 /**
  * Evaluate the relevant control body, and set the
  * relevant fields in #ctx and #config.

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -884,7 +884,7 @@ static void ResolveControlBody(EvalContext *ctx, GenericAgentConfig *config,
             config->protocol_version = ProtocolVersionParse(
                 RvalScalarValue(evaluated_rval));
             Log(LOG_LEVEL_VERBOSE, "SET common protocol_version: %s",
-                PROTOCOL_VERSION_STRING[config->protocol_version]);
+                ProtocolVersionString(config->protocol_version));
         }
 
         /* Those are package_inventory and package_module common control body options */

--- a/libpromises/expand.h
+++ b/libpromises/expand.h
@@ -54,7 +54,6 @@ bool IsNakedVar(const char *str, char vtype);
 void GetNaked(char *dst, const char *s);
 bool IsVarList(const char *var);
 
-ProtocolVersion ProtocolVersionParse(const char *s);
-
+#include <protocol.h> // ProtocolVersionParse() TODO: Remove
 
 #endif


### PR DESCRIPTION
This PR includes several improvements to the handling of network protocol version.
It also adds a v3, named "cookie", which will be used for enterprise features only. (Reporting cookies for duplicate host identification).

Merge together: 
https://github.com/cfengine/core/pull/3907
https://github.com/cfengine/enterprise/pull/557
https://github.com/cfengine/nova/pull/1537
https://github.com/cfengine/mission-portal/pull/930
https://github.com/cfengine/documentation/pull/2229