### PR TITLE
cf-remote: Fixed small issue when installing on windows

### DIFF
--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -230,7 +230,7 @@ def install_host(
         extension = None
         if "package_tags" in data and "msi" in data["package_tags"]:
             extension = ".msi"
-            del data["package_tags"]["msi"]
+            data["package_tags"].remove("msi")
         elif "dpkg" in data["bin"]:
             extension = ".deb"
         elif "rpm" in data["bin"]:


### PR DESCRIPTION
The tags are in a list, not a dictionary.