### PR TITLE
ENT-5125 Changed cf-hub.service to 'Wants' cf-postgres.service

### DIFF
--- a/misc/systemd/README.md
+++ b/misc/systemd/README.md
@@ -3,3 +3,5 @@
 On systems running systemd as their init process, the cfengine agents should be
 controlled via "systemctl start" and "systemctl stop".  This will put cfengine
 into separate cgroups and handle logging appropriately.
+
+NOTE: Any changes made here should be synchronized with masterfiles/templates/

--- a/misc/systemd/cf-hub.service.in
+++ b/misc/systemd/cf-hub.service.in
@@ -6,8 +6,8 @@ ConditionPathExists=@workdir@/inputs/promises.cf
 After=syslog.target
 After=network.target
 
+Wants=cf-postgres.service
 After=cf-postgres.service
-Requires=cf-postgres.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Requires in this dependency breaks HA because there systemd will
not be responsible for postgres start/stop and so postgres service
will fail.

Ticket: ENT-5125 (follow-up)
Changelog: title

Added related PR to masterfiles to sync between here and there (here being the master/good copy). https://github.com/cfengine/masterfiles/pull/1699