### PR TITLE
ENT-6002 Added association between host info and release package names (3.12.x)

### DIFF
--- a/contrib/cf-remote/cf_remote/packages.py
+++ b/contrib/cf-remote/cf_remote/packages.py
@@ -7,6 +7,7 @@ import re
 
 class Artifact:
     def __init__(self, data, filename=None):
+        log.debug("Artifact, data {}, filename {}".format(data, filename))
         if filename and not data:
             data = {}
             data["URL"] = "./" + filename
@@ -18,7 +19,8 @@ class Artifact:
         self.url = data["URL"]
         self.title = data["Title"]
         self.arch = canonify(data["Arch"])
-
+        if 'package' in data:
+            self.package = data["package"]
         self.filename = basename(self.url)
         self.extension = splitext(self.filename)[1]
 
@@ -28,6 +30,8 @@ class Artifact:
     def create_tags(self):
         self.add_tag(self.arch)
         self.add_tag(self.extension[1:])
+        if hasattr(self, 'package'):
+            self.add_tag('_'.join(self.package.split('_')[-2:]))
 
         look_for_tags = [
             "Windows", "CentOS", "Red Hat", "Debian", "Ubuntu", "SLES", "Solaris", "AIX", "HPUX",
@@ -172,6 +176,7 @@ class Releases:
             if "latestLTS" in release and release["latestLTS"] == True:
                 self.default = rel
                 rel.default = True
+            log.debug("Adding release {} to releases available for installing".format(release["URL"]))
             self.releases.append(rel)
 
     def pick_version(self, version):

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -108,10 +108,10 @@ def get_info(host, *, users=None, connection=None):
         if data["os_release"]:
             distro = data["os_release"]["ID"]
             major = data["os_release"]["VERSION_ID"].split(".")[0]
-            platform_tag = distro + major
 
             # Add tags with version number first, to filter by them first:
-            tags.append(platform_tag) # Example: ubuntu16
+            tags.append(distro + "_" + major) # Example for 3.12.x builds: debian_7, to match with package name
+            tags.append(distro + major)       # Example for >3.12.x builds: ubuntu16, to match filename
             if distro == "centos":
                 tags.append("el" + major)
 


### PR DESCRIPTION
3.12.x package filenames do not include any "distro" information so installing
with --version 3.12.x doesn't work well. e.g. debian_7 gets ubuntu package.

Added "debian_7" tag in addition to current "debian7" tag which matches
package attribute values from releases.json such as
PACKAGES_HUB_x86_64_linux_debian_7

Changelog: none
Ticket: ENT-6002