### PR TITLE
Renamed StringSafeEqual() to StringEqual() (3.15)

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -595,7 +595,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 0:
         {
             const char *const option_name = OPTIONS[longopt_idx].name;
-            if (StringSafeEqual(option_name, "log-modules"))
+            if (StringEqual(option_name, "log-modules"))
             {
                 bool ret = LogEnableModulesFromString(optarg);
                 if (!ret)
@@ -603,7 +603,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                     DoCleanupAndExit(EXIT_FAILURE);
                 }
             }
-            else if (StringSafeEqual(option_name, "show-evaluated-classes"))
+            else if (StringEqual(option_name, "show-evaluated-classes"))
             {
                 if (optarg == NULL)
                 {
@@ -611,7 +611,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 config->agent_specific.agent.show_evaluated_classes = xstrdup(optarg);
             }
-            else if (StringSafeEqual(option_name, "show-evaluated-vars"))
+            else if (StringEqual(option_name, "show-evaluated-vars"))
             {
                 if (optarg == NULL)
                 {
@@ -619,21 +619,21 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 config->agent_specific.agent.show_evaluated_variables = xstrdup(optarg);
             }
-            else if (StringSafeEqual(option_name, "skip-bootstrap-policy-run"))
+            else if (StringEqual(option_name, "skip-bootstrap-policy-run"))
             {
                 config->agent_specific.agent.bootstrap_trigger_policy = false;
             }
-            else if (StringSafeEqual(option_name, "skip-db-check"))
+            else if (StringEqual(option_name, "skip-db-check"))
             {
                 if (optarg == NULL)
                 {
                     PERFORM_DB_CHECK = false; // Skip (no arg), check = false
                 }
-                else if (StringSafeEqual_IgnoreCase(optarg, "yes"))
+                else if (StringEqual_IgnoreCase(optarg, "yes"))
                 {
                     PERFORM_DB_CHECK = false; // Skip = yes, check = false
                 }
-                else if (StringSafeEqual_IgnoreCase(optarg, "no"))
+                else if (StringEqual_IgnoreCase(optarg, "no"))
                 {
                     PERFORM_DB_CHECK = true; // Skip = no, check = true
                 }

--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -890,7 +890,7 @@ static bool InsertMultipleLinesToRegion(EvalContext *ctx, Item **start, Item *be
                                        const Promise *pp, EditContext *edcontext, PromiseResult *result)
 {
     Item *ip, *prev = NULL;
-    int allow_multi_lines = StringSafeEqual(a->sourcetype, "preserve_all_lines");
+    int allow_multi_lines = StringEqual(a->sourcetype, "preserve_all_lines");
 
     // Insert at the start of the file
 
@@ -962,7 +962,7 @@ static bool InsertMultipleLinesAtLocation(EvalContext *ctx, Item **start, Item *
 
 {
     const char *const type = a->sourcetype;
-    int isfileinsert = StringSafeEqual(type, "file") || StringSafeEqual(type, "file_preserve_block");
+    int isfileinsert = StringEqual(type, "file") || StringEqual(type, "file_preserve_block");
 
     if (isfileinsert)
     {
@@ -1137,7 +1137,7 @@ static int ReplacePatterns(EvalContext *ctx, Item *file_start, Item *file_end, c
     Item *ip;
     int notfound = true, cutoff = 1, replaced = false;
 
-    if (StringSafeEqual(a->replace.occurrences, "first"))
+    if (StringEqual(a->replace.occurrences, "first"))
     {
         Log(LOG_LEVEL_WARNING, "Setting replace-occurrences policy to 'first' is not convergent");
         once_only = true;
@@ -1330,7 +1330,7 @@ static bool SanityCheckInsertions(const Attributes *a)
     Rlist *rp;
     InsertMatchType opt;
     int exact = false, ignore_something = false;
-    const bool preserve_block = StringSafeEqual(a->sourcetype, "preserve_block");
+    const bool preserve_block = StringEqual(a->sourcetype, "preserve_block");
     const LineSelect line_select = a->line_select;
 
     if (line_select.startwith_from_list)
@@ -1635,7 +1635,7 @@ static bool InsertFileAtLocation(EvalContext *ctx, Item **start, Item *begin_ptr
     FILE *fin;
     bool retval = false;
     Item *loc = NULL;
-    const bool preserve_block = StringSafeEqual(a->sourcetype, "file_preserve_block");
+    const bool preserve_block = StringEqual(a->sourcetype, "file_preserve_block");
 
     if ((fin = safe_fopen(pp->promiser, "rt")) == NULL)
     {
@@ -1732,7 +1732,7 @@ static bool InsertCompoundLineAtLocation(EvalContext *ctx, char *chunk, Item **s
 {
     bool retval = false;
     const char *const type = a->sourcetype;
-    const bool preserve_all_lines = StringSafeEqual(type, "preserve_all_lines");
+    const bool preserve_all_lines = StringEqual(type, "preserve_all_lines");
     const bool preserve_block = type && (preserve_all_lines || strcmp(type, "preserve_block") == 0 || strcmp(type, "file_preserve_block") == 0);
 
     if (!preserve_all_lines && MatchRegion(ctx, chunk, location, NULL, false))
@@ -1847,7 +1847,7 @@ static bool InsertLineAtLocation(EvalContext *ctx, char *newline, Item **start, 
 
 /* Check line neighbourhood in whole file to avoid edge effects, iff we are not preseving block structure */
 
-{   int preserve_block = StringSafeEqual(a->sourcetype, "preserve_block");
+{   int preserve_block = StringEqual(a->sourcetype, "preserve_block");
 
     if (!prev)      /* Insert at first line */
     {
@@ -2226,7 +2226,7 @@ static bool DoEditColumn(Rlist **columns, const Attributes *a, EditContext *edco
     const char *const column_value = a->column.column_value;
     const char *const column_operation = a->column.column_operation;
 
-    if (StringSafeEqual(column_operation, "delete"))
+    if (StringEqual(column_operation, "delete"))
     {
         while ((found = RlistKeyIn(*columns, column_value)))
         {
@@ -2239,7 +2239,7 @@ static bool DoEditColumn(Rlist **columns, const Attributes *a, EditContext *edco
         return retval;
     }
 
-    if (StringSafeEqual(column_operation, "set"))
+    if (StringEqual(column_operation, "set"))
     {
         int length = RlistLen(*columns);
         if (length == 1 && strcmp(RlistScalarValue(*columns), column_value) == 0)
@@ -2261,7 +2261,7 @@ static bool DoEditColumn(Rlist **columns, const Attributes *a, EditContext *edco
         return true;
     }
 
-    if (StringSafeEqual(column_operation, "prepend"))
+    if (StringEqual(column_operation, "prepend"))
     {
         if (RlistPrependScalarIdemp(columns, column_value))
         {
@@ -2274,7 +2274,7 @@ static bool DoEditColumn(Rlist **columns, const Attributes *a, EditContext *edco
         }
     }
 
-    if (StringSafeEqual(column_operation, "alphanum"))
+    if (StringEqual(column_operation, "alphanum"))
     {
         if (RlistPrependScalarIdemp(columns, column_value))
         {

--- a/cf-agent/nfs.c
+++ b/cf-agent/nfs.c
@@ -644,11 +644,11 @@ PromiseResult VerifyMount(EvalContext *ctx, char *name, const Attributes *a, con
     PromiseResult result = PROMISE_RESULT_NOOP;
     if (!DONTDO)
     {
-        if (StringSafeEqual(a->mount.mount_type, "panfs"))
+        if (StringEqual(a->mount.mount_type, "panfs"))
         {
             snprintf(comm, CF_BUFSIZE, "%s -t panfs -o %s %s%s %s", CommandArg0(VMOUNTCOMM[VSYSTEMHARDCLASS]), opts, host, rmountpt, mountpt);
         }
-        else if (StringSafeEqual(a->mount.mount_type, "cifs"))
+        else if (StringEqual(a->mount.mount_type, "cifs"))
         {
             snprintf(comm, CF_BUFSIZE, "%s -t cifs -o %s %s%s %s", CommandArg0(VMOUNTCOMM[VSYSTEMHARDCLASS]), opts, host, rmountpt, mountpt);
         }

--- a/cf-agent/package_module.c
+++ b/cf-agent/package_module.c
@@ -305,11 +305,11 @@ static PackageInfo *ParseAndCheckPackageDataReply(const Rlist *data)
         if (StringStartsWith(line, "PackageType="))
         {
             const char *type = line + strlen("PackageType=");
-            if (StringSafeEqual(type, "file"))
+            if (StringEqual(type, "file"))
             {
                 package_data->type = PACKAGE_TYPE_FILE;
             }
-            else if (StringSafeEqual(type, "repo"))
+            else if (StringEqual(type, "repo"))
             {
                 package_data->type = PACKAGE_TYPE_REPO;
             }
@@ -482,7 +482,7 @@ static void GetPackageModuleExecInfo(const PackageModuleBody *package_module, ch
 
     char *package_module_path = NULL;
 
-    if (package_module->module_path != NULL && !StringSafeEqual(package_module->module_path, ""))
+    if (package_module->module_path != NULL && !StringEqual(package_module->module_path, ""))
     {
         package_module_path = xstrdup(package_module->module_path);
     }
@@ -493,7 +493,7 @@ static void GetPackageModuleExecInfo(const PackageModuleBody *package_module, ch
                                            package_module->name);
     }
 
-    if (package_module->interpreter && !StringSafeEqual(package_module->interpreter, ""))
+    if (package_module->interpreter && !StringEqual(package_module->interpreter, ""))
     {
         *script_path = package_module_path;
         *script_path_quoted = Path_GetQuoted(*script_path);
@@ -528,7 +528,7 @@ static int IsPackageInCache(EvalContext *ctx,
     /* Handle latest version in specific way for repo packages.
      * Please note that for file packages 'latest' version is not supported
      * and check against that is made in CheckPolicyAndPackageInfoMatch(). */
-    if (version && StringSafeEqual(version, "latest"))
+    if (version && StringEqual(version, "latest"))
     {
         version = NULL;
     }
@@ -1131,7 +1131,7 @@ PromiseResult RepoInstall(EvalContext *ctx,
         }
 
         const char *version = package_version;
-        if (StringSafeEqual(version, "latest"))
+        if (StringEqual(version, "latest"))
         {
             Log(LOG_LEVEL_DEBUG, "Clearing latest package version");
             version = NULL;
@@ -1154,7 +1154,7 @@ PromiseResult RepoInstall(EvalContext *ctx,
 
 
     /* We have 'latest' version in policy. */
-    if (StringSafeEqual(package_version, "latest"))
+    if (StringEqual(package_version, "latest"))
     {
         /* This can return more than one latest version if we have packages
          * with different architectures installed. */
@@ -1182,7 +1182,7 @@ PromiseResult RepoInstall(EvalContext *ctx,
              * in updates available but we are interested only in updating
              * package with specific architecture. */
             if (package_info->arch &&
-                !StringSafeEqual(package_info->arch, update_package->arch))
+                !StringEqual(package_info->arch, update_package->arch))
             {
                 Log(LOG_LEVEL_DEBUG,
                     "Skipping update check of package '%s' as updates"
@@ -1320,7 +1320,7 @@ static bool CheckPolicyAndPackageInfoMatch(const NewPackages *packages_policy,
                                            const PackageInfo *info)
 {
     if (packages_policy->package_version &&
-        StringSafeEqual(packages_policy->package_version, "latest"))
+        StringEqual(packages_policy->package_version, "latest"))
     {
         Log(LOG_LEVEL_WARNING, "Unsupported 'latest' version for package "
                 "promise of type file.");
@@ -1329,7 +1329,7 @@ static bool CheckPolicyAndPackageInfoMatch(const NewPackages *packages_policy,
 
     /* Check if file we are having matches what we want in policy. */
     if (info->arch && packages_policy->package_architecture &&
-            !StringSafeEqual(info->arch, packages_policy->package_architecture))
+            !StringEqual(info->arch, packages_policy->package_architecture))
     {
         Log(LOG_LEVEL_WARNING,
             "Package arch and one specified in policy doesn't match: %s -> %s",
@@ -1338,7 +1338,7 @@ static bool CheckPolicyAndPackageInfoMatch(const NewPackages *packages_policy,
     }
 
     if (info->version && packages_policy->package_version &&
-        !StringSafeEqual(info->version, packages_policy->package_version))
+        !StringEqual(info->version, packages_policy->package_version))
     {
 
         Log(LOG_LEVEL_WARNING,
@@ -1469,7 +1469,7 @@ PromiseResult HandleAbsentPromiseAction(EvalContext *ctx,
 {
     /* Check if we are not having 'latest' version. */
     if (policy_data->package_version &&
-            StringSafeEqual(policy_data->package_version, "latest"))
+            StringEqual(policy_data->package_version, "latest"))
     {
         Log(LOG_LEVEL_ERR, "Package version 'latest' not supported for"
                 "absent package promise");

--- a/cf-agent/retcode.c
+++ b/cf-agent/retcode.c
@@ -48,7 +48,7 @@ bool VerifyCommandRetcode(EvalContext *ctx, int retcode, const Attributes *a, co
         // inform constraint is only for commands promises,
         // a->inform is actually false for other promise types, so
         // checking the promise type here is important:
-        if (StringSafeEqual("commands", pp->parent_promise_type->name) && (!a->inform))
+        if (StringEqual("commands", pp->parent_promise_type->name) && (!a->inform))
         {
             // for commands promises which don't make changes to the system,
             // you can use this to make the log messages verbose:

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -2763,7 +2763,7 @@ static bool ExecuteSchedule(EvalContext *ctx, const PackageManager *schedule, Pa
                     {
                         bool ok = ExecPackageCommand(ctx, command_string, verify, true, &a, ppi, &result);
 
-                        if (StringSafeEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
+                        if (StringEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
                         {
                             Log(LOG_LEVEL_DEBUG, "ExecuteSchedule: Ignoring outcome for special package '%s'", pi->name);
                         }
@@ -2827,7 +2827,7 @@ static bool ExecuteSchedule(EvalContext *ctx, const PackageManager *schedule, Pa
 
                     for (const PackageItem *pi = pm->pack_list; pi != NULL; pi = pi->next)
                     {
-                        if (StringSafeEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
+                        if (StringEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
                         {
                             Log(LOG_LEVEL_DEBUG, "ExecuteSchedule: Ignoring outcome for special package '%s'", pi->name);
                         }
@@ -3009,7 +3009,7 @@ static bool ExecutePatch(EvalContext *ctx, const PackageManager *schedule, Packa
                     {
                         bool ok = ExecPackageCommand(ctx, command_string, false, true, &a, pp, &result);
 
-                        if (StringSafeEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
+                        if (StringEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
                         {
                             Log(LOG_LEVEL_DEBUG, "ExecutePatch: Ignoring outcome for special package '%s'", pi->name);
                         }
@@ -3052,7 +3052,7 @@ static bool ExecutePatch(EvalContext *ctx, const PackageManager *schedule, Packa
 
                     for (const PackageItem *pi = pm->patch_list; pi != NULL; pi = pi->next)
                     {
-                        if (StringSafeEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
+                        if (StringEqual(pi->name, PACKAGE_IGNORED_CFE_INTERNAL))
                         {
                             Log(LOG_LEVEL_DEBUG, "ExecutePatch: Ignoring outcome for special package '%s'", pi->name);
                         }

--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -204,28 +204,28 @@ int main(int argc, const char *const *argv)
     int cmd_argc = argc - optind;
     const char *command = cmd_argv[0];
 
-    if (StringSafeEqual_IgnoreCase(command, "lmdump"))
+    if (StringEqual_IgnoreCase(command, "lmdump"))
     {
         return lmdump_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual_IgnoreCase(command, "dump"))
+    if (StringEqual_IgnoreCase(command, "dump"))
     {
         return dump_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual_IgnoreCase(command, "diagnose"))
+    if (StringEqual_IgnoreCase(command, "diagnose"))
     {
         return diagnose_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual_IgnoreCase(command, "backup"))
+    if (StringEqual_IgnoreCase(command, "backup"))
     {
         return backup_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual_IgnoreCase(command, "repair") ||
-        StringSafeEqual_IgnoreCase(command, "remediate"))
+    if (StringEqual_IgnoreCase(command, "repair") ||
+        StringEqual_IgnoreCase(command, "remediate"))
     {
         return repair_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual_IgnoreCase(command, "help"))
+    if (StringEqual_IgnoreCase(command, "help"))
     {
         if (cmd_argc > 2)
         {
@@ -243,7 +243,7 @@ int main(int argc, const char *const *argv)
         }
         return EXIT_SUCCESS;
     }
-    if (StringSafeEqual_IgnoreCase(command, "version"))
+    if (StringEqual_IgnoreCase(command, "version"))
     {
         print_version();
         return EXIT_SUCCESS;

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -269,7 +269,7 @@ static void print_struct_or_string(
         }
         else if (StringEndsWith(file, "cf_observations.lmdb"))
         {
-            if (StringSafeEqual(key.mv_data, "DATABASE_AGE"))
+            if (StringEqual(key.mv_data, "DATABASE_AGE"))
             {
                 assert(sizeof(double) == value.mv_size);
                 const double *const age = value.mv_data;
@@ -290,13 +290,13 @@ static void print_struct_or_string(
         }
         else if (StringEndsWith(file, "nova_agent_execution.lmdb"))
         {
-            if (StringSafeEqual(key.mv_data, "delta_gavr"))
+            if (StringEqual(key.mv_data, "delta_gavr"))
             {
                 assert(sizeof(double) == value.mv_size);
                 const double *const average = value.mv_data;
                 printf("%f", *average);
             }
-            else if (StringSafeEqual(key.mv_data, "last_exec"))
+            else if (StringEqual(key.mv_data, "last_exec"))
             {
                 assert(sizeof(time_t) == value.mv_size);
                 const time_t *const last_exec = value.mv_data;

--- a/cf-check/validate.c
+++ b/cf-check/validate.c
@@ -482,7 +482,7 @@ static void ValidateStateLastseen(ValidatorState *state)
                 ValidationError(
                     state, "Missing address entry for '%s'", address);
             }
-            else if (!StringSafeEqual(hostkey, lookup))
+            else if (!StringEqual(hostkey, lookup))
             {
                 ValidationError(
                     state,
@@ -513,7 +513,7 @@ static void ValidateStateLastseen(ValidatorState *state)
                 ValidationError(
                     state, "Missing hostkey entry for '%s'", hostkey);
             }
-            else if (!StringSafeEqual(address, lookup))
+            else if (!StringEqual(address, lookup))
             {
                 ValidationError(
                     state,

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -325,17 +325,17 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 0:
         {
             const char *const option_name = OPTIONS[longopt_idx].name;
-            if (StringSafeEqual(option_name, "skip-db-check"))
+            if (StringEqual(option_name, "skip-db-check"))
             {
                 if (optarg == NULL)
                 {
                     PERFORM_DB_CHECK = false; // Skip (no arg), check = false
                 }
-                else if (StringSafeEqual_IgnoreCase(optarg, "yes"))
+                else if (StringEqual_IgnoreCase(optarg, "yes"))
                 {
                     PERFORM_DB_CHECK = false; // Skip = yes, check = false
                 }
-                else if (StringSafeEqual_IgnoreCase(optarg, "no"))
+                else if (StringEqual_IgnoreCase(optarg, "no"))
                 {
                     PERFORM_DB_CHECK = true; // Skip = no, check = true
                 }

--- a/cf-monitord/mon_io_linux.c
+++ b/cf-monitord/mon_io_linux.c
@@ -182,7 +182,7 @@ static void MonIoDiskstatsGatherData(double *cf_this)
         if (!strchr(buf, '\n'))
         {
             Log(LOG_LEVEL_ERR,
-                  "/proc/diskstats format error: read overlong string (> " TOSTRING(CF_BUFSIZE - 1) " bytes)");
+                  "/proc/diskstats format error: read overlong string (> " TO_STRING(CF_BUFSIZE) " bytes)");
             goto err;
         }
 

--- a/cf-secret/cf-secret.c
+++ b/cf-secret/cf-secret.c
@@ -172,7 +172,7 @@ static char *GetHostRSAKey(const char *host, HostRSAKeyType type)
         inet_ntop(res->ai_family,
                   GetIPAddress((struct sockaddr *) res->ai_addr),
                   ipaddress, sizeof(ipaddress));
-        if (StringStartsWith(ipaddress, "127.") || StringSafeEqual(ipaddress, "::1"))
+        if (StringStartsWith(ipaddress, "127.") || StringEqual(ipaddress, "::1"))
         {
             Log(LOG_LEVEL_VERBOSE, "Using localhost%s key", key_ext);
             found = true;
@@ -253,7 +253,7 @@ static FILE *OpenInputOutput(const char *path, const char *mode)
 {
     assert(path != NULL);
     assert(mode != NULL);
-    if (StringSafeEqual(path, "-"))
+    if (StringEqual(path, "-"))
     {
         if (*mode == 'r')
         {
@@ -448,9 +448,9 @@ static bool RSAEncrypt(Seq *rsa_keys, const char *input_path, const char *output
 
 static inline bool CheckHeader(const char *key, const char *value)
 {
-    if (StringSafeEqual(key, "Version"))
+    if (StringEqual(key, "Version"))
     {
-        if (!StringSafeEqual(value, "1.0"))
+        if (!StringEqual(value, "1.0"))
         {
             Log(LOG_LEVEL_ERR, "Unsupported file format version: '%s'", value);
             return false;
@@ -460,7 +460,7 @@ static inline bool CheckHeader(const char *key, const char *value)
             return true;
         }
     }
-    else if (StringSafeEqual(key, "Encrypted-for"))
+    else if (StringEqual(key, "Encrypted-for"))
     {
         /* TODO: do some verification that 'value' is valid hash digest? */
         return true;
@@ -565,14 +565,14 @@ static bool ParseHeaders(FILE *input_file, RSA *privkey, size_t *enc_key_pos, si
             return false;
         }
 
-        if (StringSafeEqual(key, "Version"))
+        if (StringEqual(key, "Version"))
         {
             version_specified = true;
         }
-        else if (StringSafeEqual(key, "Encrypted-for"))
+        else if (StringEqual(key, "Encrypted-for"))
         {
             Log(LOG_LEVEL_DEBUG, "Encrypted for '%s'", value);
-            if (StringSafeEqual(value, key_digest))
+            if (StringEqual(value, key_digest))
             {
                 found_matching_digest = true;
                 *enc_key_pos = n_enc_for_headers;
@@ -828,17 +828,17 @@ int main(int argc, char *argv[])
     bool print_headers = false;
 
     size_t offset = 0;
-    if (StringSafeEqual(argv[1], "encrypt"))
+    if (StringEqual(argv[1], "encrypt"))
     {
         encrypt = true;
         offset++;
     }
-    else if (StringSafeEqual(argv[1], "decrypt"))
+    else if (StringEqual(argv[1], "decrypt"))
     {
         offset++;
         decrypt = true;
     }
-    else if (StringSafeEqual(argv[1], "print-headers"))
+    else if (StringEqual(argv[1], "print-headers"))
     {
         print_headers = true;
         offset++;

--- a/cf-testd/cf-testd.c
+++ b/cf-testd/cf-testd.c
@@ -732,12 +732,12 @@ static char *IncrementIPaddress(const char *ip_str)
     int step = 1;
     char *last_dot = strrchr(ip_str, '.');
     assert(last_dot != NULL);   /* the doc comment says there must be dots! */
-    if (StringSafeEqual(last_dot + 1, "255"))
+    if (StringEqual(last_dot + 1, "255"))
     {
         /* avoid the network address (ending with 0) */
         step = 2;
     }
-    else if (StringSafeEqual(last_dot + 1, "254"))
+    else if (StringEqual(last_dot + 1, "254"))
     {
         /* avoid the broadcast address and the network address */
         step = 3;

--- a/libcfnet/conn_cache.c
+++ b/libcfnet/conn_cache.c
@@ -32,7 +32,7 @@
 #include <mutex.h>                                     /* ThreadLock */
 #include <communication.h>                             /* Hostname2IPString */
 #include <misc_lib.h>                                  /* CF_ASSERT */
-#include <string_lib.h>                                /* StringSafeEqual */
+#include <string_lib.h>                                /* StringEqual */
 
 
 /**
@@ -95,8 +95,8 @@ static bool ConnCacheEntryMatchesConnection(ConnCache_entry *entry,
                                             ConnectionFlags flags)
 {
     return ConnectionFlagsEqual(&flags, &entry->conn->flags) &&
-           StringSafeEqual(port, entry->conn->this_port)     &&
-           StringSafeEqual(server, entry->conn->this_server);
+           StringEqual(port, entry->conn->this_port)     &&
+           StringEqual(server, entry->conn->this_server);
 }
 
 AgentConnection *ConnCache_FindIdleMarkBusy(const char *server,

--- a/libcfnet/protocol.c
+++ b/libcfnet/protocol.c
@@ -75,7 +75,7 @@ Seq *ProtocolOpenDir(AgentConnection *conn, const char *path)
          */
         for (int i = 0; i < len && buf[i] != '\0'; i += strlen(buf + i) + 1)
         {
-            if (StringSafeEqualN(buf + i, CFD_TERMINATOR,
+            if (StringEqualN(buf + i, CFD_TERMINATOR,
                                  sizeof(CFD_TERMINATOR) - 1))
             {
                 more = 0;
@@ -159,7 +159,7 @@ bool ProtocolGet(AgentConnection *conn, const char *remote_path,
             break;
         }
 
-        if (StringSafeEqualN(buf, cfchangedstr, sizeof(cfchangedstr) - 1))
+        if (StringEqualN(buf, cfchangedstr, sizeof(cfchangedstr) - 1))
         {
             Log(LOG_LEVEL_ERR,
                 "Remote file %s:%s changed during file transfer",

--- a/libcfnet/protocol_version.c
+++ b/libcfnet/protocol_version.c
@@ -17,19 +17,19 @@ ProtocolVersion ParseProtocolVersionNetwork(const char *const s)
 
 ProtocolVersion ParseProtocolVersionPolicy(const char *const s)
 {
-    if ((s == NULL) || StringSafeEqual(s, "0") || StringSafeEqual(s, "undefined"))
+    if ((s == NULL) || StringEqual(s, "0") || StringEqual(s, "undefined"))
     {
         return CF_PROTOCOL_UNDEFINED;
     }
-    if (StringSafeEqual(s, "1") || StringSafeEqual(s, "classic"))
+    if (StringEqual(s, "1") || StringEqual(s, "classic"))
     {
         return CF_PROTOCOL_CLASSIC;
     }
-    else if (StringSafeEqual(s, "2") || StringSafeEqual(s, "tls"))
+    else if (StringEqual(s, "2") || StringEqual(s, "tls"))
     {
         return CF_PROTOCOL_TLS;
     }
-    else if (StringSafeEqual(s, "latest"))
+    else if (StringEqual(s, "latest"))
     {
         return CF_PROTOCOL_LATEST;
     }

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -901,7 +901,7 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
         bool found = false;
         for (enum tls_version v = TLS_1_0; !found && v <= TLS_LAST; v++)
         {
-            if (StringSafeEqual(min_version, tls_version_strings[v]))
+            if (StringEqual(min_version, tls_version_strings[v]))
             {
                 found = true;
                 if (v < TLS_LOWEST_REQUIRED)

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1139,7 +1139,7 @@ static void OSReleaseParse(EvalContext *ctx, const char *file_path)
             CanonifyNameInPlace(os_release_id);
 
             const char *alias = NULL;
-            if (StringSafeEqual(os_release_id, "rhel"))
+            if (StringEqual(os_release_id, "rhel"))
             {
                 alias = "redhat";
             }

--- a/libpromises/class.c
+++ b/libpromises/class.c
@@ -48,7 +48,7 @@ TYPED_MAP_DECLARE(Class, char *, Class *)
 
 TYPED_MAP_DEFINE(Class, char *, Class *,
                  StringHash_untyped,
-                 StringSafeEqual_untyped,
+                 StringEqual_untyped,
                  free,
                  ClassDestroy_untyped)
 

--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -203,7 +203,7 @@ static
 bool IsSubHandle(DBHandle *handle, dbid id, const char *name)
 {
     char *sub_path = DBIdToSubPath(id, name);
-    bool result = StringSafeEqual(handle->filename, sub_path);
+    bool result = StringEqual(handle->filename, sub_path);
     free(sub_path);
     return result;
 }
@@ -452,7 +452,7 @@ DBHandle *GetDBHandleFromFilename(const char *db_file_name)
     ThreadLock(&db_handles_lock);
     for(dbid id=0; id < dbid_max; id++)
     {
-        if (StringSafeEqual(db_handles[id].filename, db_file_name))
+        if (StringEqual(db_handles[id].filename, db_file_name))
         {
             ThreadUnlock(&db_handles_lock);
             return &(db_handles[id]);

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -101,7 +101,7 @@ TYPED_MAP_DECLARE(RemoteVarPromises, char *, Seq *)
 
 TYPED_MAP_DEFINE(RemoteVarPromises, char *, Seq *,
                  StringHash_untyped,
-                 StringSafeEqual_untyped,
+                 StringEqual_untyped,
                  free,
                  SeqDestroy_untyped)
 
@@ -613,7 +613,7 @@ static bool EvalWithTokenFromList(const char *expr, StringSet *token_set)
 bool EvalProcessResult(const char *process_result, StringSet *proc_attr)
 {
     assert(process_result != NULL);
-    if (StringSafeEqual(process_result, ""))
+    if (StringEqual(process_result, ""))
     {
         /* nothing to evaluate */
         return false;
@@ -1466,7 +1466,7 @@ void EvalContextStackPushPromiseFrame(EvalContext *ctx, const Promise *owner)
     for (size_t i = 0; i < SeqLength(owner->conlist); i++)
     {
         Constraint *cp = SeqAt(owner->conlist, i);
-        if (StringSafeEqual(cp->lval, "with"))
+        if (StringEqual(cp->lval, "with"))
         {
             Rval final = EvaluateFinalRval(ctx, PromiseGetPolicy(owner), NULL,
                                            "this", cp->rval, false, owner);
@@ -2418,7 +2418,7 @@ const Bundle *EvalContextResolveBundleExpression(const EvalContext *ctx, const P
         const Bundle *curr_bp = SeqAt(policy->bundles, i);
         if ((strcmp(curr_bp->type, callee_type) != 0) ||
             (strcmp(curr_bp->name, ref.name) != 0) ||
-            !StringSafeEqual(curr_bp->ns, ref.ns))
+            !StringEqual(curr_bp->ns, ref.ns))
         {
             continue;
         }
@@ -2439,7 +2439,7 @@ const Body *EvalContextFindFirstMatchingBody(const Policy *policy, const char *t
         const Body *curr_bp = SeqAt(policy->bodies, i);
         if ((strcmp(curr_bp->type, type) == 0) &&
             (strcmp(curr_bp->name, name) == 0) &&
-            StringSafeEqual(curr_bp->ns, namespace))
+            StringEqual(curr_bp->ns, namespace))
         {
             return curr_bp;
         }

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1259,15 +1259,15 @@ static FnCallResult FnCallClassesMatching(EvalContext *ctx, ARG_UNUSED const Pol
     bool check_only = false;
     unsigned count = 0;
 
-    if (StringSafeEqual(fp->name, "classesmatching"))
+    if (StringEqual(fp->name, "classesmatching"))
     {
         // Expected / default case
     }
-    else if (StringSafeEqual(fp->name, "classmatch"))
+    else if (StringEqual(fp->name, "classmatch"))
     {
         check_only = true;
     }
-    else if (StringSafeEqual(fp->name, "countclassesmatching"))
+    else if (StringEqual(fp->name, "countclassesmatching"))
     {
         count_only = true;
     }
@@ -4022,7 +4022,7 @@ static FnCallResult FnCallFileStat(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const
 
     if (lstat(path, &statbuf) == -1)
     {
-        if (StringSafeEqual(fp->name, "filesize"))
+        if (StringEqual(fp->name, "filesize"))
         {
             return FnFailure();
         }
@@ -5148,7 +5148,7 @@ static FnCallResult FnCallFormat(EvalContext *ctx, ARG_UNUSED const Policy *poli
                 if (SeqLength(s) >= 2)
                 {
                     const char *format_piece = BufferData(SeqAt(s, 1));
-                    bool percent = StringSafeEqualN(format_piece, "%%", 2);
+                    bool percent = StringEqualN(format_piece, "%%", 2);
                     char *data = NULL;
 
                     if (percent)
@@ -6665,7 +6665,7 @@ static FnCallResult FnCallReadData(ARG_UNUSED EvalContext *ctx,
     const char *input_path = RlistScalarValue(args);
     const char *const mode_string = RlistScalarValue(args->next);
     DataFileType requested_mode = DATAFILETYPE_UNKNOWN;
-    if (StringSafeEqual("auto", mode_string))
+    if (StringEqual("auto", mode_string))
     {
         requested_mode = GetDataFileTypeFromSuffix(input_path);
         Log(LOG_LEVEL_VERBOSE,

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -251,10 +251,10 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
         const char *key;
         while ((key = JsonIteratorNextKey(&iter)))
         {
-            if (!(StringSafeEqual(key, "vars") ||
-                  StringSafeEqual(key, "classes") ||
-                  StringSafeEqual(key, "inputs") ||
-                  StringSafeEqual(key, "augments")))
+            if (!(StringEqual(key, "vars") ||
+                  StringEqual(key, "classes") ||
+                  StringEqual(key, "inputs") ||
+                  StringEqual(key, "augments")))
             {
                 Log(LOG_LEVEL_VERBOSE, "Unknown augments key '%s' in file '%s', skipping it",
                     key, filename);

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -1054,7 +1054,7 @@ bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
     for (size_t i = 0; i < SeqLength(iterctx->pp->conlist); i++)
     {
         Constraint *cp = SeqAt(iterctx->pp->conlist, i);
-        if (StringSafeEqual(cp->lval, "with"))
+        if (StringEqual(cp->lval, "with"))
         {
             Rval final = EvaluateFinalRval(evalctx, PromiseGetPolicy(iterctx->pp), NULL,
                                            "this", cp->rval, false, iterctx->pp);

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -281,10 +281,10 @@ static void RenameMainBundle(EvalContext *ctx, Policy *policy)
     for (int i = 0; i < length; ++i)
     {
         Bundle *const bundle = SeqAt(bundles, i);
-        if (StringSafeEqual(bundle->name, "__main__"))
+        if (StringEqual(bundle->name, "__main__"))
         {
             char *abspath = GetRealPath(bundle->source_path);
-            if (StringSafeEqual(abspath, entry_point))
+            if (StringEqual(abspath, entry_point))
             {
                 Log(LOG_LEVEL_VERBOSE,
                     "Redefining __main__ bundle from file %s to be main",

--- a/libpromises/mod_methods.c
+++ b/libpromises/mod_methods.c
@@ -51,7 +51,7 @@ static bool MethodsParseTreeCheck(const Promise *pp, Seq *errors)
         const Constraint *cp = SeqAt(pp->conlist, i);
 
         // ensure: if call and callee are resolved, then they have matching arity
-        if (StringSafeEqual(cp->lval, "usebundle"))
+        if (StringEqual(cp->lval, "usebundle"))
         {
             if (cp->rval.type == RVAL_TYPE_FNCALL)
             {

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -991,7 +991,7 @@ bool PolicyCheckDuplicateHandles(const Policy *policy, Seq *errors)
 {
     bool success = true;
 
-    Map *recorded = MapNew(StringHash_untyped, StringSafeEqual_untyped, NULL, NULL);
+    Map *recorded = MapNew(StringHash_untyped, StringEqual_untyped, NULL, NULL);
 
     for (size_t bpi = 0; bpi < SeqLength(policy->bundles); bpi++)
     {

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -300,7 +300,7 @@ bool RlistContainsString(const Rlist *list, const char *string)
     for (const Rlist *rp = list; rp != NULL; rp = rp->next)
     {
         if (rp->val.type == RVAL_TYPE_SCALAR &&
-            StringSafeEqual(RlistScalarValue(rp), string))
+            StringEqual(RlistScalarValue(rp), string))
         {
             return true;
         }

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -82,7 +82,7 @@ static bool IsLegalVariableName(EvalContext *ctx, const Promise *pp)
         char *prefix = xstrndup(var_name, dot - var_name);
         const Bundle *cur_bundle = PromiseGetBundle(pp);
 
-        if (!StringSafeEqual(prefix, cur_bundle->name))
+        if (!StringEqual(prefix, cur_bundle->name))
         {
             Log(LOG_LEVEL_VERBOSE,
                 "Variable '%s' may be attempted to be injected into a remote bundle",

--- a/tests/unit/logging_test.c
+++ b/tests/unit/logging_test.c
@@ -67,7 +67,7 @@ static void test_set_host(void)
 #define check_level(str, lvl) \
 {\
     assert_int_equal(LogLevelFromString(str), lvl);\
-    assert_true(StringSafeEqual_IgnoreCase(str, LogLevelToString(lvl)));\
+    assert_true(StringEqual_IgnoreCase(str, LogLevelToString(lvl)));\
 }
 
 static void test_log_level(void)


### PR DESCRIPTION
Backported commit:
a60798f53c0297277fe38c6e6b44952f29529b33

Merge together:
https://github.com/cfengine/core/pull/4231
https://github.com/cfengine/enterprise/pull/623
https://github.com/cfengine/nova/pull/1682