### PR TITLE
storage promises managing nfs mounts should now correctly mount after editing fstab entries

### DIFF
--- a/cf-agent/verify_storage.c
+++ b/cf-agent/verify_storage.c
@@ -492,7 +492,7 @@ static PromiseResult VerifyMountPromise(EvalContext *ctx, char *name, const Attr
             }
         }
 
-        if (changes)
+        if (changes > 0)
         {
             CF_MOUNTALL = true;
         }


### PR DESCRIPTION
Intention of code seemed to be to track number of changes to fstab, and then
in the end, perform mounting if there were more than 1 change.