### PR TITLE
[3.12.x] Find the matching parenthesis in variable reference

### DIFF
--- a/tests/acceptance/01_vars/01_basic/nested_parens_var_ref.cf
+++ b/tests/acceptance/01_vars/01_basic/nested_parens_var_ref.cf
@@ -1,0 +1,41 @@
+###########################################################
+#
+# Test that a variable reference with nested parentheses works
+#
+###########################################################
+
+body common control
+{
+    inputs => { "../../default.cf.sub" };
+    bundlesequence => { default($(this.promise_filename)) };
+    version => "1.0";
+}
+
+###########################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-3242" }
+        string => "Test that a variable reference with nested parentheses works";
+
+  vars:
+      "my_array[key(1)]" string => "value";
+      "value" string => "$(my_array[key(1)])";
+}
+
+###########################################################
+
+bundle agent check
+{
+  classes:
+      "ok" and => { isvariable( "test.value" ),
+                    strcmp( "$(test.value)", "value")
+      };
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
If a variable reference contains parentheses, we need to make
sure we find the matching parenthesis for the opening one, not
the first opposite parenthesis.

For example '$(my_array[key(1)])' needs to match the second
closing parenthesis not the first one.

Ticket: CFE-3242
Changelog: Variable references with nested parentheses no longer
cause errors

(cherry picked from commit d3a144e829dd3e8fc3c9ae36b221e9efde969062)