### PR TITLE
LGTM: Fixed false positives in NULL check query

### DIFF
--- a/.lgtm/cpp-queries/missing-argument-null-check.ql
+++ b/.lgtm/cpp-queries/missing-argument-null-check.ql
@@ -19,10 +19,11 @@ predicate hasNullCheck(Function func, Parameter p){
     and m.getEnclosingFunction() = func
     and m.getUnexpandedArgument(0) = p.getName() + " != NULL")
   or
-  exists(EqualityOperation comparison |
+  exists(EqualityOperation comparison, MacroInvocation m|
     comparison.getEnclosingFunction() = func
     and comparison.getLeftOperand().toString() = p.getName()
-    and comparison.getRightOperand().findRootCause().toString() = "NULL")
+    and comparison.getRightOperand() = m.getExpr()
+    and m.getMacroName() = "NULL")
 }
 
 from Function func, PointerFieldAccess acc, Parameter p, PointerType pt


### PR DESCRIPTION
Using .findRootCause() was incorrect, since it returned
the whole macro definition line (`#define NULL ...`),
not just the macro's name. Looking for the NULL
MacroInvocation seems more straight forward and reliable.

Before changing this query, it had 4931 results.
After fixing it, the query returns 4502 results.
(Most results are true positives, and there are so many, because
each pointer access is counted, not each bad function or
parameter). Some functions have many pointer accesses,
where 1 NULL check would get rid of all the alerts.

Verified results manually for sequence.c file, which had 5
alerts before this fix. The fix removes the 3 false positives,
but leaves the 2 true positives.

Tested query locally using vscode extension:
https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html