### PR TITLE
ENT-5528/3.15.x: Fixed service status cfengine3 on systemd managed hosts

### DIFF
--- a/misc/init.d/cfengine3.in
+++ b/misc/init.d/cfengine3.in
@@ -226,7 +226,7 @@ cf_get_matching_pids()
             for pid in $pids; do
                 # If the last character of the cgroup is not the root directory,
                 # then this is a container process.
-                if [ -f /proc/$pid/cgroup ] && sed 's_/\(-\|system\|user\).slice__;s_/user-[0-9]*.slice__;s_/session-[0-9]*.scope__;s_/cfengine3.service__' /proc/$pid/cgroup | egrep '[0-9]+:devices:/[^:]' > /dev/null; then
+                if [ -f /proc/$pid/cgroup ] && sed 's_/\(-\|system\|user\).slice__;s_/user-[0-9]*.slice__;s_/session-[0-9]*.scope__;s_/cfengine3.service__;s_/cf-execd.service__;s_/cf-serverd.service__;s_/cf-monitord.service__' /proc/$pid/cgroup | egrep '[0-9]+:devices:/[^:]' > /dev/null; then
                     if [ $INSIDE_CONTAINER = 1 ]; then
                         echo $pid
                     fi


### PR DESCRIPTION
ENT-5528/master: Fixed service status cfengine3 on systemd managed hosts

Before change:

[root@host001 ~]# service cfengine3 status
Warning: PID file '/var/cfengine/cf-execd.pid' does not contain the right PID ('' != '5991'). Should restart CFEngine.
cf-execd is not running
Warning: PID file '/var/cfengine/cf-serverd.pid' does not contain the right PID ('' != '5992'). Should restart CFEngine.
cf-serverd is not running
Warning: PID file '/var/cfengine/cf-monitord.pid' does not contain the right PID ('' != '5993'). Should restart CFEngine.
cf-monitord is not running
[root@host001 ~]# ps aux | grep [c]f-
root      5991  0.0  3.1 137460  7648 ?        Ss   17:33   0:01 /var/cfengine/bin/cf-execd --no-fork
root      5992  0.0  6.0 239056 14468 ?        Ss   17:33   0:04 /var/cfengine/bin/cf-serverd --no-fork
root      5993  0.1  3.0  70264  7392 ?        Ss   17:33   0:07 /var/cfengine/bin/cf-monitord --no-fork
[root@host001 ~]# cat /var/cfengine/cf-execd.pid /var/cfengine/cf-serverd.pid /var/cfengine/cf-monitord.pid
5991
5992
5993

After change:
[root@host001 ~]# service cfengine3 status
● cfengine3.service - CFEngine 3 umbrella service
   Loaded: loaded (/usr/lib/systemd/system/cfengine3.service; enabled; vendor preset: disabled)
   Active: active (exited) since Thu 2020-04-16 17:33:10 UTC; 1h 52min ago
     Docs: https://docs.cfengine.com/
           https://tracker.mender.io
  Process: 5987 ExecStart=/bin/true (code=exited, status=0/SUCCESS)
 Main PID: 5987 (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/cfengine3.service

Apr 16 17:33:09 host001.example.com systemd[1]: Starting CFEngine 3 umbrella service...
Apr 16 17:33:10 host001.example.com systemd[1]: Started CFEngine 3 umbrella service.
● cfengine3.service - CFEngine 3 umbrella service
   Loaded: loaded (/usr/lib/systemd/system/cfengine3.service; enabled; vendor preset: disabled)
   Active: active (exited) since Thu 2020-04-16 17:33:10 UTC; 1h 52min ago
     Docs: https://docs.cfengine.com/
           https://tracker.mender.io
  Process: 5987 ExecStart=/bin/true (code=exited, status=0/SUCCESS)
 Main PID: 5987 (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/cfengine3.service

Apr 16 17:33:09 host001.example.com systemd[1]: Starting CFEngine 3 umbrella service...
Apr 16 17:33:10 host001.example.com systemd[1]: Started CFEngine 3 umbrella service.
● cfengine3.service - CFEngine 3 umbrella service
   Loaded: loaded (/usr/lib/systemd/system/cfengine3.service; enabled; vendor preset: disabled)
   Active: active (exited) since Thu 2020-04-16 17:33:10 UTC; 1h 52min ago
     Docs: https://docs.cfengine.com/
           https://tracker.mender.io
  Process: 5987 ExecStart=/bin/true (code=exited, status=0/SUCCESS)
 Main PID: 5987 (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/cfengine3.service

Apr 16 17:33:09 host001.example.com systemd[1]: Starting CFEngine 3 umbrella service...
Apr 16 17:33:10 host001.example.com systemd[1]: Started CFEngine 3 umbrella service.

Ticket: ENT-5528
Changelog: Title
(cherry picked from commit 380a60c2c9571544e284c381d3b22bb6d60d7055)


----

#