### PR TITLE
Log a NOTICE-level message when force-writing critical section lock

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -429,7 +429,7 @@ void WaitForCriticalSection(const char *section_id)
      * have. */
     if (!got_lock)
     {
-        Log(LOG_LEVEL_DEBUG, "Failed to wait for critical section lock '%s', force-writing new lock", section_id);
+        Log(LOG_LEVEL_NOTICE, "Failed to wait for critical section lock '%s', force-writing new lock", section_id);
         if (!WriteDB(dbp, section_id, &entry, sizeof(entry)))
         {
             Log(LOG_LEVEL_CRIT, "Failed to force-write critical section lock '%s'", section_id);


### PR DESCRIPTION
This is something that should ideally never happen and if it
does, it should definitely be logged. At the same time, it is not
exactly an error in the process that logs it because it is just
dealing with some trash left behind by some other process. Still
a message worth noticing, though.

Ticket: CFE-3361
Changelog: None