### PR TITLE
CFE-3046: Only add unique IPv4 and MAC addresses to sys interfaces (3.12)

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -164,8 +164,14 @@ static void GetMacAddress(EvalContext *ctx, int fd, struct ifreq *ifr, struct if
              (unsigned char) ifr->ifr_hwaddr.sa_data[5]);
 
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, name, hw_mac, CF_DATA_TYPE_STRING, "source=agent");
-    RlistAppend(hardware, hw_mac, RVAL_TYPE_SCALAR);
-    RlistAppend(interfaces, ifp->ifr_name, RVAL_TYPE_SCALAR);
+    if (!RlistContainsString(*hardware, hw_mac))
+    {
+        RlistAppend(hardware, hw_mac, RVAL_TYPE_SCALAR);
+    }
+    if (!RlistContainsString(*interfaces, ifp->ifr_name))
+    {
+        RlistAppend(interfaces, ifp->ifr_name, RVAL_TYPE_SCALAR);
+    }
 
     snprintf(name, sizeof(name), "mac_%s", CanonifyName(hw_mac));
     EvalContextClassPutHard(ctx, name, "inventory,attribute_name=none,source=agent");
@@ -203,7 +209,10 @@ static void GetMacAddress(EvalContext *ctx, int fd, struct ifreq *ifr, struct if
                     (unsigned char) m[5]);
 
                 EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, name, hw_mac, CF_DATA_TYPE_STRING, "source=agent");
-                RlistAppend(hardware, hw_mac, RVAL_TYPE_SCALAR);
+                if (!RlistContainsString(*hardware, hw_mac))
+                {
+                    RlistAppend(hardware, hw_mac, RVAL_TYPE_SCALAR);
+                }
                 RlistAppend(interfaces, ifa->ifa_name, RVAL_TYPE_SCALAR);
 
                 snprintf(name, sizeof(name), "mac_%s", CanonifyName(hw_mac));
@@ -224,8 +233,15 @@ static void GetMacAddress(EvalContext *ctx, int fd, struct ifreq *ifr, struct if
 	       mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, name, hw_mac, CF_DATA_TYPE_STRING, "source=agent");
-        RlistAppend(hardware, hw_mac, RVAL_TYPE_SCALAR);
-        RlistAppend(interfaces, ifp->ifr_name, RVAL_TYPE_SCALAR);
+
+        if (!RlistContainsString(*hardware, hw_mac))
+        {
+            RlistAppend(hardware, hw_mac, RVAL_TYPE_SCALAR);
+        }
+        if (!RlistContainsString(*interfaces, ifp->ifr_name))
+        {
+            RlistAppend(interfaces, ifp->ifr_name, RVAL_TYPE_SCALAR);
+        }
 
         snprintf(name, CF_MAXVARSIZE, "mac_%s", CanonifyName(hw_mac));
         EvalContextClassPutHard(ctx, name, "inventory,attribute_name=none,source=agent");
@@ -272,8 +288,16 @@ static void GetMacAddress(EvalContext *ctx, int fd, struct ifreq *ifr, struct if
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, name,
                                   hw_mac, CF_DATA_TYPE_STRING,
                                   "source=agent");
-    RlistAppend(hardware, hw_mac, RVAL_TYPE_SCALAR);
-    RlistAppend(interfaces, ifp->ifr_name, RVAL_TYPE_SCALAR);
+
+    if (!RlistContainsString(*hardware, hw_mac))
+    {
+        RlistAppend(hardware, hw_mac, RVAL_TYPE_SCALAR);
+    }
+
+    if (!RlistContainsString(*interfaces, ifp->ifr_name))
+    {
+        RlistAppend(interfaces, ifp->ifr_name, RVAL_TYPE_SCALAR);
+    }
 
     snprintf(name, sizeof(name), "mac_%s", CanonifyName(hw_mac));
     EvalContextClassPutHard(ctx, name,


### PR DESCRIPTION
Previously, when an interface had multiple IPv4 addresses set, the parsing of
these addresses would add the interface to the sys.interfaces and sys.hardware
variables multiple times, resulting in the interface showing up as a duplicate
in the list.

This fix makes sure that an interface is only added once for every interface
type, regardless of how many IPv4 addresses the interface contains.

Changelog: Fixed an issue causing duplicate entries in sys.interfaces, and
sys.hardware.

Ticket: CFE-3046

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
(cherry picked from commit 3f1bc9d2c97d760bbb31979516fe8afbd9a7b4cc)