### PR TITLE
ENT-3710 Improved management of secondary groups to avoid intermediary state failures

### DIFF
--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -907,6 +907,7 @@ static void TransformGidsToGroups(StringSet **list);
 
 static bool GetGroupInfo (const char *user, const User *u, StringSet **groups_to_set, StringSet **groups_missing, StringSet **current_secondary_groups)
 {
+    assert(u != NULL);
     bool ret = true;
     struct group *group_info;
 
@@ -988,11 +989,13 @@ static bool GetGroupInfo (const char *user, const User *u, StringSet **groups_to
 
 static bool EqualGid(const char *key, const struct group *entry)
 {
+    assert(entry != NULL);
     return (atoi(key) == entry->gr_gid);
 }
 
 static bool EqualGroupName(const char *key, const struct group *entry)
 {
+    assert(entry != NULL);
     return (strcmp(key, entry->gr_name) == 0);
 }
 

--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -903,8 +903,9 @@ static bool SetAccountLocked(const char *puser, const char *hash, bool lock)
 
     return SetAccountLockExpiration(puser, lock);
 }
+static void TransformGidsToGroups(StringSet **list);
 
-static bool GroupGetUserMembership (const char *user, StringSet *result)
+static bool GetGroupInfo (const char *user, const User *u, StringSet **groups_to_set, StringSet **groups_missing, StringSet **current_secondary_groups)
 {
     bool ret = true;
     struct group *group_info;
@@ -914,6 +915,18 @@ static bool GroupGetUserMembership (const char *user, StringSet *result)
     {
         Log(LOG_LEVEL_ERR, "Could not open '/etc/group': %s", GetErrorStr());
         return false;
+    }
+
+    StringSet *wanted_groups = StringSetNew();
+    if (u->groups_secondary_given)
+    {
+        for (Rlist *ptr = u->groups_secondary; ptr != NULL; ptr = ptr->next)
+        {
+            StringSetAdd(*groups_missing, xstrdup(RvalScalarValue(ptr->val)));
+            StringSetAdd(wanted_groups, xstrdup(RvalScalarValue(ptr->val)));
+        }
+        TransformGidsToGroups(groups_missing);
+        TransformGidsToGroups(&wanted_groups);
     }
 
     while (true)
@@ -935,16 +948,31 @@ static bool GroupGetUserMembership (const char *user, StringSet *result)
             }
             break;
         }
+
+        if (StringSetContains(wanted_groups, group_info->gr_name))
+        {
+            StringSetRemove(*groups_missing, group_info->gr_name);
+        }
+
         // At least on FreeBSD, gr_mem can be NULL:
         if (group_info->gr_mem != NULL)
         {
-            for (int i = 0; group_info->gr_mem[i] != NULL; i++)
+            bool found = false;
+            for (int i = 0; !found && group_info->gr_mem[i] != NULL; i++)
             {
                 if (strcmp(user, group_info->gr_mem[i]) == 0)
                 {
-                    StringSetAdd(result, xstrdup(group_info->gr_name));
-                    break;
+                    found = true;
+                    StringSetAdd(*current_secondary_groups, xstrdup(group_info->gr_name));
+                    if (StringSetContains(wanted_groups, group_info->gr_name))
+                    {
+                        StringSetAdd(*groups_to_set, xstrdup(group_info->gr_name));
+                    }
                 }
+            }
+            if (!found && StringSetContains(wanted_groups, group_info->gr_name))
+            {
+                StringSetAdd(*groups_to_set, xstrdup(group_info->gr_name));
             }
         }
 #ifdef __FreeBSD__
@@ -952,6 +980,7 @@ static bool GroupGetUserMembership (const char *user, StringSet *result)
 #endif
     }
 
+    StringSetDestroy(wanted_groups);
     fclose(fptr);
 
     return ret;
@@ -1104,7 +1133,7 @@ static void TransformGidsToGroups(StringSet **list)
 }
 
 static bool VerifyIfUserNeedsModifs (const char *puser, const User *u, const struct passwd *passwd_info,
-                             uint32_t *changemap)
+                             uint32_t *changemap, StringSet *groups_to_set, StringSet *current_secondary_groups)
 {
     assert(u != NULL);
     if (u->description != NULL && strcmp (u->description, passwd_info->pw_gecos))
@@ -1138,7 +1167,10 @@ static bool VerifyIfUserNeedsModifs (const char *puser, const User *u, const str
             CFUSR_SETBIT (*changemap, i_password);
         }
     }
-
+    if (u->groups_secondary_given && !StringSetIsEqual(groups_to_set, current_secondary_groups))
+    {
+        CFUSR_SETBIT (*changemap, i_groups);
+    }
     if (SafeStringLength(u->group_primary))
     {
         bool group_could_be_gid = (strlen(u->group_primary) == strspn(u->group_primary, "0123456789"));
@@ -1178,27 +1210,6 @@ static bool VerifyIfUserNeedsModifs (const char *puser, const User *u, const str
 #ifdef __FreeBSD__
         free(group_info);
 #endif
-    }
-
-    if (u->groups_secondary_given)
-    {
-        StringSet *wanted_groups = StringSetNew();
-        for (Rlist *ptr = u->groups_secondary; ptr; ptr = ptr->next)
-        {
-            StringSetAdd(wanted_groups, xstrdup(RvalScalarValue(ptr->val)));
-        }
-        TransformGidsToGroups(&wanted_groups);
-        StringSet *current_groups = StringSetNew();
-        if (!GroupGetUserMembership (puser, current_groups))
-        {
-            CFUSR_SETBIT (*changemap, i_groups);
-        }
-        else if (!StringSetIsEqual (current_groups, wanted_groups))
-        {
-            CFUSR_SETBIT (*changemap, i_groups);
-        }
-        StringSetDestroy(current_groups);
-        StringSetDestroy(wanted_groups);
     }
 
     ////////////////////////////////////////////
@@ -1575,7 +1586,7 @@ static bool DoRemoveUser (const char *puser, enum cfopaction action)
 #endif
 }
 
-static bool DoModifyUser (const char *puser, const User *u, const struct passwd *passwd_info, uint32_t changemap, enum cfopaction action)
+static bool DoModifyUser (const char *puser, const User *u, const struct passwd *passwd_info, uint32_t changemap, enum cfopaction action, StringSet *groups_to_set)
 {
     assert(u != NULL);
     char cmd[CF_BUFSIZE];
@@ -1610,20 +1621,6 @@ static bool DoModifyUser (const char *puser, const User *u, const struct passwd 
         StringAppend(cmd, "\"", sizeof(cmd));
     }
 
-#ifndef __hpux
-    // HP-UX does not support -G with empty argument
-    if (CFUSR_CHECKBIT (changemap, i_groups) != 0)
-    {
-        /* Work around bug on SUSE. If secondary groups contain a group that is
-           the same group as the primary group, the secondary group is not set.
-           This happens even if the primary group is changed in the same call.
-           Therefore, set an empty group list first, and then set it to the real
-           list later.
-        */
-        StringAppend(cmd, " -G \"\"", sizeof(cmd));
-    }
-#endif
-
     if (CFUSR_CHECKBIT (changemap, i_home) != 0)
     {
         StringAppend(cmd, " -d \"", sizeof(cmd));
@@ -1637,10 +1634,6 @@ static bool DoModifyUser (const char *puser, const User *u, const struct passwd 
         StringAppend(cmd, u->shell, sizeof(cmd));
         StringAppend(cmd, "\"", sizeof(cmd));
     }
-#ifndef HAVE_PW
-    StringAppend(cmd, " ", sizeof(cmd));
-    StringAppend(cmd, puser, sizeof(cmd));
-#endif
 
     if (CFUSR_CHECKBIT (changemap, i_password) != 0)
     {
@@ -1690,6 +1683,19 @@ static bool DoModifyUser (const char *puser, const User *u, const struct passwd 
         }
     }
 
+    if (CFUSR_CHECKBIT (changemap, i_groups) != 0)
+    {
+        StringAppend(cmd, " -G \"", sizeof(cmd));
+        Buffer *buf = BufferNew();
+        buf = StringSetToBuffer(groups_to_set, ',');
+        StringAppend(cmd, buf->buffer, sizeof(cmd));
+        BufferDestroy(buf);
+        StringAppend(cmd, "\" ", sizeof(cmd));
+    }
+#ifndef HAVE_PW
+        StringAppend(cmd, " ", sizeof(cmd));
+        StringAppend(cmd, puser, sizeof(cmd));
+#endif
     // If password and locking were the only things changed, don't run the command.
     CFUSR_CLEARBIT(changemap, i_password);
     CFUSR_CLEARBIT(changemap, i_locked);
@@ -1700,49 +1706,10 @@ static bool DoModifyUser (const char *puser, const User *u, const struct passwd 
     }
     else if (changemap != 0)
     {
-#ifdef __hpux
-        // This is to overcome the Suse hack above which does not work on HP-UX and thus we
-        // risk getting an empty command if change of secondary groups is the only change
-        // Only run for other changes than i_groups, otherwise the command will be empty
-        uint32_t changemap_without_groups = changemap;
-        CFUSR_CLEARBIT(changemap_without_groups, i_groups);
-        if(changemap_without_groups != 0)
-#endif
+
+        if (!ExecuteUserCommand(puser, cmd, sizeof(cmd), "modifying", "Modifying"))
         {
-            if (!ExecuteUserCommand(puser, cmd, sizeof(cmd), "modifying", "Modifying"))
-            {
-                return false;
-            }
-        }
-        if (CFUSR_CHECKBIT (changemap, i_groups) != 0)
-        {
-            // Set real group list (see -G comment earlier).
-#ifdef HAVE_PW
-            strcpy (cmd, PW);
-            StringAppend(cmd, " usermod -n \"", sizeof(cmd));
-            StringAppend(cmd, puser, sizeof(cmd));
-            StringAppend(cmd, "\" ", sizeof(cmd));
-#else
-            strcpy(cmd, USERMOD);
-#endif
-            StringAppend(cmd, " -G \"", sizeof(cmd));
-            char sep[2] = { '\0', '\0' };
-            for (Rlist *i = u->groups_secondary; i; i = i->next)
-            {
-                StringAppend(cmd, sep, sizeof(cmd));
-                StringAppend(cmd, RvalScalarValue(i->val), sizeof(cmd));
-                sep[0] = ',';
-            }
-#ifdef HAVE_PW
-            StringAppend(cmd, "\"", sizeof(cmd));
-#else
-            StringAppend(cmd, "\" ", sizeof(cmd));
-            StringAppend(cmd, puser, sizeof(cmd));
-#endif
-            if (!ExecuteUserCommand(puser, cmd, sizeof(cmd), "modifying", "Modifying"))
-            {
-                return false;
-            }
+            return false;
         }
     }
     return true;
@@ -1834,6 +1801,9 @@ void VerifyOneUsersPromise (const char *puser, const User *u, PromiseResult *res
     bool res;
 
     struct passwd *passwd_info;
+    StringSet *groups_to_set = StringSetNew();
+    StringSet *current_secondary_groups = StringSetNew();
+    StringSet *groups_missing = StringSetNew();
     passwd_info = GetPwEntry(puser);
     if (!passwd_info && errno != 0)
     {
@@ -1845,22 +1815,30 @@ void VerifyOneUsersPromise (const char *puser, const User *u, PromiseResult *res
     {
         if (passwd_info)
         {
-            uint32_t cmap = 0;
-            if (VerifyIfUserNeedsModifs (puser, u, passwd_info, &cmap))
+            res = GetGroupInfo(puser, u, &groups_to_set, &groups_missing, &current_secondary_groups);
+            if (res)
             {
-                res = DoModifyUser (puser, u, passwd_info, cmap, action);
-                if (res)
+                uint32_t cmap = 0;
+                if (VerifyIfUserNeedsModifs (puser, u, passwd_info, &cmap, groups_to_set, current_secondary_groups))
                 {
-                    *result = PROMISE_RESULT_CHANGE;
+                    res = DoModifyUser (puser, u, passwd_info, cmap, action, groups_to_set);
+                    if (res)
+                    {
+                        *result = PROMISE_RESULT_CHANGE;
+                    }
+                    else
+                    {
+                        *result = PROMISE_RESULT_FAIL;
+                    }
                 }
                 else
                 {
-                    *result = PROMISE_RESULT_FAIL;
+                    *result = PROMISE_RESULT_NOOP;
                 }
             }
             else
             {
-                *result = PROMISE_RESULT_NOOP;
+                *result = PROMISE_RESULT_FAIL;
             }
         }
         else

--- a/tests/acceptance/17_users/unsafe/10_password_hash_is_not_cached.cf
+++ b/tests/acceptance/17_users/unsafe/10_password_hash_is_not_cached.cf
@@ -123,12 +123,12 @@ bundle agent check
 {
   methods:
       "any" usebundle => user_has_password_hash("user1", "$(test.hash)", "user1_success", "user1_failure"),
-        classes => always("methods_run");
+        classes => always("user1_methods_run");
       "any" usebundle => user_has_password_hash("user2", "$(init.hash)", "user2_failure", "user2_success"),
-        classes => always("methods_run");
+        classes => always("user2_methods_run");
 
   classes:
-      "ready" expression => "methods_run";
+      "ready" and => { "user1_methods_run", "user2_methods_run" };
       "ok" and => { "user1_success", "!user1_failure",
                     "user2_success", "!user2_failure"
                   };

--- a/tests/acceptance/17_users/unsafe/20_modify_user_missing_secondary_group.cf
+++ b/tests/acceptance/17_users/unsafe/20_modify_user_missing_secondary_group.cf
@@ -7,16 +7,16 @@ body common control
 bundle agent init
 {
   commands:
-    "/usr/bin/sudo $(user_tests.pw_path) userdel testu";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testu";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg1";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg2";
-    "/usr/bin/sudo $(user_tests.pw_path) groupadd testg1";
-    "/usr/bin/sudo $(user_tests.pw_path) useradd testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.userdel) testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testg1";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testg2";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupadd) testg1";
+    "$(G.sudo) $(user_tests.pw_path) $(G.useradd) testu";
     freebsd::
-      "/usr/bin/sudo $(user_tests.pw_path) usermod testu --groups testg1 --append";
+      "$(G.sudo) $(user_tests.pw_path) $(G.usermod) testu -G testg1";
     !freebsd::
-      "/usr/bin/sudo $(user_tests.pw_path) usermod --groups testg1 --append testu";
+      "$(G.sudo) $(user_tests.pw_path) $(G.usermod) -G testg1  testu";
 }
 
 bundle agent test

--- a/tests/acceptance/17_users/unsafe/20_modify_user_missing_secondary_group.cf
+++ b/tests/acceptance/17_users/unsafe/20_modify_user_missing_secondary_group.cf
@@ -1,0 +1,57 @@
+body common control
+{
+      inputs => { "../../default.cf.sub", "user_queries.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+}
+
+bundle agent init
+{
+  commands:
+    "/usr/bin/sudo $(user_tests.pw_path) userdel testu";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testu";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg1";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg2";
+    "/usr/bin/sudo $(user_tests.pw_path) groupadd testg1";
+    "/usr/bin/sudo $(user_tests.pw_path) useradd testu";
+    freebsd::
+      "/usr/bin/sudo $(user_tests.pw_path) usermod testu --groups testg1 --append";
+    !freebsd::
+      "/usr/bin/sudo $(user_tests.pw_path) usermod --groups testg1 --append testu";
+}
+
+bundle agent test
+{
+  meta:
+    "description" -> { "ENT-3710" }
+      string => "Managing a user without specifying any secondary groups attribute
+                 should result in no changes to existing secondary groups.";
+
+  users:
+    "testu"
+      policy => "present";
+}
+
+bundle agent check
+{
+  methods:
+    "any" usebundle => user_is_in_secondary_group("testu", "testg1", "testg1_success", "testg1_failure"),
+      classes => always("testg1_method_run");
+
+    "any" usebundle => user_is_in_secondary_group("testu", "testg2", "testg2_success", "testg2_failure"),
+      classes => always("testg2_method_run");
+
+    "any" usebundle => user_exists("testu", "testu_success", "testu_failure"),
+      classes => always("testu_method_run");
+
+  classes:
+    "ready" and => { "testg1_method_run", "testg2_method_run", "testu_method_run" };
+    "ok" and => { "testg1_success", "!testg1_failure",
+                  "!testg2_success", "testg2_failure",
+                  "testu_success", "!testu_failure" };
+
+  reports:
+    ok.ready::
+      "$(this.promise_filename) Pass";
+    !ok.ready::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/17_users/unsafe/20_modify_user_secondary_groups.cf
+++ b/tests/acceptance/17_users/unsafe/20_modify_user_secondary_groups.cf
@@ -7,16 +7,16 @@ body common control
 bundle agent init
 {
   commands:
-    "/usr/bin/sudo $(user_tests.pw_path) userdel testu";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testu";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg1";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg2";
-    "/usr/bin/sudo $(user_tests.pw_path) groupadd testg1";
-    "/usr/bin/sudo $(user_tests.pw_path) useradd testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.userdel) testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testg1";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testg2";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupadd) testg1";
+    "$(G.sudo) $(user_tests.pw_path) $(G.useradd) testu";
     freebsd::
-      "/usr/bin/sudo $(user_tests.pw_path) usermod testu --groups testg1 --append";
+      "$(G.sudo) $(user_tests.pw_path) $(G.usermod) testu -G testg1";
     !freebsd::
-      "/usr/bin/sudo $(user_tests.pw_path) usermod --groups testg1 --append testu";
+      "$(G.sudo) $(user_tests.pw_path) $(G.usermod) -G testg1 testu";
 }
 
 bundle agent test

--- a/tests/acceptance/17_users/unsafe/20_modify_user_secondary_groups.cf
+++ b/tests/acceptance/17_users/unsafe/20_modify_user_secondary_groups.cf
@@ -1,0 +1,57 @@
+body common control
+{
+      inputs => { "../../default.cf.sub", "user_queries.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+}
+
+bundle agent init
+{
+  commands:
+    "/usr/bin/sudo $(user_tests.pw_path) userdel testu";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testu";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg1";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg2";
+    "/usr/bin/sudo $(user_tests.pw_path) groupadd testg1";
+    "/usr/bin/sudo $(user_tests.pw_path) useradd testu";
+    freebsd::
+      "/usr/bin/sudo $(user_tests.pw_path) usermod testu --groups testg1 --append";
+    !freebsd::
+      "/usr/bin/sudo $(user_tests.pw_path) usermod --groups testg1 --append testu";
+}
+
+bundle agent test
+{
+  meta:
+    "description" -> { "ENT-3710" }
+      string => "Adding a secondary group which doesn't exist should not remove existing secondary groups";
+
+  users:
+    "testu"
+      groups_secondary => { "testg1", "testg2" },
+      policy => "present";
+}
+
+bundle agent check
+{
+  methods:
+    "any" usebundle => user_is_in_secondary_group("testu", "testg1", "testg1_success", "testg1_failure"),
+      classes => always("testg1_method_run");
+
+    "any" usebundle => user_is_in_secondary_group("testu", "testg2", "testg2_success", "testg2_failure"),
+      classes => always("testg2_method_run");
+
+    "any" usebundle => user_exists("testu", "testu_success", "testu_failure"),
+      classes => always("testu_method_run");
+
+  classes:
+    "ready" and => { "testg1_method_run", "testg2_method_run", "testu_method_run" };
+    "ok" and => { "testg1_success", "!testg1_failure",
+                  "!testg2_success", "testg2_failure",
+                  "testu_success", "!testu_failure" };
+
+  reports:
+    ok.ready::
+      "$(this.promise_filename) Pass";
+    !ok.ready::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/17_users/unsafe/user_queries.cf.sub
+++ b/tests/acceptance/17_users/unsafe/user_queries.cf.sub
@@ -14,6 +14,13 @@ bundle common user_tests
       "group1" string => "Users";
       "group2" string => "Administrators";
 
+    freebsd::
+      "pw_path" string => "/usr/sbin/pw";
+      "sudo_path" string => "/usr/local/bin/sudo";
+    !freebsd::
+      "pw_path" string => "";
+      "sudo_path" string => "/usr/bin/sudo";
+
   classes:
     # On HPUX we use a sudo hack, which doesn't support '-u'.
     !windows.!hpux::
@@ -22,10 +29,14 @@ bundle common user_tests
     hpux::
       "passwords_in_shadow" expression => fileexists("/etc/shadow");
       "passwords_in_passwd" not => fileexists("/etc/shadow");
+    freebsd::
+      "passwords_in_shadow" expression => "!any";
+      "passwords_in_passwd" expression => "!any";
+      "passwords_in_master_passwd" expression => "any";
     windows|aix::
       "passwords_in_shadow" expression => "!any";
       "passwords_in_passwd" expression => "!any";
-    !hpux.!windows.!aix::
+    !hpux.!windows.!aix.!freebsd::
       "passwords_in_shadow" expression => "any";
       "passwords_in_passwd" expression => "!any";
     windows|aix::
@@ -43,7 +54,7 @@ bundle agent remove_stale_groups
       "rmgroup johndoe"
         contain => in_shell;
     !aix::
-      "groupdel johndoe"
+      "$(user_tests.pw_path) groupdel johndoe"
         contain => in_shell;
 }
 
@@ -215,6 +226,8 @@ bundle agent user_has_password_hash(user, hash, true_class, false_class)
       "passwd_file" string => "/etc/passwd";
     passwords_in_shadow::
       "passwd_file" string => "/etc/shadow";
+    passwords_in_master_passwd::
+      "passwd_file" string => "/etc/master.passwd";
 
   classes:
     aix::

--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -37,6 +37,7 @@ bundle common G
                         "ls",
                         "mkdir",
                         "mkfifo",
+                        "mkgroup",  # AIX equivalent of groupadd
                         "mock_package_manager",
                         "mv",
                         "no_fds",
@@ -62,7 +63,8 @@ bundle common G
                       };
       # Special cases.
       "make_cmds" slist => { "gmake", "make" };
-      "sbin_cmds" slist => { "groupadd", "groupdel", "useradd", "userdel", "usermod" };
+      # rmgroup is AIX equivalent of groupdel
+      "sbin_cmds" slist => { "rmgroup", "groupadd", "groupdel", "useradd", "userdel", "usermod" };
 
     any::
       "paths[tests]" string                  => "$(this.promise_dirname)";
@@ -123,6 +125,11 @@ bundle common G
       ifvarclass => canonify("$(paths_indices)_make$(exeext)");
       "make" string => "$(paths[$(paths_indices)])$(const.dirsep)gmake$(exeext)",
       ifvarclass => canonify("$(paths_indices)_gmake$(exeext)");
+
+    # on AIX groupdel is rmgroup and groupadd is mkgroup
+    aix::
+      "groupdel" string => "$(G.rmgroup)";
+      "groupadd" string => "$(G.mkgroup)";
 
     want_color.have_colordiff::
       "diff_maybecolor" string => $(colordiff);

--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -53,6 +53,7 @@ bundle common G
                         "sleep",
                         "sort",
                         "stat",
+                        "sudo",
                         "tee",
                         "touch",
                         "true",
@@ -61,6 +62,7 @@ bundle common G
                       };
       # Special cases.
       "make_cmds" slist => { "gmake", "make" };
+      "sbin_cmds" slist => { "groupadd", "groupdel", "useradd", "userdel", "usermod" };
 
     any::
       "paths[tests]" string                  => "$(this.promise_dirname)";
@@ -72,6 +74,7 @@ bundle common G
     !windows::
       "paths[bin]" string                    => "/bin";
       "paths[usr_bin]" string                => "/usr/bin";
+      "paths[usr_sbin]" string               => "/usr/sbin";
       "paths[usr_local_bin]" string          => "/usr/local/bin";
       "paths[usr_contrib_bin]" string        => "/usr/contrib/bin";
     windows::
@@ -99,6 +102,7 @@ bundle common G
           scope => "namespace";
 
       # Special cases.
+      "$(paths_indices)_$(sbin_cmds)$(exeext)" expression => fileexists("$(paths[$(paths_indices)])$(const.dirsep)$(sbin_cmds)$(exeext)");
       "$(paths_indices)_$(make_cmds)$(exeext)" expression => fileexists("$(paths[$(paths_indices)])$(const.dirsep)$(make_cmds)$(exeext)");
       "has_make"                          expression => fileexists("$(paths[$(paths_indices)])$(const.dirsep)$(make_cmds)$(exeext)"),
       scope => "namespace";
@@ -112,6 +116,8 @@ bundle common G
       ifvarclass => canonify("$(paths_indices)_$(cmds)$(exeext)");
 
       # Special cases.
+      "$(sbin_cmds)" string => "$(paths[$(paths_indices)])$(const.dirsep)$(sbin_cmds)$(exeext)",
+      ifvarclass => canonify("$(paths_indices)_$(sbin_cmds)$(exeext)");
       # gmake has higher priority, so should come last.
       "make" string => "$(paths[$(paths_indices)])$(const.dirsep)make$(exeext)",
       ifvarclass => canonify("$(paths_indices)_make$(exeext)");

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -273,6 +273,7 @@ usage() {
     echo " -jobs=[n] Run tests in parallel, works like make -j option. Note that some"
     echo "           tests will always run one by one."
     echo " --verbose  Run tests with verbose logging"
+    echo " --debug    Run tests with debug logging"
 }
 
 workdir() {
@@ -485,12 +486,12 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
             then
                 printf "\"$LIBTOOL\" --mode=execute " >> "$WORKDIR/runtest"
             fi
-            printf "valgrind ${VALGRIND_OPTS} \"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES} 2>&1\n" >> "$WORKDIR/runtest"
+            printf "valgrind ${VALGRIND_OPTS} \"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES} 2>&1\n" >> "$WORKDIR/runtest"
         elif [ x"$PRELOAD_ASAN" != x ]
         then
-            printf "LD_PRELOAD=$PRELOAD_ASAN \"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
+            printf "LD_PRELOAD=$PRELOAD_ASAN \"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
         else
-            printf "\"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
+            printf "\"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
         fi
 
         chmod +x "$WORKDIR/runtest"
@@ -856,6 +857,8 @@ do
             NO_CLEAN=1;;
         --verbose)
             VERBOSE="-v";;
+        --debug)
+           DEBUG="--debug";;
         --stay-in-workdir)
             # Internal option. Meant to keep sub invocations from interfering by
             # writing files only into the workdir.
@@ -889,6 +892,7 @@ then
     # each test is horribly slow.
     echo "export GAINROOT=" > runtests.sh
     echo "export TESTALL_DO_NOT_RECURSE=1" >> runtests.sh
+    echo "export DEBUG='$DEBUG'" >> runtests.sh
     echo "export VERBOSE='$VERBOSE'" >> runtests.sh
     echo "$0 $ORIG_ARGS $@ &" >> runtests.sh
     # Note quote change. We want to keep below variables unexpanded.


### PR DESCRIPTION
Modify user promise secondary groups attribute handling to examine current state and set new state appropriately instead of clearing all secondary groups and then setting (workaround for SUSE issue).

TODO:
- [x] test HP-UX when secondary groups is set to empty list to ensure `-G ""` is honored.
- [x] test SUSE for when secondary groups includes the user's primary group, this was the workaround which caused ENT-3710 in the first place.

Ticket: ENT-3710