### PR TITLE
cf-check: Added nice printing for nova_agent_executions.lmdb

### DIFF
--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -49,9 +49,14 @@ static void print_json_string(
     {
         const size_t len = strnlen(data, size);
 
-        // Unfortunately, the packages_installed_apt_get.lmdb database
-        // has unterminated strings:
-        assert((size == 1) || (len == (size - 1)) || (data[size - 1] == '\n'));
+        // We expect the data to either be single byte ("0" or "1"),
+        // or a C-string
+        bool known_data = ((size == 1) || (len == (size - 1)) || (data[size - 1] == '\n'));
+        if (!known_data)
+        {
+            printf("\nError: This database contains unknown binary data - use --simple to print anyway\n");
+            exit(1);
+        }
 
         // Most of what we store are C strings except 1 byte '0' or '1',
         // and some structs. So in nice mode, we try to default to printing

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -288,6 +288,25 @@ static void print_struct_or_string(
         {
             print_struct_persistent_class(value, strip_strings);
         }
+        else if (StringEndsWith(file, "nova_agent_execution.lmdb"))
+        {
+            if (StringSafeEqual(key.mv_data, "delta_gavr"))
+            {
+                assert(sizeof(double) == value.mv_size);
+                const double *const average = value.mv_data;
+                printf("%f", *average);
+            }
+            else if (StringSafeEqual(key.mv_data, "last_exec"))
+            {
+                assert(sizeof(time_t) == value.mv_size);
+                const time_t *const last_exec = value.mv_data;
+                printf("%ju", (uintmax_t) (*last_exec));
+            }
+            else
+            {
+                debug_abort_if_reached();
+            }
+        }
         else
         {
             print_json_string(value.mv_data, value.mv_size, strip_strings);


### PR DESCRIPTION
**Example:**

```
root@dev core $ cf-check dump /var/cfengine/state/nova_agent_execution.lmdb
{
        "delta_gavr": 297.001673,
        "last_exec": 1578593375,
}
```