### PR TITLE
Add a recommended minimum TLS version and default to it

### DIFF
--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -63,6 +63,9 @@ enum tls_version {
 /* the lowest version of TLS we always require */
 #define TLS_LOWEST_REQUIRED TLS_1_0
 
+/* the lowest version of TLS we recommend (also the default) */
+#define TLS_LOWEST_RECOMMENDED TLS_1_1
+
 #ifndef SSL_OP_NO_TLSv1_3
 #define SSL_OP_NO_TLSv1_3 0     /* no-op when ORed with bit flags */
 #endif
@@ -891,7 +894,8 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
     /* In any case use only TLS v1 or later. */
     long options = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
 
-    enum tls_version min_tls_version = TLS_LOWEST_REQUIRED;
+    assert(TLS_LOWEST_RECOMMENDED >= TLS_LOWEST_REQUIRED);
+    enum tls_version min_tls_version = TLS_LOWEST_RECOMMENDED;
     if (!NULL_OR_EMPTY(min_version))
     {
         bool found = false;
@@ -907,6 +911,13 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
                         " Using the minimum required version.",
                         min_version, tls_version_strings[TLS_LOWEST_REQUIRED]);
                     min_tls_version = TLS_LOWEST_REQUIRED;
+                }
+                else if (v < TLS_LOWEST_RECOMMENDED)
+                {
+                    Log(LOG_LEVEL_WARNING, "Minimum requested TLS version is %s,"
+                        " but minimum version recommended by CFEngine is %s.",
+                        min_version, tls_version_strings[TLS_LOWEST_RECOMMENDED]);
+                    min_tls_version = v;
                 }
                 else if (v > TLS_HIGHEST_SUPPORTED)
                 {


### PR DESCRIPTION
Security vulnerabilities were found in TLS 1.0 [1]. None of them
applies to the mutually authenticated peer-to-peer TLS
communication in CFEngine, but the version 1.0 of the protocol is
now considered deprecated.

TLS 1.1 is supported by CFEngine 3.7.0 and newer so it is safe to
default the minimum required TLS version to 1.1 while making it
possible to change the minimum required version to 1.0 in policy.

[1] https://www.acunetix.com/blog/articles/tls-vulnerabilities-attacks-final-part/

Ticket: ENT-4616
Changelog: Default minimum allowed TLS version is now 1.1

Merge together:
https://github.com/cfengine/core/pull/3936
https://github.com/cfengine/masterfiles/pull/1574