### PR TITLE
ENT-3710 Improved management of secondary groups to avoid intermediary state failures (3.15.x)

### DIFF
--- a/tests/acceptance/17_users/unsafe/10_password_hash_is_not_cached.cf
+++ b/tests/acceptance/17_users/unsafe/10_password_hash_is_not_cached.cf
@@ -123,12 +123,12 @@ bundle agent check
 {
   methods:
       "any" usebundle => user_has_password_hash("user1", "$(test.hash)", "user1_success", "user1_failure"),
-        classes => always("methods_run");
+        classes => always("user1_methods_run");
       "any" usebundle => user_has_password_hash("user2", "$(init.hash)", "user2_failure", "user2_success"),
-        classes => always("methods_run");
+        classes => always("user2_methods_run");
 
   classes:
-      "ready" expression => "methods_run";
+      "ready" and => { "user1_methods_run", "user2_methods_run" };
       "ok" and => { "user1_success", "!user1_failure",
                     "user2_success", "!user2_failure"
                   };

--- a/tests/acceptance/17_users/unsafe/20_modify_user_missing_secondary_group.cf
+++ b/tests/acceptance/17_users/unsafe/20_modify_user_missing_secondary_group.cf
@@ -7,16 +7,16 @@ body common control
 bundle agent init
 {
   commands:
-    "/usr/bin/sudo $(user_tests.pw_path) userdel testu";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testu";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg1";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg2";
-    "/usr/bin/sudo $(user_tests.pw_path) groupadd testg1";
-    "/usr/bin/sudo $(user_tests.pw_path) useradd testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.userdel) testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testg1";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testg2";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupadd) testg1";
+    "$(G.sudo) $(user_tests.pw_path) $(G.useradd) testu";
     freebsd::
-      "/usr/bin/sudo $(user_tests.pw_path) usermod testu --groups testg1 --append";
+      "$(G.sudo) $(user_tests.pw_path) $(G.usermod) testu -G testg1";
     !freebsd::
-      "/usr/bin/sudo $(user_tests.pw_path) usermod --groups testg1 --append testu";
+      "$(G.sudo) $(user_tests.pw_path) $(G.usermod) -G testg1  testu";
 }
 
 bundle agent test

--- a/tests/acceptance/17_users/unsafe/20_modify_user_missing_secondary_group.cf
+++ b/tests/acceptance/17_users/unsafe/20_modify_user_missing_secondary_group.cf
@@ -1,0 +1,57 @@
+body common control
+{
+      inputs => { "../../default.cf.sub", "user_queries.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+}
+
+bundle agent init
+{
+  commands:
+    "/usr/bin/sudo $(user_tests.pw_path) userdel testu";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testu";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg1";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg2";
+    "/usr/bin/sudo $(user_tests.pw_path) groupadd testg1";
+    "/usr/bin/sudo $(user_tests.pw_path) useradd testu";
+    freebsd::
+      "/usr/bin/sudo $(user_tests.pw_path) usermod testu --groups testg1 --append";
+    !freebsd::
+      "/usr/bin/sudo $(user_tests.pw_path) usermod --groups testg1 --append testu";
+}
+
+bundle agent test
+{
+  meta:
+    "description" -> { "ENT-3710" }
+      string => "Managing a user without specifying any secondary groups attribute
+                 should result in no changes to existing secondary groups.";
+
+  users:
+    "testu"
+      policy => "present";
+}
+
+bundle agent check
+{
+  methods:
+    "any" usebundle => user_is_in_secondary_group("testu", "testg1", "testg1_success", "testg1_failure"),
+      classes => always("testg1_method_run");
+
+    "any" usebundle => user_is_in_secondary_group("testu", "testg2", "testg2_success", "testg2_failure"),
+      classes => always("testg2_method_run");
+
+    "any" usebundle => user_exists("testu", "testu_success", "testu_failure"),
+      classes => always("testu_method_run");
+
+  classes:
+    "ready" and => { "testg1_method_run", "testg2_method_run", "testu_method_run" };
+    "ok" and => { "testg1_success", "!testg1_failure",
+                  "!testg2_success", "testg2_failure",
+                  "testu_success", "!testu_failure" };
+
+  reports:
+    ok.ready::
+      "$(this.promise_filename) Pass";
+    !ok.ready::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/17_users/unsafe/20_modify_user_secondary_groups.cf
+++ b/tests/acceptance/17_users/unsafe/20_modify_user_secondary_groups.cf
@@ -7,16 +7,16 @@ body common control
 bundle agent init
 {
   commands:
-    "/usr/bin/sudo $(user_tests.pw_path) userdel testu";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testu";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg1";
-    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg2";
-    "/usr/bin/sudo $(user_tests.pw_path) groupadd testg1";
-    "/usr/bin/sudo $(user_tests.pw_path) useradd testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.userdel) testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testu";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testg1";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupdel) testg2";
+    "$(G.sudo) $(user_tests.pw_path) $(G.groupadd) testg1";
+    "$(G.sudo) $(user_tests.pw_path) $(G.useradd) testu";
     freebsd::
-      "/usr/bin/sudo $(user_tests.pw_path) usermod testu --groups testg1 --append";
+      "$(G.sudo) $(user_tests.pw_path) $(G.usermod) testu -G testg1";
     !freebsd::
-      "/usr/bin/sudo $(user_tests.pw_path) usermod --groups testg1 --append testu";
+      "$(G.sudo) $(user_tests.pw_path) $(G.usermod) -G testg1 testu";
 }
 
 bundle agent test

--- a/tests/acceptance/17_users/unsafe/20_modify_user_secondary_groups.cf
+++ b/tests/acceptance/17_users/unsafe/20_modify_user_secondary_groups.cf
@@ -1,0 +1,57 @@
+body common control
+{
+      inputs => { "../../default.cf.sub", "user_queries.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+}
+
+bundle agent init
+{
+  commands:
+    "/usr/bin/sudo $(user_tests.pw_path) userdel testu";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testu";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg1";
+    "/usr/bin/sudo $(user_tests.pw_path) delgroup testg2";
+    "/usr/bin/sudo $(user_tests.pw_path) groupadd testg1";
+    "/usr/bin/sudo $(user_tests.pw_path) useradd testu";
+    freebsd::
+      "/usr/bin/sudo $(user_tests.pw_path) usermod testu --groups testg1 --append";
+    !freebsd::
+      "/usr/bin/sudo $(user_tests.pw_path) usermod --groups testg1 --append testu";
+}
+
+bundle agent test
+{
+  meta:
+    "description" -> { "ENT-3710" }
+      string => "Adding a secondary group which doesn't exist should not remove existing secondary groups";
+
+  users:
+    "testu"
+      groups_secondary => { "testg1", "testg2" },
+      policy => "present";
+}
+
+bundle agent check
+{
+  methods:
+    "any" usebundle => user_is_in_secondary_group("testu", "testg1", "testg1_success", "testg1_failure"),
+      classes => always("testg1_method_run");
+
+    "any" usebundle => user_is_in_secondary_group("testu", "testg2", "testg2_success", "testg2_failure"),
+      classes => always("testg2_method_run");
+
+    "any" usebundle => user_exists("testu", "testu_success", "testu_failure"),
+      classes => always("testu_method_run");
+
+  classes:
+    "ready" and => { "testg1_method_run", "testg2_method_run", "testu_method_run" };
+    "ok" and => { "testg1_success", "!testg1_failure",
+                  "!testg2_success", "testg2_failure",
+                  "testu_success", "!testu_failure" };
+
+  reports:
+    ok.ready::
+      "$(this.promise_filename) Pass";
+    !ok.ready::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/17_users/unsafe/user_queries.cf.sub
+++ b/tests/acceptance/17_users/unsafe/user_queries.cf.sub
@@ -14,6 +14,13 @@ bundle common user_tests
       "group1" string => "Users";
       "group2" string => "Administrators";
 
+    freebsd::
+      "pw_path" string => "/usr/sbin/pw";
+      "sudo_path" string => "/usr/local/bin/sudo";
+    !freebsd::
+      "pw_path" string => "";
+      "sudo_path" string => "/usr/bin/sudo";
+
   classes:
     # On HPUX we use a sudo hack, which doesn't support '-u'.
     !windows.!hpux::
@@ -22,10 +29,14 @@ bundle common user_tests
     hpux::
       "passwords_in_shadow" expression => fileexists("/etc/shadow");
       "passwords_in_passwd" not => fileexists("/etc/shadow");
+    freebsd::
+      "passwords_in_shadow" expression => "!any";
+      "passwords_in_passwd" expression => "!any";
+      "passwords_in_master_passwd" expression => "any";
     windows|aix::
       "passwords_in_shadow" expression => "!any";
       "passwords_in_passwd" expression => "!any";
-    !hpux.!windows.!aix::
+    !hpux.!windows.!aix.!freebsd::
       "passwords_in_shadow" expression => "any";
       "passwords_in_passwd" expression => "!any";
     windows|aix::
@@ -43,7 +54,7 @@ bundle agent remove_stale_groups
       "rmgroup johndoe"
         contain => in_shell;
     !aix::
-      "groupdel johndoe"
+      "$(user_tests.pw_path) groupdel johndoe"
         contain => in_shell;
 }
 
@@ -215,6 +226,8 @@ bundle agent user_has_password_hash(user, hash, true_class, false_class)
       "passwd_file" string => "/etc/passwd";
     passwords_in_shadow::
       "passwd_file" string => "/etc/shadow";
+    passwords_in_master_passwd::
+      "passwd_file" string => "/etc/master.passwd";
 
   classes:
     aix::

--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -37,6 +37,7 @@ bundle common G
                         "ls",
                         "mkdir",
                         "mkfifo",
+                        "mkgroup",  # AIX equivalent of groupadd
                         "mock_package_manager",
                         "mv",
                         "no_fds",
@@ -62,7 +63,8 @@ bundle common G
                       };
       # Special cases.
       "make_cmds" slist => { "gmake", "make" };
-      "sbin_cmds" slist => { "groupadd", "groupdel", "useradd", "userdel", "usermod" };
+      # rmgroup is AIX equivalent of groupdel
+      "sbin_cmds" slist => { "rmgroup", "groupadd", "groupdel", "useradd", "userdel", "usermod" };
 
     any::
       "paths[tests]" string                  => "$(this.promise_dirname)";
@@ -123,6 +125,11 @@ bundle common G
       ifvarclass => canonify("$(paths_indices)_make$(exeext)");
       "make" string => "$(paths[$(paths_indices)])$(const.dirsep)gmake$(exeext)",
       ifvarclass => canonify("$(paths_indices)_gmake$(exeext)");
+
+    # on AIX groupdel is rmgroup and groupadd is mkgroup
+    aix::
+      "groupdel" string => "$(G.rmgroup)";
+      "groupadd" string => "$(G.mkgroup)";
 
     want_color.have_colordiff::
       "diff_maybecolor" string => $(colordiff);

--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -53,6 +53,7 @@ bundle common G
                         "sleep",
                         "sort",
                         "stat",
+                        "sudo",
                         "tee",
                         "touch",
                         "true",
@@ -61,6 +62,7 @@ bundle common G
                       };
       # Special cases.
       "make_cmds" slist => { "gmake", "make" };
+      "sbin_cmds" slist => { "groupadd", "groupdel", "useradd", "userdel", "usermod" };
 
     any::
       "paths[tests]" string                  => "$(this.promise_dirname)";
@@ -72,6 +74,7 @@ bundle common G
     !windows::
       "paths[bin]" string                    => "/bin";
       "paths[usr_bin]" string                => "/usr/bin";
+      "paths[usr_sbin]" string               => "/usr/sbin";
       "paths[usr_local_bin]" string          => "/usr/local/bin";
       "paths[usr_contrib_bin]" string        => "/usr/contrib/bin";
     windows::
@@ -99,6 +102,7 @@ bundle common G
           scope => "namespace";
 
       # Special cases.
+      "$(paths_indices)_$(sbin_cmds)$(exeext)" expression => fileexists("$(paths[$(paths_indices)])$(const.dirsep)$(sbin_cmds)$(exeext)");
       "$(paths_indices)_$(make_cmds)$(exeext)" expression => fileexists("$(paths[$(paths_indices)])$(const.dirsep)$(make_cmds)$(exeext)");
       "has_make"                          expression => fileexists("$(paths[$(paths_indices)])$(const.dirsep)$(make_cmds)$(exeext)"),
       scope => "namespace";
@@ -112,6 +116,8 @@ bundle common G
       ifvarclass => canonify("$(paths_indices)_$(cmds)$(exeext)");
 
       # Special cases.
+      "$(sbin_cmds)" string => "$(paths[$(paths_indices)])$(const.dirsep)$(sbin_cmds)$(exeext)",
+      ifvarclass => canonify("$(paths_indices)_$(sbin_cmds)$(exeext)");
       # gmake has higher priority, so should come last.
       "make" string => "$(paths[$(paths_indices)])$(const.dirsep)make$(exeext)",
       ifvarclass => canonify("$(paths_indices)_make$(exeext)");

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -270,6 +270,7 @@ usage() {
     echo " -jobs=[n] Run tests in parallel, works like make -j option. Note that some"
     echo "           tests will always run one by one."
     echo " --verbose  Run tests with verbose logging"
+    echo " --debug    Run tests with debug logging"
 }
 
 workdir() {
@@ -481,9 +482,12 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
             then
                 printf "\"$LIBTOOL\" --mode=execute " >> "$WORKDIR/runtest"
             fi
-            printf "valgrind ${VALGRIND_OPTS} \"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES} 2>&1\n" >> "$WORKDIR/runtest"
+            printf "valgrind ${VALGRIND_OPTS} \"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES} 2>&1\n" >> "$WORKDIR/runtest"
+        elif [ x"$PRELOAD_ASAN" != x ]
+        then
+            printf "LD_PRELOAD=$PRELOAD_ASAN \"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
         else
-            printf "\"$AGENT\" $VERBOSE -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
+            printf "\"$AGENT\" $VERBOSE $DEBUG -Klf \"$TEST\" -D ${PASS_NUM:+test_pass_$PASS_NUM,}${BASECLASSES},${EXTRACLASSES}\n" >> "$WORKDIR/runtest"
         fi
 
         chmod +x "$WORKDIR/runtest"
@@ -847,6 +851,8 @@ do
             NO_CLEAN=1;;
         --verbose)
             VERBOSE="-v";;
+        --debug)
+           DEBUG="--debug";;
         --stay-in-workdir)
             # Internal option. Meant to keep sub invocations from interfering by
             # writing files only into the workdir.
@@ -880,6 +886,7 @@ then
     # each test is horribly slow.
     echo "export GAINROOT=" > runtests.sh
     echo "export TESTALL_DO_NOT_RECURSE=1" >> runtests.sh
+    echo "export DEBUG='$DEBUG'" >> runtests.sh
     echo "export VERBOSE='$VERBOSE'" >> runtests.sh
     echo "$0 $ORIG_ARGS $@ &" >> runtests.sh
     # Note quote change. We want to keep below variables unexpanded.


### PR DESCRIPTION
Modify user promise secondary groups attribute handling to examine current state and set new state appropriately instead of clearing all secondary groups and then setting (workaround for SUSE issue).

Cherry picked manually due to lots of conflicts in the C code.

Based on https://github.com/cfengine/core/pull/4126