### PR TITLE
Fixed problems highlighted by gcc warnings

### DIFF
--- a/cf-agent/files_editxml.c
+++ b/cf-agent/files_editxml.c
@@ -846,7 +846,7 @@ static bool XmlSelectNode(EvalContext *ctx, char *rawxpath, xmlDocPtr doc, xmlNo
 
     if ((xpathExpr = CharToXmlChar(rawxpath)) == NULL)
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a, "Unable to create new XPath expression '%s'", rawxpath);
+        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a, "Unable to create new XPath expression");
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_INTERRUPTED);
         return false;
     }
@@ -1034,8 +1034,8 @@ static bool InsertTreeInFile(EvalContext *ctx, char *rawtree, xmlDocPtr doc, con
     if ((buf = CharToXmlChar(rawtree)) == NULL)
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a,
-             "Tree to be inserted '%s' into an empty XML document '%s', was NOT successfully loaded into an XML buffer",
-             rawtree, edcontext->filename);
+             "Failed to load tree to be inserted into an empty XML document '%s' into an XML buffer",
+             edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_INTERRUPTED);
         return false;
     }
@@ -1125,8 +1125,8 @@ static bool DeleteTreeInNode(EvalContext *ctx, char *rawtree, xmlDocPtr doc, xml
     if (!buf)
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a,
-             "Tree to be deleted '%s' at XPath '%s' in XML document '%s', was NOT successfully loaded into an XML buffer",
-             rawtree, a->xml.select_xpath, edcontext->filename);
+             "Failed to load the tree to be deleted at XPath '%s' in XML document '%s' into an XML buffer",
+             a->xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_INTERRUPTED);
         return false;
     }
@@ -1209,8 +1209,8 @@ static bool InsertTreeInNode(EvalContext *ctx, char *rawtree, xmlDocPtr doc, xml
     if ((buf = CharToXmlChar(rawtree)) == NULL)
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a,
-             "Tree to be inserted '%s' at XPath '%s' in XML document '%s', was NOT successfully loaded into an XML buffer",
-             rawtree, a->xml.select_xpath, edcontext->filename);
+             "Failed to load the tree to be inserted at XPath '%s' in XML document '%s' into an XML buffer",
+             a->xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_INTERRUPTED);
         return false;
     }
@@ -1287,8 +1287,8 @@ static bool DeleteAttributeInNode(EvalContext *ctx, char *rawname, xmlNodePtr do
     if ((name = CharToXmlChar(rawname)) == NULL)
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a,
-             "Name of attribute to be deleted '%s', at XPath '%s' in XML document '%s', was NOT successfully loaded into an XML buffer",
-             rawname, a->xml.select_xpath, edcontext->filename);
+             "Failed to load the name of attribute to be deleted at XPath '%s' in XML document '%s' into an XML buffer",
+             a->xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_INTERRUPTED);
         return false;
     }
@@ -1349,8 +1349,8 @@ static bool SetAttributeInNode(EvalContext *ctx, char *rawname, char *rawvalue, 
     if ((name = CharToXmlChar(rawname)) == NULL)
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a,
-             "Name of attribute to be set '%s', at XPath '%s' in XML document '%s', was NOT successfully loaded into an XML buffer",
-             rawname, a->xml.select_xpath, edcontext->filename);
+             "Failed to load the name of attribute to set at XPath '%s' in XML document '%s' into an XML buffer",
+             a->xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_INTERRUPTED);
         return false;
     }
@@ -1358,8 +1358,8 @@ static bool SetAttributeInNode(EvalContext *ctx, char *rawname, char *rawvalue, 
     if ((value = CharToXmlChar(rawvalue)) == NULL)
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a,
-             "Value of attribute to be set '%s', at XPath '%s' in XML document '%s', was NOT successfully loaded into an XML buffer",
-             rawvalue, a->xml.select_xpath, edcontext->filename);
+             "Failed to load value of attribute to set at XPath '%s' in XML document '%s' into an XML buffer",
+             a->xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_INTERRUPTED);
         return false;
     }
@@ -1419,8 +1419,8 @@ static bool DeleteTextInNode(EvalContext *ctx, char *rawtext, xmlDocPtr doc, xml
     if ((text = CharToXmlChar(rawtext)) == NULL)
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a,
-             "Text to be deleted '%s' at XPath '%s' in XML document '%s', was NOT successfully loaded into an XML buffer",
-             rawtext, a->xml.select_xpath, edcontext->filename);
+             "Failed to load text to delete at XPath '%s' in XML document '%s' into an XML buffer",
+             a->xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_INTERRUPTED);
         return false;
     }
@@ -1490,8 +1490,8 @@ static bool SetTextInNode(EvalContext *ctx, char *rawtext, xmlDocPtr doc, xmlNod
     if ((text = CharToXmlChar(rawtext)) == NULL)
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a,
-             "Text to be set '%s' at XPath '%s' in XML document '%s', was NOT successfully loaded into an XML buffer",
-             rawtext, a->xml.select_xpath, edcontext->filename);
+             "Failed to load text to set at XPath '%s' in XML document '%s' into an XML buffer",
+             a->xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_INTERRUPTED);
         return false;
     }
@@ -1561,8 +1561,8 @@ static bool InsertTextInNode(EvalContext *ctx, char *rawtext, xmlDocPtr doc, xml
     if ((text = CharToXmlChar(rawtext)) == NULL)
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_INTERRUPTED, pp, a,
-             "Text to be inserted '%s' at XPath '%s' in XML document '%s', was NOT successfully loaded into an XML buffer",
-             rawtext, a->xml.select_xpath, edcontext->filename);
+             "Failed to load text to insert at XPath '%s' in XML document '%s' into an XML buffer",
+             a->xml.select_xpath, edcontext->filename);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_INTERRUPTED);
         return false;
     }

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -122,7 +122,7 @@ void SetFileAutoDefineList(const Rlist *auto_define_list)
     AUTO_DEFINE_LIST = auto_define_list;
 }
 
-void VerifyFileLeaf(EvalContext *ctx, char *path, const struct stat *sb, const Attributes *attr, const Promise *pp, PromiseResult *result)
+void VerifyFileLeaf(EvalContext *ctx, char *path, const struct stat *sb, ARG_UNUSED const Attributes *attr, const Promise *pp, PromiseResult *result)
 {
     // FIXME: This function completely ignores it's attr argument
     assert(attr != NULL);

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -1167,14 +1167,14 @@ static PromiseResult LinkCopy(EvalContext *ctx, char *sourcefile, char *destfile
 #else                           /* !__MINGW32__ */
 {
     assert(attr != NULL);
-    char linkbuf[CF_BUFSIZE];
+    char linkbuf[CF_BUFSIZE - 1];
     const char *lastnode;
     struct stat dsb;
     PromiseResult result = PROMISE_RESULT_NOOP;
 
     linkbuf[0] = '\0';
 
-    if ((S_ISLNK(sb->st_mode)) && (cf_readlink(ctx, sourcefile, linkbuf, CF_BUFSIZE, attr, pp, conn, &result) == -1))
+    if ((S_ISLNK(sb->st_mode)) && (cf_readlink(ctx, sourcefile, linkbuf, sizeof(linkbuf), attr, pp, conn, &result) == -1))
     {
         cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr, "Can't readlink '%s'", sourcefile);
         return PROMISE_RESULT_FAIL;

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -220,9 +220,9 @@ static void print_struct_persistent_class(
         assert(tags > (char *) class_info);
 
         const size_t offset = (tags - (char *) class_info);
-        const size_t offset_no_padding =
-            (sizeof(unsigned int) + sizeof(PersistentClassPolicy));
-        assert(offset >= offset_no_padding);
+
+        /* (sizeof(unsigned int) + sizeof(PersistentClassPolicy)) is offset without the padding */
+        assert(offset >= (sizeof(unsigned int) + sizeof(PersistentClassPolicy)));
 
         assert(value.mv_size > offset);
         const size_t str_size = value.mv_size - offset;

--- a/cf-secret/cf-secret.c
+++ b/cf-secret/cf-secret.c
@@ -546,6 +546,13 @@ static inline bool ParseHeader(FILE *input_file, char *key, char *value)
 
 static bool ParseHeaders(FILE *input_file, RSA *privkey, size_t *enc_key_pos, size_t *n_enc_keys)
 {
+    assert(enc_key_pos != NULL);
+    assert(n_enc_keys != NULL);
+
+    /* Make sure these are always set by this function. */
+    *enc_key_pos = 0;
+    *n_enc_keys = 0;
+
     /* Actually works for a private RSA key too because it contains the public
      * key. */
     char *key_digest = GetPubkeyDigest(privkey);

--- a/libpromises/cf3lex.l
+++ b/libpromises/cf3lex.l
@@ -498,7 +498,7 @@ promise_guard  [a-zA-Z_]+:
                           {
                               yyerror("identifier too long");
                           }
-                          strncpy(P.currentid, yytext, CF_MAXVARSIZE);
+                          strncpy(P.currentid, yytext, CF_MAXVARSIZE - 1);
                           return IDENTIFIER;
                       }
 
@@ -511,7 +511,7 @@ promise_guard  [a-zA-Z_]+:
                           {
                               yyerror("qualified identifier too long");
                           }
-                          strncpy(P.currentid, yytext, CF_MAXVARSIZE);
+                          strncpy(P.currentid, yytext, CF_MAXVARSIZE - 1);
                           return IDENTIFIER;
                       }
 
@@ -609,7 +609,7 @@ promise_guard  [a-zA-Z_]+:
                           assert(strlen(tmp) > 0);
                           assert(tmp[strlen(tmp) - 1] != ':');
 
-                          strncpy(P.currenttype, tmp, CF_MAXVARSIZE);
+                          strncpy(P.currenttype, tmp, CF_MAXVARSIZE - 1);
 
                           if (P.currentclasses != NULL)
                           {

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -744,7 +744,7 @@ functionid:            IDENTIFIER
                      | NAKEDVAR
                        {
                            ParserDebug("\tP:%s:%s:%s:%s function nakedvar = %s\n", ParserBlockString(P.block), P.blocktype, P.blockid, P.currentclasses ? P.currentclasses : "any", P.currentstring);
-                           strncpy(P.currentid,P.currentstring,CF_MAXVARSIZE); // Make a var look like an ID
+                           strncpy(P.currentid, P.currentstring, CF_MAXVARSIZE - 1); // Make a var look like an ID
                            free(P.currentstring);
                            P.currentstring = NULL;
                        }

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -146,7 +146,7 @@ const ConstraintSyntax *PromiseTypeSyntaxGetConstraintSyntax(const PromiseTypeSy
     return GetCommonConstraint(lval);
 }
 
-const BodySyntax *BodySyntaxGet(ParserBlock block, const char *body_type)
+const BodySyntax *BodySyntaxGet(ARG_UNUSED ParserBlock block, const char *body_type)
 {
     assert(block == PARSER_BLOCK_BODY); // Will be used for promise blocks later
     for (int i = 0; i < CF3_MODULES; i++)


### PR DESCRIPTION
Makes `make CFLAGS="-Wno-format-truncation -Werror"` work, at least on my Fedora system.