### PR TITLE
CFE-3187/3.15.x: Added example illustrating use of cifs mount_type

### DIFF
--- a/examples/storage-cifs.cf
+++ b/examples/storage-cifs.cf
@@ -1,0 +1,30 @@
+bundle agent main
+# @brief Example illustrating CIFS/Samba storage type promise mount
+{
+  vars:
+    redhat|centos::
+      "cifs" data => '{ "server": "192.168.42.251", "path": "/Audio" }';
+
+  packages:
+    redhat|centos::
+      "cifs-utils"   policy => "present";
+      "samba-client" policy => "present";
+
+  files:
+    redhat|centos::
+      "/mnt/CIFS/." create => "true";
+
+  storage:
+    redhat|centos::
+      "/mnt/CIFS"
+        mount => cifs_guest( $(cifs[server]) , $(cifs[path]) );
+}
+
+body mount cifs_guest(server,source)
+{
+        mount_type => "cifs";
+        mount_source => "$(source)";
+        mount_server => "$(server)";
+        mount_options => { "guest" };
+        edit_fstab => "false";
+}


### PR DESCRIPTION
Merge together:
https://github.com/cfengine/documentation/pull/2312

Ticket: CFE-3187
Changelog: None
(cherry picked from commit f5ea3145f68b930e0e3e1ce15229ac7c8c0a0a63)