### PR TITLE
WIP ENT-4653 fixed ifelse() to return fallback when unresolved vars

### DIFF
--- a/bisect-test
+++ b/bisect-test
@@ -1,0 +1,7 @@
+set -e
+set -x
+make clean
+autoreconf -f -i
+./autogen.sh --enable-debug && make -j16
+sudo make install
+sudo cf-agent/cf-agent -KIf ./test3.cf

--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1527,6 +1527,7 @@ static void CheckAgentAccess(const Rlist *list, const Policy *policy)
 
 static PromiseResult DefaultVarPromise(EvalContext *ctx, const Promise *pp)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG cf-agent DefaultVarPromise");
     char *regex = PromiseGetConstraintAsRval(pp, "if_match_regex", RVAL_TYPE_SCALAR);
     bool okay = true;
 

--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1527,7 +1527,7 @@ static void CheckAgentAccess(const Rlist *list, const Policy *policy)
 
 static PromiseResult DefaultVarPromise(EvalContext *ctx, const Promise *pp)
 {
-Log(LOG_LEVEL_WARNING, "CRAIG cf-agent DefaultVarPromise");
+Log(LOG_LEVEL_DEBUG, "CRAIG cf-agent DefaultVarPromise");
     char *regex = PromiseGetConstraintAsRval(pp, "if_match_regex", RVAL_TYPE_SCALAR);
     bool okay = true;
 

--- a/d
+++ b/d
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+set -x
+make -j16
+./libtool --mode=execute gdb --args -KIf ./defined.cf cf-agent/cf-agent

--- a/defined.cf
+++ b/defined.cf
@@ -1,0 +1,11 @@
+bundle agent main
+{
+  vars:
+    "myvar" string => "I_AM_HERE";
+    "I_AM_HERE" string => "YIKES_RECURSIVE";
+    "foo" string => ifelse( isvariable( "myvar" ), "$(myvar)", "FALLBACK");
+    "bar" string => ifelse( isvariable( "myvar" ), "$($(myvar))", "FALLBACK");
+  reports:
+    "foo is $(foo)";
+    "bar is $(bar)";
+}

--- a/i
+++ b/i
@@ -1,7 +1,9 @@
 #!/bin/bash
+# a list of various test iteration steps I used during testing
 set -e
 set -x
 make -j16 2>&1 | tee make.log
+#make -C tests/unit expand_test && tests/unit/expand_test
 cf-agent/cf-agent -K --debug -f ./test.cf | tee log
 #cf-agent/cf-agent -KIf ./defined.cf
 #./libtool --mode=execute gdb cf-agent/cf-agent

--- a/i
+++ b/i
@@ -4,7 +4,8 @@ set -e
 set -x
 make -j16 2>&1 | tee make.log
 #make -C tests/unit expand_test && tests/unit/expand_test
-cf-agent/cf-agent -K --debug -f ./test.cf | tee log
+cf-agent/cf-agent -K --debug -f ./test2.cf | tee log
+#cf-agent/cf-agent -K --debug -f ./test.cf | tee log
 #cf-agent/cf-agent -KIf ./defined.cf
 #./libtool --mode=execute gdb cf-agent/cf-agent
 #./libtool --mode=execute gdb --args -KIf ./defined.cf cf-agent/cf-agent

--- a/i
+++ b/i
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 set -x
-make -j16
-#cf-agent/cf-agent -K --debug -f ./test.cf | tee log
+make -j16 2>&1 | tee make.log
+cf-agent/cf-agent -K --debug -f ./test.cf | tee log
 #cf-agent/cf-agent -KIf ./defined.cf
-./libtool --mode=execute gdb cf-agent/cf-agent
+#./libtool --mode=execute gdb cf-agent/cf-agent
 #./libtool --mode=execute gdb --args -KIf ./defined.cf cf-agent/cf-agent

--- a/i
+++ b/i
@@ -5,7 +5,11 @@ set -x
 #make -j16 2>&1 && true || exit | tee make.log
 make -j16
 #make -C tests/unit expand_test && tests/unit/expand_test
-cf-agent/cf-agent -K --debug -f ./test2.cf | tee log
+
+# TEST PHASE
+scp test3.cf debian10:
+ssh debian10 sudo /var/cfengine/bin/cf-agent -KIf ./test3.cf
+#cf-agent/cf-agent -K --debug -f ./test2.cf | tee log
 #cf-agent/cf-agent -K --debug -f ./test.cf | tee log
 #cf-agent/cf-agent -KIf ./defined.cf
 #./libtool --mode=execute gdb cf-agent/cf-agent

--- a/i
+++ b/i
@@ -3,5 +3,6 @@ set -e
 set -x
 make -j16
 pushd tests/acceptance
-./testall --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf
+./testall --debug --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf | tee ../../log
+#./testall --verbose --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf | tee ../../log
 popd

--- a/i
+++ b/i
@@ -1,8 +1,5 @@
 #!/bin/bash
-set -e
-set -x
 make -j16
-pushd tests/acceptance
-./testall --debug --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf | tee ../../log
-#./testall --verbose --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf | tee ../../log
-popd
+cf-agent/cf-agent -KIf ./test.cf | tee log
+#cf-agent/cf-agent -KIf ./defined.cf
+#./libtool --mode=execute gdb --args -KIf ./defined.cf cf-agent/cf-agent

--- a/i
+++ b/i
@@ -2,7 +2,8 @@
 # a list of various test iteration steps I used during testing
 set -e
 set -x
-make -j16 2>&1 | tee make.log
+#make -j16 2>&1 && true || exit | tee make.log
+make -j16
 #make -C tests/unit expand_test && tests/unit/expand_test
 cf-agent/cf-agent -K --debug -f ./test2.cf | tee log
 #cf-agent/cf-agent -K --debug -f ./test.cf | tee log

--- a/i
+++ b/i
@@ -7,8 +7,10 @@ make -j16
 #make -C tests/unit expand_test && tests/unit/expand_test
 
 # TEST PHASE
-scp test3.cf debian10:
-ssh debian10 sudo /var/cfengine/bin/cf-agent -KIf ./test3.cf
+cf-agent/cf-agent -K --debug -f ./test4.cf | tee log
+#cf-agent/cf-agent -K --debug -f ./test3.cf | tee log
+#scp test3.cf debian10:
+#ssh debian10 sudo /var/cfengine/bin/cf-agent -KIf ./test3.cf
 #cf-agent/cf-agent -K --debug -f ./test2.cf | tee log
 #cf-agent/cf-agent -K --debug -f ./test.cf | tee log
 #cf-agent/cf-agent -KIf ./defined.cf

--- a/i
+++ b/i
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+set -x
+make -j16
+pushd tests/acceptance
+./testall --printlog 01_vars/02_functions/ifelse_isvariable-ENT-4653.cf
+popd

--- a/i
+++ b/i
@@ -1,5 +1,8 @@
 #!/bin/bash
+set -e
+set -x
 make -j16
-cf-agent/cf-agent -KIf ./test.cf | tee log
+#cf-agent/cf-agent -K --debug -f ./test.cf | tee log
 #cf-agent/cf-agent -KIf ./defined.cf
+./libtool --mode=execute gdb cf-agent/cf-agent
 #./libtool --mode=execute gdb --args -KIf ./defined.cf cf-agent/cf-agent

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1485,6 +1485,7 @@ void EvalContextStackPushPromiseFrame(EvalContext *ctx, const Promise *owner)
 
 Promise *EvalContextStackPushPromiseIterationFrame(EvalContext *ctx, const PromiseIterator *iter_ctx)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, EvalContextStackPushPromiseIterationFrame()");
     const StackFrame *last_frame = LastStackFrame(ctx, 0);
 
     assert(last_frame       != NULL);

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1485,7 +1485,7 @@ void EvalContextStackPushPromiseFrame(EvalContext *ctx, const Promise *owner)
 
 Promise *EvalContextStackPushPromiseIterationFrame(EvalContext *ctx, const PromiseIterator *iter_ctx)
 {
-Log(LOG_LEVEL_WARNING, "CRAIG, EvalContextStackPushPromiseIterationFrame()");
+Log(LOG_LEVEL_DEBUG, "CRAIG, EvalContextStackPushPromiseIterationFrame()");
     const StackFrame *last_frame = LastStackFrame(ctx, 0);
 
     assert(last_frame       != NULL);

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1495,6 +1495,7 @@ Log(LOG_LEVEL_DEBUG, "CRAIG, EvalContextStackPushPromiseIterationFrame()");
     bool excluded;
     Promise *pexp = ExpandDeRefPromise(ctx, last_frame->data.promise.owner,
                                        &excluded);
+Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandDeRefPromise() returned pexp = %p and excluded = %d", pexp, excluded);
     if (excluded || !pexp)
     {
         PromiseDestroy(pexp);

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1217,7 +1217,7 @@ static FnCallResult FnCallIfElse(EvalContext *ctx,
                                  ARG_UNUSED const FnCall *fp,
                                  const Rlist *finalargs)
 {
-Log(LOG_LEVEL_WARNING, "CRAIG FnCallIfElse");
+Log(LOG_LEVEL_DEBUG, "CRAIG FnCallIfElse");
     unsigned int argcount = 0;
     char id[CF_BUFSIZE];
 
@@ -1241,14 +1241,14 @@ Log(LOG_LEVEL_WARNING, "CRAIG FnCallIfElse");
     }
 
     const Rlist *arg;
-Log(LOG_LEVEL_WARNING, "CRAIG finalargs=%p", finalargs);
+Log(LOG_LEVEL_DEBUG, "CRAIG finalargs=%p", finalargs);
     for (arg = finalargs;        /* Start with arg set to finalargs. */
          arg && arg->next;       /* We must have arg and arg->next to proceed. */
          arg = arg->next->next)  /* arg steps forward *twice* every time. */
     {
-Log(LOG_LEVEL_WARNING, "CRAIG, LOOP, arg=%p", arg);
-if (arg) { Log(LOG_LEVEL_WARNING, "CRAIG, LOOP, arg->next=%p", arg->next); }
-if (arg && arg->next) { Log(LOG_LEVEL_WARNING, "CRAIG, LOOP, arg->next->next=%p", arg->next->next); }
+Log(LOG_LEVEL_DEBUG, "CRAIG, LOOP, arg=%p", arg);
+if (arg) { Log(LOG_LEVEL_DEBUG, "CRAIG, LOOP, arg->next=%p", arg->next); }
+if (arg && arg->next) { Log(LOG_LEVEL_DEBUG, "CRAIG, LOOP, arg->next->next=%p", arg->next->next); }
         /* Similar to classmatch(), we evaluate the first of the two
          * arguments as a class. */
         if (IsDefinedClass(ctx, RlistScalarValue(arg)))
@@ -1256,15 +1256,15 @@ if (arg && arg->next) { Log(LOG_LEVEL_WARNING, "CRAIG, LOOP, arg->next->next=%p"
             /* If the evaluation returned true in the current context,
              * return the second of the two arguments. */
 /* CRAIG, DARN, this seems to NOT be the place that is evaluated/used for this issue */
-            Log(LOG_LEVEL_WARNING, "CRAIG arg->next is %p", arg->next);
-            Log(LOG_LEVEL_WARNING, "CRAIG RlistScalarValue(arg->next) is '%s'", RlistScalarValue(arg->next));
+            Log(LOG_LEVEL_DEBUG, "CRAIG arg->next is %p", arg->next);
+            Log(LOG_LEVEL_DEBUG, "CRAIG RlistScalarValue(arg->next) is '%s'", RlistScalarValue(arg->next));
             FnCallResult res = FnReturn(RlistScalarValue(arg->next));
-            Log(LOG_LEVEL_WARNING, "CRAIG FnCallResult status is '%d'", res.status);
+            Log(LOG_LEVEL_DEBUG, "CRAIG FnCallResult status is '%d'", res.status);
             return FnReturn(RlistScalarValue(arg->next));
         }
     }
 
-Log(LOG_LEVEL_WARNING, "CRAIG default fallback value being used");
+Log(LOG_LEVEL_DEBUG, "CRAIG default fallback value being used");
     /* If we get here, we've reached the last argument (arg->next is NULL). */
     return FnReturn(RlistScalarValue(arg));
 }

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1260,7 +1260,7 @@ if (arg && arg->next) { Log(LOG_LEVEL_DEBUG, "CRAIG, LOOP, arg->next->next=%p", 
             Log(LOG_LEVEL_DEBUG, "CRAIG RlistScalarValue(arg->next) is '%s'", RlistScalarValue(arg->next));
             FnCallResult res = FnReturn(RlistScalarValue(arg->next));
             Log(LOG_LEVEL_DEBUG, "CRAIG FnCallResult status is '%d'", res.status);
-            return FnReturn(RlistScalarValue(arg->next));
+            return res;
         }
     }
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1217,6 +1217,7 @@ static FnCallResult FnCallIfElse(EvalContext *ctx,
                                  ARG_UNUSED const FnCall *fp,
                                  const Rlist *finalargs)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG FnCallIfElse");
     unsigned int argcount = 0;
     char id[CF_BUFSIZE];
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1250,6 +1250,11 @@ static FnCallResult FnCallIfElse(EvalContext *ctx,
         {
             /* If the evaluation returned true in the current context,
              * return the second of the two arguments. */
+/* CRAIG, DARN, this seems to NOT be the place that is evaluated/used for this issue */
+            Log(LOG_LEVEL_WARNING, "CRAIG arg->next is %p", arg->next);
+            Log(LOG_LEVEL_WARNING, "CRAIG RlistScalarValue(arg->next) is '%s'", RlistScalarValue(arg->next));
+            FnCallResult res = FnReturn(RlistScalarValue(arg->next));
+            Log(LOG_LEVEL_WARNING, "CRAIG FnCallResult status is '%d'", res.status);
             return FnReturn(RlistScalarValue(arg->next));
         }
     }

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1241,10 +1241,14 @@ Log(LOG_LEVEL_WARNING, "CRAIG FnCallIfElse");
     }
 
     const Rlist *arg;
+Log(LOG_LEVEL_WARNING, "CRAIG finalargs=%p", finalargs);
     for (arg = finalargs;        /* Start with arg set to finalargs. */
          arg && arg->next;       /* We must have arg and arg->next to proceed. */
          arg = arg->next->next)  /* arg steps forward *twice* every time. */
     {
+Log(LOG_LEVEL_WARNING, "CRAIG, LOOP, arg=%p", arg);
+if (arg) { Log(LOG_LEVEL_WARNING, "CRAIG, LOOP, arg->next=%p", arg->next); }
+if (arg && arg->next) { Log(LOG_LEVEL_WARNING, "CRAIG, LOOP, arg->next->next=%p", arg->next->next); }
         /* Similar to classmatch(), we evaluate the first of the two
          * arguments as a class. */
         if (IsDefinedClass(ctx, RlistScalarValue(arg)))
@@ -1260,6 +1264,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG FnCallIfElse");
         }
     }
 
+Log(LOG_LEVEL_WARNING, "CRAIG default fallback value being used");
     /* If we get here, we've reached the last argument (arg->next is NULL). */
     return FnReturn(RlistScalarValue(arg));
 }

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -200,7 +200,7 @@ Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandPromiseAndDo(), do_ifelse is %d, ENTER <===",
      *      act_on_promise is CommonEvalPromise(). */
 /* CRAIG TODO HACK, here I want to go through this loop ONCE in case of ifelse involved */
     bool done = ! do_ifelse;
-Log(LOG_LEVEL_WARNING, "CRAIG, before while loop, done is %d", done);
+Log(LOG_LEVEL_DEBUG, "CRAIG, before while loop, done is %d", done);
     while (PromiseIteratorNext(iterctx, ctx) || !done)
     {
 Log(LOG_LEVEL_DEBUG, "CRAIG, ACTUAL WORK PART 1: get a(nother) copy of the promise, done is %d", done);
@@ -256,7 +256,7 @@ Log(LOG_LEVEL_DEBUG, "CRAIG, EVALUATE VARS PROMISES again");
          * are Put() on the previous scope? */
         EvalContextStackPopFrame(ctx);
 
-Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise(), at end of while block, done is %d, setting to true", done);
+Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandPromise(), at end of while block, done is %d, setting to true", done);
 done = true;
     }
 

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -219,11 +219,11 @@ Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 1: get a(nother) copy of the promise");
 Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 2: run the actuator");
         /* ACTUAL WORK PART 2: run the actuator */
         PromiseResult iteration_result = act_on_promise(ctx, pexp, param);
-Log(LOG_LEVEL_WARNING, "act_on_promise(ctx, pexp, param) => %p", iteration_result);
+Log(LOG_LEVEL_WARNING, "act_on_promise(ctx, pexp, param) => %p", (void *)iteration_result);
 
         /* iteration_result is always NOOP for PRE-EVAL. */
         result = PromiseResultUpdate(result, iteration_result);
-Log(LOG_LEVEL_WARNING, "PromiseResultUpdate() => %p", result);
+Log(LOG_LEVEL_WARNING, "PromiseResultUpdate() => %p", (void *)result);
 
         /* Redmine#6484: Do not store promise handles during PRE-EVAL, to
          *               avoid package promise always running. */

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -137,12 +137,12 @@ static void MapIteratorsFromRval(EvalContext *ctx,
                                  PromiseIterator *iterctx,
                                  Rval rval)
 {
-Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval()");
+Log(LOG_LEVEL_DEBUG, "CRAIG, MapIteratorsFromRval()");
     switch (rval.type)
     {
 
     case RVAL_TYPE_SCALAR:
-Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval(), RVAL_TYPE_SCALAR, PromiseIteratorPrepare()");
+Log(LOG_LEVEL_DEBUG, "CRAIG, MapIteratorsFromRval(), RVAL_TYPE_SCALAR, PromiseIteratorPrepare()");
         PromiseIteratorPrepare(iterctx, ctx, RvalScalarValue(rval));
         break;
 
@@ -158,7 +158,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval(), RVAL_TYPE_SCALAR, Promise
     {
         char *fn_name = RvalFnCallValue(rval)->name;
 
-Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval, RVAL_TYPE_FNCALL, fn_name is '%s'", fn_name);
+Log(LOG_LEVEL_DEBUG, "CRAIG, MapIteratorsFromRval, RVAL_TYPE_FNCALL, fn_name is '%s'", fn_name);
         /* Check function name. */
         PromiseIteratorPrepare(iterctx, ctx, fn_name);
 
@@ -193,7 +193,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval, RVAL_TYPE_FNCALL, fn_name i
 static PromiseResult ExpandPromiseAndDo(EvalContext *ctx, PromiseIterator *iterctx,
                                         PromiseActuator *act_on_promise, void *param)
 {
-Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromiseAndDo(), ENTER <===");
+Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandPromiseAndDo(), ENTER <===");
     PromiseResult result = PROMISE_RESULT_SKIPPED;
 
     /* TODO this loop could be completely skipped for for non vars/classes if
@@ -227,10 +227,10 @@ Log(LOG_LEVEL_WARNING, "PromiseResultUpdate() => %p", (void *)result);
 
         /* Redmine#6484: Do not store promise handles during PRE-EVAL, to
          *               avoid package promise always running. */
-Log(LOG_LEVEL_WARNING, "CRAIG act_on_promise != &CommonEvalPromise?");
+Log(LOG_LEVEL_DEBUG, "CRAIG act_on_promise != &CommonEvalPromise?");
         if (act_on_promise != &CommonEvalPromise)
         {
-Log(LOG_LEVEL_WARNING, "CRAIG yep, so NotifyDependentPromises()");
+Log(LOG_LEVEL_DEBUG, "CRAIG yep, so NotifyDependentPromises()");
             NotifyDependantPromises(ctx, pexp, iteration_result);
         }
 
@@ -252,20 +252,20 @@ Log(LOG_LEVEL_WARNING, "EVALUATE VARS PROMISES again");
         EvalContextStackPopFrame(ctx);
     }
 
-Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromiseAndDo(), EXIT ===>");
+Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandPromiseAndDo(), EXIT ===>");
     return result;
 }
 
 PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
                             PromiseActuator *act_on_promise, void *param)
 {
-Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise(), pp->promiser is '%s'", pp->promiser);
+Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandPromise(), pp->promiser is '%s'", pp->promiser);
     if (!IsDefinedClass(ctx, pp->classes))
     {
         return PROMISE_RESULT_SKIPPED;
     }
 
-Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 1. Copy the promise while expanding '@' slists and body arguments (including body inheritance)");
+Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandPromise() 1. Copy the promise while expanding '@' slists and body arguments (including body inheritance)");
     /* 1. Copy the promise while expanding '@' slists and body arguments
      *    (including body inheritance). */
     Promise *pcopy = DeRefCopyPromise(ctx, pp);
@@ -273,7 +273,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 1. Copy the promise while expandi
     EvalContextStackPushPromiseFrame(ctx, pcopy);
     PromiseIterator *iterctx = PromiseIteratorNew(pcopy);
 
-Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 2. Parse all strings (promiser-promisee-constraints), find all expanded vars, etc");
+Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandPromise() 2. Parse all strings (promiser-promisee-constraints), find all expanded vars, etc");
     /* 2. Parse all strings (promiser-promisee-constraints), find all
           unexpanded variables, mangle them if needed (if they are
           namespaced/scoped), and start the iteration engine (iterctx) to
@@ -293,7 +293,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 2. Parse all strings (promiser-pr
         MapIteratorsFromRval(ctx, iterctx, cp->rval);
     }
 
-Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 3. GO!");
+Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandPromise() 3. GO!");
     /* 3. GO! */
     PutHandleVariable(ctx, pcopy);
     PromiseResult result = ExpandPromiseAndDo(ctx, iterctx,
@@ -992,7 +992,7 @@ static void ResolvePackageManagerBody(EvalContext *ctx, const Body *pm_body)
 void PolicyResolve(EvalContext *ctx, const Policy *policy,
                    GenericAgentConfig *config)
 {
-Log(LOG_LEVEL_WARNING, "CRAIG, PolicyResolve(), common bundles: classes, vars");
+Log(LOG_LEVEL_DEBUG, "CRAIG, PolicyResolve(), common bundles: classes, vars");
     /* PRE-EVAL: common bundles: classes,vars. */
     for (size_t i = 0; i < SeqLength(policy->bundles); i++)
     {
@@ -1011,7 +1011,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, PolicyResolve(), common bundles: classes, vars");
  */
 #if 1
 
-Log(LOG_LEVEL_WARNING, "CRAIG, PolicyResolve(), PRE_EVAL, non-common bundles: only vars");
+Log(LOG_LEVEL_DEBUG, "CRAIG, PolicyResolve(), PRE_EVAL, non-common bundles: only vars");
     /* PRE-EVAL: non-common bundles: only vars. */
     for (size_t i = 0; i < SeqLength(policy->bundles); i++)
     {

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -200,7 +200,7 @@ Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandPromiseAndDo(), ENTER <===");
      *      act_on_promise is CommonEvalPromise(). */
     while (PromiseIteratorNext(iterctx, ctx))
     {
-Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 1: get a(nother) copy of the promise");
+Log(LOG_LEVEL_DEBUG, "CRAIG, ACTUAL WORK PART 1: get a(nother) copy of the promise");
         /*
          * ACTUAL WORK PART 1: Get a (another) copy of the promise.
          *
@@ -216,14 +216,14 @@ Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 1: get a(nother) copy of the promise");
             continue;
         }
 
-Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 2: run the actuator");
+Log(LOG_LEVEL_DEBUG, "CRAIG, ACTUAL WORK PART 2: run the actuator");
         /* ACTUAL WORK PART 2: run the actuator */
         PromiseResult iteration_result = act_on_promise(ctx, pexp, param);
-Log(LOG_LEVEL_WARNING, "act_on_promise(ctx, pexp, param) => %p", (void *)iteration_result);
+Log(LOG_LEVEL_DEBUG, "CRAIG, act_on_promise(ctx, pexp, param) => %p", (void *)iteration_result);
 
         /* iteration_result is always NOOP for PRE-EVAL. */
         result = PromiseResultUpdate(result, iteration_result);
-Log(LOG_LEVEL_WARNING, "PromiseResultUpdate() => %p", (void *)result);
+Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseResultUpdate() => %p", (void *)result);
 
         /* Redmine#6484: Do not store promise handles during PRE-EVAL, to
          *               avoid package promise always running. */
@@ -234,7 +234,7 @@ Log(LOG_LEVEL_DEBUG, "CRAIG yep, so NotifyDependentPromises()");
             NotifyDependantPromises(ctx, pexp, iteration_result);
         }
 
-Log(LOG_LEVEL_WARNING, "EVALUATE VARS PROMISES again");
+Log(LOG_LEVEL_DEBUG, "CRAIG, EVALUATE VARS PROMISES again");
         /* EVALUATE VARS PROMISES again, allowing redefinition of
          * variables. The theory behind this is that the "sampling rate" of
          * vars promise needs to be double than the rest. */

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -137,10 +137,12 @@ static void MapIteratorsFromRval(EvalContext *ctx,
                                  PromiseIterator *iterctx,
                                  Rval rval)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval()");
     switch (rval.type)
     {
 
     case RVAL_TYPE_SCALAR:
+Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval(), RVAL_TYPE_SCALAR, PromiseIteratorPrepare()");
         PromiseIteratorPrepare(iterctx, ctx, RvalScalarValue(rval));
         break;
 
@@ -156,6 +158,7 @@ static void MapIteratorsFromRval(EvalContext *ctx,
     {
         char *fn_name = RvalFnCallValue(rval)->name;
 
+Log(LOG_LEVEL_WARNING, "CRAIG, MapIteratorsFromRval, RVAL_TYPE_FNCALL, fn_name is '%s'", fn_name);
         /* Check function name. */
         PromiseIteratorPrepare(iterctx, ctx, fn_name);
 
@@ -190,6 +193,7 @@ static void MapIteratorsFromRval(EvalContext *ctx,
 static PromiseResult ExpandPromiseAndDo(EvalContext *ctx, PromiseIterator *iterctx,
                                         PromiseActuator *act_on_promise, void *param)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromiseAndDo(), ENTER <===");
     PromiseResult result = PROMISE_RESULT_SKIPPED;
 
     /* TODO this loop could be completely skipped for for non vars/classes if
@@ -248,12 +252,14 @@ Log(LOG_LEVEL_WARNING, "EVALUATE VARS PROMISES again");
         EvalContextStackPopFrame(ctx);
     }
 
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromiseAndDo(), EXIT ===>");
     return result;
 }
 
 PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
                             PromiseActuator *act_on_promise, void *param)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise(), pp->promiser is '%s'", pp->promiser);
     if (!IsDefinedClass(ctx, pp->classes))
     {
         return PROMISE_RESULT_SKIPPED;

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -196,6 +196,7 @@ static PromiseResult ExpandPromiseAndDo(EvalContext *ctx, PromiseIterator *iterc
      *      act_on_promise is CommonEvalPromise(). */
     while (PromiseIteratorNext(iterctx, ctx))
     {
+Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 1: get a(nother) copy of the promise");
         /*
          * ACTUAL WORK PART 1: Get a (another) copy of the promise.
          *
@@ -211,19 +212,25 @@ static PromiseResult ExpandPromiseAndDo(EvalContext *ctx, PromiseIterator *iterc
             continue;
         }
 
+Log(LOG_LEVEL_WARNING, "ACTUAL WORK PART 2: run the actuator");
         /* ACTUAL WORK PART 2: run the actuator */
         PromiseResult iteration_result = act_on_promise(ctx, pexp, param);
+Log(LOG_LEVEL_WARNING, "act_on_promise(ctx, pexp, param) => %p", iteration_result);
 
         /* iteration_result is always NOOP for PRE-EVAL. */
         result = PromiseResultUpdate(result, iteration_result);
+Log(LOG_LEVEL_WARNING, "PromiseResultUpdate() => %p", result);
 
         /* Redmine#6484: Do not store promise handles during PRE-EVAL, to
          *               avoid package promise always running. */
+Log(LOG_LEVEL_WARNING, "CRAIG act_on_promise != &CommonEvalPromise?");
         if (act_on_promise != &CommonEvalPromise)
         {
+Log(LOG_LEVEL_WARNING, "CRAIG yep, so NotifyDependentPromises()");
             NotifyDependantPromises(ctx, pexp, iteration_result);
         }
 
+Log(LOG_LEVEL_WARNING, "EVALUATE VARS PROMISES again");
         /* EVALUATE VARS PROMISES again, allowing redefinition of
          * variables. The theory behind this is that the "sampling rate" of
          * vars promise needs to be double than the rest. */
@@ -252,6 +259,7 @@ PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
         return PROMISE_RESULT_SKIPPED;
     }
 
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 1. Copy the promise while expanding '@' slists and body arguments (including body inheritance)");
     /* 1. Copy the promise while expanding '@' slists and body arguments
      *    (including body inheritance). */
     Promise *pcopy = DeRefCopyPromise(ctx, pp);
@@ -259,6 +267,7 @@ PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
     EvalContextStackPushPromiseFrame(ctx, pcopy);
     PromiseIterator *iterctx = PromiseIteratorNew(pcopy);
 
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 2. Parse all strings (promiser-promisee-constraints), find all expanded vars, etc");
     /* 2. Parse all strings (promiser-promisee-constraints), find all
           unexpanded variables, mangle them if needed (if they are
           namespaced/scoped), and start the iteration engine (iterctx) to
@@ -278,6 +287,7 @@ PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
         MapIteratorsFromRval(ctx, iterctx, cp->rval);
     }
 
+Log(LOG_LEVEL_WARNING, "CRAIG, ExpandPromise() 3. GO!");
     /* 3. GO! */
     PutHandleVariable(ctx, pcopy);
     PromiseResult result = ExpandPromiseAndDo(ctx, iterctx,
@@ -976,6 +986,7 @@ static void ResolvePackageManagerBody(EvalContext *ctx, const Body *pm_body)
 void PolicyResolve(EvalContext *ctx, const Policy *policy,
                    GenericAgentConfig *config)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, PolicyResolve(), common bundles: classes, vars");
     /* PRE-EVAL: common bundles: classes,vars. */
     for (size_t i = 0; i < SeqLength(policy->bundles); i++)
     {
@@ -994,6 +1005,7 @@ void PolicyResolve(EvalContext *ctx, const Policy *policy,
  */
 #if 1
 
+Log(LOG_LEVEL_WARNING, "CRAIG, PolicyResolve(), PRE_EVAL, non-common bundles: only vars");
     /* PRE-EVAL: non-common bundles: only vars. */
     for (size_t i = 0; i < SeqLength(policy->bundles); i++)
     {

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -364,6 +364,7 @@ if (expargs->next != NULL)
   Log(LOG_LEVEL_WARNING, "CRAIG expargs->next->next is %p", expargs->next->next);
   Log(LOG_LEVEL_WARNING, "CRAIG RlistIsUnresolved(expargs->next->next) is %d", RlistIsUnresolved(expargs->next->next));
 }
+#if 0
         if (strcmp(fp->name, "ifelse") == 0 &&
             RlistLen(expargs) == 3 &&
             strcmp("!any", RlistScalarValueSafe(expargs)) == 0 &&
@@ -387,6 +388,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG SKIPPING FUNCTION EVAL FOR NOW, ARGS CONTAIN UNRES
             RlistDestroy(expargs);
             return (FnCallResult) { FNCALL_FAILURE, { FnCallCopy(fp), RVAL_TYPE_FNCALL } };
         }
+#endif // ifdef 0 - skip checks for unresolved?
     }
 
 Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -364,7 +364,7 @@ if (expargs->next != NULL)
   Log(LOG_LEVEL_WARNING, "CRAIG expargs->next->next is %p", expargs->next->next);
   Log(LOG_LEVEL_WARNING, "CRAIG RlistIsUnresolved(expargs->next->next) is %d", RlistIsUnresolved(expargs->next->next));
 }
-#if 0
+#if 1
         if (strcmp(fp->name, "ifelse") == 0 &&
             RlistLen(expargs) == 3 &&
             strcmp("!any", RlistScalarValueSafe(expargs)) == 0 &&

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -354,15 +354,15 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
     {
         // Special case: ifelse(isvariable("x"), $(x), "default")
         // (the first argument will come down expanded as "!any")
-Log(LOG_LEVEL_WARNING, "CRAIG deciding whether to evaluate function: %s", fncall_string);
-Log(LOG_LEVEL_WARNING, "CRAIG fp->name is '%s'", fp->name);
-Log(LOG_LEVEL_WARNING, "CRAIG RlistLen(expargs) is %d", RlistLen(expargs));
-Log(LOG_LEVEL_WARNING, "CRAIG RlistScalarValueSafe(expargs) is '%s'", RlistScalarValueSafe(expargs));
-Log(LOG_LEVEL_WARNING, "CRAIG expargs->next is %p", expargs->next);
+Log(LOG_LEVEL_DEBUG, "CRAIG deciding whether to evaluate function: %s", fncall_string);
+Log(LOG_LEVEL_DEBUG, "CRAIG fp->name is '%s'", fp->name);
+Log(LOG_LEVEL_DEBUG, "CRAIG RlistLen(expargs) is %d", RlistLen(expargs));
+Log(LOG_LEVEL_DEBUG, "CRAIG RlistScalarValueSafe(expargs) is '%s'", RlistScalarValueSafe(expargs));
+Log(LOG_LEVEL_DEBUG, "CRAIG expargs->next is %p", expargs->next);
 if (expargs->next != NULL)
 {
-  Log(LOG_LEVEL_WARNING, "CRAIG expargs->next->next is %p", expargs->next->next);
-  Log(LOG_LEVEL_WARNING, "CRAIG RlistIsUnresolved(expargs->next->next) is %d", RlistIsUnresolved(expargs->next->next));
+  Log(LOG_LEVEL_DEBUG, "CRAIG expargs->next->next is %p", expargs->next->next);
+  Log(LOG_LEVEL_DEBUG, "CRAIG RlistIsUnresolved(expargs->next->next) is %d", RlistIsUnresolved(expargs->next->next));
 }
 #if 1
         if (strcmp(fp->name, "ifelse") == 0 &&
@@ -370,14 +370,14 @@ if (expargs->next != NULL)
             strcmp("!any", RlistScalarValueSafe(expargs)) == 0 &&
             !RlistIsUnresolved(expargs->next->next))
         {
-Log(LOG_LEVEL_WARNING, "CRAIG ALLOWING IFELSE EVEN THOUGH ARGS CONTAIN UNRESOLVED VARS");
+Log(LOG_LEVEL_DEBUG, "CRAIG ALLOWING IFELSE EVEN THOUGH ARGS CONTAIN UNRESOLVED VARS");
                 Log(LOG_LEVEL_DEBUG, "Allowing ifelse() function evaluation even"
                     " though its arguments contain unresolved variables: %s",
                     fncall_string);
         }
         else
         {
-Log(LOG_LEVEL_WARNING, "CRAIG SKIPPING FUNCTION EVAL FOR NOW, ARGS CONTAIN UNRESOLVED VARS");
+Log(LOG_LEVEL_DEBUG, "CRAIG SKIPPING FUNCTION EVAL FOR NOW, ARGS CONTAIN UNRESOLVED VARS");
             if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
             {
                 Log(LOG_LEVEL_DEBUG, "Skipping function evaluation for now,"
@@ -391,7 +391,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG SKIPPING FUNCTION EVAL FOR NOW, ARGS CONTAIN UNRES
 #endif // ifdef 0 - skip checks for unresolved?
     }
 
-Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);
+Log(LOG_LEVEL_DEBUG, "CRAIG evaluating function: %s", fncall_string);
 
     Rval cached_rval;
     if ((fp_type->options & FNCALL_OPTION_CACHED) && EvalContextFunctionCacheGet(ctx, fp, expargs, &cached_rval))
@@ -408,7 +408,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);
         WriterClose(w);
         RlistDestroy(expargs);
 
-Log(LOG_LEVEL_WARNING, "CRAIG returning FNCALL_SUCCESS line 411");
+Log(LOG_LEVEL_DEBUG, "CRAIG returning FNCALL_SUCCESS line 411");
         return (FnCallResult) { FNCALL_SUCCESS, RvalCopy(cached_rval) };
     }
 
@@ -425,7 +425,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG returning FNCALL_SUCCESS line 411");
     {
         RlistDestroy(expargs);
         RvalDestroy(result.rval);
-Log(LOG_LEVEL_WARNING, "CRAIG return FNCALL_FAILURE at 428, result.status was that");
+Log(LOG_LEVEL_DEBUG, "CRAIG return FNCALL_FAILURE at 428, result.status was that");
         return (FnCallResult) { FNCALL_FAILURE, { FnCallCopy(fp), RVAL_TYPE_FNCALL } };
     }
 
@@ -441,7 +441,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG return FNCALL_FAILURE at 428, result.status was th
 
     RlistDestroy(expargs);
 
-Log(LOG_LEVEL_WARNING, "CRAIG returning result at end of function");
+Log(LOG_LEVEL_DEBUG, "CRAIG returning result at end of function");
     return result;
 }
 

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -347,6 +347,7 @@ Log(LOG_LEVEL_DEBUG, "CRAIG, FnCallEvaluate()");
         fncall_writer = StringWriter();
         FnCallWrite(fncall_writer, fp);
         fncall_string = StringWriterData(fncall_writer);
+        StringWriterClose(fncall_writer);
 //    }
 
     // Check if arguments are resolved, except for delayed evaluation functions

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -341,12 +341,12 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
 
     Writer *fncall_writer = NULL;
     const char *fncall_string = "";
-    if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
-    {
+//    if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
+//    {
         fncall_writer = StringWriter();
         FnCallWrite(fncall_writer, fp);
         fncall_string = StringWriterData(fncall_writer);
-    }
+//    }
 
     // Check if arguments are resolved, except for delayed evaluation functions
     if ( ! (fp_type->options & FNCALL_OPTION_DELAYED_EVALUATION) &&
@@ -354,6 +354,7 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
     {
         // Special case: ifelse(isvariable("x"), $(x), "default")
         // (the first argument will come down expanded as "!any")
+Log(LOG_LEVEL_WARNING, "CRAIG deciding whether to evaluate function: %s", fncall_string);
 Log(LOG_LEVEL_WARNING, "CRAIG fp->name is '%s'", fp->name);
 Log(LOG_LEVEL_WARNING, "CRAIG RlistLen(expargs) is %d", RlistLen(expargs));
 Log(LOG_LEVEL_WARNING, "CRAIG RlistScalarValueSafe(expargs) is '%s'", RlistScalarValueSafe(expargs));
@@ -387,6 +388,8 @@ Log(LOG_LEVEL_WARNING, "CRAIG SKIPPING FUNCTION EVAL FOR NOW, ARGS CONTAIN UNRES
             return (FnCallResult) { FNCALL_FAILURE, { FnCallCopy(fp), RVAL_TYPE_FNCALL } };
         }
     }
+
+Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);
 
     Rval cached_rval;
     if ((fp_type->options & FNCALL_OPTION_CACHED) && EvalContextFunctionCacheGet(ctx, fp, expargs, &cached_rval))

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -342,13 +342,12 @@ Log(LOG_LEVEL_DEBUG, "CRAIG, FnCallEvaluate()");
 
     Writer *fncall_writer = NULL;
     const char *fncall_string = "";
-//    if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
-//    {
+    if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
+    {
         fncall_writer = StringWriter();
         FnCallWrite(fncall_writer, fp);
         fncall_string = StringWriterData(fncall_writer);
-        StringWriterClose(fncall_writer);
-//    }
+    }
 
     // Check if arguments are resolved, except for delayed evaluation functions
     if ( ! (fp_type->options & FNCALL_OPTION_DELAYED_EVALUATION) &&

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -354,17 +354,28 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
     {
         // Special case: ifelse(isvariable("x"), $(x), "default")
         // (the first argument will come down expanded as "!any")
+Log(LOG_LEVEL_WARNING, "CRAIG fp->name is '%s'", fp->name);
+Log(LOG_LEVEL_WARNING, "CRAIG RlistLen(expargs) is %d", RlistLen(expargs));
+Log(LOG_LEVEL_WARNING, "CRAIG RlistScalarValueSafe(expargs) is '%s'", RlistScalarValueSafe(expargs));
+Log(LOG_LEVEL_WARNING, "CRAIG expargs->next is %p", expargs->next);
+if (expargs->next != NULL)
+{
+  Log(LOG_LEVEL_WARNING, "CRAIG expargs->next->next is %p", expargs->next->next);
+  Log(LOG_LEVEL_WARNING, "CRAIG RlistIsUnresolved(expargs->next->next) is %d", RlistIsUnresolved(expargs->next->next));
+}
         if (strcmp(fp->name, "ifelse") == 0 &&
             RlistLen(expargs) == 3 &&
             strcmp("!any", RlistScalarValueSafe(expargs)) == 0 &&
             !RlistIsUnresolved(expargs->next->next))
         {
+Log(LOG_LEVEL_WARNING, "CRAIG ALLOWING IFELSE EVEN THOUGH ARGS CONTAIN UNRESOLVED VARS");
                 Log(LOG_LEVEL_DEBUG, "Allowing ifelse() function evaluation even"
                     " though its arguments contain unresolved variables: %s",
                     fncall_string);
         }
         else
         {
+Log(LOG_LEVEL_WARNING, "CRAIG SKIPPING FUNCTION EVAL FOR NOW, ARGS CONTAIN UNRESOLVED VARS");
             if (LogGetGlobalLevel() >= LOG_LEVEL_DEBUG)
             {
                 Log(LOG_LEVEL_DEBUG, "Skipping function evaluation for now,"

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -312,6 +312,7 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
     assert(policy);
     assert(fp);
     fp->caller = caller;
+Log(LOG_LEVEL_DEBUG, "CRAIG, FnCallEvaluate()");
 
     if (!EvalContextGetEvalOption(ctx, EVAL_OPTION_EVAL_FUNCTIONS))
     {

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -408,6 +408,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);
         WriterClose(w);
         RlistDestroy(expargs);
 
+Log(LOG_LEVEL_WARNING, "CRAIG returning FNCALL_SUCCESS line 411");
         return (FnCallResult) { FNCALL_SUCCESS, RvalCopy(cached_rval) };
     }
 
@@ -424,6 +425,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);
     {
         RlistDestroy(expargs);
         RvalDestroy(result.rval);
+Log(LOG_LEVEL_WARNING, "CRAIG return FNCALL_FAILURE at 428, result.status was that");
         return (FnCallResult) { FNCALL_FAILURE, { FnCallCopy(fp), RVAL_TYPE_FNCALL } };
     }
 
@@ -439,6 +441,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG evaluating function: %s", fncall_string);
 
     RlistDestroy(expargs);
 
+Log(LOG_LEVEL_WARNING, "CRAIG returning result at end of function");
     return result;
 }
 

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -517,6 +517,7 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
 {
     assert(s != NULL);
     assert(c == '(' || c == '{');
+Log(LOG_LEVEL_WARNING, "ProcessVar() s is '%s'", s);
 
     char *s_end = FindClosingParen(s, c);
     const size_t s_max = strlen(s);
@@ -531,6 +532,7 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
 
     while (next_var < s_end)              /* does it have nested variables? */
     {
+Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), It's a dependent variable, the wheels of the dependencies must be added first.");
         /* It's a dependent variable, the wheels of the dependencies must be
          * added first. Example: "$(blah_$(dependency))" */
 
@@ -582,6 +584,7 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
         /* Change the variable name in order to mangle namespaces and scopes. */
         MangleVarRefString(s, s_len);
 
+Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), adding a wheel based on ShouldAddVariableAsIterationWheel() result");
         Wheel *new_wheel = WheelNew(s, s_len);
 
         /* If identical variable is already inserted, it means that it has
@@ -601,6 +604,7 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
         }
         else
         {
+Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), we need the wheel so append it");
             /* If this variable is dependent on other variables, we've already
              * appended the wheels of the dependencies during the recursive
              * calls. Or it happens and this is an independent variable. So
@@ -633,6 +637,7 @@ void PromiseIteratorPrepare(PromiseIterator *iterctx,
                             const EvalContext *evalctx,
                             char *s)
 {
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorPrepare(), s is '%s'");
     assert(s != NULL);
     LogDebug(LOG_MOD_ITERATIONS, "PromiseIteratorPrepare(\"%s\")", s);
     const size_t s_len = strlen(s);
@@ -991,14 +996,17 @@ static bool RunOnlyOnce(PromiseIterator *iterctx)
 bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
 {
     size_t wheels_num = SeqLength(iterctx->wheels);
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), wheels_num is '%zd'", wheels_num);
 
     if (wheels_num == 0)
     {
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), wheels_num == 0 so return RunOnlyOnce(iterctx)");
         return RunOnlyOnce(iterctx);
     }
 
     bool done = false;
 
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), first iteration: we initialise all wheels");
     /* First iteration: we initialise all wheels. */
     if (iterctx->count == 0)
     {
@@ -1014,8 +1022,10 @@ bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
     while (!done)
     {
         size_t i = WheelRightmostIncrement(iterctx);
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), WheelRightmostIncrement() gave i as %zd", i);
         if (i == (size_t) -1)       /* all combinations have been tried */
         {
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), all combinations have been tried, exiting");
             Log(LOG_LEVEL_DEBUG, "Iteration engine finished"
                 "   ---   WARPING OUT");
             return false;
@@ -1030,6 +1040,7 @@ bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
         Wheel *wheel    = SeqAt(iterctx->wheels, i);
         void *new_value = SeqAt(wheel->values, wheel->iter_index);
 
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), new_value = %p, unexpanded variable name is '%s', expanded variable name is '%s'", new_value, wheel->varname_unexp, wheel->varname_exp);
         IterListElementVariablePut(
             evalctx, wheel->varname_exp, wheel->vartype, new_value);
 
@@ -1041,6 +1052,7 @@ bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
          * should be skipped completely; so the function doesn't yield any
          * result yet, it just loops over until it finds a meaningful one. */
         done = ! IteratorHasEmptyWheel(iterctx);
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), If any of the wheels has no values to offer, then this iteration should be skipped completely; so the function does not yield any result yet, it just loops over until it finds a meaningful one.");
 
         LogDebug(LOG_MOD_ITERATIONS, "PromiseIteratorNext():"
                  " count=%zu wheels_num=%zu current_wheel=%zd",

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -1035,7 +1035,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, HACK, wheels_num=1 and WheelRightmostIncrement()=
 }
 else
 {
-Log(LOG_LEVEL_WARNING, "CRAIG, HACK, legacy behavior, return false");
+Log(LOG_LEVEL_WARNING, "CRAIG, legacy behavior, return false");
   return false;
 }
 //            return false;

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -1037,7 +1037,7 @@ Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), WheelRightmostIncrement() ga
 Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), all combinations have been tried, exiting");
             Log(LOG_LEVEL_DEBUG, "Iteration engine finished"
                 "   ---   WARPING OUT");
-#if 0
+#if 1
             return false;
 #else
             if (wheels_num == 1 && i == -1)

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -980,7 +980,7 @@ static size_t WheelRightmostIncrement(PromiseIterator *iterctx)
  * expanded in them, must be evaluated. */
 static bool RunOnlyOnce(PromiseIterator *iterctx)
 {
-    assert(SeqLength(iterctx->wheels) == 0);
+/*    assert(SeqLength(iterctx->wheels) == 0); */
 
     if (iterctx->count == 0)
     {

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -532,7 +532,7 @@ Log(LOG_LEVEL_WARNING, "ProcessVar() s is '%s'", s);
 
     while (next_var < s_end)              /* does it have nested variables? */
     {
-Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), It's a dependent variable, the wheels of the dependencies must be added first.");
+Log(LOG_LEVEL_DEBUG, "CRAIG, ProcessVar(), It's a dependent variable, the wheels of the dependencies must be added first.");
         /* It's a dependent variable, the wheels of the dependencies must be
          * added first. Example: "$(blah_$(dependency))" */
 
@@ -584,7 +584,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), It's a dependent variable, the whee
         /* Change the variable name in order to mangle namespaces and scopes. */
         MangleVarRefString(s, s_len);
 
-Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), adding a wheel based on ShouldAddVariableAsIterationWheel() result");
+Log(LOG_LEVEL_DEBUG, "CRAIG, ProcessVar(), adding a wheel based on ShouldAddVariableAsIterationWheel() result");
         Wheel *new_wheel = WheelNew(s, s_len);
 
         /* If identical variable is already inserted, it means that it has
@@ -604,7 +604,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), adding a wheel based on ShouldAddVa
         }
         else
         {
-Log(LOG_LEVEL_WARNING, "CRAIG, ProcessVar(), we need the wheel so append it");
+Log(LOG_LEVEL_DEBUG, "CRAIG, ProcessVar(), we need the wheel so append it");
             /* If this variable is dependent on other variables, we've already
              * appended the wheels of the dependencies during the recursive
              * calls. Or it happens and this is an independent variable. So
@@ -639,7 +639,7 @@ void PromiseIteratorPrepare(PromiseIterator *iterctx,
 {
     assert(s != NULL);
     LogDebug(LOG_MOD_ITERATIONS, "PromiseIteratorPrepare(\"%s\")", s);
-Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorPrepare(), s is '%s'", s);
+Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorPrepare(), s is '%s'", s);
     const size_t s_len = strlen(s);
     const size_t offset = FindDollarParen(s, s_len);
 
@@ -996,17 +996,17 @@ static bool RunOnlyOnce(PromiseIterator *iterctx)
 bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
 {
     size_t wheels_num = SeqLength(iterctx->wheels);
-Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), wheels_num is '%zd'", wheels_num);
+Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), wheels_num is '%zd'", wheels_num);
 
     if (wheels_num == 0)
     {
-Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), wheels_num == 0 so return RunOnlyOnce(iterctx)");
+Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), wheels_num == 0 so return RunOnlyOnce(iterctx)");
         return RunOnlyOnce(iterctx);
     }
 
     bool done = false;
 
-Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), first iteration: we initialise all wheels");
+Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), first iteration: we initialise all wheels");
     /* First iteration: we initialise all wheels. */
     if (iterctx->count == 0)
     {
@@ -1022,10 +1022,10 @@ Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), first iteration: we initia
     while (!done)
     {
         size_t i = WheelRightmostIncrement(iterctx);
-Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), WheelRightmostIncrement() gave i as %zd", i);
+Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), WheelRightmostIncrement() gave i as %zd", i);
         if (i == (size_t) -1)       /* all combinations have been tried */
         {
-Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), all combinations have been tried, exiting");
+Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), all combinations have been tried, exiting");
             Log(LOG_LEVEL_DEBUG, "Iteration engine finished"
                 "   ---   WARPING OUT");
 #if 0
@@ -1033,12 +1033,12 @@ Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), all combinations have been
 #else
 if (wheels_num == 1 && i == -1)
 {
-Log(LOG_LEVEL_WARNING, "CRAIG, HACK, wheels_num=1 and WheelRightmostIncrement()=-1 so RunOnlyOnce()");
+Log(LOG_LEVEL_DEBUG, "CRAIG, HACK, wheels_num=1 and WheelRightmostIncrement()=-1 so RunOnlyOnce()");
   return RunOnlyOnce(iterctx);
 }
 else
 {
-Log(LOG_LEVEL_WARNING, "CRAIG, legacy behavior, return false");
+Log(LOG_LEVEL_DEBUG, "CRAIG, legacy behavior, return false");
   return false;
 }
 #endif
@@ -1053,7 +1053,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, legacy behavior, return false");
         Wheel *wheel    = SeqAt(iterctx->wheels, i);
         void *new_value = SeqAt(wheel->values, wheel->iter_index);
 
-Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), new_value = %p, unexpanded variable name is '%s', expanded variable name is '%s'", new_value, wheel->varname_unexp, wheel->varname_exp);
+Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), new_value = %p, unexpanded variable name is '%s', expanded variable name is '%s'", new_value, wheel->varname_unexp, wheel->varname_exp);
         IterListElementVariablePut(
             evalctx, wheel->varname_exp, wheel->vartype, new_value);
 
@@ -1065,7 +1065,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), new_value = %p, unexpanded
          * should be skipped completely; so the function doesn't yield any
          * result yet, it just loops over until it finds a meaningful one. */
         done = ! IteratorHasEmptyWheel(iterctx);
-Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), If any of the wheels has no values to offer, then this iteration should be skipped completely; so the function does not yield any result yet, it just loops over until it finds a meaningful one.");
+Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), If any of the wheels has no values to offer, then this iteration should be skipped completely; so the function does not yield any result yet, it just loops over until it finds a meaningful one.");
 
         LogDebug(LOG_MOD_ITERATIONS, "PromiseIteratorNext():"
                  " count=%zu wheels_num=%zu current_wheel=%zd",

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -809,6 +809,7 @@ static void ExpandAndPutWheelVariablesAfter(
     EvalContext *evalctx,
     size_t wheel_idx)
 {
+Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandAndPutWheelVariablesAfter()");
     /* Buffer to store the expanded wheel variable name, for each wheel. */
     Buffer *tmpbuf = BufferNew();
 
@@ -924,6 +925,7 @@ Log(LOG_LEVEL_DEBUG, "CRAIG, variable name expanded to the same name");
 
 static bool IteratorHasEmptyWheel(const PromiseIterator *iterctx)
 {
+Log(LOG_LEVEL_DEBUG, "CRAIG, IteratorHasEmptyWheel()");
     size_t wheels_num = SeqLength(iterctx->wheels);
     for (size_t i = 0; i < wheels_num; i++)
     {
@@ -932,6 +934,7 @@ static bool IteratorHasEmptyWheel(const PromiseIterator *iterctx)
 
         if (VarIsSpecial(wheel->varname_unexp))       /* TODO this is ugly! */
         {
+Log(LOG_LEVEL_DEBUG, "CRAIG, wheel->varname_unexp is '%s', VarIsSpecial() so return false", wheel->varname_unexp);
             return false;
         }
 
@@ -941,10 +944,12 @@ static bool IteratorHasEmptyWheel(const PromiseIterator *iterctx)
             ||
             wheel->vartype == CF_DATA_TYPE_NONE)
         {
+Log(LOG_LEVEL_DEBUG, "CRAIG, variable resolves to empty iterable or did not resolve, returning true");
             return true;
         }
     }
 
+Log(LOG_LEVEL_DEBUG, "CRAIG, default case, return false");
     return false;
 }
 
@@ -1020,6 +1025,7 @@ Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), first iteration: we initiali
         ExpandAndPutWheelVariablesAfter(iterctx, evalctx, 0);
 
         done = ! IteratorHasEmptyWheel(iterctx);
+Log(LOG_LEVEL_DEBUG, "CRAIG, first iteration, after ExpandAndPutWheelVariablesAfter(), done = %d", done);
     }
 
     while (!done)
@@ -1034,16 +1040,16 @@ Log(LOG_LEVEL_DEBUG, "CRAIG, PromiseIteratorNext(), all combinations have been t
 #if 0
             return false;
 #else
-if (wheels_num == 1 && i == -1)
-{
-Log(LOG_LEVEL_DEBUG, "CRAIG, HACK, wheels_num=1 and WheelRightmostIncrement()=-1 so RunOnlyOnce()");
-  return RunOnlyOnce(iterctx);
-}
-else
-{
-Log(LOG_LEVEL_DEBUG, "CRAIG, legacy behavior, return false");
-  return false;
-}
+            if (wheels_num == 1 && i == -1)
+            {
+            Log(LOG_LEVEL_DEBUG, "CRAIG, HACK, wheels_num=1 and WheelRightmostIncrement()=-1 so RunOnlyOnce()");
+              return RunOnlyOnce(iterctx);
+            }
+            else
+            {
+            Log(LOG_LEVEL_DEBUG, "CRAIG, legacy behavior, return false");
+              return false;
+            }
 #endif
         }
 

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -1028,7 +1028,18 @@ Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), WheelRightmostIncrement() 
 Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), all combinations have been tried, exiting");
             Log(LOG_LEVEL_DEBUG, "Iteration engine finished"
                 "   ---   WARPING OUT");
-            return false;
+if (wheels_num == 1 && i == -1)
+{
+Log(LOG_LEVEL_WARNING, "CRAIG, HACK, wheels_num=1 and WheelRightmostIncrement()=-1 so RunOnlyOnce()");
+  return RunOnlyOnce(iterctx);
+}
+else
+{
+Log(LOG_LEVEL_WARNING, "CRAIG, HACK, legacy behavior, return false");
+  return false;
+}
+//            return false;
+return RunOnlyOnce(iterctx);
         }
 
         /*

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -1028,7 +1028,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), WheelRightmostIncrement() 
 Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), all combinations have been tried, exiting");
             Log(LOG_LEVEL_DEBUG, "Iteration engine finished"
                 "   ---   WARPING OUT");
-#if 1
+#if 0
             return false;
 #else
 if (wheels_num == 1 && i == -1)

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -830,10 +830,12 @@ static void ExpandAndPutWheelVariablesAfter(
                                            NULL,
                                            wheel->varname_unexp, tmpbuf);
 
+Log(LOG_LEVEL_DEBUG, "CRAIG, varname is '%s', wheel->varname_exp is '%s'", varname, wheel->varname_exp);
         /* If it expanded to something different than before. */
         if (wheel->varname_exp == NULL
             || strcmp(varname, wheel->varname_exp) != 0)
         {
+Log(LOG_LEVEL_DEBUG, "CRAIG, it expanded to something different than before");
             free(wheel->varname_exp);                      /* could be NULL */
             wheel->varname_exp = xstrdup(varname);
 
@@ -903,6 +905,7 @@ static void ExpandAndPutWheelVariablesAfter(
         }
         else                 /* The variable name expanded to the same name */
         {
+Log(LOG_LEVEL_DEBUG, "CRAIG, variable name expanded to the same name");
             /* speedup: the variable name expanded to the same name, so the
              * value is the same and wheel->values is already correct. So if
              * it's an iterable, we VariablePut() the first element. */

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -1028,6 +1028,9 @@ Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), WheelRightmostIncrement() 
 Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorNext(), all combinations have been tried, exiting");
             Log(LOG_LEVEL_DEBUG, "Iteration engine finished"
                 "   ---   WARPING OUT");
+#if 1
+            return false;
+#else
 if (wheels_num == 1 && i == -1)
 {
 Log(LOG_LEVEL_WARNING, "CRAIG, HACK, wheels_num=1 and WheelRightmostIncrement()=-1 so RunOnlyOnce()");
@@ -1038,8 +1041,7 @@ else
 Log(LOG_LEVEL_WARNING, "CRAIG, legacy behavior, return false");
   return false;
 }
-//            return false;
-return RunOnlyOnce(iterctx);
+#endif
         }
 
         /*

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -637,9 +637,9 @@ void PromiseIteratorPrepare(PromiseIterator *iterctx,
                             const EvalContext *evalctx,
                             char *s)
 {
-Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorPrepare(), s is '%s'");
     assert(s != NULL);
     LogDebug(LOG_MOD_ITERATIONS, "PromiseIteratorPrepare(\"%s\")", s);
+Log(LOG_LEVEL_WARNING, "CRAIG, PromiseIteratorPrepare(), s is '%s'", s);
     const size_t s_len = strlen(s);
     const size_t offset = FindDollarParen(s, s_len);
 

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -517,7 +517,7 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
 {
     assert(s != NULL);
     assert(c == '(' || c == '{');
-Log(LOG_LEVEL_WARNING, "ProcessVar() s is '%s'", s);
+Log(LOG_LEVEL_DEBUG, "CRAIG, ProcessVar() s is '%s'", s);
 
     char *s_end = FindClosingParen(s, c);
     const size_t s_max = strlen(s);

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -471,22 +471,26 @@ static void AddDefaultBodiesToPromise(EvalContext *ctx, Promise *promise, const 
 
 static bool EvaluateConstraintIteration(EvalContext *ctx, const Constraint *cp, Rval *rval_out)
 {
+Log(LOG_LEVEL_DEBUG, "CRAIG, EvaluateConstraintIteration");
     assert(cp->type == POLICY_ELEMENT_TYPE_PROMISE);
     const Promise *pp = cp->parent.promise;
 
     if (!IsDefinedClass(ctx, cp->classes))
     {
+Log(LOG_LEVEL_DEBUG, "CRAIG, IsDefinedClass(ctx, cp->classes) is false so return false");
         return false;
     }
 
     if (ExpectedDataType(cp->lval) == CF_DATA_TYPE_BUNDLE)
     {
         *rval_out = ExpandBundleReference(ctx, NULL, "this", cp->rval);
+Log(LOG_LEVEL_DEBUG, "CRAIG, CF_DATA_TYPE_BUNDLE, rval_out = %p", rval_out);
     }
     else
     {
         *rval_out = EvaluateFinalRval(ctx, PromiseGetPolicy(pp), NULL,
                                       "this", cp->rval, false, pp);
+Log(LOG_LEVEL_DEBUG, "CRAIG, NOT CF_DATA_TYPE_BUNDLE, rval_out = %p", rval_out);
     }
 
     return true;

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -283,7 +283,7 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
         if (bodies_and_args != NULL &&
             SeqLength(bodies_and_args) > 0)
         {
-Log(LOG_LEVEL_WARNING, "CRAIG first case is: we have a body to expand lval = body(args)");
+Log(LOG_LEVEL_DEBUG, "CRAIG first case is: we have a body to expand lval = body(args)");
             const Body *bp = SeqAt(bodies_and_args, 0);
             assert(bp != NULL);
 
@@ -356,10 +356,10 @@ Log(LOG_LEVEL_WARNING, "CRAIG first case is: we have a body to expand lval = bod
         }
         else                                    /* constraint is not a body */
         {
-Log(LOG_LEVEL_WARNING, "CRAIG constraint is not a body");
+Log(LOG_LEVEL_DEBUG, "CRAIG constraint is not a body");
             if (cp->references_body)
             {
-Log(LOG_LEVEL_WARNING, "CRAIG assume this is a typed bundle (e.g. edit_line)");
+Log(LOG_LEVEL_DEBUG, "CRAIG assume this is a typed bundle (e.g. edit_line)");
                 // assume this is a typed bundle (e.g. edit_line)
                 const Bundle *callee =
                     EvalContextResolveBundleExpression(ctx, policy,
@@ -367,7 +367,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG assume this is a typed bundle (e.g. edit_line)");
                                                        cp->lval);
                 if (!callee)
                 {
-Log(LOG_LEVEL_WARNING, "CRAIG otherwise, assume this is a method-type call");
+Log(LOG_LEVEL_DEBUG, "CRAIG otherwise, assume this is a method-type call");
                     // otherwise, assume this is a method-type call
                     callee = EvalContextResolveBundleExpression(ctx, policy,
                                                                 body_reference,
@@ -433,7 +433,7 @@ Log(LOG_LEVEL_WARNING, "CRAIG otherwise, assume this is a method-type call");
     const PromiseTypeSyntax *global_syntax = PromiseTypeSyntaxGet("*", "*");
     AddDefaultBodiesToPromise(ctx, pcopy, global_syntax);
 
-Log(LOG_LEVEL_WARNING, "CRAIG returning pcopy=%p", pcopy);
+Log(LOG_LEVEL_DEBUG, "CRAIG returning pcopy=%p", pcopy);
     return pcopy;
 }
 

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -283,6 +283,7 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
         if (bodies_and_args != NULL &&
             SeqLength(bodies_and_args) > 0)
         {
+Log(LOG_LEVEL_WARNING, "CRAIG first case is: we have a body to expand lval = body(args)");
             const Body *bp = SeqAt(bodies_and_args, 0);
             assert(bp != NULL);
 
@@ -355,8 +356,10 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
         }
         else                                    /* constraint is not a body */
         {
+Log(LOG_LEVEL_WARNING, "CRAIG constraint is not a body");
             if (cp->references_body)
             {
+Log(LOG_LEVEL_WARNING, "CRAIG assume this is a typed bundle (e.g. edit_line)");
                 // assume this is a typed bundle (e.g. edit_line)
                 const Bundle *callee =
                     EvalContextResolveBundleExpression(ctx, policy,
@@ -364,6 +367,7 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
                                                        cp->lval);
                 if (!callee)
                 {
+Log(LOG_LEVEL_WARNING, "CRAIG otherwise, assume this is a method-type call");
                     // otherwise, assume this is a method-type call
                     callee = EvalContextResolveBundleExpression(ctx, policy,
                                                                 body_reference,
@@ -429,6 +433,7 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
     const PromiseTypeSyntax *global_syntax = PromiseTypeSyntaxGet("*", "*");
     AddDefaultBodiesToPromise(ctx, pcopy, global_syntax);
 
+Log(LOG_LEVEL_WARNING, "CRAIG returning pcopy=%p", pcopy);
     return pcopy;
 }
 

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -575,15 +575,20 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
     assert(pp->promiser != NULL);
     assert(pp->classes != NULL);
     assert(excluded != NULL);
+Log(LOG_LEVEL_DEBUG, "CRAIG, ExpandDeRefPromise, promiser is '%s'", pp->promiser);
 
     *excluded = false;
 
     Rval returnval = ExpandPrivateRval(ctx, NULL, "this", pp->promiser, RVAL_TYPE_SCALAR);
     if (returnval.item == NULL)
     {
+Log(LOG_LEVEL_DEBUG, "CRAIG, returnval.item is NULL");
+
+
         assert(returnval.type == RVAL_TYPE_LIST ||
                returnval.type == RVAL_TYPE_NOPROMISEE);
         /* TODO Log() empty slist, promise skipped? */
+Log(LOG_LEVEL_DEBUG, "CRAIG, log empty slist, promise skipped?");
         *excluded = true;
         return NULL;
     }

--- a/test.cf
+++ b/test.cf
@@ -1,9 +1,13 @@
 bundle agent main
 {
   vars:
+    "x" string => "this-is-x";
+    "y" string => "this-is-y";
+    "baz" string => "$(x)-$(y)";
     "foo" string => ifelse( isvariable( "missing" ), "$(missing)", "FALLBACK");
     "bar" string => ifelse( isvariable( "missing" ), "$($(missing))", "FALLBACK");
   reports:
+    "baz is $(baz)";
     "foo is $(foo)";
     "bar is $(bar)";
 }

--- a/test.cf
+++ b/test.cf
@@ -1,0 +1,9 @@
+bundle agent main
+{
+  vars:
+    "foo" string => ifelse( isvariable( "missing" ), "$(missing)", "FALLBACK");
+    "bar" string => ifelse( isvariable( "missing" ), "$($(missing))", "FALLBACK");
+  reports:
+    "foo is $(foo)";
+    "bar is $(bar)";
+}

--- a/test.cf
+++ b/test.cf
@@ -1,11 +1,15 @@
 bundle agent main
 {
+  classes:
+    "lessthan" expression => islessthan("0","1");
+    "lessthan_with_fn" expression => islessthan(length("foobar"),"1");
   vars:
     "x" string => "this-is-x";
     "y" string => "this-is-y";
     "baz" string => "$(x)-$(y)";
     "foo" string => ifelse( isvariable( "missing" ), "$(missing)", "FALLBACK");
     "bar" string => ifelse( isvariable( "missing" ), "$($(missing))", "FALLBACK");
+
   reports:
     "baz is $(baz)";
     "foo is $(foo)";

--- a/test2.cf
+++ b/test2.cf
@@ -1,0 +1,9 @@
+bundle agent main
+{
+  vars:
+    "array" string => "zero";
+    "keys" slist => getindices("array");
+  reports:
+    "keys is $(keys)";
+# I want the above to NOT print out at all because $(keys) is unresolved
+}

--- a/test3.cf
+++ b/test3.cf
@@ -1,0 +1,9 @@
+bundle agent main
+{
+  vars:
+    "foo" string => ifelse( isvariable( "missing" ), "$(missing)", "FALLBACK");
+    "bar" string => ifelse( isvariable( "missing" ), "$($(missing))", "FALLBACK");
+  reports:
+    "foo is $(foo)";
+    "bar is $(bar)";
+}

--- a/test4.cf
+++ b/test4.cf
@@ -1,0 +1,12 @@
+bundle agent main
+{
+  vars:
+    "foo" string => ifelse( isvariable( "missing" ), "$(missing)", "FALLBACK");
+    "bar" string => ifelse( isvariable( "missing" ), "$($(missing))", "FALLBACK");
+    "array" string => "zero";
+    "keys" slist => getindices("array");
+  reports:
+    "foo is $(foo)";
+    "bar is $(bar)";
+    "keys is $(keys)";
+}

--- a/tests/acceptance/00_basics/01_compiler/800.cf
+++ b/tests/acceptance/00_basics/01_compiler/800.cf
@@ -20,6 +20,8 @@ bundle agent init
 
 bundle agent test
 {
+  meta:
+      "test_skip_unsupported" string => "pureos";  # reports as debian but /etc/issue has no information, rather it is in /etc/os-release
   vars:
     debian::
       "myflavor" string => execresult("/bin/grep Debian.*GNU /etc/issue | /usr/bin/cut -d' ' -f3 | cut -d. -f1 | cut -d/ -f1", "useshell");

--- a/tests/acceptance/01_vars/02_functions/ifelse_isvariable-ENT-4653.cf
+++ b/tests/acceptance/01_vars/02_functions/ifelse_isvariable-ENT-4653.cf
@@ -17,7 +17,7 @@ bundle agent test
   vars:
       "lookup" string => "THIS_IS_NOT_A_DEFINED_VARIABLE";
 
-      "BOINK" string =>
+      "test" string =>
       ifelse( isvariable( "$(lookup)" ),
               "$($(lookup))",
               "FALLBACK");
@@ -28,11 +28,11 @@ bundle agent check
 
   reports:
       'PASS'
-        if => strcmp( "FALLBACK", $(test.BOINK) ) ;
+        if => strcmp( "FALLBACK", $(test.test) ) ;
 
       'FAIL'
-        if => not( isvariable( "test.BOINK" ) );
+        if => not( isvariable( "test.test" ) );
 
       'FAIL'
-        if => not( strcmp( "FALLBACK", $(test.BOINK) ) );
+        if => not( strcmp( "FALLBACK", $(test.test) ) );
 }

--- a/tests/acceptance/01_vars/02_functions/ifelse_isvariable-ENT-4653.cf
+++ b/tests/acceptance/01_vars/02_functions/ifelse_isvariable-ENT-4653.cf
@@ -17,7 +17,7 @@ bundle agent test
   vars:
       "lookup" string => "THIS_IS_NOT_A_DEFINED_VARIABLE";
 
-      "test" string =>
+      "BOINK" string =>
       ifelse( isvariable( "$(lookup)" ),
               "$($(lookup))",
               "FALLBACK");
@@ -28,11 +28,11 @@ bundle agent check
 
   reports:
       'PASS'
-        if => strcmp( "FALLBACK", $(test.test) ) ;
+        if => strcmp( "FALLBACK", $(test.BOINK) ) ;
 
       'FAIL'
-        if => not( isvariable( "test.test" ) );
+        if => not( isvariable( "test.BOINK" ) );
 
       'FAIL'
-        if => not( strcmp( "FALLBACK", $(test.test) ) );
+        if => not( strcmp( "FALLBACK", $(test.BOINK) ) );
 }

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -273,6 +273,7 @@ usage() {
     echo " -jobs=[n] Run tests in parallel, works like make -j option. Note that some"
     echo "           tests will always run one by one."
     echo " --verbose  Run tests with verbose logging"
+    echo " --debug    Run tests with debug logging"
 }
 
 workdir() {
@@ -485,12 +486,12 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
             then
                 printf "\"$LIBTOOL\" --mode=execute " >> "$WORKDIR/runtest"
             fi
-            printf "valgrind ${VALGRIND_OPTS} \"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES} 2>&1\n" >> "$WORKDIR/runtest"
+            printf "valgrind ${VALGRIND_OPTS} \"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES} 2>&1\n" >> "$WORKDIR/runtest"
         elif [ x"$PRELOAD_ASAN" != x ]
         then
-            printf "LD_PRELOAD=$PRELOAD_ASAN \"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
+            printf "LD_PRELOAD=$PRELOAD_ASAN \"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
         else
-            printf "\"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
+            printf "\"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
         fi
 
         chmod +x "$WORKDIR/runtest"
@@ -856,6 +857,8 @@ do
             NO_CLEAN=1;;
         --verbose)
             VERBOSE="-v";;
+        --debug)
+           DEBUG="--debug";;
         --stay-in-workdir)
             # Internal option. Meant to keep sub invocations from interfering by
             # writing files only into the workdir.
@@ -889,6 +892,7 @@ then
     # each test is horribly slow.
     echo "export GAINROOT=" > runtests.sh
     echo "export TESTALL_DO_NOT_RECURSE=1" >> runtests.sh
+    echo "export DEBUG='$DEBUG'" >> runtests.sh
     echo "export VERBOSE='$VERBOSE'" >> runtests.sh
     echo "$0 $ORIG_ARGS $@ &" >> runtests.sh
     # Note quote change. We want to keep below variables unexpanded.


### PR DESCRIPTION
Root cause is that if there is only one iteration wheel remaining and
that wheel has an unresolved value PromiseIteratorNext() was returning
false which cause ExpandPromiseAndDo() to not evaluate the ifelse
function and not assign the default value in the ifelse() expression.

Changelog: title
Ticket: ENT-4653

