### PR TITLE
libntech: Bumped to latest; rename TO_STRING macro

### DIFF
--- a/cf-monitord/mon_io_linux.c
+++ b/cf-monitord/mon_io_linux.c
@@ -182,7 +182,7 @@ static void MonIoDiskstatsGatherData(double *cf_this)
         if (!strchr(buf, '\n'))
         {
             Log(LOG_LEVEL_ERR,
-                  "/proc/diskstats format error: read overlong string (> " TOSTRING(CF_BUFSIZE - 1) " bytes)");
+                  "/proc/diskstats format error: read overlong string (> " TO_STRING(CF_BUFSIZE) " bytes)");
             goto err;
         }
 


### PR DESCRIPTION
Latest libntech renamed TOSTRING to TO_STRING. Fix here accordingly and
clean the wrongly used "- 1" from the log expression.

Merge together:
https://github.com/cfengine/core/pull/4207
https://github.com/cfengine/nova/pull/1678