### PR TITLE
CFE-3188: Fixed issue when removing comments from files in various policy functions

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7651,17 +7651,27 @@ static char *StripPatterns(char *file_buffer, const char *pattern, const char *f
     }
 
     int start, end, count = 0;
+    const size_t original_length = strlen(file_buffer);
     while (StringMatchWithPrecompiledRegex(rx, file_buffer, &start, &end))
     {
         CloseStringHole(file_buffer, start, end);
 
-        if (count++ > strlen(file_buffer))
+        if (start == end)
         {
+            Log(LOG_LEVEL_WARNING,
+                "Comment regex '%s' matched empty string in '%s'",
+                pattern,
+                filename);
+            break;
+        }
+        assert(start < end);
+        if (count++ > original_length)
+        {
+            debug_abort_if_reached();
             Log(LOG_LEVEL_ERR,
                 "Comment regex '%s' was irreconcilable reading input '%s' probably because it legally matches nothing",
                 pattern, filename);
-            pcre_free(rx);
-            return file_buffer;
+            break;
         }
     }
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -90,7 +90,6 @@ static JsonElement *CURL_CACHE = NULL;
 static FnCallResult FilterInternal(EvalContext *ctx, const FnCall *fp, const char *regex, const Rlist* rp, bool do_regex, bool invert, long max);
 
 static char *StripPatterns(char *file_buffer, const char *pattern, const char *filename);
-static void CloseStringHole(char *s, int start, int end);
 static int BuildLineArray(EvalContext *ctx, const Bundle *bundle, const char *array_lval, const char *file_buffer,
                           const char *split, int maxent, DataType type, bool int_index);
 static JsonElement* BuildData(EvalContext *ctx, const char *file_buffer,  const char *split, int maxent, bool make_array);
@@ -7654,7 +7653,7 @@ static char *StripPatterns(char *file_buffer, const char *pattern, const char *f
     const size_t original_length = strlen(file_buffer);
     while (StringMatchWithPrecompiledRegex(rx, file_buffer, &start, &end))
     {
-        CloseStringHole(file_buffer, start, end);
+        StringCloseHole(file_buffer, start, end);
 
         if (start == end)
         {
@@ -7680,16 +7679,6 @@ static char *StripPatterns(char *file_buffer, const char *pattern, const char *f
 }
 
 /*********************************************************************/
-
-static void CloseStringHole(char *s, int start, int end)
-{
-    if (end > start)
-    {
-        memmove(s + start, s + end,
-                /* The 1+ ensures we copy the final '\0' */
-                1 + strlen(s + end));
-    }
-}
 
 static JsonElement* BuildData(ARG_UNUSED EvalContext *ctx, const char *file_buffer,  const char *split, int maxent, bool make_array)
 {

--- a/tests/acceptance/01_vars/02_functions/readstringlist-many-comments.cf
+++ b/tests/acceptance/01_vars/02_functions/readstringlist-many-comments.cf
@@ -12,10 +12,6 @@ bundle agent test
         string => "Test that readstringlist correctly ignores many comment lines";
         # https://regex101.com/r/OZUgku/1/
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "ENT-5042" };
-
   vars:
       "my_list_of_strings"
         slist => readstringlist( "$(this.promise_filename).list.txt", # File to read


### PR DESCRIPTION
This should also fix many erroneous occurences of the following error message:

```
   error: Comment regex '\s*#[^\n]*' was irreconcilable reading input 'test.txt' probably because it legally matches nothing
```

(A warning can still appear if a comment regex actually matches nothing).

Also made this comment removing logic faster.

Affected functions include:

* readstringlist()
* readintlist()
* readreallist()
* peers()
* peerleader()
* peerleaders()
* data_readstringarray()
* data_readstringarrayidx()
* data_expand()
* readstringarray()
* readstringarrayidx()
* readintarray()
* readrealarray()
* parsestringarray()
* parsestringarrayidx()
* parseintarray()
* parserealarray()