### PR TITLE
CFE-3260/3.12.x: cf-agent: files: report purged dirs and files as repaired

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -681,8 +681,6 @@ static PromiseResult PurgeLocalFiles(EvalContext *ctx, Item *filelist, const cha
             }
             else
             {
-                Log(LOG_LEVEL_INFO, "Purging '%s' in copy dest directory", filename);
-
                 if (lstat(filename, &sb) == -1)
                 {
                     cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_INTERRUPTED, pp, attr, "Couldn't stat '%s' while purging. (lstat: %s)",
@@ -704,11 +702,21 @@ static PromiseResult PurgeLocalFiles(EvalContext *ctx, Item *filelist, const cha
                             result = PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
                         }
                     }
+                    else
+                    {
+                        cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_CHANGE, pp, attr, "Purged directory '%s' in copy dest directory", filename);
+                        result = PromiseResultUpdate(result, PROMISE_RESULT_CHANGE);
+                    }
                 }
                 else if (unlink(filename) == -1)
                 {
                     cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr, "Couldn't delete '%s' while purging", filename);
                     result = PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
+                }
+                else
+                {
+                    cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_CHANGE, pp, attr, "Purged file '%s' in copy dest directory", filename);
+                    result = PromiseResultUpdate(result, PROMISE_RESULT_CHANGE);
                 }
             }
         }

--- a/tests/acceptance/10_files/purge_reports_as_repaired.cf
+++ b/tests/acceptance/10_files/purge_reports_as_repaired.cf
@@ -1,0 +1,48 @@
+bundle common test_meta
+{
+  vars:
+      "description" string => "Test that purging a directory in a target propagates promise as repaired";
+}
+
+#######################################################
+
+body common control
+{
+      inputs => { "../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "dirs" slist => {
+        "$(G.testdir)/source/.",
+        "$(G.testdir)/target/.",
+        "$(G.testdir)/target/subdir/."
+    };
+
+   files:
+    "$(dirs)" create => "true";
+}
+
+bundle agent test
+{
+  files:
+    "$(G.testdir)/target/" copy_from => copyfrom_sync("$(G.testdir)/source/."),
+        depth_search => recurse("inf"),
+        classes => if_repaired("purge_propagated");
+}
+
+#######################################################
+
+bundle agent check
+{
+  reports:
+    purge_propagated::
+      "$(this.promise_filename) Pass";
+    !purge_propagated::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Given a recursive file promise with purging enabled, the promise will
not be propagated as repaired if the target directory contains some
directory hierarchy that is removed by the promise. While the function
`PurgeLocalFiles` correctly keeps track of any failed attempts to remove
files from the target directory, it does not report the repaired promise
in case it removes files or directories from the target directory
successfully.

Fix the issue by properly updating the promise to PROMISE_RESULT_CHANGE
if puring either a directory or file successfully. Add an acceptance
test to verify behaviour.

Changelog: Title
Ticket: CFE-3260
Signed-off-by: Patrick Steinhardt <ps@pks.im>
(cherry picked from commit 24fbbca3921d34e205342a303e74234870496ca5)