### PR TITLE
Properly inform about changes in the new 'packages' promise

### DIFF
--- a/cf-agent/package_module.c
+++ b/cf-agent/package_module.c
@@ -92,18 +92,18 @@ PackageModuleWrapper *NewPackageModuleWrapper(PackageModuleBody *package_module)
         if (access(interpreter_path, X_OK) != 0)
         {
             Log(LOG_LEVEL_ERR,
-                "can not find package wrapper interpreter in provided location '%s' "
-                "or access to file is restricted: %s",
-                wrapper->path, strerror(errno));
+                "Cannot find package module interpreter at location '%s'"
+                " or access to the file is restricted: %s",
+                wrapper->path, GetErrorStr());
             DeletePackageModuleWrapper(wrapper);
             return NULL;
         }
         if (access(script_path, R_OK) != 0)
         {
             Log(LOG_LEVEL_ERR,
-                "can not find the package wrapper script in provided location '%s' "
-                "or access to file is restricted: %s",
-                wrapper->script_path, strerror(errno));
+                "Cannot find package module script at location '%s'"
+                " or access to the file is restricted: %s",
+                wrapper->script_path, GetErrorStr());
             DeletePackageModuleWrapper(wrapper);
             return NULL;
         }
@@ -112,9 +112,8 @@ PackageModuleWrapper *NewPackageModuleWrapper(PackageModuleBody *package_module)
     {
         /* no script path specified --> the given path has to be executable */
         Log(LOG_LEVEL_ERR,
-            "can not find package wrapper in provided location '%s' "
-            "or access to file is restricted: %s",
-            wrapper->path, strerror(errno));
+            "Cannot find package module at location '%s' or access to file is restricted: %s",
+            wrapper->path, GetErrorStr());
         DeletePackageModuleWrapper(wrapper);
         return NULL;
     }
@@ -124,7 +123,7 @@ PackageModuleWrapper *NewPackageModuleWrapper(PackageModuleBody *package_module)
     if (wrapper->supported_api_version != 1)
     {
         Log(LOG_LEVEL_ERR,
-            "unsupported package module wrapper API version: %d",
+            "Unsupported package module wrapper API version: %d",
             wrapper->supported_api_version);
         DeletePackageModuleWrapper(wrapper);
         return NULL;

--- a/cf-agent/verify_new_packages.h
+++ b/cf-agent/verify_new_packages.h
@@ -27,8 +27,6 @@
 
 #include <cf3.defs.h>
 
-PromiseResult HandleNewPackagePromiseType(EvalContext *ctx, const Promise *pp,
-                                          const Attributes *a, char **promise_log_msg,
-                                          LogLevel *log_lvl);
+PromiseResult HandleNewPackagePromiseType(EvalContext *ctx, const Promise *pp, const Attributes *a);
 
 #endif

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -181,8 +181,6 @@ PromiseResult VerifyPackagesPromise(EvalContext *ctx, const Promise *pp)
     assert(pp != NULL); // Dereferenced in cfPS macros
 
     PromiseResult result = PROMISE_RESULT_FAIL;
-    char *promise_log_message = NULL;
-    LogLevel level;
 
     Attributes a = GetPackageAttributes(ctx, pp);
     PackagePromiseType package_promise_type =
@@ -193,19 +191,11 @@ PromiseResult VerifyPackagesPromise(EvalContext *ctx, const Promise *pp)
         case PACKAGE_PROMISE_TYPE_NEW:
             Log(LOG_LEVEL_VERBOSE, "Using new package promise.");
 
-            result = HandleNewPackagePromiseType(ctx, pp, &a, &promise_log_message,
-                    &level);
-
-            assert(promise_log_message != NULL);
-
-            if (result != PROMISE_RESULT_SKIPPED)
-            {
-                cfPS(ctx, level, result, pp, &a, "%s", promise_log_message);
-            }
-            free(promise_log_message);
+            result = HandleNewPackagePromiseType(ctx, pp, &a);
             break;
+
         case PACKAGE_PROMISE_TYPE_OLD:
-            Log(LOG_LEVEL_VERBOSE,
+            Log(LOG_LEVEL_NOTICE,
                 "Using old package promise. Please note that this old "
                 "implementation is being phased out. The old "
                 "implementation will continue to work, but forward development "

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -2934,7 +2934,10 @@ void cfPS(EvalContext *ctx, LogLevel level, PromiseResult status, const Promise 
 
     /* Now complete the exits status classes and auditing */
 
-    ClassAuditLog(ctx, pp, attr, status);
+    if (status != PROMISE_RESULT_SKIPPED)
+    {
+        ClassAuditLog(ctx, pp, attr, status);
+    }
 }
 
 void RecordChange(EvalContext *ctx, const Promise *pp, const Attributes *attr, const char *fmt, ...)


### PR DESCRIPTION
Just move the cfPS() calls into the HandleNewPackagePromiseType()
function instead of passing things back and forth for no good
reason.

Also change some of the log messages to be in sync with other log
messages produced by an agent run.

Ticket: ENT-5291
Changelog: None