### PR TITLE
CFE-3276: Added files promise content attribute

### DIFF
--- a/examples/files_content.cf
+++ b/examples/files_content.cf
@@ -1,0 +1,46 @@
+#+begin_src cfengine3
+bundle agent example_file_content
+# @brief Example showing files content
+{
+  vars:
+      "my_content"
+        string => "Hello from var!";
+
+  files:
+      "/tmp/hello_string"
+        create => "true",
+        content => "Hello from string!";
+
+      "/tmp/hello_var"
+        create => "true",
+        content => "$(my_content)";
+
+  reports:
+      "/tmp/hello_string"
+        printfile => cat( $(this.promiser) );
+      "/tmp/hello_var"
+        printfile => cat( $(this.promiser) );
+}
+
+body printfile cat(file)
+# @brief Report the contents of a file
+# @param file The full path of the file to report
+{
+        file_to_print => "$(file)";
+        number_of_lines => "inf";
+}
+
+bundle agent __main__
+{
+  methods: "example_file_content";
+}
+###############################################################################
+#+end_src
+#+begin_src example_output
+#@ ```
+#@ R: /tmp/hello_string
+#@ R: Hello from string!
+#@ R: /tmp/hello_var
+#@ R: Hello from var!
+#@ ```
+#+end_src

--- a/examples/helloworld.cf
+++ b/examples/helloworld.cf
@@ -20,18 +20,10 @@
 # (COSL) may apply to this file if you as a licensee so wish it. See
 # included file COSL.txt.
 
-# Hard promises
-
-body common control
+bundle agent main
 {
-      bundlesequence => { "hello" };
-}
-
-# soft promises
-
-bundle agent hello
-{
-  reports:
-
-      "Hello world!";
+  files:
+      "/tmp/hello_world"
+        create => "true",
+        content => "Hello, CFEngine!$(const.n)";
 }

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -53,6 +53,7 @@ Attributes GetFilesAttributes(const EvalContext *ctx, const Promise *pp)
     attr.haveselect = PromiseGetConstraintAsBoolean(ctx, "file_select", pp);
     attr.haverename = PromiseGetConstraintAsBoolean(ctx, "rename", pp);
     attr.havedelete = PromiseGetConstraintAsBoolean(ctx, "delete", pp);
+    attr.content = PromiseGetConstraintAsRval(pp, "content", RVAL_TYPE_SCALAR);
     attr.haveperms = PromiseGetConstraintAsBoolean(ctx, "perms", pp);
     attr.havechange = PromiseGetConstraintAsBoolean(ctx, "changes", pp);
     attr.havecopy = PromiseGetConstraintAsBoolean(ctx, "copy_from", pp);

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1537,6 +1537,7 @@ typedef struct
     FilePerms perms;
     FileCopy copy;
     FileDelete delete;
+    char *content;
     FileRename rename;
     FileChange change;
     FileLink link;
@@ -1628,6 +1629,7 @@ typedef struct
     .perms = {0},\
     .copy = {0},\
     .delete = {0},\
+    .content = NULL,\
     .rename = {0},\
     .change = {0},\
     .link = {0},\

--- a/libpromises/mod_files.c
+++ b/libpromises/mod_files.c
@@ -339,6 +339,7 @@ static const ConstraintSyntax CF_FILES_BODIES[] =
     ConstraintSyntaxNewBody("copy_from", &copy_from_body, "Criteria for copying file from a source", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBool("create", "true/false whether to create non-existing file. Default value: false", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBody("delete", &delete_body, "Criteria for deleting files", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewString("content", CF_ANYSTRING, "Complete content the promised file should contain", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBody("depth_search", &depth_search_body, "Criteria for file depth searches", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBody("edit_defaults", &edit_defaults_body, "Default promise details for file edits", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewBundle("edit_line", "Line editing model for file", SYNTAX_STATUS_NORMAL),

--- a/tests/acceptance/10_files/08_field_edits/file_content.cf
+++ b/tests/acceptance/10_files/08_field_edits/file_content.cf
@@ -1,0 +1,76 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "expected.singleline" string => "content in file";
+      "expected.multiline" string => "multiline
+content
+in
+file";
+
+  # Create the expected files using insert_lines
+  files:
+      "$(G.testfile).expected.singleline"
+        create => "true",
+        edit_line => init_insert("$(expected.singleline)"),
+        edit_defaults => init_empty;
+
+      "$(G.testfile).expected.multiline"
+        create => "true",
+        edit_line => init_insert("$(expected.multiline)"),
+        edit_defaults => init_empty;
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+body edit_defaults init_empty
+{
+      empty_file_before_editing => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+  files:
+      "$(G.testfile).actual.singleline"
+        create => "true",
+        content => "content in file
+";
+
+      "$(G.testfile).actual.multiline"
+        create => "true",
+        content => "multiline
+content
+in
+file
+";
+
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+      "" usebundle => dcs_check_diff("$(G.testfile).actual.singleline",
+                                     "$(G.testfile).expected.singleline",
+                                     "$(this.promise_filename)");
+
+      "" usebundle => dcs_check_diff("$(G.testfile).actual.multiline",
+                                     "$(G.testfile).expected.multiline",
+                                     "$(this.promise_filename)");
+
+}

--- a/tests/acceptance/10_files/08_field_edits/file_content.error.cf
+++ b/tests/acceptance/10_files/08_field_edits/file_content.error.cf
@@ -1,0 +1,89 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  # Create a blank file to compare
+  files:
+      "$(G.testfile).expected.blank"
+        create => "true",
+        edit_defaults => init_empty;
+}
+
+bundle edit_line init_insert(str)
+{
+  insert_lines:
+      "$(str)";
+}
+
+body edit_defaults init_empty
+{
+      empty_file_before_editing => "true";
+}
+
+#######################################################
+
+bundle agent test
+{
+  files:
+      "$(G.testfile).error.edit_line"
+        create => "true",
+        content => "whatever",
+        edit_line => whatever_line;
+
+      "$(G.testfile).error.edit_xml"
+        create => "true",
+        content => "whatever",
+        edit_xml => whatever_xml;
+
+      "$(G.testfile).error.edit_template"
+        create => "true",
+        content => "whatever",
+        edit_template => "/path/to/whatever";
+
+      "$(G.testfile).error.edit_template_string"
+        create => "true",
+        content => "whatever",
+        edit_template_string => "whatever";
+
+
+}
+
+bundle edit_line whatever_line
+{
+
+}
+
+bundle edit_xml whatever_xml
+{
+
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+
+      "" usebundle => dcs_check_diff("$(G.testfile).error.edit_line",
+                                     "$(G.testfile).expected.blank",
+                                     "$(this.promise_filename)");
+
+      "" usebundle => dcs_check_diff("$(G.testfile).error.edit_xml",
+                                     "$(G.testfile).expected.blank",
+                                     "$(this.promise_filename)");
+
+      "" usebundle => dcs_check_diff("$(G.testfile).error.edit_template",
+                                     "$(G.testfile).expected.blank",
+                                     "$(this.promise_filename)");
+
+      "" usebundle => dcs_check_diff("$(G.testfile).error.edit_template_string",
+                                     "$(G.testfile).expected.blank",
+                                     "$(this.promise_filename)");
+}


### PR DESCRIPTION
To allow a promise for the full contents of a file.

- [x] Implementation done
- [ ] ~Figure out why the Attributes copy fixes the SEGFAULT~
- [x] Add example
- [x] Add documentation
- [x] Add acceptance tests

Merge together:
https://github.com/cfengine/documentation/pull/2327