### PR TITLE
CFE-3234/3.15.x: Moved error reading file in countlinesmatching() from verbose to error

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -3000,7 +3000,7 @@ static FnCallResult FnCallCountLinesMatching(ARG_UNUSED EvalContext *ctx, ARG_UN
     FILE *fin = safe_fopen(filename, "rt");
     if (!fin)
     {
-        Log(LOG_LEVEL_VERBOSE, "File '%s' could not be read in countlinesmatching(). (fopen: %s)", filename, GetErrorStr());
+        Log(LOG_LEVEL_ERR, "File '%s' could not be read in countlinesmatching(). (fopen: %s)", filename, GetErrorStr());
         pcre_free(rx);
         return FnReturn("0");
     }

--- a/tests/acceptance/01_vars/02_functions/countlinesmatching_errors_on_absent_file.cf
+++ b/tests/acceptance/01_vars/02_functions/countlinesmatching_errors_on_absent_file.cf
@@ -1,0 +1,51 @@
+#######################################################
+#
+# Test countlinesmatching() errors when file is absent
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-3234" }
+        string => "Test that the agent emits error output when countlinesmatching() is used on a file that is inaccessible.";
+
+      "test_skip_needs_work"
+        string => "windows",
+        meta => { "CFE-3234" };
+
+  vars:
+
+      "subout" string => execresult("$(sys.cf_agent) -Kv --define AUTO -f $(this.promise_dirname)/countlinesmatching_returns_0_on_inaccessable_file.cf 2>&1 | $(G.grep) countlinesmatching", "useshell");
+
+}
+
+#######################################################
+
+bundle agent check
+{
+
+  vars:
+      "expression" string => ".* error: File '/asd/fgh/qwertyio0p' could not be read in countlinesmatching.*";
+
+  classes:
+      "__pass" expression => regcmp( $(expression), $(test.subout) );
+
+  methods:
+
+  __pass::
+      "Pass" usebundle => dcs_pass( $(this.promise_filename) );
+  !__pass::
+      "FAIL" usebundle => dcs_pass( $(this.promise_filename) );
+}

--- a/tests/acceptance/01_vars/02_functions/countlinesmatching_returns_0_on_inaccessable_file.cf
+++ b/tests/acceptance/01_vars/02_functions/countlinesmatching_returns_0_on_inaccessable_file.cf
@@ -23,6 +23,10 @@ bundle agent init
 
 bundle agent test
 {
+  meta:
+      "description" -> { "Mantis 320", "CFE-3234" }
+        string => "Test that countlinesmatching() returns 0 when the file is inaccessible.";
+
   vars:
       "zero_regex" string => "impossible line";
 


### PR DESCRIPTION
countlinesmatching() did not error when the file being counted does not exist or
was unable to be accessed. The result of 0 matching lines is correct, but there
is also an expectation of an error message to indicate the file is missing.

Added test for countlinesmatching() erroring on absent file.

This test simply runs an existing test and inspects the agent run output for an
error.

Ticket: CFE-3234
Changelog: Title
(cherry picked from commit 5b4ab064165b7f35ac46cde37c8fb7dd096fc61c)