### PR TITLE
Changed occurences of `(f)open` to `safe_(f)open`

### DIFF
--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -121,7 +121,7 @@ static int PasswordSupplier(int num_msg, const struct pam_message **msg,
  */
 static bool GetAIXShadowHash(const char *puser, const char **result)
 {
-    FILE *fptr = fopen("/etc/security/passwd", "r");
+    FILE *fptr = safe_fopen("/etc/security/passwd", "r");
     if (fptr == NULL)
     {
         return false;
@@ -209,7 +209,7 @@ end:
 // is a local user, and not for example from LDAP.
 static struct spwd *GetSpEntry(const char *puser)
 {
-    FILE *fptr = fopen("/etc/shadow", "r");
+    FILE *fptr = safe_fopen("/etc/shadow", "r");
     if (!fptr)
     {
         Log(LOG_LEVEL_ERR, "Could not open '/etc/shadow': %s", GetErrorStr());
@@ -483,7 +483,7 @@ static bool ChangePasswordHashUsingLckpwdf(const char *puser, const char *passwo
         goto unlock_passwd;
     }
 
-    FILE *passwd_fd = fopen(passwd_file, "r");
+    FILE *passwd_fd = safe_fopen(passwd_file, "r");
     if (!passwd_fd)
     {
         Log(LOG_LEVEL_ERR, "Could not open password database '%s'. (fopen: '%s')", passwd_file, GetErrorStr());
@@ -780,7 +780,7 @@ static bool GroupGetUserMembership (const char *user, StringSet *result)
     bool ret = true;
     struct group *group_info;
 
-    FILE *fptr = fopen("/etc/group", "r");
+    FILE *fptr = safe_fopen("/etc/group", "r");
     if (!fptr)
     {
         Log(LOG_LEVEL_ERR, "Could not open '/etc/group': %s", GetErrorStr());
@@ -836,7 +836,7 @@ static bool EqualGroupName(const char *key, const struct group *entry)
 static struct group *GetGrEntry(const char *key,
                                 bool (*equal_fn)(const char *key, const struct group *entry))
 {
-    FILE *fptr = fopen("/etc/group", "r");
+    FILE *fptr = safe_fopen("/etc/group", "r");
     if (!fptr)
     {
         Log(LOG_LEVEL_ERR, "Could not open '/etc/group': %s", GetErrorStr());
@@ -1407,7 +1407,7 @@ static bool DoModifyUser (const char *puser, const User *u, const struct passwd 
 // is a local user, and not for example from LDAP.
 static struct passwd *GetPwEntry(const char *puser)
 {
-    FILE *fptr = fopen("/etc/passwd", "r");
+    FILE *fptr = safe_fopen("/etc/passwd", "r");
     if (!fptr)
     {
         Log(LOG_LEVEL_ERR, "Could not open '/etc/passwd': %s", GetErrorStr());

--- a/cf-monitord/mon_cpu.c
+++ b/cf-monitord/mon_cpu.c
@@ -24,6 +24,7 @@
 
 #include <cf3.defs.h>
 
+#include <file_lib.h>
 #include <mon.h>
 
 #if !defined(__MINGW32__)
@@ -45,10 +46,10 @@ void MonCPUGatherData(double *cf_this)
     char cpuname[CF_MAXVARSIZE], buf[CF_BUFSIZE];
     long cpuidx, userticks = 0, niceticks = 0, systemticks = 0, idle = 0, iowait = 0, irq = 0, softirq = 0;
     long total_time = 1;
-    FILE *fp;
     enum observables slot = ob_spare;
 
-    if ((fp = fopen("/proc/stat", "r")) == NULL)
+    FILE *fp = safe_fopen("/proc/stat", "r");
+    if (fp == NULL)
     {
         Log(LOG_LEVEL_VERBOSE, "Could not open /proc/stat while gathering CPU data (fopen: %s)", GetErrorStr());
         return;

--- a/cf-monitord/mon_io_linux.c
+++ b/cf-monitord/mon_io_linux.c
@@ -26,6 +26,7 @@
 
 #include <string_lib.h>
 #include <files_names.h>
+#include <file_lib.h>
 #include <mon_cumulative.h>
 #include <monitoring.h>
 #include <probes.h>
@@ -49,7 +50,6 @@ static void SysfsizeDeviceName(char *name)
 static int DiskSectorSize(const char *sysfsname)
 {
     char sysfspath[CF_BUFSIZE];
-    FILE *fh;
     int size = 512;             /* Long-time default value */
 
     if (snprintf(sysfspath, CF_BUFSIZE, SYSFSBLOCK "%s/queue/logical_block_size", sysfsname) >= CF_BUFSIZE)
@@ -58,7 +58,8 @@ static int DiskSectorSize(const char *sysfsname)
         return -1;
     }
 
-    if (!(fh = fopen(sysfspath, "r")))
+    FILE *fh = safe_fopen(sysfspath, "r");
+    if (fh == NULL)
     {
         /*
          * Older Linux systems don't work correctly with new 4K drives. It's safe to

--- a/cf-monitord/mon_mem_linux.c
+++ b/cf-monitord/mon_mem_linux.c
@@ -25,6 +25,7 @@
 
 #include <cf3.defs.h>
 
+#include <file_lib.h>
 #include <monitoring.h>
 #include <probes.h>
 #include <proc_keyvalue.h>
@@ -81,10 +82,10 @@ static bool AcceptMemoryField(const char *field, off_t value, void *param)
 
 static void MonMeminfoGatherData(double *cf_this)
 {
-    FILE *fh;
     MemoryInfo info = { 0 };
 
-    if (!(fh = fopen("/proc/meminfo", "r")))
+    FILE *fh = safe_fopen("/proc/meminfo", "r");
+    if (fh == NULL)
     {
         Log(LOG_LEVEL_ERR, "Unable to open /proc/meminfo. (fopen: %s)", GetErrorStr());
         return;

--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -1300,7 +1300,7 @@ static void CheckPsLineLimitations(void)
     char *buf = NULL;
     size_t bufsize = 0;
 
-    ps_fd = fopen("/etc/default/ps", "r");
+    ps_fd = safe_fopen("/etc/default/ps", "r");
     if (!ps_fd)
     {
         Log(LOG_LEVEL_VERBOSE, "Could not open '/etc/default/ps' "
@@ -1660,12 +1660,7 @@ bool LoadProcessTable()
 
     snprintf(vbuff, CF_MAXVARSIZE, "%s%ccf_procs", statedir, FILE_SEPARATOR);
 
-    // TODO: Change safe_fopen() to default to 0600, then remove this.
-    {
-        const mode_t old_umask = SetUmask(0077);
-        RawSaveItemList(PROCESSTABLE, vbuff, NewLineMode_Unix);
-        RestoreUmask(old_umask);
-    }
+    RawSaveItemList(PROCESSTABLE, vbuff, NewLineMode_Unix);
 
 # ifdef HAVE_GETZONEID
     if (global_zone) /* pidlist and rootpidlist are empty if we're not in the global zone */


### PR DESCRIPTION
Should be the last ones in core.