### PR TITLE
Refactor read(data|csv|yaml|envfile|json) to use new DATAFILETYPE enums instead of parsing strings

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1122,7 +1122,7 @@ static void DefineVersionedHardClasses(
 static void OSReleaseParse(EvalContext *ctx, const char *file_path)
 {
     JsonElement *os_release_json = JsonReadDataFile("system info discovery",
-                                                    file_path, "ENV",
+                                                    file_path, DATAFILETYPE_ENV,
                                                     100 * 1024);
     if (os_release_json != NULL)
     {


### PR DESCRIPTION
This was originally just meant for `validdata`, but I wanted to make the existing functions a bit more modular (and hopefully more readable as well).