### PR TITLE
LGTM: Marked rpmvercmp.c as an external "library"

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,3 +1,7 @@
+path_classifiers:
+  library:
+    - "ext/rpmvercmp.c"
+
 extraction:
   cpp:
     after_prepare:


### PR DESCRIPTION
Since this file is from another project, and not following our
coding style it makes sense to exclude it from LGTM alerts.

https://help.semmle.com/lgtm-enterprise/user/help/file-classification.html#built-in-tags