### PR TITLE
address a 'dereferenced without an explicit null-check' issue

### DIFF
--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -148,6 +148,7 @@ static bool SelectProcess(const char *procentry,
     Rlist *rp;
 
     assert(process_regex);
+    assert(a != NULL);
 
     StringSet *process_select_attributes = StringSetNew();
 


### PR DESCRIPTION
While working on PR 3905 (CFE-1655) a potential code fault was highlighted: multiple occurrences of a pointer argument not being null-checked in "SelectProcess()".  But this same fault was also present in the original code.  This fix addresses that original fault in the same way that it is already addressed in the nearby "SelectProcesses()".