### PR TITLE
ENT-5162 cf-check: Symlinked LMDB databases are now preserved in repair

### DIFF
--- a/cf-check/diagnose.c
+++ b/cf-check/diagnose.c
@@ -507,6 +507,23 @@ static int fork_and_diagnose(const char *path, bool validate, bool test_write)
     return CF_CHECK_OK;
 }
 
+static char *follow_symlink(const char *path)
+{
+    char target_buf[4096] = { 0 };
+    const ssize_t r = readlink(path, target_buf, sizeof(target_buf));
+    if (r < 0)
+    {
+        return NULL;
+    }
+    if (r >= sizeof(target_buf))
+    {
+        Log(LOG_LEVEL_ERR, "Symlink target path too long: %s", path);
+        return NULL;
+    }
+    target_buf[r] = '\0';
+    return xstrdup(target_buf);
+}
+
 /**
  * @param[in]  filenames  DB files to diagnose/check
  * @param[out] corrupt    place to store the resulting sequence of corrupted
@@ -534,8 +551,31 @@ size_t diagnose_files(
     for (int i = 0; i < length; ++i)
     {
         const char *filename = SeqAt(filenames, i);
-        int r;
-        if (foreground)
+        const char *symlink = NULL; // Only initialized because of gcc warning
+        int r = 0; // Only initialized because of LGTM alert
+        char *symlink_target = follow_symlink(filename);
+        bool broken_symlink_handled = false;
+        if (symlink_target != NULL)
+        {
+            symlink = filename;
+            // If the LMDB file path is a symlink
+            filename = symlink_target;
+            if (access(symlink_target, F_OK) != 0)
+            {
+                // Symlink target file does not exist
+                r = CF_CHECK_OK_DOES_NOT_EXIST;
+                broken_symlink_handled = true;
+            }
+            // If this is not the case, continue repair as normal,
+            // using the symlink target instead of the symlink in diagnose
+            // and repair functions
+        }
+        if (broken_symlink_handled)
+        {
+            // The LMDB database was a broken symlink,
+            // we don't need to do anything, agent will recreate it.
+        }
+        else if (foreground)
         {
             r = diagnose(filename, true, validate);
             if ((r == CF_CHECK_OK) && test_write)
@@ -547,12 +587,25 @@ size_t diagnose_files(
         {
             r = fork_and_diagnose(filename, validate, test_write);
         }
-        Log(LOG_LEVEL_INFO,
-            "Status of '%s': %s\n",
-            filename,
-            CF_CHECK_STRING(r));
 
-        if (r != CF_CHECK_OK)
+        if (symlink_target != NULL)
+        {
+            Log(LOG_LEVEL_INFO,
+                "Status of '%s' -> '%s': %s\n",
+                symlink,
+                symlink_target,
+                CF_CHECK_STRING(r));
+        }
+        else
+        {
+            Log(LOG_LEVEL_INFO,
+                "Status of '%s': %s\n",
+                filename,
+                CF_CHECK_STRING(r));
+        }
+
+
+        if (r != CF_CHECK_OK && r != CF_CHECK_OK_DOES_NOT_EXIST)
         {
             ++corruptions;
             if (corrupt != NULL)
@@ -560,6 +613,7 @@ size_t diagnose_files(
                 SeqAppend(*corrupt, xstrdup(filename));
             }
         }
+        free(symlink_target);
     }
     if (corruptions == 0)
     {

--- a/cf-check/diagnose.h
+++ b/cf-check/diagnose.h
@@ -13,6 +13,7 @@
 // clang-format off
 #define CF_CHECK_RUN_CODES(macro)                         \
     macro(OK)                                             \
+    macro(OK_DOES_NOT_EXIST)                              \
     macro(SIGNAL_HANGUP)                                  \
     macro(SIGNAL_INTERRUPT)                               \
     macro(SIGNAL_QUIT)                                    \


### PR DESCRIPTION
Performs diagnosis and repair on symlink target instead of symlink.
Repaired files / copies are placed alongside symlink target.
In some cases, the symlink target is deleted to repair a corrupt
database, and the symlink is left as a broken symlink. This is
handled gracefully by the agent, it will be recreated. Broken
symlinks are now detected as an acceptable condition in diagnose,
it won't try to repair them or delete them.