### PR TITLE
Autotools: Pick up flags from environment when building cf-check

### DIFF
--- a/cf-check/Makefile.am
+++ b/cf-check/Makefile.am
@@ -25,17 +25,20 @@ noinst_LTLIBRARIES = libcf-check.la
 
 AM_CPPFLAGS = -I$(srcdir)/../libntech/libutils \
 	-I$(srcdir)/../libntech/libcompat \
+	@CPPFLAGS@ \
 	$(PCRE_CPPFLAGS) \
 	$(LIBYAML_CPPFLAGS) \
 	$(LMDB_CPPFLAGS)
 
 AM_CFLAGS = \
+	@CFLAGS@ \
 	$(LMDB_CFLAGS) \
 	$(PCRE_CFLAGS) \
 	$(LIBYAML_CFLAGS) \
 	$(PTHREAD_CFLAGS)
 
 AM_LDFLAGS = \
+	@LDFLAGS@ \
 	$(PCRE_LDFLAGS) \
 	$(LIBYAML_LDFLAGS) \
 	$(LMDB_LDFLAGS)


### PR DESCRIPTION
Needed for compiling with ASAN, using env vars. There are other/better ways of handling these things, but I copied the pattern from another of our Makefiles to at least make it more consistent (and make it work).