### PR TITLE
ENT-4829: Enabled skipping CRLF termination of reporting lines

### DIFF
--- a/libcfnet/protocol_version.h
+++ b/libcfnet/protocol_version.h
@@ -84,6 +84,11 @@ static inline bool ProtocolIsClassic(const ProtocolVersion p)
     return (p == CF_PROTOCOL_CLASSIC);
 }
 
+static inline bool ProtocolTerminateCSV(const ProtocolVersion p)
+{
+    return (p < CF_PROTOCOL_COOKIE);
+}
+
 /**
  * Returns CF_PROTOCOL_TLS or CF_PROTOCOL_CLASSIC (or CF_PROTOCOL_UNDEFINED)
  * Maps all versions using TLS to CF_PROTOCOL_TLS for convenience


### PR DESCRIPTION
Merge together:
https://github.com/cfengine/core/pull/4071
https://github.com/cfengine/enterprise/pull/593
https://github.com/cfengine/nova/pull/1612