### PR TITLE
Mitigate race condition in the promiser_match_is_correct.cf test

### DIFF
--- a/tests/acceptance/05_processes/01_matching/promiser_match_is_correct.cf
+++ b/tests/acceptance/05_processes/01_matching/promiser_match_is_correct.cf
@@ -39,6 +39,9 @@ bundle agent init
   commands:
       "$(G.no_fds) --no-std $(sys.cf_agent) -Kf $(this.promise_filename).sub -D AUTO,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_underscore_marks_the_81st_character_of_this_string___STRINGBEYOND80CHARS &"
         contain => in_shell;
+
+      # give the process a chance to actually start
+      "$(G.sleep) 1";
 }
 
 body process_count at_least_one(class)


### PR DESCRIPTION
We spawn an agent process in a shell and then immediately check
that it is running. If it takes a bit to start (easy to happen on
a heavy-loaded machine running tests) the process is not
found. Let's give it a second to start before we try extracting
information about it.