### PR TITLE
[3.15.x] Refactor readdata to use new json-utils from libntech

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1122,7 +1122,7 @@ static void DefineVersionedHardClasses(
 static void OSReleaseParse(EvalContext *ctx, const char *file_path)
 {
     JsonElement *os_release_json = JsonReadDataFile("system info discovery",
-                                                    file_path, "ENV",
+                                                    file_path, DATAFILETYPE_ENV,
                                                     100 * 1024);
     if (os_release_json != NULL)
     {


### PR DESCRIPTION
Now uses an enum defined in `json-utils.h` instead of trying to find the
same data several times by comparing the function name. Also split
readdata and e.g. readcsv into different functions, since their
functionality is a bit different.

Created two generic functions, one for the readcsv/yaml/envfile/json
functions, and one that is used by both readdata and the former generic
function that calls `JsonReadDataFile`.

Also changed occurence of `JsonReadDataFile` in `libenv/sysinfo.c` to
use `DATAFILETYPE_ENV` instead of `"env"`. This was minor enough to keep
in this commit.

Ticket: None
Changelog: None