### PR TITLE
libcfnet and cf-serverd cleanup

### DIFF
--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -728,8 +728,7 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
             goto protocol_error;
         }
 
-        Log(LOG_LEVEL_VERBOSE, "%14s %7s %s",
-            "Received:", "GET", filename);
+        Log(LOG_LEVEL_VERBOSE, "Received: GET %s", filename);
 
         /* TODO batch all the following in one function since it's very
          * similar in all of GET, OPENDIR and STAT. */
@@ -752,8 +751,7 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
 
         PathRemoveTrailingSlash(filename, strlen(filename));
 
-        Log(LOG_LEVEL_VERBOSE, "%14s %7s %s",
-            "Translated to:", "GET", filename);
+        Log(LOG_LEVEL_VERBOSE, "Translated to: GET %s", filename);
 
         if (acl_CheckPath(paths_acl, filename,
                           conn->ipaddr, conn->revdns,
@@ -791,8 +789,7 @@ bool BusyWithNewProtocol(EvalContext *ctx, ServerConnectionState *conn)
             goto protocol_error;
         }
 
-        Log(LOG_LEVEL_VERBOSE, "%14s %7s %s",
-            "Received:", "OPENDIR", filename);
+        Log(LOG_LEVEL_VERBOSE, "Received: OPENDIR %s", filename);
 
         /* sizeof()-1 because we need one extra byte for
            appending '/' afterwards. */

--- a/libcfnet/cfnet.h
+++ b/libcfnet/cfnet.h
@@ -51,6 +51,15 @@ extern int CFENGINE_PORT;                              /* GLOBAL_P GLOBAL_E */
 #define CF_INBAND_OFFSET 8
 #define CF_MSGSIZE (CF_BUFSIZE - CF_INBAND_OFFSET)
 
+#define CF_FAILEDSTR "BAD: Unspecified server refusal (see verbose server output)"
+
+/* Split this in two so it won't be recognised when transferring a CFEngine
+ * binary */
+#define CF_CHANGEDSTR1 "BAD: File changed "
+#define CF_CHANGEDSTR2 "while copying"
+
+#define CF_START_DOMAIN "undefined.domain"
+
 typedef struct
 {
     ProtocolVersion protocol_version : 3;

--- a/libcfnet/net.c
+++ b/libcfnet/net.c
@@ -74,10 +74,10 @@ int SendTransaction(ConnectionInfo *conn_info,
     /* Not allowed to send zero-payload packets */
     assert(len > 0);
 
-    if (len > CF_BUFSIZE - CF_INBAND_OFFSET)
+    if (len > CF_MSGSIZE)
     {
-        Log(LOG_LEVEL_ERR, "SendTransaction: len (%d) > %d - %d",
-            len, CF_BUFSIZE, CF_INBAND_OFFSET);
+        Log(LOG_LEVEL_ERR, "SendTransaction: len (%d) > %d",
+            len, CF_MSGSIZE);
         return -1;
     }
 

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -132,12 +132,6 @@ typedef enum
 
 /*****************************************************************************/
 
-#define CF_FAILEDSTR "BAD: Unspecified server refusal (see verbose server output)"
-#define CF_CHANGEDSTR1 "BAD: File changed "     /* Split this so it cannot be recognized */
-#define CF_CHANGEDSTR2 "while copying"
-
-#define CF_START_DOMAIN "undefined.domain"
-
 #define CF_GRAINS   64
 #define CF_NETATTR   7          /* icmp udp dns tcpsyn tcpfin tcpack */
 #define CF_MEASURE_INTERVAL (5.0*60.0)


### PR DESCRIPTION
Some librarification work originally from ProtocolGet. Contains no
functionality changes, just code cleanup.

Changelog: None
Ticket: None

Needs to be split into several commits.