### PR TITLE
cf-remote: Fixed package selection for new package names

### DIFF
--- a/contrib/cf-remote/cf_remote/packages.py
+++ b/contrib/cf-remote/cf_remote/packages.py
@@ -125,9 +125,11 @@ class Release:
         log.debug("In artifacts: {}".format(artifacts))
         for tag in tags or []:
             tag = canonify(tag)
-            artifacts = [a for a in artifacts if tag in a.tags]
+            new_artifacts = [a for a in artifacts if tag in a.tags]
             # Have to force evaluation using list comprehension,
             # since we are overwriting artifacts
+            if len(new_artifacts) > 0:
+                artifacts = new_artifacts
 
         log.debug("Found artifacts: {}".format(artifacts))
         return artifacts

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -198,6 +198,23 @@ def install_host(
         release = releases.default
         if version:
             release = releases.pick_version(version)
+
+        if "os_release" in data and data["os_release"]:
+            distro = data["os_release"]["ID"]
+            major = data["os_release"]["VERSION_ID"].split(".")[0]
+            platform_tag = distro + major
+
+            # Add tags with version number first, to filter by them first:
+            tags.append(platform_tag) # Example: ubuntu16
+            if distro == "centos":
+                tags.append("el" + major)
+
+            # Then add more generic tags (lower priority):
+            tags.append(distro) # Example: ubuntu
+            if distro == "centos":
+                tags.append("rhel")
+                tags.append("el")
+
         artifacts = release.find(tags, extension)
         if not artifacts:
             user_error(

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -250,8 +250,7 @@ def uninstall_host(host, *, connection=None):
     print_info(data)
 
     if not data["agent_version"]:
-        print("CFEngine is not installed on '{}' - moving on".format(host))
-        return data
+        log.warning("CFEngine does not seem to be installed on '{}' - attempting uninstall anyway".format(host))
 
     uninstall_cfengine(host, data, connection=connection)
     data = get_info(host, connection=connection)
@@ -262,5 +261,5 @@ def uninstall_host(host, *, connection=None):
 
     print_info(data)
 
-    print("Uninstallation successful on '{}''".format(host))
+    print("Uninstallation successful on '{}'".format(host))
     return data


### PR DESCRIPTION
Tested on Ubuntu 18, Ubuntu 16, CentOS 7, CentOS 6