### PR TITLE
ENT-5329: Don't go back further than field start when parsing CMD field.

### DIFF
--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -882,7 +882,7 @@ Solaris 9:
         {
             // Last field, slurp up the rest, but discard trailing whitespace.
             last = linelen;
-            while (isspace(line[last - 1]))
+            while (last > pos && isspace(line[last - 1]))
             {
                 last--;
             }


### PR DESCRIPTION
This can happen if the CMD field is empty and filled with space, for
example in the case of zombie processes. Presumably the reason this
has passed before is because it would later result in a strndup call
with a negative size, which on most platforms would just mean the same
as zero. However, on AIX 7 this crashes instead, which is how the
issue was detected (split_process_line_test:test_platform_extra_table
test).

Changelog: Fix rare crashing bug when parsing zombie entries in ps
output. The problem was only ever observed on AIX, but could
theoretically happen on any platform depending on exact libc behavior.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

note to cf-bottom:
Merge together:
https://github.com/cfengine/buildscripts/pull/705