### PR TITLE
cf-remote: Added hub schedule to --demo (pull collect)

### DIFF
--- a/contrib/cf-remote/cf_remote/demo.py
+++ b/contrib/cf-remote/cf_remote/demo.py
@@ -46,7 +46,8 @@ def def_json(call_collect=False):
             "default_data_select_host_monitoring_include": [".*"],
             "default_data_select_policy_hub_monitoring_include": [".*"],
             "control_executor_splaytime": "1",
-            "control_executor_schedule": ["any"]
+            "control_executor_schedule": ["any"],
+            "control_hub_hub_schedule": ["any"]
         }
     }
 


### PR DESCRIPTION
When using --demo mode (without call collect), cf-hub will now
collect reports every minute instead of every 5 minutes.