### PR TITLE
CFE-2973: Added read_module_protocol() policy function

### DIFF
--- a/examples/read_module_protocol.cf
+++ b/examples/read_module_protocol.cf
@@ -1,0 +1,44 @@
+bundle agent cache_maintenance
+# Creates a module protocol cache, refreshes it if minute is 30-35
+{
+    vars:
+      "file"
+        string => "$(this.promise_dirname)/cached_module";
+
+  classes:
+    "cache_refresh"
+      if => not(fileexists("$(file)"));
+    Min30_35::
+      "cache_refresh";
+
+  files:
+    cache_refresh::
+      "$(file)"
+        create => "true",
+        edit_template_string => "=my_variable=$(sys.date)",
+        template_data => "{}",
+        template_method => "inline_mustache";
+}
+
+bundle agent demo
+# Demonstrates read_module_protocol function, prints a variable from it
+{
+    classes:
+      "cache_was_read"
+        if => read_module_protocol("$(cache_maintenance.file)");
+
+    reports:
+      cache_was_read::
+        "Module cache was read!";
+        "cached_module.my_variable = $(cached_module.my_variable)";
+}
+
+
+bundle agent __main__
+{
+  methods:
+    "cache_maintenance"
+      handle => "cache_maintenance_done";
+    "demo"
+      depends_on => { "cache_maintenance_done" };
+}

--- a/libpromises/evalfunction.h
+++ b/libpromises/evalfunction.h
@@ -34,7 +34,7 @@ FnCallResult FnCallHostInNetgroup(EvalContext *ctx, const Policy *policy, const 
 
 int FnNumArgs(const FnCallType *call_type);
 
-void ModuleProtocol(EvalContext *ctx, char *command, const char *line, int print, char* context, size_t context_size, StringSet *tags, long *persistence);
+void ModuleProtocol(EvalContext *ctx, const char *command, const char *line, int print, char* context, size_t context_size, StringSet *tags, long *persistence);
 
 /* Implemented in Nova for Win32 */
 FnCallResult FnCallGroupExists(EvalContext *ctx, const Policy *policy, const FnCall *fp, const Rlist *finalargs);


### PR DESCRIPTION
This function reads module protocol from a file, and can be used
for caching the results of commands modules.

Running the example:

```
root@dev core $ cf-agent -K /northern.tech/cfengine/core/examples/read_module_protocol.cf
R: Module cache was read!
R: cached_module.my_variable = Mon Dec  9 13:10:33 2019
root@dev core $ cf-agent -K /northern.tech/cfengine/core/examples/read_module_protocol.cf
R: Module cache was read!
R: cached_module.my_variable = Mon Dec  9 13:10:33 2019
root@dev core $ rm /northern.tech/cfengine/core/examples/cached_module
root@dev core $ cf-agent -K /northern.tech/cfengine/core/examples/read_module_protocol.cf
R: Module cache was read!
R: cached_module.my_variable = Mon Dec  9 13:10:41 2019
root@dev core $
```