### PR TITLE
Preserve contrib/vagrant-ci/centos-6-x64/Makefile.in on 'make clean'

### DIFF
--- a/contrib/vagrant-ci/centos-6-x64/Makefile.am
+++ b/contrib/vagrant-ci/centos-6-x64/Makefile.am
@@ -12,4 +12,4 @@ destroy-vms:
 
 EXTRA_DIST = Vagrantfile Makefile.in
 
-CLEANFILES = Makefile.in
+MAINTAINERCLEANFILES = Makefile.in


### PR DESCRIPTION
The file is created by './autogen.sh' and 'make clean' should
only remove files created by './configure' and 'make'.
'make maintainer-clean' is the more thorough cleanup.