### PR TITLE
CFE-2973: Added inform constraint to commands promises

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -207,6 +207,8 @@ static char *GetLockNameExec(const Attributes *a, const Promise *pp)
 static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
                                const Promise *pp, PromiseResult *result)
 {
+    assert(a != NULL);
+    assert(pp != NULL);
     char eventname[CF_BUFSIZE];
     char cmdline[CF_BUFSIZE];
     char comm[20];
@@ -268,7 +270,8 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
     snprintf(cmdline, CF_BUFSIZE, "%s", temp); // TODO: remove CF_BUFSIZE limitation
     free(temp);
 
-    Log(LOG_LEVEL_INFO, "Executing '%s%s%s' ... '%s'", timeout_str, owner_str, group_str, cmdline);
+    const LogLevel info_or_verbose = a->inform ? LOG_LEVEL_INFO : LOG_LEVEL_VERBOSE;
+    Log(info_or_verbose, "Executing '%s%s%s' ... '%s'", timeout_str, owner_str, group_str, cmdline);
 
     BeginMeasure();
 
@@ -455,7 +458,8 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
         signal(SIGALRM, SIG_DFL);
     }
 
-    Log(LOG_LEVEL_INFO, "Completed execution of '%s'", cmdline);
+    Log(info_or_verbose, "Completed execution of '%s'", cmdline);
+
 #ifndef __MINGW32__
     umask(maskval);
 #endif

--- a/examples/inform.cf
+++ b/examples/inform.cf
@@ -1,0 +1,16 @@
+# The inform constraint can be used to select which commands promises
+# generate output in INFO log level. INFO log level, is intendeted for
+# events which alter the state of the system, such as editing files, users,
+# etc. Since commands promises CAN modify the system, they create INFO
+# messages by default. However, not all commands promises do change the
+# system, so we let the policy writer customize this.
+
+bundle agent main
+{
+  commands:
+    "/bin/touch /tmp/module_cache"
+      inform => "true"; # Default
+    "/bin/cat /tmp/module_cache"
+      inform => "false", # Read-only promise, no INFO logging wanted
+      module => "true";
+}

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -252,6 +252,16 @@ Attributes GetExecAttributes(const EvalContext *ctx, const Promise *pp)
     attr.arglist = PromiseGetConstraintAsList(ctx, "arglist", pp);
     attr.module = PromiseGetConstraintAsBoolean(ctx, "module", pp);
 
+    // Possible to suppress info level messages per commands promise:
+    if (PromiseBundleOrBodyConstraintExists(ctx, "inform", pp))
+    {
+        attr.inform = PromiseGetConstraintAsBoolean(ctx, "inform", pp);
+    }
+    else
+    {
+        attr.inform = true; // Default to printing the inform messages
+    }
+
 /* Common ("included") */
 
     attr.havetrans = PromiseGetConstraintAsBoolean(ctx, CF_TRANSACTION, pp);

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1571,6 +1571,7 @@ typedef struct
     char *args;
     Rlist *arglist;
     int module;
+    bool inform;
 
     Rlist *signals;
     char *process_stop;
@@ -1659,6 +1660,7 @@ typedef struct
     .args = NULL,\
     .arglist = NULL,\
     .module = 0,\
+    .inform = false,\
     .signals = NULL,\
     .process_stop = NULL,\
     .restart_class = NULL,\

--- a/libpromises/mod_exec.c
+++ b/libpromises/mod_exec.c
@@ -49,6 +49,7 @@ static const ConstraintSyntax commands_constraints[] =
     ConstraintSyntaxNewStringList("arglist", CF_ANYSTRING, "Alternative string list of arguments for the command (concatenated with promiser string and 'args' attribute)", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBody("contain", &contain_body, "Containment options for the execution process", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBool("module", "true/false whether to expect the cfengine module protocol. Default value: false", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewBool("inform", "true/false whether to print info messages for command execution. Default value: true", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewNull()
 };
 


### PR DESCRIPTION
This constraint can be used to suppress the sometimes spammy
INFO log messages, emitted by commands promises:

```
    info: Executing 'no timeout' ... '/bin/cat /tmp/module_cache'
    info: Completed execution of '/bin/cat /tmp/module_cache'
```

Not all commands promises change the system. Thus, we allow
policy writers to customize whether the promise should be
logged in INFO, or not.

Example policy:

```
bundle agent main
{
  commands:
    "/bin/touch /tmp/module_cache"
      inform => "true"; # Default
    "/bin/cat /tmp/module_cache"
      inform => "false", # Read-only promise, no INFO logging wanted
      module => "true";
}
```