### PR TITLE
[3.12.x] Try harder to kill agent process in case of 'agent_expireafter' in cf-execd

### DIFF
--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -557,10 +557,9 @@ static void Apoptosis(void)
         Rlist *owners = NULL;
         RlistPrepend(&owners, myuid, RVAL_TYPE_SCALAR);
 
-        ProcessSelect process_select = {
-            .owner = owners,
-            .process_result = "process_owner",
-        };
+        ProcessSelect process_select = PROCESS_SELECT_INIT;
+        process_select.owner = owners;
+        process_select.process_result = "process_owner";
 
         Item *killlist = SelectProcesses(promiser_buf, process_select, true);
         RlistDestroy(owners);

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1158,6 +1158,32 @@ typedef struct
     char *process_result;
 } ProcessSelect;
 
+#define PROCESS_SELECT_INIT { \
+    .owner = NULL,          \
+    .min_pid = CF_NOINT,    \
+    .max_pid = CF_NOINT,    \
+    .min_ppid = CF_NOINT,   \
+    .max_ppid = CF_NOINT,   \
+    .min_pgid = CF_NOINT,   \
+    .max_pgid = CF_NOINT,   \
+    .min_rsize = CF_NOINT,  \
+    .max_rsize = CF_NOINT,  \
+    .min_vsize = CF_NOINT,  \
+    .max_vsize = CF_NOINT,  \
+    .min_ttime = CF_NOINT,  \
+    .max_ttime = CF_NOINT,  \
+    .min_stime = CF_NOINT,  \
+    .max_stime = CF_NOINT,  \
+    .min_pri = CF_NOINT,    \
+    .max_pri = CF_NOINT,    \
+    .min_thread = CF_NOINT, \
+    .max_thread = CF_NOINT, \
+    .status = NULL,         \
+    .command = NULL,        \
+    .tty = NULL,            \
+    .process_result = NULL, \
+}
+
 /*************************************************************************/
 
 typedef struct

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -612,6 +612,12 @@ static bool EvalWithTokenFromList(const char *expr, StringSet *token_set)
 
 bool EvalProcessResult(const char *process_result, StringSet *proc_attr)
 {
+    assert(process_result != NULL);
+    if (StringSafeEqual(process_result, ""))
+    {
+        /* nothing to evaluate */
+        return false;
+    }
     return EvalWithTokenFromList(process_result, proc_attr);
 }
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7668,7 +7668,10 @@ static FnCallResult FnCallProcessExists(ARG_UNUSED EvalContext *ctx, ARG_UNUSED 
         return FnFailure();
     }
 
-    ProcessSelect ps = { .owner = NULL, .process_result = "" };
+    ProcessSelect ps = PROCESS_SELECT_INIT;
+    ps.owner = NULL;
+    ps.process_result = "";
+
     // ps is unused because attrselect = false below
     Item *matched = SelectProcesses(regex, ps, false);
     ClearProcessTable();

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -53,7 +53,11 @@ void ProcessSignalTerminate(pid_t pid)
     }
 
     sleep(1);
-
+    if (kill(pid, 0) != 0)
+    {
+        /* can no longer send signals to the process => it's dead now */
+        return;
+    }
 
     if(kill(pid, SIGTERM) == -1)
     {
@@ -62,7 +66,11 @@ void ProcessSignalTerminate(pid_t pid)
     }
 
     sleep(5);
-
+    if (kill(pid, 0) != 0)
+    {
+        /* can no longer send signals to the process => it's dead now */
+        return;
+    }
 
     if(kill(pid, SIGKILL) == -1)
     {


### PR DESCRIPTION
3.12.x version of #3935 