### PR TITLE
CFE-3046: Only add unique IPv4 interfaces to sys.interfaces (3.12)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 3.12.3:
+	- Fixed an issue causing duplicate entries in sys.interfaces, and
+	  sys.hardware (CFE-3046)
 	- Agent runs that hit abortclasses now record results (ENT-2471)
 	- Fixed issue when removing comments from files in various policy functions
 	  Affected functions include:

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -409,10 +409,12 @@ void GetInterfacesInfo(EvalContext *ctx)
         /* If interface name appears a second time in a row then it has more
            than one IP addresses (linux: ip addr add $IP dev $IF).
            But the variable is already added so don't set it again. */
+        bool add_mac_addr = false;
         if (strcmp(last_name, ifp->ifr_name) != 0)
         {
             strcpy(last_name, ifp->ifr_name);
             EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "interface", last_name, CF_DATA_TYPE_STRING, "source=agent");
+            add_mac_addr = true;
         }
 
         snprintf(workbuf, sizeof(workbuf), "net_iface_%s", CanonifyName(ifp->ifr_name));
@@ -548,8 +550,12 @@ void GetInterfacesInfo(EvalContext *ctx)
                 }
             }
 
-            // Set the hardware/mac address array
-            GetMacAddress(ctx, fd, &ifr, ifp, &interfaces, &hardware);
+            /* [CFE-3046] Only add unique interfaces to sys interfaces and hardware */
+            if (add_mac_addr)
+            {
+                // Set the hardware/mac address array
+                GetMacAddress(ctx, fd, &ifr, ifp, &interfaces, &hardware);
+            }
         }
     }
 


### PR DESCRIPTION
Previously, when an interface had multiple IPv4 addresses set, the parsing of
these addresses would add the interface to the sys.interfaces and sys.hardware
variables multiple times, resulting in the interface showing up as a duplicate
in the list.

This fix makes sure that an interface is only added once for every interface
type, regardless of how many IPv4 addresses the interface contains.

(cherry picked from commit c40f502)