### PR TITLE
ENT-5162 cf-check: Symlinked LMDB databases are now preserved in repair (3.12)

### DIFF
--- a/cf-check/diagnose.h
+++ b/cf-check/diagnose.h
@@ -13,6 +13,7 @@
 // clang-format off
 #define CF_CHECK_RUN_CODES(macro)                         \
     macro(OK)                                             \
+    macro(OK_DOES_NOT_EXIST)                              \
     macro(SIGNAL_HANGUP)                                  \
     macro(SIGNAL_INTERRUPT)                               \
     macro(SIGNAL_QUIT)                                    \


### PR DESCRIPTION
Performs diagnosis and repair on symlink target instead of symlink.
Repaired files / copies are placed alongside symlink target.
In some cases, the symlink target is deleted to repair a corrupt
database, and the symlink is left as a broken symlink. This is
handled gracefully by the agent, it will be recreated. Broken
symlinks are now detected as an acceptable condition in diagnose,
it won't try to repair them or delete them.