### PR TITLE
Added macros: maximum_version, between_version, before_version, after_version, at_version (3.12)

### DIFF
--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -90,6 +90,9 @@ comment    #[^\n]*
 
 macro_if_minimum_version  @if\ minimum_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
 macro_if_maximum_version  @if\ maximum_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
+macro_if_before_version   @if\ before_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
+macro_if_at_version       @if\ at_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
+macro_if_after_version    @if\ after_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
 macro_if_between_versions @if\ between_versions\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\ *,\ *[0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
 macro_if_feature          @if\ feature\([a-zA-Z0-9_]+\)
 macro_else  @else
@@ -207,6 +210,108 @@ promise_type   [a-zA-Z_]+:
                             ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
                         }
                         else if (result == VERSION_GREATER)
+                        {
+                            ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
+                            BEGIN(if_ignore_state);
+                        }
+                        else
+                        {
+                            assert(result == VERSION_ERROR);
+                            yyerror("fatal: macro @if requested an unparseable version");
+                        }
+                      }
+
+{macro_if_before_version} {
+                        if (  P.line_pos != 1 )
+                        {
+                             yyerror("fatal: macro @if must be at beginning of the line.");
+                             return 0;
+                        }
+                        if (P.if_depth > 0)
+                        {
+                          yyerror("fatal: nested @if macros are not allowed");
+                          return 0;
+                        }
+
+                        P.if_depth++;
+
+                        const char* target = yytext + strlen("@if before_version(");
+                        ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, target);
+
+                        VersionComparison result = CompareVersion(Version(), target);
+                        if (result == VERSION_SMALLER)
+                        {
+                            ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
+                        }
+                        else if (result == VERSION_GREATER || result == VERSION_EQUAL)
+                        {
+                            ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
+                            BEGIN(if_ignore_state);
+                        }
+                        else
+                        {
+                            assert(result == VERSION_ERROR);
+                            yyerror("fatal: macro @if requested an unparseable version");
+                        }
+                      }
+
+{macro_if_at_version} {
+                        if (  P.line_pos != 1 )
+                        {
+                             yyerror("fatal: macro @if must be at beginning of the line.");
+                             return 0;
+                        }
+                        if (P.if_depth > 0)
+                        {
+                          yyerror("fatal: nested @if macros are not allowed");
+                          return 0;
+                        }
+
+                        P.if_depth++;
+
+                        const char* target = yytext + strlen("@if at_version(");
+                        ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, target);
+
+                        VersionComparison result = CompareVersion(Version(), target);
+                        if (result == VERSION_EQUAL)
+                        {
+                            ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
+                        }
+                        else if (result == VERSION_GREATER || result == VERSION_SMALLER)
+                        {
+                            ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
+                            BEGIN(if_ignore_state);
+                        }
+                        else
+                        {
+                            assert(result == VERSION_ERROR);
+                            yyerror("fatal: macro @if requested an unparseable version");
+                        }
+                      }
+
+{macro_if_after_version} {
+                        if (  P.line_pos != 1 )
+                        {
+                             yyerror("fatal: macro @if must be at beginning of the line.");
+                             return 0;
+                        }
+                        if (P.if_depth > 0)
+                        {
+                          yyerror("fatal: nested @if macros are not allowed");
+                          return 0;
+                        }
+
+                        P.if_depth++;
+
+                        const char* target = yytext + strlen("@if after_version(");
+                        ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, target);
+
+                        VersionComparison result = CompareVersion(Version(), target);
+                        if (result == VERSION_GREATER)
+                        {
+                            ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
+                        }
+                        else if (result == VERSION_EQUAL || result == VERSION_SMALLER)
                         {
                             ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
                             BEGIN(if_ignore_state);

--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -88,9 +88,9 @@ eat_line  ([\n]|[\xd][\xa]).*
 
 comment    #[^\n]*
 
-macro_if_minimum_version  @if\ minimum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
-macro_if_maximum_version  @if\ maximum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
-macro_if_between_versions @if\ between_versions\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\ *,\ *[0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
+macro_if_minimum_version  @if\ minimum_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
+macro_if_maximum_version  @if\ maximum_version\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
+macro_if_between_versions @if\ between_versions\([0-9]{1,5}(\.[0-9]{1,5}){0,2}\ *,\ *[0-9]{1,5}(\.[0-9]{1,5}){0,2}\)
 macro_if_feature          @if\ feature\([a-zA-Z0-9_]+\)
 macro_else  @else
 macro_endif @endif

--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -89,6 +89,7 @@ eat_line  ([\n]|[\xd][\xa]).*
 comment    #[^\n]*
 
 macro_if_minimum_version @if\ minimum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
+macro_if_maximum_version @if\ maximum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
 macro_if_feature         @if\ feature\([a-zA-Z0-9_]+\)
 macro_endif @endif
 macro_line [^@\n\xd\xa].*
@@ -170,6 +171,40 @@ promise_type   [a-zA-Z_]+:
                             ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
                         }
                         else if (result == VERSION_SMALLER)
+                        {
+                            ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
+                            BEGIN(if_ignore_state);
+                        }
+                        else
+                        {
+                            assert(result == VERSION_ERROR);
+                            yyerror("fatal: macro @if requested an unparseable version");
+                        }
+                      }
+
+{macro_if_maximum_version} {
+                        if (  P.line_pos != 1 )
+                        {
+                             yyerror("fatal: macro @if must be at beginning of the line.");
+                             return 0;
+                        }
+                        if (P.if_depth > 0)
+                        {
+                          yyerror("fatal: nested @if macros are not allowed");
+                          return 0;
+                        }
+
+                        P.if_depth++;
+
+                        const char* maximum = yytext+20;
+                        ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, maximum);
+
+                        VersionComparison result = CompareVersion(Version(), maximum);
+                        if (result == VERSION_SMALLER || result == VERSION_EQUAL)
+                        {
+                            ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
+                        }
+                        else if (result == VERSION_GREATER)
                         {
                             ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
                             BEGIN(if_ignore_state);

--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -91,6 +91,7 @@ comment    #[^\n]*
 macro_if_minimum_version @if\ minimum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
 macro_if_maximum_version @if\ maximum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
 macro_if_feature         @if\ feature\([a-zA-Z0-9_]+\)
+macro_else  @else
 macro_endif @endif
 macro_line [^@\n\xd\xa].*
 
@@ -270,6 +271,20 @@ promise_type   [a-zA-Z_]+:
 <if_ignore_state>{macro_line}  {
                                   ParserDebug("\tL:inside macro @if, ignoring line text:\"%s\"\n", yytext);
                                }
+
+<if_ignore_state>{macro_else} {
+                                ParserDebug("\tL:macro @else, will no longer ignore lines\n", P.line_pos);
+                                BEGIN(INITIAL);
+                              }
+{macro_else}                  {
+                                if (P.if_depth <= 0)
+                                {
+                                  yyerror("fatal: @else macro without a matching @if are not allowed");
+                                  return 0;
+                                }
+                                ParserDebug("\tL:macro @else, will now ignore lines\n", P.line_pos);
+                                BEGIN(if_ignore_state);
+                              }
 
 <if_ignore_state>{macro_endif} {
                                  ParserDebug("\tL:macro @endif %d\n", P.line_pos);

--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -88,9 +88,10 @@ eat_line  ([\n]|[\xd][\xa]).*
 
 comment    #[^\n]*
 
-macro_if_minimum_version @if\ minimum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
-macro_if_maximum_version @if\ maximum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
-macro_if_feature         @if\ feature\([a-zA-Z0-9_]+\)
+macro_if_minimum_version  @if\ minimum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
+macro_if_maximum_version  @if\ maximum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
+macro_if_between_versions @if\ between_versions\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\ *,\ *[0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
+macro_if_feature          @if\ feature\([a-zA-Z0-9_]+\)
 macro_else  @else
 macro_endif @endif
 macro_line [^@\n\xd\xa].*
@@ -214,6 +215,45 @@ promise_type   [a-zA-Z_]+:
                         {
                             assert(result == VERSION_ERROR);
                             yyerror("fatal: macro @if requested an unparseable version");
+                        }
+                      }
+
+{macro_if_between_versions} {
+                        if ( P.line_pos != 1 )
+                        {
+                             yyerror("fatal: macro @if must be at beginning of the line.");
+                             return 0;
+                        }
+                        if (P.if_depth > 0)
+                        {
+                          yyerror("fatal: nested @if macros are not allowed");
+                          return 0;
+                        }
+
+                        P.if_depth++;
+
+                        const char* from = yytext + strlen("@if between_versions(");
+
+                        const char *to = strchr(from, ',');
+                        to += 1;
+                        while (*to == ' ')
+                        {
+                            to += 1;
+                        }
+
+                        ParserDebug("\tL:macro @if %d:between_versions(%s\n", P.line_pos, from);
+
+                        VersionComparison a = CompareVersion(Version(), from);
+                        VersionComparison b = CompareVersion(Version(), to);
+                        if ((a == VERSION_EQUAL || a == VERSION_GREATER)
+                            && (b == VERSION_EQUAL || b == VERSION_SMALLER))
+                        {
+                            ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
+                        }
+                        else
+                        {
+                            ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
+                            BEGIN(if_ignore_state);
                         }
                       }
 

--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -36,6 +36,7 @@
 #include <file_lib.h>
 #include <regex.h>
 #include <feature.h>
+#include <version_comparison.h>
 }
 
 %{
@@ -146,70 +147,37 @@ promise_type   [a-zA-Z_]+:
                           yyless(1);
                       }
 
-{macro_if_minimum_version}
-                      {
+{macro_if_minimum_version} {
                         if (  P.line_pos != 1 )
                         {
                              yyerror("fatal: macro @if must be at beginning of the line.");
                              return 0;
                         }
-
-                        const char* version_text = yytext+20;
-                        ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, version_text);
+                        if (P.if_depth > 0)
                         {
-                          int request_major = 0;
-                          int request_minor = 0;
-                          int request_patch = 0;
-                          int request_level = 0;
-                          int major = 0;
-                          int minor = 0;
-                          int patch = 0;
+                          yyerror("fatal: nested @if macros are not allowed");
+                          return 0;
+                        }
 
-                          if (P.if_depth > 0)
-                          {
-                            yyerror("fatal: nested @if macros are not allowed");
-                            return 0;
-                          }
+                        P.if_depth++;
 
-                          P.if_depth++;
+                        const char* minimum = yytext+20;
+                        ParserDebug("\tL:macro @if %d:version=%s\n", P.line_pos, minimum);
 
-                          if (sscanf(Version(), "%d.%d.%d", &major, &minor, &patch) == 3)
-                          {
-                            request_level = sscanf(version_text, "%d.%d.%d", &request_major, &request_minor, &request_patch);
-                            if (request_level >= 1)
-                            {
-                              if (request_major > major) {
-                                ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
-                                BEGIN(if_ignore_state);
-                              } else if (request_major < major || request_level == 1) {
-                                ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
-                              } else { // request_major==major && request_level > 1
-                                if (request_minor > minor) {
-                                  ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
-                                  BEGIN(if_ignore_state);
-                                } else if (request_minor < minor || request_level == 2) {
-                                  ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
-                                } else { // request_minor==minor && request_level > 2
-                                  if (request_patch > patch) {
-                                    ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
-                                    BEGIN(if_ignore_state);
-                                  } else { // request_patch <= patch
-                                    ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
-                                  }
-                                }
-                              }
-                            }
-                            else
-                            {
-                              yyerror("fatal: macro @if requested an unparseable version");
-                              return 0;
-                            }
-                          }
-                          else
-                          {
-                            yyerror("fatal: Version() was unparseable");
-                            return 0;
-                          }
+                        VersionComparison result = CompareVersion(Version(), minimum);
+                        if (result == VERSION_GREATER || result == VERSION_EQUAL)
+                        {
+                            ParserDebug("\tL:macro @if %d:accepted to next @endif\n", P.line_pos);
+                        }
+                        else if (result == VERSION_SMALLER)
+                        {
+                            ParserDebug("\tL:macro @if %d:ignoring to next @endif or EOF\n", P.line_pos);
+                            BEGIN(if_ignore_state);
+                        }
+                        else
+                        {
+                            assert(result == VERSION_ERROR);
+                            yyerror("fatal: macro @if requested an unparseable version");
                         }
                       }
 

--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -87,8 +87,8 @@ eat_line  ([\n]|[\xd][\xa]).*
 
 comment    #[^\n]*
 
-macro_if_version    @if\ minimum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
-macro_if_feature    @if\ feature\([a-zA-Z0-9_]+\)
+macro_if_minimum_version @if\ minimum_version\([0-9]{1,10}\.[0-9]{1,10}(\.[0-9]{1,10})?\)
+macro_if_feature         @if\ feature\([a-zA-Z0-9_]+\)
 macro_endif @endif
 macro_line [^@\n\xd\xa].*
 
@@ -146,7 +146,8 @@ promise_type   [a-zA-Z_]+:
                           yyless(1);
                       }
 
-{macro_if_version}    {
+{macro_if_minimum_version}
+                      {
                         if (  P.line_pos != 1 )
                         {
                              yyerror("fatal: macro @if must be at beginning of the line.");

--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -367,7 +367,7 @@ promise_type   [a-zA-Z_]+:
 
 {varclass}            {
                           char *tmp = NULL;
-                        
+
                           P.line_pos += yyleng;
                           ParserDebug("\tL:varclass %s %d\n", yytext, P.line_pos);
 
@@ -394,7 +394,7 @@ promise_type   [a-zA-Z_]+:
 
 {class}               {
                           char *tmp = NULL;
-                        
+
                           P.line_pos += yyleng;
                           ParserDebug("\tL:class %s %d\n", yytext, P.line_pos);
                           if (context_expression_whitespace_rx == NULL)

--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -78,6 +78,7 @@ libutils_la_SOURCES = \
 	statistics.c statistics.h \
 	string_lib.c string_lib.h \
 	unicode.c unicode.h \
+	version_comparison.c version_comparison.h \
 	writer.c writer.h \
 	xml_writer.c xml_writer.h
 

--- a/libutils/version_comparison.c
+++ b/libutils/version_comparison.c
@@ -1,0 +1,78 @@
+#include <version_comparison.h>
+#include <stdio.h> // sscanf
+#include <assert.h> // assert()
+
+VersionComparison CompareVersion(const char *a, const char *b)
+{
+    int a_major = 0;
+    int a_minor = 0;
+    int a_patch = 0;
+
+    const int a_num = sscanf(a, "%d.%d.%d", &a_major, &a_minor, &a_patch);
+    if (a_num < 1 || a_num > 3)
+    {
+        return VERSION_ERROR;
+    }
+
+    int b_major = 0;
+    int b_minor = 0;
+    int b_patch = 0;
+
+    const int b_num = sscanf(b, "%d.%d.%d", &b_major, &b_minor, &b_patch);
+    if (b_num < 1 || b_num > 3)
+    {
+        return VERSION_ERROR;
+    }
+
+    if (a_major > b_major)
+    {
+        return VERSION_GREATER;
+    }
+
+    if (a_major < b_major)
+    {
+        return VERSION_SMALLER;
+    }
+
+    assert(a_major == b_major);
+
+    if (a_num == 1 || b_num == 1)
+    {
+        return VERSION_EQUAL;
+    }
+
+    assert(a_num >= 2 && b_num >= 2);
+
+    if (a_minor < b_minor)
+    {
+        return VERSION_SMALLER;
+    }
+
+    if (a_minor > b_minor)
+    {
+        return VERSION_GREATER;
+    }
+
+    assert(a_minor == b_minor);
+
+    if (a_num == 2 || b_num == 2)
+    {
+        return VERSION_EQUAL;
+    }
+
+    assert(a_num == 3 && b_num == 3);
+
+    if (a_patch < b_patch)
+    {
+        return VERSION_SMALLER;
+    }
+
+    if (a_patch > b_patch)
+    {
+        return VERSION_GREATER;
+    }
+
+    assert(a_patch == b_patch);
+
+    return VERSION_EQUAL;
+}

--- a/libutils/version_comparison.h
+++ b/libutils/version_comparison.h
@@ -1,0 +1,14 @@
+#ifndef CF_VERSION_COMPARISON_H
+#define CF_VERSION_COMPARISON_H
+
+typedef enum VersionComparison
+{
+    VERSION_SMALLER,
+    VERSION_EQUAL,
+    VERSION_GREATER,
+    VERSION_ERROR,
+} VersionComparison;
+
+VersionComparison CompareVersion(const char *a, const char *b);
+
+#endif

--- a/tests/acceptance/00_basics/macros/if.cf
+++ b/tests/acceptance/00_basics/macros/if.cf
@@ -77,20 +77,20 @@ bundle common test
       "not_expected_4_0_0";
 @endif
 
-@if between_versions(3.15.0, 4.0.0)
+@if between_versions(3.12.0, 4.0.0)
     classes:
-      "expected_3_15_0_4_0_0";
+      "expected_3_12_0_4_0_0";
 @else
     classes:
-      "not_expected_3_15_0_4_0_0";
+      "not_expected_3_12_0_4_0_0";
 @endif
 
-@if between_versions(3.11, 3.12)
+@if between_versions(3.10, 3.11)
     classes:
-      "not_expected_3_11_3_12";
+      "not_expected_3_10_3_11";
 @else
     classes:
-      "expected_3_11_3_12";
+      "expected_3_10_3_11";
 @endif
 
 @if before_version(4)

--- a/tests/acceptance/00_basics/macros/if.cf
+++ b/tests/acceptance/00_basics/macros/if.cf
@@ -92,6 +92,54 @@ bundle common test
     classes:
       "expected_3_11_3_12";
 @endif
+
+@if before_version(4)
+    classes:
+      "expected_before_version_4";
+@else
+    classes:
+      "not_expected_before_version_4";
+@endif
+
+@if before_version(3)
+    classes:
+      "not_expected_before_version_3";
+@else
+    classes:
+      "expected_before_version_3";
+@endif
+
+@if at_version(3)
+    classes:
+      "expected_at_version_3";
+@else
+    classes:
+      "not_expected_at_version_3";
+@endif
+
+@if at_version(2)
+    classes:
+      "not_expected_at_version_2";
+@else
+    classes:
+      "expected_at_version_2";
+@endif
+
+@if after_version(2)
+    classes:
+      "expected_after_version_2";
+@else
+    classes:
+      "not_expected_after_version_2";
+@endif
+
+@if after_version(3)
+    classes:
+      "not_expected_after_version_3";
+@else
+    classes:
+      "expected_after_version_3";
+@endif
 }
 
 bundle agent check
@@ -102,7 +150,7 @@ bundle agent check
     "expected_length"      int => length("expected_classes");
     "not_expected_length"  int => length("not_expected_classes");
   classes:
-    "pass_expected"     if => strcmp("$(expected_length)", "10");
+    "pass_expected"     if => strcmp("$(expected_length)", "16");
     "pass_not_expected" if => strcmp("$(not_expected_length)", "0");
     "ok" and => { "pass_expected", "pass_not_expected" };
   methods:
@@ -170,4 +218,19 @@ body body body body {{}};;::
 @if between_versions(1, 3.6)
 more invalid syntax
 body body body body {{}};;::
+@endif
+
+@if at_version(2)
+body invalid syntax
+{{{reports:}}};;;:::
+@endif
+
+@if before_version(3)
+body invalid syntax
+{{{reports:}}};;;:::
+@endif
+
+@if after_version(3)
+body invalid syntax
+{{{reports:}}};;;:::
 @endif

--- a/tests/acceptance/00_basics/macros/if.cf
+++ b/tests/acceptance/00_basics/macros/if.cf
@@ -13,6 +13,14 @@ body common control
 
 bundle common test
 {
+@if minimum_version(3)
+  classes:
+      "expected_3";
+@else
+  classes:
+      "not_expected_3";
+@endif
+
 @if minimum_version(3.7)
   classes:
       "expected_3_7";
@@ -53,12 +61,12 @@ bundle common test
       "expected_3_0";
 @endif
 
-@if maximum_version(4.0)
+@if maximum_version(4)
     classes:
-      "expected_4_0";
+      "expected_4";
 @else
     classes:
-      "not_expected_4_0";
+      "not_expected_4";
 @endif
 
 @if maximum_version(4.0.0)
@@ -94,7 +102,7 @@ bundle agent check
     "expected_length"      int => length("expected_classes");
     "not_expected_length"  int => length("not_expected_classes");
   classes:
-    "pass_expected"     if => strcmp("$(expected_length)", "9");
+    "pass_expected"     if => strcmp("$(expected_length)", "10");
     "pass_not_expected" if => strcmp("$(not_expected_length)", "0");
     "ok" and => { "pass_expected", "pass_not_expected" };
   methods:
@@ -113,6 +121,12 @@ bundle agent check
 }
 
 @if minimum_version(3.12)
+@else
+some invalid syntax here
+body {} {}{}{{}}
+@endif
+
+@if minimum_version(3)
 @else
 some invalid syntax here
 body {} {}{}{{}}
@@ -149,6 +163,11 @@ body files control { {} }
 @endif
 
 @if between_versions(2.0, 3.0)
+more invalid syntax
+body body body body {{}};;::
+@endif
+
+@if between_versions(1, 3.6)
 more invalid syntax
 body body body body {{}};;::
 @endif

--- a/tests/acceptance/00_basics/macros/if.cf
+++ b/tests/acceptance/00_basics/macros/if.cf
@@ -16,36 +16,57 @@ bundle common test
 @if minimum_version(3.7)
   classes:
       "expected_3_7";
+@else
+  classes:
+      "not_expected_3_7";
 @endif
 
 @if minimum_version(3.6)
   classes:
       "expected_3_6";
+@else
+  classes:
+      "not_expected_3_6";
 @endif
 
 @if minimum_version(2.100)
   classes:
       "expected_2_100";
+@else
+  classes:
+      "not_xpected_2_100";
 @endif
 
 @if minimum_version(300.700)
   classes:
-      "not_expected";
+      "not_expected_300_700";
+@else
+  classes:
+      "expected_300_700";
 @endif
 
 @if maximum_version(3.0)
     classes:
-      "not_expected_2";
+      "not_expected_3_0";
+@else
+    classes:
+      "expected_3_0";
 @endif
 
 @if maximum_version(4.0)
     classes:
       "expected_4_0";
+@else
+    classes:
+      "not_expected_4_0";
 @endif
 
 @if maximum_version(4.0.0)
     classes:
       "expected_4_0_0";
+@else
+    classes:
+      "not_expected_4_0_0";
 @endif
 }
 
@@ -57,22 +78,29 @@ bundle agent check
     "expected_length"      int => length("expected_classes");
     "not_expected_length"  int => length("not_expected_classes");
   classes:
-    "pass_expected"     if => strcmp("$(expected_length)", "5");
+    "pass_expected"     if => strcmp("$(expected_length)", "7");
     "pass_not_expected" if => strcmp("$(not_expected_length)", "0");
     "ok" and => { "pass_expected", "pass_not_expected" };
   methods:
     ok::
       "" usebundle => dcs_pass($(this.promise_filename));
   reports:
-    "Expected classes: $(expected_classes)";
-    "Not expected classes: $(not_expected_classes)";
-    "Expected length: $(expected_length)";
-    "Not expected length: $(not_expected_length)";
-    pass_expected::
+    DEBUG::
+      "Expected classes: $(expected_classes)";
+      "Not expected classes: $(not_expected_classes)";
+      "Expected length: $(expected_length)";
+      "Not expected length: $(not_expected_length)";
+    DEBUG.pass_expected::
       "pass_expected";
-    pass_not_expected::
+    DEBUG.pass_not_expected::
       "pass_not_expected";
 }
+
+@if minimum_version(3.12)
+@else
+some invalid syntax here
+body {} {}{}{{}}
+@endif
 
 @if minimum_version(300.600)
 

--- a/tests/acceptance/00_basics/macros/if.cf
+++ b/tests/acceptance/00_basics/macros/if.cf
@@ -15,31 +15,63 @@ bundle common test
 {
 @if minimum_version(3.7)
   classes:
-      "expected" expression => "any";
+      "expected_3_7";
 @endif
 
 @if minimum_version(3.6)
   classes:
-      "expected2" expression => "any";
+      "expected_3_6";
 @endif
 
 @if minimum_version(2.100)
   classes:
-      "expected_2_100" expression => "any";
+      "expected_2_100";
 @endif
 
 @if minimum_version(300.700)
   classes:
-      "not_expected" expression => "any";
+      "not_expected";
+@endif
+
+@if maximum_version(3.0)
+    classes:
+      "not_expected_2";
+@endif
+
+@if maximum_version(4.0)
+    classes:
+      "expected_4_0";
+@endif
+
+@if maximum_version(4.0.0)
+    classes:
+      "expected_4_0_0";
 @endif
 }
 
 bundle agent check
 {
+  vars:
+    "expected_classes"     slist => classesmatching("expected.*");
+    "not_expected_classes" slist => classesmatching("not_expected.*");
+    "expected_length"      int => length("expected_classes");
+    "not_expected_length"  int => length("not_expected_classes");
+  classes:
+    "pass_expected"     if => strcmp("$(expected_length)", "5");
+    "pass_not_expected" if => strcmp("$(not_expected_length)", "0");
+    "ok" and => { "pass_expected", "pass_not_expected" };
   methods:
-      "" usebundle => dcs_passif_expected("expected,expected2,expected_2_100",
-                                         "not_expected",
-                                         $(this.promise_filename));
+    ok::
+      "" usebundle => dcs_pass($(this.promise_filename));
+  reports:
+    "Expected classes: $(expected_classes)";
+    "Not expected classes: $(not_expected_classes)";
+    "Expected length: $(expected_length)";
+    "Not expected length: $(not_expected_length)";
+    pass_expected::
+      "pass_expected";
+    pass_not_expected::
+      "pass_not_expected";
 }
 
 @if minimum_version(300.600)
@@ -66,4 +98,8 @@ Nothing should be seen here really
 
 Who knows, perhaps this text doesn't exist..?
 
+@endif
+
+@if maximum_version(3.6.0)
+body files control { {} }
 @endif

--- a/tests/acceptance/00_basics/macros/if.cf
+++ b/tests/acceptance/00_basics/macros/if.cf
@@ -68,6 +68,22 @@ bundle common test
     classes:
       "not_expected_4_0_0";
 @endif
+
+@if between_versions(3.15.0, 4.0.0)
+    classes:
+      "expected_3_15_0_4_0_0";
+@else
+    classes:
+      "not_expected_3_15_0_4_0_0";
+@endif
+
+@if between_versions(3.11, 3.12)
+    classes:
+      "not_expected_3_11_3_12";
+@else
+    classes:
+      "expected_3_11_3_12";
+@endif
 }
 
 bundle agent check
@@ -78,7 +94,7 @@ bundle agent check
     "expected_length"      int => length("expected_classes");
     "not_expected_length"  int => length("not_expected_classes");
   classes:
-    "pass_expected"     if => strcmp("$(expected_length)", "7");
+    "pass_expected"     if => strcmp("$(expected_length)", "9");
     "pass_not_expected" if => strcmp("$(not_expected_length)", "0");
     "ok" and => { "pass_expected", "pass_not_expected" };
   methods:
@@ -130,4 +146,9 @@ Who knows, perhaps this text doesn't exist..?
 
 @if maximum_version(3.6.0)
 body files control { {} }
+@endif
+
+@if between_versions(2.0, 3.0)
+more invalid syntax
+body body body body {{}};;::
 @endif

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -184,6 +184,7 @@ check_PROGRAMS = \
 	matching_test \
 	ring_buffer_test \
 	strlist_test \
+	version_comparison_test \
 	addr_lib_test \
 	policy_server_test \
 	libcompat_test \

--- a/tests/unit/version_comparison_test.c
+++ b/tests/unit/version_comparison_test.c
@@ -1,0 +1,62 @@
+#include <version_comparison.h>
+#include <test.h>
+
+static void test_CompareVersion(void)
+{
+    assert_true(VERSION_EQUAL == CompareVersion("3.15.0", "3.15.0"));
+    assert_true(VERSION_EQUAL == CompareVersion("3.15.0", "3.15.0a"));
+    assert_true(VERSION_EQUAL == CompareVersion("3.15.0", "3.15.0a1"));
+    assert_true(VERSION_EQUAL == CompareVersion("3.15", "3.15.0"));
+    assert_true(VERSION_EQUAL == CompareVersion("3.15.0", "3.15"));
+    assert_true(VERSION_EQUAL == CompareVersion("3.15.0", "3"));
+    assert_true(VERSION_EQUAL == CompareVersion("3", "3.15.0"));
+    assert_true(VERSION_EQUAL == CompareVersion("3.", "3"));
+    assert_true(VERSION_EQUAL == CompareVersion("3.15.0", "3.15.0-2"));
+    assert_true(VERSION_EQUAL == CompareVersion("3.15.0-1", "3.15.0-2"));
+    assert_true(VERSION_EQUAL == CompareVersion("3.15.0.123", "3.15.0-2"));
+    assert_true(VERSION_EQUAL == CompareVersion("3.15.0.123", "3.15.0.321"));
+
+    assert_true(VERSION_GREATER == CompareVersion("4", "3"));
+    assert_true(VERSION_GREATER == CompareVersion("3", "1"));
+    assert_true(VERSION_GREATER == CompareVersion("4", "3.15"));
+    assert_true(VERSION_GREATER == CompareVersion("4", "3.999"));
+    assert_true(VERSION_GREATER == CompareVersion("4", "3.999.999"));
+    assert_true(VERSION_GREATER == CompareVersion("4", "3.999.999-999"));
+    assert_true(VERSION_GREATER == CompareVersion("3.16", "3.15"));
+    assert_true(VERSION_GREATER == CompareVersion("3.16.0", "3.15.999"));
+    assert_true(VERSION_GREATER == CompareVersion("3.16.0", "3.15"));
+    assert_true(VERSION_GREATER == CompareVersion("3.15.1", "3.15.0"));
+    assert_true(VERSION_GREATER == CompareVersion("3.15.10", "3.15.9"));
+    assert_true(VERSION_GREATER == CompareVersion("3.10", "3.1"));
+    assert_true(VERSION_GREATER == CompareVersion("3.100", "3.1"));
+
+    assert_true(VERSION_SMALLER == CompareVersion("3", "4"));
+    assert_true(VERSION_SMALLER == CompareVersion("1", "3"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.15", "4"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.999", "4"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.999.999", "4"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.999.999-999", "4"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.15", "3.16"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.15.999", "3.16.0"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.15", "3.16.0"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.15.0", "3.15.1"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.15.9", "3.15.10"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.1", "3.10"));
+    assert_true(VERSION_SMALLER == CompareVersion("3.1", "3.100"));
+
+    assert_true(VERSION_ERROR == CompareVersion("", ""));
+    assert_true(VERSION_ERROR == CompareVersion("1", ""));
+    assert_true(VERSION_ERROR == CompareVersion("", "1"));
+    assert_true(VERSION_ERROR == CompareVersion("", "3.16.0"));
+}
+
+int main()
+{
+    PRINT_TEST_BANNER();
+    const UnitTest tests[] =
+    {
+        unit_test(test_CompareVersion),
+    };
+
+    return run_tests(tests);
+}


### PR DESCRIPTION
**Conflicts:** 

[Had to add `version_comparison` from libntech.](https://github.com/cfengine/core/pull/4066/commits/42dcf4c3c6e4ae2debcc7e3aa6c797c32f830875)

**Changes:**

Had to update the test, with numbers that make sense for 3.12.x. (See last commit).

**Cherry-picked from:**

https://github.com/cfengine/core/pull/4052
https://github.com/cfengine/core/pull/4055
https://github.com/cfengine/core/pull/4062