### PR TITLE
ENT-5320 Updated paramiko version and added apache-libcloud

### DIFF
--- a/contrib/cf-remote/requirements.txt
+++ b/contrib/cf-remote/requirements.txt
@@ -1,4 +1,5 @@
 cryptography==2.8
 fabric==2.4.0
-paramiko==2.6.0
+paramiko==2.7.0
 requests==2.22.0
+apache-libcloud==2.8.0


### PR DESCRIPTION
paramiko 2.6.0 would not load openssh style private keys.
apache-libcloud is needed for cf-remote spawn.

Changelog: none
Ticket: ENT-5320