### PR TITLE
ENT-5171/3.15.x: Do not log an error in case of no match for a measurements promise

### DIFF
--- a/cf-monitord/history.c
+++ b/cf-monitord/history.c
@@ -551,7 +551,7 @@ static PromiseResult NovaExtractValueFromStream(EvalContext *ctx, const char *ha
 
     if (!found)
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a, "Could not locate the line for promise '%s'", handle);
+        cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_FAIL, pp, a, "Could not locate the line for promise '%s'", handle);
         *value_out = 0.0;
         return PROMISE_RESULT_FAIL;
     }


### PR DESCRIPTION
If a measurements promise regex doesn't match any line of a given
file, it should not produce an error logged to syslog. It's just
noise and the default value 0.0 of the measurement indicates that
nothing was measured. Running with '--verbose' then shows the log
message and helps with debugging.

Ticket: ENT-5171
Changelog: Measurements promises with no match no longer produce errors
(cherry picked from commit 29c298e649da5f87107db3d7e61533064a961a89)