### PR TITLE
Travis: Allow mac builds to fail until issue is resolved (3.15)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,10 @@ matrix:
     - os: osx
       env: JOB_TYPE=compile_and_unit_test COVERAGE=no
       sudo: false
+  allow_failures:
+    - os: osx
+      env: JOB_TYPE=compile_and_unit_test COVERAGE=no
+      sudo: false
 
 before_install:
   - chmod ug+x ./travis-scripts/*


### PR DESCRIPTION
Mac builds started failing without any changes in our code.
Most likely because of changes in one of the dependencies,
or the travis environment. Let's delay a while and see
if the issue is resolved automatically.

(cherry picked from commit 828a73f52b580ef4b7f25b91f26df12b46c3b0ef)