### PR TITLE
ENT-5986: LMDB files are now created with correct permissions and group ownership (3.15)

### DIFF
--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -1190,10 +1190,9 @@ gid_t Str2Gid(const char *gidbuff, char *groupcopy, const Promise *pp)
         }
         else if ((gr = getgrnam(gidbuff)) == NULL)
         {
-            Log(LOG_LEVEL_INFO, "Unknown group '%s' in promise", gidbuff);
-
             if (pp)
             {
+                Log(LOG_LEVEL_INFO, "Unknown group '%s' in promise", gidbuff);
                 PromiseRef(LOG_LEVEL_INFO, pp);
             }
 

--- a/tests/load/Makefile.am
+++ b/tests/load/Makefile.am
@@ -50,7 +50,7 @@ check_PROGRAMS = db_load lastseen_load lastseen_threaded_load
 
 
 db_load_SOURCES = db_load.c
-db_load_LDADD = ../unit/libdb.la
+db_load_LDADD = ../unit/libdb.la ../../libpromises/libpromises.la
 
 
 lastseen_load_SOURCES = lastseen_load.c \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -264,7 +264,7 @@ db_test_LDADD = libtest.la ../../libpromises/libpromises.la
 
 db_concurrent_test_SOURCES = db_concurrent_test.c
 #db_concurrent_test_CPPFLAGS = $(libdb_la_CPPFLAGS)
-db_concurrent_test_LDADD = libdb.la
+db_concurrent_test_LDADD = libdb.la ../../libpromises/libpromises.la
 
 lastseen_test_SOURCES = lastseen_test.c \
 	../../libpromises/item_lib.c \


### PR DESCRIPTION
When run as privileged user LMDB files will be created with
system group matching MPF body perms system_owned().

When un-privileged, no change in group will be made.

In both cases permissions will be 0600 as expected by MPF
cfe_internal/enterprise/CFE_knowledge.cf.

Ticket: ENT-5986
Changelog: Title
(cherry picked from commit 079d333a48c03d4bcd4a3ded7b7eede07e91759c)

Conflicts: libntech