### PR TITLE
[3.12.x] ENT-4016: Fix copy_from overwriting permissions on destination file

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -1272,7 +1272,6 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
     char backup[CF_BUFSIZE];
     char new[CF_BUFSIZE], *linkable;
     int remote = false, backupisdir = false, backupok = false, discardbackup;
-    struct stat s;
 
 #ifdef HAVE_UTIME_H
     struct utimbuf timebuf;
@@ -1335,9 +1334,8 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
         free(tmpstr);
     }
     else
-    {
 #endif
-
+    {
         strlcpy(new, dest, CF_BUFSIZE);
 
         if (!JoinSuffix(new, sizeof(new), CF_NEW))
@@ -1345,10 +1343,11 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
             Log(LOG_LEVEL_ERR, "Unable to construct filename for copy");
             return false;
         }
-
-#ifdef __APPLE__
     }
-#endif
+
+    struct stat dest_stat;
+    int ret = stat(dest, &dest_stat);
+    bool dest_exists = (ret == 0);
 
     if (remote)
     {
@@ -1364,80 +1363,100 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
     }
     else
     {
-        if (!CopyRegularFileDisk(source, new))
+        // If preserve is true, retain permissions of source file
+        if (attr.copy.preserve)
         {
-            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr, "Failed copying file '%s' to '%s'", source, new);
-            *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
-            return false;
+            if (!CopyRegularFileDisk(source, new))
+            {
+                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr,
+                     "Failed copying file '%s' to '%s'", source, new);
+                *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
+                return false;
+            }
+        }
+        else
+        {
+            // Never preserve SUID bit (0777)
+            int mode = dest_exists ? (dest_stat.st_mode & 0777) : 0600;
+            if (!CopyRegularFileDiskPerms(source, new, mode))
+            {
+                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr,
+                     "Failed copying file '%s' to '%s'", source, new);
+                *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
+                return false;
+            }
         }
 
+#ifdef HAVE_UTIME_H
         if (attr.copy.stealth)
         {
-#ifdef HAVE_UTIME_H
             timebuf.actime = sstat.st_atime;
             timebuf.modtime = sstat.st_mtime;
             utime(source, &timebuf);
-#endif
         }
+#endif
     }
 
     Log(LOG_LEVEL_VERBOSE, "Copy of regular file succeeded '%s' to '%s'", source, new);
 
     backup[0] = '\0';
 
-    if (!discardbackup)
+    if (dest_exists)
     {
-        char stamp[CF_BUFSIZE];
-        time_t stampnow;
-
-        Log(LOG_LEVEL_DEBUG, "Backup file '%s'", source);
-
-        strlcpy(backup, dest, CF_BUFSIZE);
-
-        if (attr.copy.backup == BACKUP_OPTION_TIMESTAMP)
+        if (!discardbackup)
         {
-            stampnow = time((time_t *) NULL);
-            snprintf(stamp, CF_BUFSIZE - 1, "_%lu_%s", CFSTARTTIME, CanonifyName(ctime(&stampnow)));
+            char stamp[CF_BUFSIZE];
+            time_t stampnow;
 
-            if (!JoinSuffix(backup, sizeof(backup), stamp))
+            Log(LOG_LEVEL_DEBUG, "Backup file '%s'", source);
+
+            strlcpy(backup, dest, CF_BUFSIZE);
+
+            if (attr.copy.backup == BACKUP_OPTION_TIMESTAMP)
+            {
+                stampnow = time((time_t *) NULL);
+                snprintf(stamp, CF_BUFSIZE - 1, "_%lu_%s",
+                         CFSTARTTIME, CanonifyName(ctime(&stampnow)));
+
+                if (!JoinSuffix(backup, sizeof(backup), stamp))
+                {
+                    return false;
+                }
+            }
+
+            if (!JoinSuffix(backup, sizeof(backup), CF_SAVED))
             {
                 return false;
             }
-        }
 
-        if (!JoinSuffix(backup, sizeof(backup), CF_SAVED))
-        {
-            return false;
-        }
+            /* Now in case of multiple copies of same object,
+             * try to avoid overwriting original backup */
 
-        /* Now in case of multiple copies of same object, try to avoid overwriting original backup */
-
-        if (lstat(backup, &s) != -1)
-        {
-            if (S_ISDIR(s.st_mode))     /* if there is a dir in the way */
+            if (lstat(backup, &dest_stat) != -1)
             {
-                backupisdir = true;
-                PurgeLocalFiles(ctx, NULL, backup, attr, pp, conn);
-                rmdir(backup);
+                /* if there is a dir in the way */
+                if (S_ISDIR(dest_stat.st_mode))
+                {
+                    backupisdir = true;
+                    PurgeLocalFiles(ctx, NULL, backup, attr, pp, conn);
+                    rmdir(backup);
+                }
+
+                unlink(backup);
             }
 
-            unlink(backup);
+            if (rename(dest, backup) == -1)
+            {
+                /* ignore */
+            }
+
+            /* Did the rename() succeed? NFS-safe */
+            backupok = (lstat(backup, &dest_stat) != -1);
         }
-
-        if (rename(dest, backup) == -1)
+        else
         {
-            /* ignore */
-        }
-
-        backupok = (lstat(backup, &s) != -1);   /* Did the rename() succeed? NFS-safe */
-    }
-    else
-    {
-        /* Mainly important if there is a dir in the way */
-
-        if (stat(dest, &s) != -1)
-        {
-            if (S_ISDIR(s.st_mode))
+            /* Mainly important if there is a dir in the way */
+            if (S_ISDIR(dest_stat.st_mode))
             {
                 PurgeLocalFiles(ctx, NULL, dest, attr, pp, conn);
                 rmdir(dest);
@@ -1445,7 +1464,8 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
         }
     }
 
-    if (lstat(new, &dstat) == -1)
+    struct stat new_stat;
+    if (lstat(new, &new_stat) == -1)
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr, "Can't stat new file '%s' - another agent has picked it up?. (stat: %s)",
              new, GetErrorStr());
@@ -1453,11 +1473,11 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
         return false;
     }
 
-    if ((S_ISREG(dstat.st_mode)) && (dstat.st_size != sstat.st_size))
+    if ((S_ISREG(new_stat.st_mode)) && (new_stat.st_size != sstat.st_size))
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr,
              "New file '%s' seems to have been corrupted in transit, destination %d and source %d, aborting.", new,
-             (int) dstat.st_size, (int) sstat.st_size);
+             (int) new_stat.st_size, (int) sstat.st_size);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
 
         if (backupok)
@@ -1472,7 +1492,7 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
     {
         Log(LOG_LEVEL_VERBOSE, "Final verification of transmission ...");
 
-        if (CompareFileHashes(source, new, &sstat, &dstat, attr.copy, conn))
+        if (CompareFileHashes(source, new, &sstat, &new_stat, attr.copy, conn))
         {
             cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr,
                  "New file '%s' seems to have been corrupted in transit, aborting.", new);
@@ -1567,9 +1587,8 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
         }
     }
     else
-    {
 #endif
-
+    {
         if (rename(new, dest) == -1)
         {
             cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr,
@@ -1584,10 +1603,7 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, str
 
             return false;
         }
-
-#ifdef __APPLE__
     }
-#endif
 
     if ((!discardbackup) && backupisdir)
     {

--- a/libpromises/files_copy.c
+++ b/libpromises/files_copy.c
@@ -105,6 +105,9 @@ bool CopyRegularFileDiskPerms(const char *source, const char *destination,
 
 bool CopyRegularFileDisk(const char *source, const char *destination)
 {
+    assert(source != NULL);
+    assert(destination != NULL);
+
     bool ok1 = false, ok2 = false;       /* initialize before the goto end; */
 
     int sd = safe_open(source, O_RDONLY | O_BINARY);
@@ -117,9 +120,9 @@ bool CopyRegularFileDisk(const char *source, const char *destination)
 
     /* We need to stat the file to get the right source permissions. */
     struct stat statbuf;
-    if (stat(source, &statbuf) == -1)
+    if (fstat(sd, &statbuf) == -1)
     {
-        Log(LOG_LEVEL_INFO, "Can't copy '%s' (stat: %s)",
+        Log(LOG_LEVEL_INFO, "Can't copy '%s' (fstat: %s)",
             source, GetErrorStr());
         goto end;
     }
@@ -129,7 +132,7 @@ bool CopyRegularFileDisk(const char *source, const char *destination)
     unlink(destination);
 
     int dd = safe_open(destination,
-                       O_WRONLY | O_CREAT | O_TRUNC | O_EXCL | O_BINARY,
+                       O_WRONLY | O_CREAT | O_EXCL | O_BINARY,
                        statbuf.st_mode);
     if (dd == -1)
     {
@@ -145,8 +148,8 @@ bool CopyRegularFileDisk(const char *source, const char *destination)
                          ST_BLKSIZE(statbuf),
                          &total_bytes_written, &last_write_was_hole);
     bool do_sync = false;
-    ok2= FileSparseClose(dd, destination, do_sync,
-                         total_bytes_written, last_write_was_hole);
+    ok2 = FileSparseClose(dd, destination, do_sync,
+                          total_bytes_written, last_write_was_hole);
 
     if (!ok1 || !ok2)
     {

--- a/libpromises/files_copy.h
+++ b/libpromises/files_copy.h
@@ -36,6 +36,8 @@
     lsetxattr((__arg1), (__arg2), (__arg3), (__arg4), 0, (__arg5))
 #endif
 
+bool CopyRegularFileDiskPerms(const char *source, const char *destination,
+                              const int mode);
 bool CopyRegularFileDisk(const char *source, const char *destination);
 bool CopyFilePermissionsDisk(const char *source, const char *destination);
 bool CopyFileExtendedAttributesDisk(const char *source, const char *destination);

--- a/tests/acceptance/10_files/02_maintain/004.cf
+++ b/tests/acceptance/10_files/02_maintain/004.cf
@@ -49,6 +49,7 @@ body perms test_og
 
 body copy_from test_copy
 {
+      preserve => "true";
       source => "$(G.etc_group)";
       compare => "atime";
 }

--- a/tests/acceptance/10_files/02_maintain/005.cf
+++ b/tests/acceptance/10_files/02_maintain/005.cf
@@ -47,6 +47,7 @@ body perms test_og
 
 body copy_from test_copy
 {
+      preserve => "true";
       source => "$(G.etc_group)";
       compare => "hash";
 }

--- a/tests/acceptance/10_files/02_maintain/006.cf
+++ b/tests/acceptance/10_files/02_maintain/006.cf
@@ -49,6 +49,7 @@ body perms test_og
 
 body copy_from test_copy
 {
+      preserve => "true";
       source => "$(G.etc_group)";
       compare => "digest";
 }

--- a/tests/acceptance/10_files/copy_from_preserve_false.cf
+++ b/tests/acceptance/10_files/copy_from_preserve_false.cf
@@ -1,0 +1,81 @@
+body file control
+{
+        inputs => { "../default.cf.sub" };
+}
+
+bundle agent main
+{
+  methods:
+      "Test" usebundle => default("$(this.promise_filename)") ;
+}
+
+bundle agent init
+{
+  files:
+
+      # We set the permissions of our source file so that we can be sure they
+      # are not the permissions of the target file at the end.
+
+      "$(this.promise_filename).src"
+        perms => m( "$(check.expect[src])" );
+
+      # We make sure the target file exists and has permissions different from
+      # the source file.
+
+      "$(this.promise_filename).target"
+        delete => tidy;
+
+      "$(this.promise_filename).target"
+        create => "true",
+        perms => m( "$(check.expect[target])" );
+}
+
+bundle agent test
+{
+  meta:
+
+      "description"
+        string => "Test that preserve false in body copy_from doesn't modify
+        permissions of the promised file";
+
+  files:
+
+      # We promise that the target is a copy of the source file Since preserve
+      # is set to false, we expect the original permissions on the target file
+      # to remain unchanged.
+
+      "$(this.promise_filename).target"
+        copy_from => local_cp_digest_preserve_false( "$(this.promise_filename).src" );
+
+}
+bundle agent check
+{
+  vars:
+      "expect[src]"      string => "500";
+      "expect[target]"   string => "600";
+
+      "observe[src]"    string => filestat( "$(this.promise_filename).src", permoct);
+      "observe[target]" string => filestat( "$(this.promise_filename).target", permoct);
+
+  methods:
+
+    "Test Result"
+        usebundle => dcs_check_strcmp(
+                                       "$(expect[target])",
+                                       "$(observe[target])",
+                                       $(this.promise_filename),
+                                       "false");
+
+  reports:
+      DEBUG|EXTRA::
+      ".src Expect $(expect[src]), observe $(observe[target])";
+      ".target Expect $(expect[target]), observe $(observe[target])";
+
+}
+body copy_from local_cp_digest_preserve_false (from)
+{
+        source      => "$(from)";
+        preserve    => "false";
+        compare     => "digest";
+        copy_backup => "false";
+}


### PR DESCRIPTION
@nickanderson wanted this cherry-picked.

There were some merge conflicts, as the new `safe_open_create_perms` function has not been backported to this version, as well as the `Attributes` parameter in `CfCopyFile` not being a pointer. I decided to keep the code improvements even though they are irrelevant to the functionality improvements.