### PR TITLE
CFE-3196: New policy function basename() added

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -69,6 +69,7 @@
 #include <processes_select.h>
 #include <sysinfo.h>
 #include <string_sequence.h>
+#include <string_lib.h>
 
 #include <math_eval.h>
 
@@ -1547,6 +1548,50 @@ static FnCallResult FnCallGetMetaTags(EvalContext *ctx, ARG_UNUSED const Policy 
 
     free(key);
     return (FnCallResult) { FNCALL_SUCCESS, { tags, RVAL_TYPE_LIST } };
+}
+
+/*********************************************************************/
+
+static FnCallResult FnCallBasename(ARG_UNUSED EvalContext *ctx,
+                                   ARG_UNUSED const Policy *policy,
+                                   const FnCall *fp,
+                                   const Rlist *args)
+{
+    assert(fp != NULL);
+    assert(fp->name != NULL);
+    if (args == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Function %s requires a filename as first arg!",
+            fp->name);
+        return FnFailure();
+    }
+
+    char dir[PATH_MAX];
+    strlcpy(dir, RlistScalarValue(args), PATH_MAX);
+    if (dir[0] == '\0')
+    {
+        return FnReturn(dir);
+    }
+
+    char *base = basename(dir);
+
+    if (args->next != NULL)
+    {
+        char *suffix = RlistScalarValue(args->next);
+        if (StringEndsWith(base, suffix))
+        {
+            size_t base_len = strlen(base);
+            size_t suffix_len = strlen(suffix);
+
+            // Remove only if actually a suffix, not the same string
+            if (suffix_len < base_len)
+            {
+                base[base_len - suffix_len] = '\0';
+            }
+        }
+    }
+
+    return FnReturn(base);
 }
 
 /*********************************************************************/
@@ -8394,6 +8439,13 @@ static const FnCallArg LATERTHAN_ARGS[] =
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
+static const FnCallArg BASENAME_ARGS[] =
+{
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "File path"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Optional suffix"},
+    {NULL, CF_DATA_TYPE_NONE, NULL},
+};
+
 static const FnCallArg DATE_ARGS[] = /* for on() */
 {
     {"1970,3000", CF_DATA_TYPE_INT, "Year"},
@@ -9287,6 +9339,8 @@ const FnCallType CF_FNCALL_TYPES[] =
     FnCallTypeNew("ago", CF_DATA_TYPE_INT, AGO_ARGS, &FnCallAgoDate, "Convert a time relative to now to an integer system representation",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("and", CF_DATA_TYPE_STRING, AND_ARGS, &FnCallAnd, "Calculate whether all arguments evaluate to true",
+                  FNCALL_OPTION_VARARG, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
+    FnCallTypeNew("basename", CF_DATA_TYPE_STRING, BASENAME_ARGS, &FnCallBasename, "Retrieves the basename of a filename.",
                   FNCALL_OPTION_VARARG, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("bundlesmatching", CF_DATA_TYPE_STRING_LIST, BUNDLESMATCHING_ARGS, &FnCallBundlesMatching, "Find all the bundles that match a regular expression and tags.",
                   FNCALL_OPTION_VARARG, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),

--- a/tests/acceptance/01_vars/02_functions/basename_1.cf
+++ b/tests/acceptance/01_vars/02_functions/basename_1.cf
@@ -1,0 +1,158 @@
+#######################################################
+#
+# Test basename() without suffix
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      # The tests starting with template will be tested with both types of
+      # directory separators on Windows.
+
+      "template_input[root]" string => "/";
+      "template_expected[root]" string => "/";
+
+      "template_input[simple]" string => "/foo/bar";
+      "template_expected[simple]" string => "bar";
+
+      "template_input[slash]" string => "/foo/bar/";
+      "template_expected[slash]" string => "bar";
+
+      "template_input[sub]" string => "/foo";
+      "template_expected[sub]" string => "foo";
+
+      "template_input[subslash]" string => "/foo/";
+      "template_expected[subslash]" string => "foo";
+
+      "template_input[dot]" string => "/foo/.";
+      "template_expected[dot]" string => ".";
+
+      "template_input[dot_subslash]" string => "/foo/./";
+      "template_expected[dot_subslash]" string => ".";
+
+      "template_input[multi]" string => "/foo/bar/baz";
+      "template_expected[multi]" string => "baz";
+
+      "template_input[multislash]" string => "/foo/bar/baz/";
+      "template_expected[multislash]" string => "baz";
+
+      "template_input[more]" string => "/a/b/c/d/e/f/g/h/i";
+      "template_expected[more]" string => "i";
+
+      "template_input[multislash]" string => "/a///b////c///";
+      "template_expected[multislash]" string => "c";
+
+      # Note: no template, because backslashes will be interpreted as UNC path on Windows.
+      "input[multislash_start]" string => "//a///b////c///";
+      "expected[multislash_start]" string => "c";
+
+      "template_input[rel_one]" string => "foo";
+      "template_expected[rel_one]" string => "foo";
+
+      "template_input[rel_more]" string => "foo/bar";
+      "template_expected[rel_more]" string => "bar";
+
+      "template_input[rel_one_subslash]" string => "foo/";
+      "template_expected[rel_one_subslash]" string => "foo";
+
+      "template_input[rel_more_subslash]" string => "foo/bar/";
+      "template_expected[rel_more_subslash]" string => "bar";
+
+      "template_input[rel_dot]" string => "foo/.";
+      "template_expected[rel_dot]" string => ".";
+
+      "template_input[rel_only_dot]" string => "./";
+      "template_expected[rel_only_dot]" string => ".";
+
+      "template_input[rel_multislash]" string => "a///b////c///";
+      "template_expected[rel_multislash]" string => "c";
+
+      "template_input[noop]" string => "";
+      "template_expected[noop]" string => "";
+
+      "template_keys" slist => getindices("template_input");
+
+    windows::
+      "template_input[full_root]" string => "C:/";
+      "template_expected[full_root]" string => "C:/";
+
+      "template_input[full_root_file]" string => "C:/foo";
+      "template_expected[full_root_file]" string => "foo";
+
+      "template_input[full_root_file_subslash]" string => "C:/foo/";
+      "template_expected[full_root_file_subslash]" string => "foo";
+
+      "template_input[full_file]" string => "C:/foo/bar";
+      "template_expected[full_file]" string => "bar";
+
+      "template_input[full_file_subslash]" string => "C:/foo/bar/";
+      "template_expected[full_file_subslash]" string => "bar";
+
+      "template_input[dir]" string => "C:foo";
+      "template_expected[dir]" string => "foo";
+
+      "template_input[two_dirs]" string => "C:foo/bar";
+      "template_expected[two_dirs]" string => "bar";
+
+      "template_input[dir_subslash]" string => "C:foo/";
+      "template_expected[dir_subslash]" string => "foo";
+
+      "template_input[two_dirs_subslash]" string => "C:foo/bar/";
+      "template_expected[two_dirs_subslash]" string => "bar";
+
+      # UNC paths don't have forward slash equivalents.
+      "input[native_unc_one]" string => "\\\\foo";
+      "expected[native_unc_one]" string => "foo";
+
+      "input[native_unc_two]" string => "\\\\foo\\bar";
+      "expected[native_unc_two]" string => "bar";
+
+      "input[native_unc_three]" string => "\\\\foo\\bar\\charlie\\";
+      "expected[native_unc_three]" string => "charlie";
+
+
+      "input[unix_$(template_keys)]" string => "$(template_input[$(template_keys)])";
+      "input[native_$(template_keys)]" string => translatepath("$(template_input[$(template_keys)])");
+      "expected[unix_$(template_keys)]" string => "$(template_expected[$(template_keys)])";
+      "expected[native_$(template_keys)]" string => translatepath("$(template_expected[$(template_keys)])");
+    !windows::
+      "input[native_$(template_keys)]" string => "$(template_input[$(template_keys)])";
+      "expected[native_$(template_keys)]" string => "$(template_expected[$(template_keys)])";
+
+    any::
+      "keys" slist => getindices("input");
+
+      "actual[$(keys)]" string => basename("$(input[$(keys)])");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "keys" slist => { @(test.keys) };
+
+  classes:
+      "failed_cmp_$(keys)" not => strcmp(basename("$(test.input[$(keys)])"), "$(test.expected[$(keys)])");
+      "ok" not => classmatch("failed_cmp_.*");
+
+  reports:
+    DEBUG::
+      "'basename($(test.input[$(keys)]))' = '$(test.actual[$(keys)])' != '$(test.expected[$(keys)])'"
+        ifvarclass => "failed_cmp_$(keys)";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/01_vars/02_functions/basename_2.cf
+++ b/tests/acceptance/01_vars/02_functions/basename_2.cf
@@ -1,0 +1,78 @@
+#######################################################
+#
+# Test basename() with suffix removal
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      # The tests starting with template will be tested with both types of
+      # directory separators on Windows.
+
+      "template_input[root]" string => "/";
+      "template_suffix[root]" string => "";
+      "template_expected[root]" string => "/";
+
+      "template_input[simple]" string => "/foo/bar.c";
+      "template_suffix[simple]" string => ".c";
+      "template_expected[simple]" string => "bar";
+
+      "template_input[rel_suffif]" string => "foo.xyz";
+      "template_suffix[rel_suffif]" string => ".xyz";
+      "template_expected[rel_suffif]" string => "foo";
+
+      "template_input[no_matching_suffix]" string => "/foo/bar";
+      "template_suffix[no_matching_suffix]" string => "baz";
+      "template_expected[no_matching_suffix]" string => "bar";
+
+      "template_input[same_suffix]" string => "foo";
+      "template_suffix[same_suffix]" string => "foo";
+      "template_expected[same_suffix]" string => "foo";
+
+      "template_input[sub_same_suffix]" string => "foo/bar";
+      "template_suffix[sub_same_suffix]" string => "bar";
+      "template_expected[sub_same_suffix]" string => "bar";
+
+      "template_keys" slist => getindices("template_input");
+
+    any::
+      "input[native_$(template_keys)]" string => "$(template_input[$(template_keys)])";
+      "expected[native_$(template_keys)]" string => "$(template_expected[$(template_keys)])";
+      "suffix[native_$(template_keys)]" string => "$(template_suffix[$(template_keys)])";
+
+      "keys" slist => getindices("input");
+
+      "actual[$(keys)]" string => basename("$(input[$(keys)])", "$(suffix[$suffix])");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "keys" slist => { @(test.keys) };
+
+  classes:
+      "failed_cmp_$(keys)" not => strcmp(basename("$(test.input[$(keys)])", "$(test.suffix[$(keys)])"), "$(test.expected[$(keys)])");
+      "ok" not => classmatch("failed_cmp_.*");
+
+  reports:
+    DEBUG::
+      "'basename($(test.input[$(keys)]), $(test.suffix[$(keys)]))' = '$(test.actual[$(keys)])' != '$(test.expected[$(keys)])'"
+        ifvarclass => "failed_cmp_$(keys)";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Acts in the same way as the POSIX basename program. It retrieves only the
last part of a given path:

```
basename("/etc/sshd/sshd_config") -> "sshd_config"
```

Also supports optional suffix exclusion:

```
basename("/etc/host.conf", ".conf") -> "host"
```

Okay currently this is probably unnecessarily convoluted.