### PR TITLE
Fixed abort / segfault in Rlist code not expecting NULL pointer

### DIFF
--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -289,8 +289,13 @@ bool RlistIsInListOfRegex(const Rlist *list, const char *str)
 
 bool RlistContainsString(const Rlist *list, const char *string)
 {
-    assert(list != NULL);
     assert(string != NULL);
+
+    if (list == NULL)
+    {
+        // Empty Rlist is represented as a NULL pointer
+        return false;
+    }
 
     for (const Rlist *rp = list; rp != NULL; rp = rp->next)
     {


### PR DESCRIPTION
An empty rlist is represented as a NULL pointer, so all Rlist
functions should handle NULL pointers at runtime.

Fixes an issue on FreeBSD, where RlistContainsString is
called on a NULL pointer (before any elements are added):

    Core was generated by `/var/cfengine/bin/cf-key'.
    Program terminated with signal SIGABRT, Aborted.
    #0  0x00000008024219ba in thr_kill () from /lib/libc.so.7
    (gdb) bt
    #0  0x00000008024219ba in thr_kill () from /lib/libc.so.7
    #1  0x0000000802421984 in __raise (s=6) at /usr/src/lib/libc/gen/raise.c:52
    #2  0x00000008024218f9 in abort () at /usr/src/lib/libc/stdlib/abort.c:65
    #3  0x000000080249d101 in __assert (func=<optimized out>, file=<optimized out>, line=<optimized out>, failedexpr=<optimized out>)
        at /usr/src/lib/libc/gen/assert.c:51
    #4  0x00000008008cc5b5 in RlistContainsString (list=0x0, string=0x8048af320 "0a:14:50:21:f0:44") at rlist.c:292
    #5  0x00000008009163e1 in FindV6InterfacesInfo (ctx=0x80481c0c0, interfaces=0x7ffffffed098, hardware=0x7ffffffed090, ips=0x7ffffffed080)
        at unix_iface.c:704
    #6  0x0000000800915f16 in GetInterfacesInfo (ctx=0x80481c0c0) at unix_iface.c:565
    #7  0x00000008009142eb in DetectEnvironment (ctx=0x80481c0c0) at sysinfo.c:3304
    #8  0x00000008008ab30f in GenericAgentDiscoverContext (ctx=0x80481c0c0, config=0x80481c000) at generic_agent.c:537
    #9  0x000000000040231b in main (argc=1, argv=0x7fffffffeaa8) at cf-key.c:148

This was introduced recently, and I don't believe it's been
in any released packages, so no changelog entry.