### PR TITLE
Added cf-postgres requirement to cf-apache and cf-hub systemd units

### DIFF
--- a/misc/systemd/cf-apache.service.in
+++ b/misc/systemd/cf-apache.service.in
@@ -2,6 +2,7 @@
 Description=CFEngine Enterprise Webserver
 After=syslog.target
 After=cf-postgres.service
+Requires=cf-postgres.service
 ConditionPathExists=@workdir@/httpd/bin/apachectl
 PartOf=cfengine3.service
 

--- a/misc/systemd/cf-hub.service.in
+++ b/misc/systemd/cf-hub.service.in
@@ -6,8 +6,8 @@ ConditionPathExists=@workdir@/inputs/promises.cf
 After=syslog.target
 After=network.target
 
-Wants=cf-postgres.service
 After=cf-postgres.service
+Requires=cf-postgres.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
During upgrades the services are started in random order and so
need a Requires= to force them to start in the proper order.

Changelog: title
Ticket: ENT-5125