### PR TITLE
ENT-5406/3.15.x: Fixed selection of standard_services when used from non-default namespace

### DIFF
--- a/cf-agent/verify_services.c
+++ b/cf-agent/verify_services.c
@@ -194,7 +194,7 @@ static FnCall *DefaultServiceBundleCall(const Promise *pp, const char *service_p
     }
     else
     {
-        call = FnCallNew("standard_services", args);
+        call = FnCallNew("default:standard_services", args);
     }
 
     return call;

--- a/tests/acceptance/09_services/standard_services-from-non-default-namespace.cf
+++ b/tests/acceptance/09_services/standard_services-from-non-default-namespace.cf
@@ -1,0 +1,50 @@
+body common control
+{
+      inputs => { "../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "ENT-5406" }
+        string => "Test that standard_services can be used from non-default namespace";
+
+  methods:
+      "Test" usebundle => ENT_5406:ns_test;
+}
+
+bundle agent standard_services(service, state) {
+  files:
+      "$(G.testfile)"
+        create => "true";
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok" expression => fileexists( $(G.testfile) );
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}
+
+body file control
+{
+        namespace => "ENT_5406";
+}
+
+bundle agent ns_test
+{
+  services:
+      "myservice"
+        service_policy => "start";
+}


### PR DESCRIPTION
When no service_method was specified the standard_services services bundle
should be used. This default only worked if you were already in the default
namespace. This change makes sure that the standard_services method used is from
the default namespace and fixes the case where services promises are used from
non default namespaces expecting to leverage the standard_services
implementation.