### PR TITLE
ENT-5986 LMDB files are now created with correct permissions

### DIFF
--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -558,7 +558,7 @@ DBPriv *DBPrivOpenDB(const char *const dbpath, const dbid id)
     open_flags |= MDB_WRITEMAP;
 #endif
 
-    rc = LmdbEnvOpen(db->env, dbpath, open_flags, 0644);
+    rc = LmdbEnvOpen(db->env, dbpath, open_flags, CF_PERMS_DEFAULT);
     if (rc)
     {
         Log(LOG_LEVEL_ERR, "Could not open database %s: %s",


### PR DESCRIPTION
Permissions will be 0600 as expected by MPF
cfe_internal/enterprise/CFE_knowledge.cf
Ticket: ENT-5986
Changelog: Title

merge with:
https://github.com/cfengine/masterfiles/pull/1768