### PR TITLE
CFE-3304 Removed restriction on bootstrap to loopback interface

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -365,8 +365,7 @@ static void ConfigureBootstrap(GenericAgentConfig *config, const char *argument)
 
     if(IsLoopbackAddress(argument))
     {
-        Log(LOG_LEVEL_ERR, "Cannot bootstrap to a loopback address");
-        DoCleanupAndExit(EXIT_FAILURE);
+        Log(LOG_LEVEL_WARNING, "Bootstrapping to loopback interface (localhost), other hosts will not be able to bootstrap to this server");
     }
 
     // temporary assure that network functions are working


### PR DESCRIPTION
This restriction blocks effective use as a development
environment on devices without a stable non-loopback
interface, such as a phone.

Ticket: CFE-3304
Changelog: title