### PR TITLE
Fixed small memory leak in policy evaluation (3.15)

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -661,7 +661,7 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
                                                        RlistAppendScalar(&synthetic_args, xstrdup(P.rval.item));
                                                        RvalDestroy(P.rval);
 
-                                                       P.rval = (Rval) { FnCallNew(xstrdup(fname), synthetic_args), RVAL_TYPE_FNCALL };
+                                                       P.rval = (Rval) { FnCallNew(fname, synthetic_args), RVAL_TYPE_FNCALL };
                                                    }
                                                    else
                                                    {


### PR DESCRIPTION
This memory leak appears when the LHS of a promise
constraint is `data` or `template_data`, and the RHS
is a string literal. If the string literal is not
valid JSON, perhaps because of unexpanded variables,
a `parsejson` function call is inserted instead. The name
of the function call (for example `parsejson`) is leaked
in this case.

Not picked up by our CI, since valgrind test only runs
community parts of masterfiles.