### PR TITLE
Made classfiltercsv() fail properly on invalid class expression index (3.15)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -6872,7 +6872,9 @@ static FnCallResult FnCallClassFilterCsv(EvalContext *ctx,
                     "%s: Class expression index is out of bounds. "
                     "Row length %zu, index %zu",
                     fp->name, num_columns, class_index);
-                FnFailure();
+                SeqDestroy(list);
+                JsonDestroy(json);
+                return FnFailure();
             }
         }
         else if (num_columns != SeqLength(list))


### PR DESCRIPTION
Reported by LGTM:
https://lgtm.com/rules/2165170567/