### PR TITLE
Add the new Vagrant-CI to 'dist'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,8 @@ SUBDIRS = \
 	misc \
 	ext \
 	examples \
-	tests
+	tests \
+	contrib/vagrant-ci/centos-6-x64
 
 
 # Hide the buildsystem's username, at least with GNU tar.

--- a/contrib/vagrant-ci/centos-6-x64/Makefile.am
+++ b/contrib/vagrant-ci/centos-6-x64/Makefile.am
@@ -9,3 +9,7 @@ vm-check-full:
 destroy-vms:
 	-vagrant destroy no-deps-build
 	-vagrant destroy full-build
+
+EXTRA_DIST = Vagrantfile Makefile.in
+
+CLEANFILES = Makefile.in


### PR DESCRIPTION
We want it to be part of the tarballs so that './configure' works
on the unpacked tarball and it is possible to run the tests this
way when starting with the tarball.