### PR TITLE
Include 'sysctl.h' as 'linux/sysctl.h' on Linux

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -73,7 +73,11 @@
 # ifdef HAVE_SYS_PARAM_H
 #  include <sys/param.h>
 # endif
+# ifdef __linux__
+#  include <linux/sysctl.h>
+# else
 # include <sys/sysctl.h>
+# endif
 #endif
 
 


### PR DESCRIPTION
This header is very OS-specific and using the generic
'sys/sysctl.h' path causes a warning on modern GNU/Linux
distributions with modern GCC:

  In file included from sysinfo.c:76:
  /usr/include/sys/sysctl.h:21:2: error: #warning "The <sys/sysctl.h> header is deprecated and will be removed." [-Werror=cpp]
     21 | #warning "The <sys/sysctl.h> header is deprecated and will be removed."
        |  ^~~~~~~