### PR TITLE
CFE-3041 Travis: Run errorlog acceptance tests

### DIFF
--- a/travis-scripts/script.sh
+++ b/travis-scripts/script.sh
@@ -66,7 +66,7 @@ chmod -R go-w .
 
 if [ "$JOB_TYPE" = acceptance_tests_common ]
 then
-    ./testall --printlog --tests=common
+    ./testall --printlog --tests=common,errorlog
     exit
 fi
 


### PR DESCRIPTION
It is debatable whether errorexit tests should be considered safe
or not, but errorlog should definitely be considered safe.