### PR TITLE
Added usage of os-release ID_LIKE/VERSION_ID_LIKE for cf-remote install

### DIFF
--- a/contrib/cf-remote/README.md
+++ b/contrib/cf-remote/README.md
@@ -85,6 +85,17 @@ Note that this demo setup (`--demo`) is notoriously insecure.
 It has default passwords and open access controls.
 Don't use it in a production environment.
 
+Note also that for distributions that we don't have packages for you might add entries to
+`/etc/os-release` on the target system to give cf-remote an alternative. For example, PureOS
+is based on debian testing, so currently the appropriate package we create would be debian 10.
+
+```
+ID_LIKE="debian"
+VERSION_ID_LIKE="10.0"
+```
+
+The non-standard `VERSION_ID_LIKE` is used. See [os-release documentation](https://www.linux.org/docs/man5/os-release.html) for more info.
+
 ### Specify an SSH key
 
 If you have more than one key in `~/.ssh` you may need to specify which key `cf-remote` is to use.

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -106,8 +106,9 @@ def get_info(host, *, users=None, connection=None):
 
         tags = []
         if data["os_release"]:
-            distro = data["os_release"]["ID"]
-            major = data["os_release"]["VERSION_ID"].split(".")[0]
+            distro = data["os_release"]["ID_LIKE"] or data["os_release"]["ID"]
+            version = data["os_release"]["VERSION_ID_LIKE"] or data["os_release"]["VERSION_ID"]
+            major = version.split(".")[0]
             platform_tag = distro + major
 
             # Add tags with version number first, to filter by them first:

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -106,13 +106,20 @@ def get_info(host, *, users=None, connection=None):
 
         tags = []
         if data["os_release"]:
-            distro = data["os_release"]["ID_LIKE"] or data["os_release"]["ID"]
-            version = data["os_release"]["VERSION_ID_LIKE"] or data["os_release"]["VERSION_ID"]
+            if "ID_LIKE" in data["os_release"]:
+                distro_like = data["os_release"]["ID_LIKE"]
+            distro = data["os_release"]["ID"]
+            version_like = None
+            if "VERSION_ID_LIKE" in data["os_release"]:
+                version_like = data["os_release"]["VERSION_ID_LIKE"]
+            version = data["os_release"]["VERSION_ID"]
             major = version.split(".")[0]
             platform_tag = distro + major
 
             # Add tags with version number first, to filter by them first:
             tags.append(platform_tag) # Example: ubuntu16
+            # in case of ID_LIKE and/or VERSION_ID_LIKE add that as a "platform tag" as well
+            tags.append(distro_like + (version_like or version))
             if distro == "centos":
                 tags.append("el" + major)
 


### PR DESCRIPTION
Added parsing and use of ID_LIKE and VERSION_ID_LIKE to cf-remote to support installing on PureOS. Should work for many other derivative distributions.

Changelog: Title
Ticket: none