### PR TITLE
ENT-5090: Removed (USE AT YOUR OWN RISK) from cf-key help menu for -x (3.12)

### DIFF
--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -104,7 +104,7 @@ static const char *const HINTS[] =
     "Show lastseen hostnames and IP addresses",
     "Don't truncate -s / --show-hosts output",
     "Remove keys for specified hostname/IP/MD5/SHA (cf-key -r SHA=12345, cf-key -r MD5=12345, cf-key -r host001, cf-key -r 203.0.113.1)",
-    "Force removal of keys (USE AT YOUR OWN RISK)",
+    "Force removal of keys",
     "Install license file on Enterprise server (CFEngine Enterprise Only)",
     "Print digest of the specified public key",
     "Make cf-serverd/cf-agent trust the specified public key. Argument value is of the form [[USER@]IPADDR:]FILENAME where FILENAME is the local path of the public key for client at IPADDR address.",


### PR DESCRIPTION
It is kind of implied that --force-removal can be destructive.
We don't have any specific reasoning for this phrasing, so it
is not so useful, just confusing / concerning for a user.