### PR TITLE
CFE-3198: Added macros before_version, at_version and after_version

### DIFF
--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -90,6 +90,9 @@ comment    #[^\n]*
 
 macro_if_minimum_version  @if\ minimum_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
 macro_if_maximum_version  @if\ maximum_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
+macro_if_before_version   @if\ before_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
+macro_if_at_version       @if\ at_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
+macro_if_after_version    @if\ after_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
 macro_if_between_versions @if\ between_versions\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\ *,\ *[0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
 macro_if_feature          @if\ feature\([a-zA-Z0-9_]+\)
 macro_else  @else
@@ -207,6 +210,108 @@ promise_type   [a-zA-Z_]+:
                             ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
                         }
                         else if (result == VERSION_GREATER)
+                        {
+                            ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
+                            BEGIN(if_ignore_state);
+                        }
+                        else
+                        {
+                            assert(result == VERSION_ERROR);
+                            yyerror("fatal: macro @if requested an unparseable version");
+                        }
+                      }
+
+{macro_if_before_version} {
+                        if (  P.line_pos != 1 )
+                        {
+                             yyerror("fatal: macro @if must be at beginning of the line.");
+                             return 0;
+                        }
+                        if (P.if_depth > 0)
+                        {
+                          yyerror("fatal: nested @if macros are not allowed");
+                          return 0;
+                        }
+
+                        P.if_depth++;
+
+                        const char* target = yytext + strlen("@if before_version(");
+                        ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, target);
+
+                        VersionComparison result = CompareVersion(Version(), target);
+                        if (result == VERSION_SMALLER)
+                        {
+                            ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
+                        }
+                        else if (result == VERSION_GREATER || result == VERSION_EQUAL)
+                        {
+                            ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
+                            BEGIN(if_ignore_state);
+                        }
+                        else
+                        {
+                            assert(result == VERSION_ERROR);
+                            yyerror("fatal: macro @if requested an unparseable version");
+                        }
+                      }
+
+{macro_if_at_version} {
+                        if (  P.line_pos != 1 )
+                        {
+                             yyerror("fatal: macro @if must be at beginning of the line.");
+                             return 0;
+                        }
+                        if (P.if_depth > 0)
+                        {
+                          yyerror("fatal: nested @if macros are not allowed");
+                          return 0;
+                        }
+
+                        P.if_depth++;
+
+                        const char* target = yytext + strlen("@if at_version(");
+                        ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, target);
+
+                        VersionComparison result = CompareVersion(Version(), target);
+                        if (result == VERSION_EQUAL)
+                        {
+                            ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
+                        }
+                        else if (result == VERSION_GREATER || result == VERSION_SMALLER)
+                        {
+                            ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
+                            BEGIN(if_ignore_state);
+                        }
+                        else
+                        {
+                            assert(result == VERSION_ERROR);
+                            yyerror("fatal: macro @if requested an unparseable version");
+                        }
+                      }
+
+{macro_if_after_version} {
+                        if (  P.line_pos != 1 )
+                        {
+                             yyerror("fatal: macro @if must be at beginning of the line.");
+                             return 0;
+                        }
+                        if (P.if_depth > 0)
+                        {
+                          yyerror("fatal: nested @if macros are not allowed");
+                          return 0;
+                        }
+
+                        P.if_depth++;
+
+                        const char* target = yytext + strlen("@if after_version(");
+                        ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, target);
+
+                        VersionComparison result = CompareVersion(Version(), target);
+                        if (result == VERSION_GREATER)
+                        {
+                            ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
+                        }
+                        else if (result == VERSION_EQUAL || result == VERSION_SMALLER)
                         {
                             ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
                             BEGIN(if_ignore_state);

--- a/tests/acceptance/00_basics/macros/if.cf
+++ b/tests/acceptance/00_basics/macros/if.cf
@@ -92,6 +92,54 @@ bundle common test
     classes:
       "expected_3_11_3_12";
 @endif
+
+@if before_version(4)
+    classes:
+      "expected_before_version_4";
+@else
+    classes:
+      "not_expected_before_version_4";
+@endif
+
+@if before_version(3)
+    classes:
+      "not_expected_before_version_3";
+@else
+    classes:
+      "expected_before_version_3";
+@endif
+
+@if at_version(3)
+    classes:
+      "expected_at_version_3";
+@else
+    classes:
+      "not_expected_at_version_3";
+@endif
+
+@if at_version(2)
+    classes:
+      "not_expected_at_version_2";
+@else
+    classes:
+      "expected_at_version_2";
+@endif
+
+@if after_version(2)
+    classes:
+      "expected_after_version_2";
+@else
+    classes:
+      "not_expected_after_version_2";
+@endif
+
+@if after_version(3)
+    classes:
+      "not_expected_after_version_3";
+@else
+    classes:
+      "expected_after_version_3";
+@endif
 }
 
 bundle agent check
@@ -102,7 +150,7 @@ bundle agent check
     "expected_length"      int => length("expected_classes");
     "not_expected_length"  int => length("not_expected_classes");
   classes:
-    "pass_expected"     if => strcmp("$(expected_length)", "10");
+    "pass_expected"     if => strcmp("$(expected_length)", "16");
     "pass_not_expected" if => strcmp("$(not_expected_length)", "0");
     "ok" and => { "pass_expected", "pass_not_expected" };
   methods:
@@ -170,4 +218,19 @@ body body body body {{}};;::
 @if between_versions(1, 3.6)
 more invalid syntax
 body body body body {{}};;::
+@endif
+
+@if at_version(2)
+body invalid syntax
+{{{reports:}}};;;:::
+@endif
+
+@if before_version(3)
+body invalid syntax
+{{{reports:}}};;;:::
+@endif
+
+@if after_version(3)
+body invalid syntax
+{{{reports:}}};;;:::
 @endif


### PR DESCRIPTION
A final PR for the version detection macros. In some cases you want to specify just one version, or versions before or after (exclusive);

```
@if maximum_version(3.15.999) # Ugly
@if before_version(3.16) # More readable
```

```
# Something which was buggy in 3.15.4:
@if minimum_version(3.15.5)
@if after_version(3.15.4)
```

```
@if between_versions(3.15.0, 3.15.0) # Ugly
@if at_version(3.15.0) # More readable
```

I guess the last one missing is `not_version` (inverse of `at`), but I don't really see a case where it's useful, and you can acheive it using `at_version` + `else`.