### PR TITLE
[3.15.x] Evaluate 'if' even in case of class context or 'ifvarclass'

### DIFF
--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -625,25 +625,40 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
 
     /* Look for 'if'/'ifvarclass' exclusion. */
     {
+        /* We need to make sure to check both 'if' and 'ifvarclass' constraints. */
+        bool checked_if = false;
         const Constraint *ifvarclass = PromiseGetConstraint(pp, "ifvarclass");
         if (!ifvarclass)
         {
             ifvarclass = PromiseGetConstraint(pp, "if");
+            checked_if = true;
         }
 
         // if - Skip if false or error:
-        if (ifvarclass && (CheckVarClassExpression(ctx, ifvarclass, pcopy) != EXPRESSION_VALUE_TRUE))
+        while (ifvarclass != NULL)
         {
-            if (LogGetGlobalLevel() >= LOG_LEVEL_VERBOSE)
+            if (CheckVarClassExpression(ctx, ifvarclass, pcopy) != EXPRESSION_VALUE_TRUE)
             {
-                char *ifvarclass_string =  RvalToString(ifvarclass->rval);
-                Log(LOG_LEVEL_VERBOSE, "Skipping promise '%s'"
-                    " because constraint '%s => %s' is not met",
-                    pp->promiser, ifvarclass->lval, ifvarclass_string);
-                free(ifvarclass_string);
+                if (LogGetGlobalLevel() >= LOG_LEVEL_VERBOSE)
+                {
+                    char *ifvarclass_string =  RvalToString(ifvarclass->rval);
+                    Log(LOG_LEVEL_VERBOSE, "Skipping promise '%s'"
+                        " because constraint '%s => %s' is not met",
+                        pp->promiser, ifvarclass->lval, ifvarclass_string);
+                    free(ifvarclass_string);
+                }
+                *excluded = true;
+                return pcopy;
             }
-            *excluded = true;
-            return pcopy;
+            if (!checked_if)
+            {
+                ifvarclass = PromiseGetConstraint(pp, "if");
+                checked_if = true;
+            }
+            else
+            {
+                ifvarclass = NULL;
+            }
         }
     }
 

--- a/tests/acceptance/02_classes/01_basic/variable_class_expressions_with_if.cf
+++ b/tests/acceptance/02_classes/01_basic/variable_class_expressions_with_if.cf
@@ -9,10 +9,8 @@ bundle agent test
 {
   meta:
 
-      "description" string => "Test that variable class expressions and the if alias work together as expected.";
-
-      "test_soft_fail"
-        string => "any",
+      "description"
+        string => "Test that variable class expressions and the if alias work together as expected.",
         meta => { "CFE-2615" };
 
   vars:
@@ -93,8 +91,8 @@ bundle agent test
       "Found class indicating failure '$(FAIL_classes)'";
 
     FAIL_classes::
-      "$(this.promise_dirname) FAIL";
+      "$(this.promise_filename) FAIL";
 
     no_FAIL_classes::
-      "$(this.promise_dirname) Pass";
+      "$(this.promise_filename) Pass";
 }


### PR DESCRIPTION
If a class context is specified in the policy or if 'ifvarclass'
constraint is used, the 'if' constraint should be evaluated as
well.

Ticket: CFE-2615
Changelog: 'if' constraint now works in combination with class contexts
(cherry picked from commit 6e1dd86e56cc977b587c92ac18b4a62bee61fdd3)