### PR TITLE
Fixed memory leak in handling of inline JSON in policy evaluation (3.12)

### DIFF
--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -658,7 +658,7 @@ constraint:            constraint_id                        /* BUNDLE ONLY */
                                                    if (json == NULL)
                                                    {
                                                        Rlist *synthetic_args = NULL;
-                                                       RlistAppendScalar(&synthetic_args, xstrdup(P.rval.item));
+                                                       RlistAppendScalar(&synthetic_args, P.rval.item);
                                                        RvalDestroy(P.rval);
 
                                                        P.rval = (Rval) { FnCallNew(xstrdup(fname), synthetic_args), RVAL_TYPE_FNCALL };


### PR DESCRIPTION
RlistAppendScalar already calls `xstrdup`. Found by running
binaries (bootstrap) built with AddressSanitizer (ASAN) enabled.