### PR TITLE
Consistent handling of make flags in cf-promises/cf-agent

### DIFF
--- a/cf-agent/Makefile.am
+++ b/cf-agent/Makefile.am
@@ -26,6 +26,7 @@ noinst_LTLIBRARIES = libcf-agent.la
 AM_CPPFLAGS = -I$(srcdir)/../libpromises -I$(srcdir)/../libntech/libutils \
 	-I$(srcdir)/../libcfnet \
 	-I$(srcdir)/../cf-check \
+	@CPPFLAGS@ \
 	$(ENTERPRISE_CPPFLAGS) \
 	$(OPENSSL_CPPFLAGS) \
 	$(PCRE_CPPFLAGS) \
@@ -36,6 +37,7 @@ AM_CPPFLAGS = -I$(srcdir)/../libpromises -I$(srcdir)/../libntech/libutils \
 	$(PAM_CPPFLAGS)
 
 AM_CFLAGS = \
+	@CFLAGS@ \
 	$(ENTERPRISE_CFLAGS) \
 	$(OPENSSL_CFLAGS) \
 	$(PCRE_CFLAGS) \
@@ -46,6 +48,7 @@ AM_CFLAGS = \
 	$(PAM_CFLAGS)
 
 AM_LDFLAGS = \
+	@LDFLAGS@ \
 	$(OPENSSL_LDFLAGS) \
 	$(PCRE_LDFLAGS) \
 	$(LIBVIRT_LDFLAGS) \

--- a/cf-promises/Makefile.am
+++ b/cf-promises/Makefile.am
@@ -36,6 +36,9 @@ AM_CFLAGS = @CFLAGS@ \
 	$(OPENSSL_CFLAGS) \
 	$(ENTERPRISE_CFLAGS)
 
+AM_LDFLAGS = \
+	@LDFLAGS@
+
 libcf_promises_la_LIBADD = ../libpromises/libpromises.la
 
 libcf_promises_la_SOURCES = cf-promises.c


### PR DESCRIPTION
When compiling with explicit CFLAGS / LDFLAGS these are not handled in
the same way in different automake files.

The way we are mixing user-provided flags with configure generated ones
is not ideal, this change doesn't fix that, but it at least makes it
more consistent.

For example, compiling like this:

```
./autogen.sh --enable-debug && make CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
```

Would cause the explicit flags to override flags from configure when
building cf-agent, but not in cf-promises. The end result is that debug
info (line numbers) is missing in some places.

**Before change:**

```
Direct leak of 9 byte(s) in 1 object(s) allocated from:
    #0 0x7fc5c3640538 in strdup (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x77538)
    #1 0x7fc5c31badc0 in xstrdup /home/vagrant/cfe/core/libntech/libutils/alloc.c:58
    #2 0x559ddf51b064 in VerifyNotInFstab (/var/cfengine/bin/cf-agent+0xa0064)
    #3 0x559ddf4d6bd1 in VerifyMountPromise (/var/cfengine/bin/cf-agent+0x5bbd1)
    #4 0x559ddf4d506c in VerifyStoragePromise (/var/cfengine/bin/cf-agent+0x5a06c)
    #5 0x559ddf529cd9 in LocateFilePromiserGroup (/var/cfengine/bin/cf-agent+0xaecd9)
    #6 0x559ddf4d4a83 in FindStoragePromiserObjects (/var/cfengine/bin/cf-agent+0x59a83)
    #7 0x559ddf4d4a2d in FindAndVerifyStoragePromises (/var/cfengine/bin/cf-agent+0x59a2d)
    #8 0x559ddf4b7239 in KeepAgentPromise (/var/cfengine/bin/cf-agent+0x3c239)
    #9 0x7fc5c3138372 in ExpandPromiseAndDo /home/vagrant/cfe/core/libpromises/expand.c:215
    #10 0x7fc5c3138713 in ExpandPromise /home/vagrant/cfe/core/libpromises/expand.c:283
    #11 0x559ddf4b5e43 in ScheduleAgentOperations (/var/cfengine/bin/cf-agent+0x3ae43)
    #12 0x559ddf4b5656 in KeepPromiseBundles (/var/cfengine/bin/cf-agent+0x3a656)
    #13 0x559ddf4b2870 in KeepPromises (/var/cfengine/bin/cf-agent+0x37870)
    #14 0x559ddf4b025b in main (/var/cfengine/bin/cf-agent+0x3525b)
    #15 0x7fc5c238cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
```

**After change:**

```
Direct leak of 9 byte(s) in 1 object(s) allocated from:
    #0 0x7fb282da4538 in strdup (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x77538)
    #1 0x7fb28291edc0 in xstrdup /home/vagrant/cfe/core/libntech/libutils/alloc.c:58
    #2 0x55d8be8f6064 in VerifyNotInFstab /home/vagrant/cfe/core/cf-agent/nfs.c:541
    #3 0x55d8be8b1bd1 in VerifyMountPromise /home/vagrant/cfe/core/cf-agent/verify_storage.c:491
    #4 0x55d8be8b006c in VerifyStoragePromise /home/vagrant/cfe/core/cf-agent/verify_storage.c:146
    #5 0x55d8be904cd9 in LocateFilePromiserGroup /home/vagrant/cfe/core/cf-agent/promiser_regex_resolver.c:62
    #6 0x55d8be8afa83 in FindStoragePromiserObjects /home/vagrant/cfe/core/cf-agent/verify_storage.c:84
    #7 0x55d8be8afa2d in FindAndVerifyStoragePromises /home/vagrant/cfe/core/cf-agent/verify_storage.c:75
    #8 0x55d8be892239 in KeepAgentPromise /home/vagrant/cfe/core/cf-agent/cf-agent.c:1697
    #9 0x7fb28289c372 in ExpandPromiseAndDo /home/vagrant/cfe/core/libpromises/expand.c:215
    #10 0x7fb28289c713 in ExpandPromise /home/vagrant/cfe/core/libpromises/expand.c:283
    #11 0x55d8be890e43 in ScheduleAgentOperations /home/vagrant/cfe/core/cf-agent/cf-agent.c:1431
    #12 0x55d8be890656 in KeepPromiseBundles /home/vagrant/cfe/core/cf-agent/cf-agent.c:1344
    #13 0x55d8be88d870 in KeepPromises /home/vagrant/cfe/core/cf-agent/cf-agent.c:831
    #14 0x55d8be88b25b in main /home/vagrant/cfe/core/cf-agent/cf-agent.c:279
    #15 0x7fb281af0b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
```