### PR TITLE
Fixed failure to build when source and build locations differ

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -140,9 +140,9 @@ coverage: clean-coverage run-coverage collect-coverage
 BUILT_SOURCES = \
 	$(srcdir)/libpromises/enterprise_extension.c \
 	$(srcdir)/libpromises/enterprise_extension.h
-libpromises/enterprise_extension.c: libpromises/extensions_template.c.pre libpromises/enterprise_extension.sed
+$(srcdir)/libpromises/enterprise_extension.c: libpromises/extensions_template.c.pre libpromises/enterprise_extension.sed
 	$(V_SED) $(SED) -f $(srcdir)/libpromises/enterprise_extension.sed $< > $@
-libpromises/enterprise_extension.h: libpromises/extensions_template.h.pre libpromises/enterprise_extension.sed
+$(srcdir)/libpromises/enterprise_extension.h: libpromises/extensions_template.h.pre libpromises/enterprise_extension.sed
 	$(V_SED) $(SED) -f $(srcdir)/libpromises/enterprise_extension.sed $< > $@
 V_PERL = $(cf__v_PERL_$(V))
 cf__v_PERL_ = $(cf__v_PERL_$(AM_DEFAULT_VERBOSITY))

--- a/autogen.sh
+++ b/autogen.sh
@@ -23,14 +23,6 @@
 # included file COSL.txt.
 #
 
-if [ ! -f libntech/libutils/sequence.h ] ; then
-    echo "Error: libntech/libutils/sequence.h is missing"
-    echo "       You probably forgot to use the --recursive option when cloning"
-    echo "       To fix it now, run:"
-    echo "       git submodule init && git submodule update"
-    exit 1
-fi
-
 #
 # Detect and replace non-POSIX shell
 #
@@ -58,6 +50,14 @@ set -e
 
 srcdir=`dirname $0`
 test -z "$srcdir" && srcdir=.
+
+if [ ! -f $srcdir/libntech/libutils/sequence.h ] ; then
+    echo "Error: $srcdir/libntech/libutils/sequence.h is missing"
+    echo "       You probably forgot to use the --recursive option when cloning"
+    echo "       To fix it now, run:"
+    echo "       git submodule init && git submodule update"
+    exit 1
+fi
 
 cd "$srcdir"
 

--- a/cf-check/Makefile.am
+++ b/cf-check/Makefile.am
@@ -40,7 +40,7 @@ AM_LDFLAGS = \
 	$(LIBYAML_LDFLAGS) \
 	$(LMDB_LDFLAGS)
 
-libcf_check_la_LIBADD = $(srcdir)/../libntech/libutils/libutils.la \
+libcf_check_la_LIBADD = ../libntech/libutils/libutils.la \
 	$(LMDB_LIBS) \
 	$(PCRE_LIBS) \
 	$(LIBYAML_LIBS) \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -398,17 +398,17 @@ strlist_test_SOURCES = strlist_test.c \
 iteration_test_SOURCES = iteration_test.c
 
 cf_upgrade_test_SOURCES = cf_upgrade_test.c \
-	../../cf-upgrade/alloc-mini.c \
-	../../cf-upgrade/alloc-mini.h \
-	../../cf-upgrade/command_line.c \
-	../../cf-upgrade/command_line.h \
-	../../cf-upgrade/configuration.c \
-	../../cf-upgrade/configuration.h \
-	../../cf-upgrade/log.c ../../cf-upgrade/log.h \
-	../../cf-upgrade/process.c ../../cf-upgrade/process.h \
-	../../cf-upgrade/update.c \
-	../../cf-upgrade/update.h
-cf_upgrade_test_CPPFLAGS = -I../../cf-upgrade -I$(top_srcdir)/libntech/libutils -I$(top_srcdir)
+	$(top_srcdir)/cf-upgrade/alloc-mini.c \
+	$(top_srcdir)/cf-upgrade/alloc-mini.h \
+	$(top_srcdir)/cf-upgrade/command_line.c \
+	$(top_srcdir)/cf-upgrade/command_line.h \
+	$(top_srcdir)/cf-upgrade/configuration.c \
+	$(top_srcdir)/cf-upgrade/configuration.h \
+	$(top_srcdir)/cf-upgrade/log.c $(top_srcdir)/cf-upgrade/log.h \
+	$(top_srcdir)/cf-upgrade/process.c $(top_srcdir)/cf-upgrade/process.h \
+	$(top_srcdir)/cf-upgrade/update.c \
+	$(top_srcdir)/cf-upgrade/update.h
+cf_upgrade_test_CPPFLAGS = -I$(top_srcdir)/cf-upgrade -I$(top_srcdir)/libntech/libutils -I$(top_srcdir)
 cf_upgrade_test_LDADD = libtest.la ../../libntech/libcompat/libcompat.la
 
 if !NT


### PR DESCRIPTION
The CFEngine code used to get this right, but a couple of issues have crept in
at some point.

Although most people build in the same directory-tree location as the source,
GNU autotools offers the ability for these locations to differ.
This is particularly useful when wanting to develop and test parallel builds
from a shared source location, for instance using different platforms and/or
different "--with-foo" options.

A typical use would be the following parallel builds:

    mkdir -p build/platform_1; cd build/platform_1; ../../autogen.sh
    mkdir -p build/platform_2; cd build/platform_2; ../../autogen.sh
    mkdir -p build/platform_3; cd build/platform_3; ../../autogen.sh

Subsequent development in the source can then be immediately tested
on those three platforms, in parallel, and with the previous cached 'make'
results within each still valid.  This is much, much faster!

This fix restores this capability.

There is one residual exception, outside CFEngine, but still easily fixable.
In the git submodule "libntech", file "libntech/tests/unit/csv_parser_test.c"
needs to use the "TESTDATADIR" macro in two places in a way very similar
to the nearby "json_test.c".  (I'm not quite sure how to submit that
particular fix as a pull-request, but can easily provide a 'diff' on request.)