### PR TITLE
Create the file with expected output first in ifelapsed_and_expireaft…

### DIFF
--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/defaults.cf
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/defaults.cf
@@ -35,7 +35,7 @@ bundle agent init
       "test_skip_needs_work" string => "windows|using_fakeroot|redhat_4|hpux|sunos_5_9|sunos_5_10";
 
   methods:
-    test_pass_4::
+    test_pass_1::
       "any" usebundle => file_make("$(G.testfile).expireafter.expected", "one promise execution");
       "any" usebundle => file_make("$(G.testfile).short_expireafter.expected", "one promise execution
 one promise execution");


### PR DESCRIPTION
…er/timed/defaults.cf

'diff -u' shows modification time timestamps in the output so by
creating the files with expected output first we can actually see
from the diff output how much time it took between starting the
test and last modification of the file which is an important
information in this time-sensitive test.