### PR TITLE
configure.ac: Removed libntech automake files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1787,9 +1787,6 @@ dnl Now make the Makefiles
 dnl ######################################################################
 
 AC_CONFIG_FILES([Makefile
-    libntech/libcompat/Makefile
-    libntech/libutils/Makefile
-    libntech/config.post.h
     libcfnet/Makefile
     libenv/Makefile
     libpromises/Makefile


### PR DESCRIPTION
It should not list them, they are listed in
libntech/configure.ac and have different AM_CONDITIONAL's