### PR TITLE
cf-remote: Added ability to set ssh key from env var

### DIFF
--- a/contrib/cf-remote/cf_remote/ssh.py
+++ b/contrib/cf-remote/cf_remote/ssh.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import fabric
 from paramiko.ssh_exception import AuthenticationException
@@ -24,7 +25,12 @@ def connect(host, users=None):
     for user in users:
         try:
             log.debug("Attempting ssh: {}@{}".format(user, host))
-            c = fabric.Connection(host=host, user=user)
+            connect_kwargs = {}
+            key = os.getenv("CF_REMOTE_SSH_KEY")
+            if key:
+                connect_kwargs["key_filename"] = os.path.expanduser(key)
+            c = fabric.Connection(
+                host=host, user=user, connect_kwargs=connect_kwargs)
             c.ssh_user = user
             c.ssh_host = host
             c.run("whoami", hide=True)


### PR DESCRIPTION
Example:

```
$ export CFREMOTE_SSH_KEY="~/.ssh/id_rsa.pub"
$ cf-remote info --hosts hub

ubuntu@34.244.238.16
OS            : ubuntu (debian)
Architecture  : x86_64
CFEngine      : 3.16.0a.c505dc774 (Enterprise)
Policy server : None
Binaries      : dpkg, apt

$
```