### PR TITLE
Fix error when source and build locations differ.

### DIFF
--- a/tests/acceptance/Makefile.am
+++ b/tests/acceptance/Makefile.am
@@ -86,7 +86,7 @@ endif
 # Keep the '+' in front for the command, needed for the sub-make
 # to run in parallel; TODO fix "make -n" not working:
 check-local:
-	+ $(TESTS_ENVIRONMENT) MAKE=$(MAKE) ./testall
+	+ $(TESTS_ENVIRONMENT) MAKE=$(MAKE) $(srcdir)/testall
 
 
 EXTRA_DIST = default.cf.sub dcs.cf.sub plucked.cf.sub run_with_server.cf.sub \


### PR DESCRIPTION
This is very similar in nature to pull request #3933 (see it for a fuller explanation).

Although most building is driven when the build tree is the same as the source tree, autotools fully supports the capability for these trees to be in different locations.

This patch corrects a particular issue with this.

I think an independent but related issue remains in "tests/acceptance/testall" in function "finish_xml" (currently near line 1125) with the use of "$XML" (two occurrences).  A fix on the existing code looks non-trivial, but that is because I think the code is not as clean as it should be.  If so, a clean-up of the code would greatly ease the fixing of that problem, but that is beyond the remit of this PR.