### PR TITLE
Fixed basename() segfault on Solaris

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1586,7 +1586,10 @@ static FnCallResult FnCallBasename(ARG_UNUSED EvalContext *ctx,
             // Remove only if actually a suffix, not the same string
             if (suffix_len < base_len)
             {
-                base[base_len - suffix_len] = '\0';
+                // On Solaris, trying to edit the buffer returned by basename
+                // causes segfault(!)
+                base = xstrndup(base, base_len - suffix_len);
+                return FnReturnNoCopy(base);
             }
         }
     }


### PR DESCRIPTION
Trying to get to the bottom of some segmentation fault which only
happens on solaris.

It looks like the buffer returned by `basename()` is marked as read only. Testing a fix.