### PR TITLE
ENT-4653 Fixed ifelse() to return fallback in case of undefined variables

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1526,6 +1526,7 @@ static void CheckAgentAccess(const Rlist *list, const Policy *policy)
 
 static PromiseResult DefaultVarPromise(EvalContext *ctx, const Promise *pp)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG cf-agent DefaultVarPromise");
     char *regex = PromiseGetConstraintAsRval(pp, "if_match_regex", RVAL_TYPE_SCALAR);
     bool okay = true;
 

--- a/d
+++ b/d
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+set -x
+make -j16
+./libtool --mode=execute gdb --args -KIf ./defined.cf cf-agent/cf-agent

--- a/defined.cf
+++ b/defined.cf
@@ -1,0 +1,11 @@
+bundle agent main
+{
+  vars:
+    "myvar" string => "I_AM_HERE";
+    "I_AM_HERE" string => "YIKES_RECURSIVE";
+    "foo" string => ifelse( isvariable( "myvar" ), "$(myvar)", "FALLBACK");
+    "bar" string => ifelse( isvariable( "myvar" ), "$($(myvar))", "FALLBACK");
+  reports:
+    "foo is $(foo)";
+    "bar is $(bar)";
+}

--- a/i
+++ b/i
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 set -x
-make -j16
-#cf-agent/cf-agent -K --debug -f ./test.cf | tee log
+make -j16 2>&1 | tee make.log
+cf-agent/cf-agent -K --debug -f ./test.cf | tee log
 #cf-agent/cf-agent -KIf ./defined.cf
-./libtool --mode=execute gdb cf-agent/cf-agent
+#./libtool --mode=execute gdb cf-agent/cf-agent
 #./libtool --mode=execute gdb --args -KIf ./defined.cf cf-agent/cf-agent

--- a/i
+++ b/i
@@ -3,5 +3,6 @@ set -e
 set -x
 make -j16
 pushd tests/acceptance
-./testall --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf
+./testall --debug --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf | tee ../../log
+#./testall --verbose --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf | tee ../../log
 popd

--- a/i
+++ b/i
@@ -1,8 +1,5 @@
 #!/bin/bash
-set -e
-set -x
 make -j16
-pushd tests/acceptance
-./testall --debug --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf | tee ../../log
-#./testall --verbose --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf | tee ../../log
-popd
+cf-agent/cf-agent -KIf ./test.cf | tee log
+#cf-agent/cf-agent -KIf ./defined.cf
+#./libtool --mode=execute gdb --args -KIf ./defined.cf cf-agent/cf-agent

--- a/i
+++ b/i
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+set -x
+make -j16
+pushd tests/acceptance
+./testall --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf
+popd

--- a/i
+++ b/i
@@ -1,5 +1,8 @@
 #!/bin/bash
+set -e
+set -x
 make -j16
-cf-agent/cf-agent -KIf ./test.cf | tee log
+#cf-agent/cf-agent -K --debug -f ./test.cf | tee log
 #cf-agent/cf-agent -KIf ./defined.cf
+./libtool --mode=execute gdb cf-agent/cf-agent
 #./libtool --mode=execute gdb --args -KIf ./defined.cf cf-agent/cf-agent

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1485,6 +1485,7 @@ void EvalContextStackPushPromiseFrame(EvalContext *ctx, const Promise *owner)
 
 Promise *EvalContextStackPushPromiseIterationFrame(EvalContext *ctx, const PromiseIterator *iter_ctx)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, EvalContextStackPushPromiseIterationFrame()");
     const StackFrame *last_frame = LastStackFrame(ctx, 0);
 
     assert(last_frame       != NULL);

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1217,6 +1217,7 @@ static FnCallResult FnCallIfElse(EvalContext *ctx,
                                  ARG_UNUSED const FnCall *fp,
                                  const Rlist *finalargs)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG FnCallIfElse");
     unsigned int argcount = 0;
     char id[CF_BUFSIZE];
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1250,6 +1250,11 @@ static FnCallResult FnCallIfElse(EvalContext *ctx,
         {
             /* If the evaluation returned true in the current context,
              * return the second of the two arguments. */
+/* CRAIG, DARN, this seems to NOT be the place that is evaluated/used for this issue */
+            Log(LOG_LEVEL_WARNING, "CRAIG arg->next is %p", arg->next);
+            Log(LOG_LEVEL_WARNING, "CRAIG RlistScalarValue(arg->next) is '%s'", RlistScalarValue(arg->next));
+            FnCallResult res = FnReturn(RlistScalarValue(arg->next));
+            Log(LOG_LEVEL_WARNING, "CRAIG FnCallResult status is '%d'", res.status);
             return FnReturn(RlistScalarValue(arg->next));
         }
     }

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1241,10 +1241,14 @@ Log(LOG_LEVEL_WARNING, "CRAIG FnCallIfElse");
     }
 
     const Rlist *arg;
+Log(LOG_LEVEL_WARNING, "CRAIG finalargs=%p", finalargs);
     for (arg = finalargs;        /* Start with arg set to finalargs. */
          arg && arg->next;       /* We must have arg and arg->next to proceed. */
          arg = arg->next->next)  /* arg steps forward *twice* every time. */
     {
+Log(LOG_LEVEL_WARNING, "CRAIG, LOOP, arg=%p", arg);
+if (arg) { Log(LOG_LEVEL_WARNING, "CRAIG, LOOP, arg->next=%p", arg->next); }
+if (arg && arg->next) { Log(LOG_LEVEL_WARNING, "CRAIG, LOOP, arg->next->next=%p", arg->next->next); }
         /* Similar to classmatch(), we evaluate the first of the two
          * arguments as a class. */
         if (IsDefinedClass(ctx, RlistScalarValue(arg)))
@@ -1260,6 +1264,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG FnCallIfElse");
         }
     }
 
+Log(LOG_LEVEL_WARNING, "CRAIG default fallback value being used");
     /* If we get here, we've reached the last argument (arg->next is NULL). */
     return FnReturn(RlistScalarValue(arg));
 }

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -219,11 +219,11 @@ Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 1: get a(nother) copy of the promise");
 Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 2: run the actuator");
         /* ACTUAL WORK PART 2: run the actuator */
         PromiseResult iteration_result = act_on_promise(ctx, pexp, param);
-Log(LOG_LEVEL_WARNING, "act_on_promise(ctx, pexp, param) => %p", iteration_result);
+Log(LOG_LEVEL_WARNING, "act_on_promise(ctx, pexp, param) => %p", (void *)iteration_result);
 
         /* iteration_result is always NOOP for PRE-EVAL. */
         result = PromiseResultUpdate(result, iteration_result);
-Log(LOG_LEVEL_WARNING, "PromiseResultUpdate() => %p", result);
+Log(LOG_LEVEL_WARNING, "PromiseResultUpdate() => %p", (void *)result);
 
         /* Redmine#6484: Do not store promise handles during PRE-EVAL, to
          *               avoid package promise always running. */

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -137,10 +137,12 @@ static void MapIteratorsFromRval(EvalContext *ctx,
                                  PromiseIterator *iterctx,
                                  Rval rval)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval()");
     switch (rval.type)
     {
 
     case RVAL_TYPE_SCALAR:
+Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval(), RVAL_TYPE_SCALAR, PromiseIteratorPrepare()");
         PromiseIteratorPrepare(iterctx, ctx, RvalScalarValue(rval));
         break;
 
@@ -156,6 +158,7 @@ static void MapIteratorsFromRval(EvalContext *ctx,
     {
         char *fn_name = RvalFnCallValue(rval)->name;
 
+Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval, RVAL_TYPE_FNCALL, fn_name is '%s'", fn_name);
         /* Check function name. */
         PromiseIteratorPrepare(iterctx, ctx, fn_name);
 
@@ -190,6 +193,7 @@ static void MapIteratorsFromRval(EvalContext *ctx,
 static PromiseResult ExpandPromiseAndDo(EvalContext *ctx, PromiseIterator *iterctx,
                                         PromiseActuator *act_on_promise, void *param)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromiseAndDo(), ENTER <===");
     PromiseResult result = PROMISE_RESULT_SKIPPED;
 
     /* TODO this loop could be completely skipped for for non vars/classes if
@@ -248,12 +252,14 @@ Log(LOG_LEVEL_WARNING, "EVALUATE VARS PROMISES again");
         EvalContextStackPopFrame(ctx);
     }
 
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromiseAndDo(), EXIT ===>");
     return result;
 }
 
 PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
                             PromiseActuator *act_on_promise, void *param)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise(), pp->promiser is '%s'", pp->promiser);
     if (!IsDefinedClass(ctx, pp->classes))
     {
         return PROMISE_RESULT_SKIPPED;

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -196,6 +196,7 @@ static PromiseResult ExpandPromiseAndDo(EvalContext *ctx, PromiseIterator *iterc
      *      act_on_promise is CommonEvalPromise(). */
     while (PromiseIteratorNext(iterctx, ctx))
     {
+Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 1: get a(nother) copy of the promise");
         /*
          * ACTUAL WORK PART 1: Get a (another) copy of the promise.
          *
@@ -211,19 +212,25 @@ static PromiseResult ExpandPromiseAndDo(EvalContext *ctx, PromiseIterator *iterc
             continue;
         }
 
+Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 2: run the actuator");
         /* ACTUAL WORK PART 2: run the actuator */
         PromiseResult iteration_result = act_on_promise(ctx, pexp, param);
+Log(LOG_LEVEL_WARNING, "act_on_promise(ctx, pexp, param) => %p", iteration_result);
 
         /* iteration_result is always NOOP for PRE-EVAL. */
         result = PromiseResultUpdate(result, iteration_result);
+Log(LOG_LEVEL_WARNING, "PromiseResultUpdate() => %p", result);
 
         /* Redmine#6484: Do not store promise handles during PRE-EVAL, to
          *               avoid package promise always running. */
+Log(LOG_LEVEL_WARNING, "CRAIG act_on_promise != &CommonEvalPromise?");
         if (act_on_promise != &CommonEvalPromise)
         {
+Log(LOG_LEVEL_WARNING, "CRAIG yep, so NotifyDependentPromises()");
             NotifyDependantPromises(ctx, pexp, iteration_result);
         }
 
+Log(LOG_LEVEL_WARNING, "EVALUATE VARS PROMISES again");
         /* EVALUATE VARS PROMISES again, allowing redefinition of
          * variables. The theory behind this is that the "sampling rate" of
          * vars promise needs to be double than the rest. */
@@ -252,6 +259,7 @@ PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
         return PROMISE_RESULT_SKIPPED;
     }
 
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 1. Copy the promise while expanding '@' slists and body arguments (including body inheritance)");
     /* 1. Copy the promise while expanding '@' slists and body arguments
      *    (including body inheritance). */
     Promise *pcopy = DeRefCopyPromise(ctx, pp);
@@ -259,6 +267,7 @@ PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
     EvalContextStackPushPromiseFrame(ctx, pcopy);
     PromiseIterator *iterctx = PromiseIteratorNew(pcopy);
 
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 2. Parse all strings (promiser-promisee-constraints), find all expanded vars, etc");
     /* 2. Parse all strings (promiser-promisee-constraints), find all
           unexpanded variables, mangle them if needed (if they are
           namespaced/scoped), and start the iteration engine (iterctx) to
@@ -278,6 +287,7 @@ PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
         MapIteratorsFromRval(ctx, iterctx, cp->rval);
     }
 
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 3. GO!");
     /* 3. GO! */
     PutHandleVariable(ctx, pcopy);
     PromiseResult result = ExpandPromiseAndDo(ctx, iterctx,
@@ -976,6 +986,7 @@ static void ResolvePackageManagerBody(EvalContext *ctx, const Body *pm_body)
 void PolicyResolve(EvalContext *ctx, const Policy *policy,
                    GenericAgentConfig *config)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, PolicyResolve(), common bundles: classes, vars");
     /* PRE-EVAL: common bundles: classes,vars. */
     for (size_t i = 0; i < SeqLength(policy->bundles); i++)
     {
@@ -994,6 +1005,7 @@ void PolicyResolve(EvalContext *ctx, const Policy *policy,
  */
 #if 1
 
+Log(LOG_LEVEL_WARNING, "CRAIG, PolicyResolve(), PRE_EVAL, non-common bundles: only vars");
     /* PRE-EVAL: non-common bundles: only vars. */
     for (size_t i = 0; i < SeqLength(policy->bundles); i++)
     {

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -364,6 +364,7 @@ if (expargs->next != NULL)
   Log(LOG_LEVEL_WARNING, "CRAIG expargs->next->next is %p", expargs->next->next);
   Log(LOG_LEVEL_WARNING, "CRAIG RlistIsUnresolved(expargs->next->next) is %d", RlistIsUnresolved(expargs->next->next));
 }
+#if 0
         if (strcmp(fp->name, "ifelse") == 0 &&
             RlistLen(expargs) == 3 &&
             strcmp("!any", RlistScalarValueSafe(expargs)) == 0 &&
@@ -387,6 +388,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG SKIPPING FUNCTION EVAL FOR NOW, ARGS CONTAIN UNRES
             RlistDestroy(expargs);
             return (FnCallResult) { FNCALL_FAILURE, { FnCallCopy(fp), RVAL_TYPE_FNCALL } };
         }
+#endif // ifdef 0 - skip checks for unresolved?
     }
 
 Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -341,12 +341,12 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
 
     Writer *fncall_writer = NULL;
     const char *fncall_string = "";
-    if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
-    {
+//    if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
+//    {
         fncall_writer = StringWriter();
         FnCallWrite(fncall_writer, fp);
         fncall_string = StringWriterData(fncall_writer);
-    }
+//    }
 
     // Check if arguments are resolved, except for delayed evaluation functions
     if ( ! (fp_type->options & FNCALL_OPTION_DELAYED_EVALUATION) &&
@@ -354,6 +354,7 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
     {
         // Special case: ifelse(isvariable("x"), $(x), "default")
         // (the first argument will come down expanded as "!any")
+Log(LOG_LEVEL_WARNING, "CRAIG deciding whether to evaluate function: %s", fncall_string);
 Log(LOG_LEVEL_WARNING, "CRAIG fp->name is '%s'", fp->name);
 Log(LOG_LEVEL_WARNING, "CRAIG RlistLen(expargs) is %d", RlistLen(expargs));
 Log(LOG_LEVEL_WARNING, "CRAIG RlistScalarValueSafe(expargs) is '%s'", RlistScalarValueSafe(expargs));
@@ -387,6 +388,8 @@ Log(LOG_LEVEL_WARNING, "CRAIG SKIPPING FUNCTION EVAL FOR NOW, ARGS CONTAIN UNRES
             return (FnCallResult) { FNCALL_FAILURE, { FnCallCopy(fp), RVAL_TYPE_FNCALL } };
         }
     }
+
+Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);
 
     Rval cached_rval;
     if ((fp_type->options & FNCALL_OPTION_CACHED) && EvalContextFunctionCacheGet(ctx, fp, expargs, &cached_rval))

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -354,17 +354,28 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
     {
         // Special case: ifelse(isvariable("x"), $(x), "default")
         // (the first argument will come down expanded as "!any")
+Log(LOG_LEVEL_WARNING, "CRAIG fp->name is '%s'", fp->name);
+Log(LOG_LEVEL_WARNING, "CRAIG RlistLen(expargs) is %d", RlistLen(expargs));
+Log(LOG_LEVEL_WARNING, "CRAIG RlistScalarValueSafe(expargs) is '%s'", RlistScalarValueSafe(expargs));
+Log(LOG_LEVEL_WARNING, "CRAIG expargs->next is %p", expargs->next);
+if (expargs->next != NULL)
+{
+  Log(LOG_LEVEL_WARNING, "CRAIG expargs->next->next is %p", expargs->next->next);
+  Log(LOG_LEVEL_WARNING, "CRAIG RlistIsUnresolved(expargs->next->next) is %d", RlistIsUnresolved(expargs->next->next));
+}
         if (strcmp(fp->name, "ifelse") == 0 &&
             RlistLen(expargs) == 3 &&
             strcmp("!any", RlistScalarValueSafe(expargs)) == 0 &&
             !RlistIsUnresolved(expargs->next->next))
         {
+Log(LOG_LEVEL_WARNING, "CRAIG ALLOWING IFELSE EVEN THOUGH ARGS CONTAIN UNRESOLVED VARS");
                 Log(LOG_LEVEL_DEBUG, "Allowing ifelse() function evaluation even"
                     " though its arguments contain unresolved variables: %s",
                     fncall_string);
         }
         else
         {
+Log(LOG_LEVEL_WARNING, "CRAIG SKIPPING FUNCTION EVAL FOR NOW, ARGS CONTAIN UNRESOLVED VARS");
             if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
             {
                 Log(LOG_LEVEL_DEBUG, "Skipping function evaluation for now,"

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -408,6 +408,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);
         WriterClose(w);
         RlistDestroy(expargs);
 
+Log(LOG_LEVEL_WARNING, "CRAIG returning FNCALL_SUCCESS line 411");
         return (FnCallResult) { FNCALL_SUCCESS, RvalCopy(cached_rval) };
     }
 
@@ -424,6 +425,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);
     {
         RlistDestroy(expargs);
         RvalDestroy(result.rval);
+Log(LOG_LEVEL_WARNING, "CRAIG return FNCALL_FAILURE at 428, result.status was that");
         return (FnCallResult) { FNCALL_FAILURE, { FnCallCopy(fp), RVAL_TYPE_FNCALL } };
     }
 
@@ -439,6 +441,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);
 
     RlistDestroy(expargs);
 
+Log(LOG_LEVEL_WARNING, "CRAIG returning result at end of function");
     return result;
 }
 

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -517,6 +517,7 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
 {
     assert(s != NULL);
     assert(c == '(' || c == '{');
+Log(LOG_LEVEL_WARNING, "ProcessVar() s is '%s'", s);
 
     char *s_end = FindClosingParen(s, c);
     const size_t s_max = strlen(s);
@@ -531,6 +532,7 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
 
     while (next_var < s_end)              /* does it have nested variables? */
     {
+Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), It's a dependent variable, the wheels of the dependencies must be added first.");
         /* It's a dependent variable, the wheels of the dependencies must be
          * added first. Example: "$(blah_$(dependency))" */
 
@@ -582,6 +584,7 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
         /* Change the variable name in order to mangle namespaces and scopes. */
         MangleVarRefString(s, s_len);
 
+Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), adding a wheel based on ShouldAddVariableAsIterationWheel() result");
         Wheel *new_wheel = WheelNew(s, s_len);
 
         /* If identical variable is already inserted, it means that it has
@@ -601,6 +604,7 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
         }
         else
         {
+Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), we need the wheel so append it");
             /* If this variable is dependent on other variables, we've already
              * appended the wheels of the dependencies during the recursive
              * calls. Or it happens and this is an independent variable. So
@@ -633,6 +637,7 @@ void PromiseIteratorPrepare(PromiseIterator *iterctx,
                             const EvalContext *evalctx,
                             char *s)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorPrepare(), s is '%s'");
     assert(s != NULL);
     LogDebug(LOG_MOD_ITERATIONS, "PromiseIteratorPrepare(\"%s\")", s);
     const size_t s_len = strlen(s);
@@ -991,14 +996,17 @@ static bool RunOnlyOnce(PromiseIterator *iterctx)
 bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
 {
     size_t wheels_num = SeqLength(iterctx->wheels);
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), wheels_num is '%zd'", wheels_num);
 
     if (wheels_num == 0)
     {
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), wheels_num == 0 so return RunOnlyOnce(iterctx)");
         return RunOnlyOnce(iterctx);
     }
 
     bool done = false;
 
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), first iteration: we initialise all wheels");
     /* First iteration: we initialise all wheels. */
     if (iterctx->count == 0)
     {
@@ -1014,8 +1022,10 @@ bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
     while (!done)
     {
         size_t i = WheelRightmostIncrement(iterctx);
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), WheelRightmostIncrement() gave i as %zd", i);
         if (i == (size_t) -1)       /* all combinations have been tried */
         {
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), all combinations have been tried, exiting");
             Log(LOG_LEVEL_DEBUG, "Iteration engine finished"
                 "   ---   WARPING OUT");
             return false;
@@ -1030,6 +1040,7 @@ bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
         Wheel *wheel    = SeqAt(iterctx->wheels, i);
         void *new_value = SeqAt(wheel->values, wheel->iter_index);
 
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), new_value = %p, unexpanded variable name is '%s', expanded variable name is '%s'", new_value, wheel->varname_unexp, wheel->varname_exp);
         IterListElementVariablePut(
             evalctx, wheel->varname_exp, wheel->vartype, new_value);
 
@@ -1041,6 +1052,7 @@ bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
          * should be skipped completely; so the function doesn't yield any
          * result yet, it just loops over until it finds a meaningful one. */
         done = ! IteratorHasEmptyWheel(iterctx);
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), If any of the wheels has no values to offer, then this iteration should be skipped completely; so the function does not yield any result yet, it just loops over until it finds a meaningful one.");
 
         LogDebug(LOG_MOD_ITERATIONS, "PromiseIteratorNext():"
                  " count=%zu wheels_num=%zu current_wheel=%zd",

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -1035,7 +1035,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, HACK, wheels_num=1 and WheelRightmostIncrement()=
 }
 else
 {
-Log(LOG_LEVEL_WARNING, "CRAIG, HACK, legacy behavior, return false");
+Log(LOG_LEVEL_WARNING, "CRAIG, legacy behavior, return false");
   return false;
 }
 //            return false;

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -1028,7 +1028,18 @@ Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), WheelRightmostIncrement() 
 Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), all combinations have been tried, exiting");
             Log(LOG_LEVEL_DEBUG, "Iteration engine finished"
                 "   ---   WARPING OUT");
-            return false;
+if (wheels_num == 1 && i == -1)
+{
+Log(LOG_LEVEL_WARNING, "CRAIG, HACK, wheels_num=1 and WheelRightmostIncrement()=-1 so RunOnlyOnce()");
+  return RunOnlyOnce(iterctx);
+}
+else
+{
+Log(LOG_LEVEL_WARNING, "CRAIG, HACK, legacy behavior, return false");
+  return false;
+}
+//            return false;
+return RunOnlyOnce(iterctx);
         }
 
         /*

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -283,6 +283,7 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
         if (bodies_and_args != NULL &&
             SeqLength(bodies_and_args) > 0)
         {
+Log(LOG_LEVEL_WARNING, "CRAIG first case is: we have a body to expand lval = body(args)");
             const Body *bp = SeqAt(bodies_and_args, 0);
             assert(bp != NULL);
 
@@ -355,8 +356,10 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
         }
         else                                    /* constraint is not a body */
         {
+Log(LOG_LEVEL_WARNING, "CRAIG constraint is not a body");
             if (cp->references_body)
             {
+Log(LOG_LEVEL_WARNING, "CRAIG assume this is a typed bundle (e.g. edit_line)");
                 // assume this is a typed bundle (e.g. edit_line)
                 const Bundle *callee =
                     EvalContextResolveBundleExpression(ctx, policy,
@@ -364,6 +367,7 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
                                                        cp->lval);
                 if (!callee)
                 {
+Log(LOG_LEVEL_WARNING, "CRAIG otherwise, assume this is a method-type call");
                     // otherwise, assume this is a method-type call
                     callee = EvalContextResolveBundleExpression(ctx, policy,
                                                                 body_reference,
@@ -429,6 +433,7 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
     const PromiseTypeSyntax *global_syntax = PromiseTypeSyntaxGet("*", "*");
     AddDefaultBodiesToPromise(ctx, pcopy, global_syntax);
 
+Log(LOG_LEVEL_WARNING, "CRAIG returning pcopy=%p", pcopy);
     return pcopy;
 }
 

--- a/test.cf
+++ b/test.cf
@@ -1,9 +1,13 @@
 bundle agent main
 {
   vars:
+    "x" string => "this-is-x";
+    "y" string => "this-is-y";
+    "baz" string => "$(x)-$(y)";
     "foo" string => ifelse( isvariable( "missing" ), "$(missing)", "FALLBACK");
     "bar" string => ifelse( isvariable( "missing" ), "$($(missing))", "FALLBACK");
   reports:
+    "baz is $(baz)";
     "foo is $(foo)";
     "bar is $(bar)";
 }

--- a/test.cf
+++ b/test.cf
@@ -1,0 +1,9 @@
+bundle agent main
+{
+  vars:
+    "foo" string => ifelse( isvariable( "missing" ), "$(missing)", "FALLBACK");
+    "bar" string => ifelse( isvariable( "missing" ), "$($(missing))", "FALLBACK");
+  reports:
+    "foo is $(foo)";
+    "bar is $(bar)";
+}

--- a/tests/acceptance/01_vars/02_functions/ifelse_isvariable-ENT-4653.cf
+++ b/tests/acceptance/01_vars/02_functions/ifelse_isvariable-ENT-4653.cf
@@ -17,7 +17,7 @@ bundle agent test
   vars:
       "lookup" string => "THIS_IS_NOT_A_DEFINED_VARIABLE";
 
-      "test" string =>
+      "BOINK" string =>
       ifelse( isvariable( "$(lookup)" ),
               "$($(lookup))",
               "FALLBACK");
@@ -28,11 +28,11 @@ bundle agent check
 
   reports:
       'PASS'
-        if => strcmp( "FALLBACK", $(test.test) ) ;
+        if => strcmp( "FALLBACK", $(test.BOINK) ) ;
 
       'FAIL'
-        if => not( isvariable( "test.test" ) );
+        if => not( isvariable( "test.BOINK" ) );
 
       'FAIL'
-        if => not( strcmp( "FALLBACK", $(test.test) ) );
+        if => not( strcmp( "FALLBACK", $(test.BOINK) ) );
 }

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -273,6 +273,7 @@ usage() {
     echo " -jobs=[n] Run tests in parallel, works like make -j option. Note that some"
     echo "           tests will always run one by one."
     echo " --verbose  Run tests with verbose logging"
+    echo " --debug    Run tests with debug logging"
 }
 
 workdir() {
@@ -485,12 +486,12 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
             then
                 printf "\"$LIBTOOL\" --mode=execute " >> "$WORKDIR/runtest"
             fi
-            printf "valgrind ${VALGRIND_OPTS} \"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES} 2>&1\n" >> "$WORKDIR/runtest"
+            printf "valgrind ${VALGRIND_OPTS} \"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES} 2>&1\n" >> "$WORKDIR/runtest"
         elif [ x"$PRELOAD_ASAN" != x ]
         then
-            printf "LD_PRELOAD=$PRELOAD_ASAN \"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
+            printf "LD_PRELOAD=$PRELOAD_ASAN \"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
         else
-            printf "\"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
+            printf "\"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
         fi
 
         chmod +x "$WORKDIR/runtest"
@@ -856,6 +857,8 @@ do
             NO_CLEAN=1;;
         --verbose)
             VERBOSE="-v";;
+        --debug)
+           DEBUG="--debug";;
         --stay-in-workdir)
             # Internal option. Meant to keep sub invocations from interfering by
             # writing files only into the workdir.
@@ -889,6 +892,7 @@ then
     # each test is horribly slow.
     echo "export GAINROOT=" > runtests.sh
     echo "export TESTALL_DO_NOT_RECURSE=1" >> runtests.sh
+    echo "export DEBUG='$DEBUG'" >> runtests.sh
     echo "export VERBOSE='$VERBOSE'" >> runtests.sh
     echo "$0 $ORIG_ARGS $@ &" >> runtests.sh
     # Note quote change. We want to keep below variables unexpanded.


### PR DESCRIPTION
Root cause is that if there is only one iteration wheel remaining and
that wheel has an unresolved value PromiseIteratorNext() was returning
false which cause ExpandPromiseAndDo() to not evaluate the ifelse
function and not assign the default value in the ifelse() expression.

Changelog: title
Ticket: ENT-4653