### PR TITLE
Added 'admin' as user in `cf-remote`

### DIFF
--- a/contrib/cf-remote/cf_remote/ssh.py
+++ b/contrib/cf-remote/cf_remote/ssh.py
@@ -16,7 +16,7 @@ def connect(host, users=None):
         if not users:
             users = [parts[0]]
     if not users:
-        users = ["Administrator", "ubuntu", "ec2-user", "centos", "vagrant", "root"]
+        users = ["Administrator", "admin", "ubuntu", "ec2-user", "centos", "vagrant", "root"]
         # Similar to ssh, try own username first,
         # some systems will lock us out if we have too many failed attempts.
         if whoami() not in users:

--- a/contrib/cf-remote/requirements.txt
+++ b/contrib/cf-remote/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==2.7
+cryptography==2.8
 fabric==2.4.0
 paramiko==2.6.0
 requests==2.22.0


### PR DESCRIPTION
Some hosts are configured to use 'admin' as administration user and
refuse to allow access to root.