### PR TITLE
Expect success in evalfunction_test on mac

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -191,7 +191,6 @@ TESTS = $(check_PROGRAMS) $(check_SCRIPTS)
 
 if MACOSX
 XFAIL_TESTS = set_domainname_test
-XFAIL_TESTS += evalfunction_test
 XFAIL_TESTS += process_test
 XFAIL_TESTS += mon_processes_test
 endif


### PR DESCRIPTION
Looks like I fixed it on accident.