### PR TITLE
CFE-3074: Added string_trim() policy function

### DIFF
--- a/examples/string_trim.cf
+++ b/examples/string_trim.cf
@@ -1,0 +1,28 @@
+#+begin_src cfengine3
+bundle agent example_trim
+# @brief Example showing string_trim
+{
+  vars:
+      "my_string_one" string => string_trim( "  Trim spaces please   ");
+      "my_string_two" string => string_trim( "
+        Trim newlines also please
+
+      ");
+
+  reports:
+      "my_string_one: '$(my_string_one)'";
+      "my_string_two: '$(my_string_two)'";
+}
+
+bundle agent __main__
+{
+  methods: "example_trim";
+}
+###############################################################################
+#+end_src
+#+begin_src example_output
+#@ ```
+#@ R: my_string_one: 'Trim spaces please'
+#@ R: my_string_two: 'Trim newlines also please'
+#@ ```
+#+end_src

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7630,6 +7630,15 @@ static FnCallResult FnCallStringReplace(ARG_UNUSED EvalContext *ctx,
 
 /*********************************************************************/
 
+static FnCallResult FnCallStringTrim(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const Policy *policy, ARG_UNUSED const FnCall *fp, const Rlist *finalargs)
+{
+    char *string = RlistScalarValue(finalargs);
+
+    return FnReturn(TrimWhitespace(string));
+}
+
+/*********************************************************************/
+
 static FnCallResult FnCallFileSexist(EvalContext *ctx, ARG_UNUSED const Policy *policy, ARG_UNUSED const FnCall *fp, const Rlist *finalargs)
 {
     bool allocated = false;
@@ -9458,6 +9467,12 @@ static const FnCallArg STRING_REPLACE_ARGS[] =
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
+static const FnCallArg STRING_TRIM_ARGS[] =
+{
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Input string"},
+    {NULL, CF_DATA_TYPE_NONE, NULL}
+};
+
 static const FnCallArg SUBLIST_ARGS[] =
 {
     {CF_ANYSTRING, CF_DATA_TYPE_STRING, "CFEngine variable identifier or inline JSON"},
@@ -9659,7 +9674,7 @@ static const FnCallArg DATA_SYSCTLVALUES_ARGS[] =
 /* FnCalls are rvalues in certain promise constraints    */
 /*********************************************************/
 
-/* see cf3.defs.h enum fncalltype */
+/* see fncall.h enum FnCallType */
 
 const FnCallType CF_FNCALL_TYPES[] =
 {
@@ -9983,6 +9998,8 @@ const FnCallType CF_FNCALL_TYPES[] =
     FnCallTypeNew("string_split", CF_DATA_TYPE_STRING_LIST, SPLITSTRING_ARGS, &FnCallStringSplit, "Convert a string in arg1 into a list of at most arg3 strings by splitting on a regular expression in arg2",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("string_replace", CF_DATA_TYPE_STRING, STRING_REPLACE_ARGS, &FnCallStringReplace, "Search through arg1, replacing occurences of arg2 with arg3.",
+                  FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
+    FnCallTypeNew("string_trim", CF_DATA_TYPE_STRING, STRING_TRIM_ARGS, &FnCallStringTrim, "Trim whitespace from beginning and end of string",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),
     FnCallTypeNew("regex_replace", CF_DATA_TYPE_STRING, REGEX_REPLACE_ARGS, &FnCallRegReplace, "Replace occurrences of arg1 in arg2 with arg3, allowing backreferences.  Perl-style options accepted in arg4.",
                   FNCALL_OPTION_NONE, FNCALL_CATEGORY_DATA, SYNTAX_STATUS_NORMAL),

--- a/tests/acceptance/01_vars/02_functions/string_trim.cf
+++ b/tests/acceptance/01_vars/02_functions/string_trim.cf
@@ -1,0 +1,47 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "abcd1" string => string_trim("abcd");
+      "abcd2" string => string_trim(" abcd");
+      "abcd3" string => string_trim("abcd ");
+      "abcd4" string => string_trim("         abcd               ");
+      "abcd5" string => string_trim("abcd
+
+      ");
+      "abcd6" string => string_trim("
+      
+      abcd");
+      "abcd7" string => string_trim("   
+      
+      abcd
+      
+      ");
+      "abcd_abcd" string => string_trim("  abcd    abcd      ");
+
+      # empty cases
+      "empty1" string => string_trim("");
+      "empty2" string => string_trim("     ");
+      "empty3" string => string_trim("   
+      
+      
+      ");
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_check_state(test,
+                                      "$(this.promise_filename).expected.json",
+                                       $(this.promise_filename));
+}

--- a/tests/acceptance/01_vars/02_functions/string_trim.cf.expected.json
+++ b/tests/acceptance/01_vars/02_functions/string_trim.cf.expected.json
@@ -1,0 +1,13 @@
+{
+  "abcd1": "abcd",
+  "abcd2": "abcd",
+  "abcd3": "abcd",
+  "abcd4": "abcd",
+  "abcd5": "abcd",
+  "abcd6": "abcd",
+  "abcd7": "abcd",
+  "abcd_abcd": "abcd    abcd",
+  "empty1": "",
+  "empty2": "",
+  "empty3": ""
+}


### PR DESCRIPTION
The function will remove leading and trailing white spaces (including
newline) from the input string.

Added an example file and a simple acceptance test.

Ticket: CFE-3074
Changelog: Title
Signed-off-by: Lluis Campos <lluis.campos@northern.tech>