### PR TITLE
Renamed StringSafeEqual() to StringEqual() (3.12)

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -583,7 +583,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 0:
         {
             const char *const option_name = OPTIONS[longopt_idx].name;
-            if (StringSafeEqual(option_name, "log-modules"))
+            if (StringEqual(option_name, "log-modules"))
             {
                 bool ret = LogEnableModulesFromString(optarg);
                 if (!ret)
@@ -591,7 +591,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                     DoCleanupAndExit(EXIT_FAILURE);
                 }
             }
-            else if (StringSafeEqual(option_name, "show-evaluated-classes"))
+            else if (StringEqual(option_name, "show-evaluated-classes"))
             {
                 if (optarg == NULL)
                 {
@@ -599,7 +599,7 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 config->agent_specific.agent.show_evaluated_classes = xstrdup(optarg);
             }
-            else if (StringSafeEqual(option_name, "show-evaluated-vars"))
+            else if (StringEqual(option_name, "show-evaluated-vars"))
             {
                 if (optarg == NULL)
                 {
@@ -607,17 +607,17 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 }
                 config->agent_specific.agent.show_evaluated_variables = xstrdup(optarg);
             }
-            else if (StringSafeEqual(option_name, "skip-db-check"))
+            else if (StringEqual(option_name, "skip-db-check"))
             {
                 if (optarg == NULL)
                 {
                     PERFORM_DB_CHECK = false; // Skip (no arg), check = false
                 }
-                else if (StringSafeEqual_IgnoreCase(optarg, "yes"))
+                else if (StringEqual_IgnoreCase(optarg, "yes"))
                 {
                     PERFORM_DB_CHECK = false; // Skip = yes, check = false
                 }
-                else if (StringSafeEqual_IgnoreCase(optarg, "no"))
+                else if (StringEqual_IgnoreCase(optarg, "no"))
                 {
                     PERFORM_DB_CHECK = true; // Skip = no, check = true
                 }

--- a/cf-agent/package_module.c
+++ b/cf-agent/package_module.c
@@ -306,11 +306,11 @@ static PackageInfo *ParseAndCheckPackageDataReply(const Rlist *data)
         if (StringStartsWith(line, "PackageType="))
         {
             const char *type = line + strlen("PackageType=");
-            if (StringSafeEqual(type, "file"))
+            if (StringEqual(type, "file"))
             {
                 package_data->type = PACKAGE_TYPE_FILE;
             }
-            else if (StringSafeEqual(type, "repo"))
+            else if (StringEqual(type, "repo"))
             {
                 package_data->type = PACKAGE_TYPE_REPO;
             }
@@ -483,7 +483,7 @@ static void GetPackageModuleExecInfo(const PackageModuleBody *package_module, ch
 
     char *package_module_path = NULL;
 
-    if (package_module->module_path != NULL && !StringSafeEqual(package_module->module_path, ""))
+    if (package_module->module_path != NULL && !StringEqual(package_module->module_path, ""))
     {
         package_module_path = xstrdup(package_module->module_path);
     }
@@ -494,7 +494,7 @@ static void GetPackageModuleExecInfo(const PackageModuleBody *package_module, ch
                                            package_module->name);
     }
 
-    if (package_module->interpreter && !StringSafeEqual(package_module->interpreter, ""))
+    if (package_module->interpreter && !StringEqual(package_module->interpreter, ""))
     {
         *script_path = package_module_path;
         *script_path_quoted = Path_GetQuoted(*script_path);
@@ -529,7 +529,7 @@ static int IsPackageInCache(EvalContext *ctx,
     /* Handle latest version in specific way for repo packages.
      * Please note that for file packages 'latest' version is not supported
      * and check against that is made in CheckPolicyAndPackageInfoMatch(). */
-    if (version && StringSafeEqual(version, "latest"))
+    if (version && StringEqual(version, "latest"))
     {
         version = NULL;
     }
@@ -1132,7 +1132,7 @@ PromiseResult RepoInstall(EvalContext *ctx,
 
         const char *version = package_info->version;
         if (package_info->version &&
-                StringSafeEqual(package_info->version, "latest"))
+                StringEqual(package_info->version, "latest"))
         {
             Log(LOG_LEVEL_DEBUG, "Clearing latest package version");
             version = NULL;
@@ -1156,7 +1156,7 @@ PromiseResult RepoInstall(EvalContext *ctx,
 
     /* We have 'latest' version in policy. */
     if (package_info->version &&
-        StringSafeEqual(package_info->version, "latest"))
+        StringEqual(package_info->version, "latest"))
     {
         /* This can return more than one latest version if we have packages
          * with different architectures installed. */
@@ -1184,7 +1184,7 @@ PromiseResult RepoInstall(EvalContext *ctx,
              * in updates available but we are interested only in updating
              * package with specific architecture. */
             if (package_info->arch &&
-                    !StringSafeEqual(package_info->arch, update_package->arch))
+                    !StringEqual(package_info->arch, update_package->arch))
             {
                 Log(LOG_LEVEL_DEBUG,
                     "Skipping update check of package '%s' as updates"
@@ -1322,7 +1322,7 @@ static bool CheckPolicyAndPackageInfoMatch(const NewPackages *packages_policy,
                                            const PackageInfo *info)
 {
     if (packages_policy->package_version &&
-        StringSafeEqual(packages_policy->package_version, "latest"))
+        StringEqual(packages_policy->package_version, "latest"))
     {
         Log(LOG_LEVEL_WARNING, "Unsupported 'latest' version for package "
                 "promise of type file.");
@@ -1331,7 +1331,7 @@ static bool CheckPolicyAndPackageInfoMatch(const NewPackages *packages_policy,
 
     /* Check if file we are having matches what we want in policy. */
     if (info->arch && packages_policy->package_architecture &&
-            !StringSafeEqual(info->arch, packages_policy->package_architecture))
+            !StringEqual(info->arch, packages_policy->package_architecture))
     {
         Log(LOG_LEVEL_WARNING,
             "Package arch and one specified in policy doesn't match: %s -> %s",
@@ -1340,7 +1340,7 @@ static bool CheckPolicyAndPackageInfoMatch(const NewPackages *packages_policy,
     }
 
     if (info->version && packages_policy->package_version &&
-        !StringSafeEqual(info->version, packages_policy->package_version))
+        !StringEqual(info->version, packages_policy->package_version))
     {
 
         Log(LOG_LEVEL_WARNING,
@@ -1471,7 +1471,7 @@ PromiseResult HandleAbsentPromiseAction(EvalContext *ctx,
 {
     /* Check if we are not having 'latest' version. */
     if (policy_data->package_version &&
-            StringSafeEqual(policy_data->package_version, "latest"))
+            StringEqual(policy_data->package_version, "latest"))
     {
         Log(LOG_LEVEL_ERR, "Package version 'latest' not supported for"
                 "absent package promise");

--- a/cf-check/cf-check.c
+++ b/cf-check/cf-check.c
@@ -203,28 +203,28 @@ int main(int argc, const char *const *argv)
     int cmd_argc = argc - optind;
     const char *command = cmd_argv[0];
 
-    if (StringSafeEqual_IgnoreCase(command, "lmdump"))
+    if (StringEqual_IgnoreCase(command, "lmdump"))
     {
         return lmdump_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual_IgnoreCase(command, "dump"))
+    if (StringEqual_IgnoreCase(command, "dump"))
     {
         return dump_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual_IgnoreCase(command, "diagnose"))
+    if (StringEqual_IgnoreCase(command, "diagnose"))
     {
         return diagnose_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual_IgnoreCase(command, "backup"))
+    if (StringEqual_IgnoreCase(command, "backup"))
     {
         return backup_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual_IgnoreCase(command, "repair") ||
-        StringSafeEqual_IgnoreCase(command, "remediate"))
+    if (StringEqual_IgnoreCase(command, "repair") ||
+        StringEqual_IgnoreCase(command, "remediate"))
     {
         return repair_main(cmd_argc, cmd_argv);
     }
-    if (StringSafeEqual_IgnoreCase(command, "help"))
+    if (StringEqual_IgnoreCase(command, "help"))
     {
         if (cmd_argc > 2)
         {
@@ -242,7 +242,7 @@ int main(int argc, const char *const *argv)
         }
         return EXIT_SUCCESS;
     }
-    if (StringSafeEqual_IgnoreCase(command, "version"))
+    if (StringEqual_IgnoreCase(command, "version"))
     {
         print_version();
         return EXIT_SUCCESS;

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -269,7 +269,7 @@ static void print_struct_or_string(
         }
         else if (StringEndsWith(file, "cf_observations.lmdb"))
         {
-            if (StringSafeEqual(key.mv_data, "DATABASE_AGE"))
+            if (StringEqual(key.mv_data, "DATABASE_AGE"))
             {
                 assert(sizeof(double) == value.mv_size);
                 const double *const age = value.mv_data;
@@ -290,13 +290,13 @@ static void print_struct_or_string(
         }
         else if (StringEndsWith(file, "nova_agent_execution.lmdb"))
         {
-            if (StringSafeEqual(key.mv_data, "delta_gavr"))
+            if (StringEqual(key.mv_data, "delta_gavr"))
             {
                 assert(sizeof(double) == value.mv_size);
                 const double *const average = value.mv_data;
                 printf("%f", *average);
             }
-            else if (StringSafeEqual(key.mv_data, "last_exec"))
+            else if (StringEqual(key.mv_data, "last_exec"))
             {
                 assert(sizeof(time_t) == value.mv_size);
                 const time_t *const last_exec = value.mv_data;

--- a/cf-check/utilities.c
+++ b/cf-check/utilities.c
@@ -53,7 +53,7 @@ bool matches_option(
     }
     else if (length == 2)
     {
-        return StringSafeEqual(supplied, shortopt);
+        return StringEqual(supplied, shortopt);
     }
-    return StringSafeEqualN_IgnoreCase(supplied, longopt, length);
+    return StringEqualN_IgnoreCase(supplied, longopt, length);
 }

--- a/cf-check/validate.c
+++ b/cf-check/validate.c
@@ -482,7 +482,7 @@ static void ValidateStateLastseen(ValidatorState *state)
                 ValidationError(
                     state, "Missing address entry for '%s'", address);
             }
-            else if (!StringSafeEqual(hostkey, lookup))
+            else if (!StringEqual(hostkey, lookup))
             {
                 ValidationError(
                     state,
@@ -513,7 +513,7 @@ static void ValidateStateLastseen(ValidatorState *state)
                 ValidationError(
                     state, "Missing hostkey entry for '%s'", hostkey);
             }
-            else if (!StringSafeEqual(address, lookup))
+            else if (!StringEqual(address, lookup))
             {
                 ValidationError(
                     state,

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -324,17 +324,17 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
         case 0:
         {
             const char *const option_name = OPTIONS[longopt_idx].name;
-            if (StringSafeEqual(option_name, "skip-db-check"))
+            if (StringEqual(option_name, "skip-db-check"))
             {
                 if (optarg == NULL)
                 {
                     PERFORM_DB_CHECK = false; // Skip (no arg), check = false
                 }
-                else if (StringSafeEqual_IgnoreCase(optarg, "yes"))
+                else if (StringEqual_IgnoreCase(optarg, "yes"))
                 {
                     PERFORM_DB_CHECK = false; // Skip = yes, check = false
                 }
-                else if (StringSafeEqual_IgnoreCase(optarg, "no"))
+                else if (StringEqual_IgnoreCase(optarg, "no"))
                 {
                     PERFORM_DB_CHECK = true; // Skip = no, check = true
                 }

--- a/cf-testd/cf-testd.c
+++ b/cf-testd/cf-testd.c
@@ -723,12 +723,12 @@ static char *IncrementIPaddress(const char *ip_str)
     int step = 1;
     char *last_dot = strrchr(ip_str, '.');
     assert(last_dot != NULL);   /* the doc comment says there must be dots! */
-    if (StringSafeEqual(last_dot + 1, "255"))
+    if (StringEqual(last_dot + 1, "255"))
     {
         /* avoid the network address (ending with 0) */
         step = 2;
     }
-    else if (StringSafeEqual(last_dot + 1, "254"))
+    else if (StringEqual(last_dot + 1, "254"))
     {
         /* avoid the broadcast address and the network address */
         step = 3;

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -897,7 +897,7 @@ void TLSSetDefaultOptions(SSL_CTX *ssl_ctx, const char *min_version)
         bool found = false;
         for (enum tls_version v = TLS_1_0; !found && v <= TLS_LAST; v++)
         {
-            if (StringSafeEqual(min_version, tls_version_strings[v]))
+            if (StringEqual(min_version, tls_version_strings[v]))
             {
                 found = true;
                 if (v < TLS_LOWEST_REQUIRED)

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1134,7 +1134,7 @@ static void OSReleaseParse(EvalContext *ctx, const char *file_path)
             CanonifyNameInPlace(os_release_id);
 
             const char *alias = NULL;
-            if (StringSafeEqual(os_release_id, "rhel"))
+            if (StringEqual(os_release_id, "rhel"))
             {
                 alias = "redhat";
             }

--- a/libpromises/class.c
+++ b/libpromises/class.c
@@ -48,7 +48,7 @@ TYPED_MAP_DECLARE(Class, char *, Class *)
 
 TYPED_MAP_DEFINE(Class, char *, Class *,
                  StringHash_untyped,
-                 StringSafeEqual_untyped,
+                 StringEqual_untyped,
                  free,
                  ClassDestroy_untyped)
 

--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -200,7 +200,7 @@ static
 bool IsSubHandle(DBHandle *handle, dbid id, const char *name)
 {
     char *sub_path = DBIdToSubPath(id, name);
-    bool result = StringSafeEqual(handle->filename, sub_path);
+    bool result = StringEqual(handle->filename, sub_path);
     free(sub_path);
     return result;
 }
@@ -462,7 +462,7 @@ DBHandle *GetDBHandleFromFilename(const char *db_file_name)
     ThreadLock(&db_handles_lock);
     for(dbid id=0; id < dbid_max; id++)
     {
-        if (StringSafeEqual(db_handles[id].filename, db_file_name))
+        if (StringEqual(db_handles[id].filename, db_file_name))
         {
             ThreadUnlock(&db_handles_lock);
             return &(db_handles[id]);

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -101,7 +101,7 @@ TYPED_MAP_DECLARE(RemoteVarPromises, char *, Seq *)
 
 TYPED_MAP_DEFINE(RemoteVarPromises, char *, Seq *,
                  StringHash_untyped,
-                 StringSafeEqual_untyped,
+                 StringEqual_untyped,
                  free,
                  SeqDestroy_untyped)
 
@@ -613,7 +613,7 @@ static bool EvalWithTokenFromList(const char *expr, StringSet *token_set)
 bool EvalProcessResult(const char *process_result, StringSet *proc_attr)
 {
     assert(process_result != NULL);
-    if (StringSafeEqual(process_result, ""))
+    if (StringEqual(process_result, ""))
     {
         /* nothing to evaluate */
         return false;
@@ -1466,7 +1466,7 @@ void EvalContextStackPushPromiseFrame(EvalContext *ctx, const Promise *owner)
     for (size_t i = 0; i < SeqLength(owner->conlist); i++)
     {
         Constraint *cp = SeqAt(owner->conlist, i);
-        if (StringSafeEqual(cp->lval, "with"))
+        if (StringEqual(cp->lval, "with"))
         {
             Rval final = EvaluateFinalRval(ctx, PromiseGetPolicy(owner), NULL,
                                            "this", cp->rval, false, owner);
@@ -2391,7 +2391,7 @@ const Bundle *EvalContextResolveBundleExpression(const EvalContext *ctx, const P
         const Bundle *curr_bp = SeqAt(policy->bundles, i);
         if ((strcmp(curr_bp->type, callee_type) != 0) ||
             (strcmp(curr_bp->name, ref.name) != 0) ||
-            !StringSafeEqual(curr_bp->ns, ref.ns))
+            !StringEqual(curr_bp->ns, ref.ns))
         {
             continue;
         }
@@ -2412,7 +2412,7 @@ const Body *EvalContextFindFirstMatchingBody(const Policy *policy, const char *t
         const Body *curr_bp = SeqAt(policy->bodies, i);
         if ((strcmp(curr_bp->type, type) == 0) &&
             (strcmp(curr_bp->name, name) == 0) &&
-            StringSafeEqual(curr_bp->ns, namespace))
+            StringEqual(curr_bp->ns, namespace))
         {
             return curr_bp;
         }

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -3977,7 +3977,7 @@ static FnCallResult FnCallFileStat(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const
 
     if (lstat(path, &statbuf) == -1)
     {
-        if (StringSafeEqual(fp->name, "filesize"))
+        if (StringEqual(fp->name, "filesize"))
         {
             return FnFailure();
         }

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -250,10 +250,10 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
         const char *key;
         while ((key = JsonIteratorNextKey(&iter)))
         {
-            if (!(StringSafeEqual(key, "vars") ||
-                  StringSafeEqual(key, "classes") ||
-                  StringSafeEqual(key, "inputs") ||
-                  StringSafeEqual(key, "augments")))
+            if (!(StringEqual(key, "vars") ||
+                  StringEqual(key, "classes") ||
+                  StringEqual(key, "inputs") ||
+                  StringEqual(key, "augments")))
             {
                 Log(LOG_LEVEL_VERBOSE, "Unknown augments key '%s' in file '%s', skipping it",
                     key, filename);

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -1054,7 +1054,7 @@ bool PromiseIteratorNext(PromiseIterator *iterctx, EvalContext *evalctx)
     for (size_t i = 0; i < SeqLength(iterctx->pp->conlist); i++)
     {
         Constraint *cp = SeqAt(iterctx->pp->conlist, i);
-        if (StringSafeEqual(cp->lval, "with"))
+        if (StringEqual(cp->lval, "with"))
         {
             Rval final = EvaluateFinalRval(evalctx, PromiseGetPolicy(iterctx->pp), NULL,
                                            "this", cp->rval, false, iterctx->pp);

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -274,10 +274,10 @@ static void RenameMainBundle(EvalContext *ctx, Policy *policy)
     for (int i = 0; i < length; ++i)
     {
         Bundle *const bundle = SeqAt(bundles, i);
-        if (StringSafeEqual(bundle->name, "__main__"))
+        if (StringEqual(bundle->name, "__main__"))
         {
             char *abspath = GetRealPath(bundle->source_path);
-            if (StringSafeEqual(abspath, entry_point))
+            if (StringEqual(abspath, entry_point))
             {
                 Log(LOG_LEVEL_VERBOSE,
                     "Redefining __main__ bundle from file %s to be main",

--- a/libpromises/mod_methods.c
+++ b/libpromises/mod_methods.c
@@ -51,7 +51,7 @@ static bool MethodsParseTreeCheck(const Promise *pp, Seq *errors)
         const Constraint *cp = SeqAt(pp->conlist, i);
 
         // ensure: if call and callee are resolved, then they have matching arity
-        if (StringSafeEqual(cp->lval, "usebundle"))
+        if (StringEqual(cp->lval, "usebundle"))
         {
             if (cp->rval.type == RVAL_TYPE_FNCALL)
             {

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -938,7 +938,7 @@ bool PolicyCheckDuplicateHandles(const Policy *policy, Seq *errors)
 {
     bool success = true;
 
-    Map *recorded = MapNew(StringHash_untyped, StringSafeEqual_untyped, NULL, NULL);
+    Map *recorded = MapNew(StringHash_untyped, StringEqual_untyped, NULL, NULL);
 
     for (size_t bpi = 0; bpi < SeqLength(policy->bundles); bpi++)
     {

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -300,7 +300,7 @@ bool RlistContainsString(const Rlist *list, const char *string)
     for (const Rlist *rp = list; rp != NULL; rp = rp->next)
     {
         if (rp->val.type == RVAL_TYPE_SCALAR &&
-            StringSafeEqual(RlistScalarValue(rp), string))
+            StringEqual(RlistScalarValue(rp), string))
         {
             return true;
         }

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -82,7 +82,7 @@ static bool IsLegalVariableName(EvalContext *ctx, const Promise *pp)
         char *prefix = xstrndup(var_name, dot - var_name);
         const Bundle *cur_bundle = PromiseGetBundle(pp);
 
-        if (!StringSafeEqual(prefix, cur_bundle->name))
+        if (!StringEqual(prefix, cur_bundle->name))
         {
             Log(LOG_LEVEL_VERBOSE,
                 "Variable '%s' may be attempted to be injected into a remote bundle",

--- a/libutils/json.c
+++ b/libutils/json.c
@@ -682,7 +682,7 @@ bool JsonPrimitiveGetAsBool(const JsonElement *primitive)
     assert(primitive->type == JSON_ELEMENT_TYPE_PRIMITIVE);
     assert(primitive->primitive.type == JSON_PRIMITIVE_TYPE_BOOL);
 
-    return StringSafeEqual(JSON_TRUE, primitive->primitive.value);
+    return StringEqual(JSON_TRUE, primitive->primitive.value);
 }
 
 long JsonPrimitiveGetAsInteger(const JsonElement *primitive)

--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -143,31 +143,31 @@ LogLevel LogLevelFromString(const char *const level)
     {
         return LOG_LEVEL_NOTHING;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "CRITICAL", len))
+    if (StringEqualN_IgnoreCase(level, "CRITICAL", len))
     {
         return LOG_LEVEL_CRIT;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "errors", len))
+    if (StringEqualN_IgnoreCase(level, "errors", len))
     {
         return LOG_LEVEL_ERR;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "warnings", len))
+    if (StringEqualN_IgnoreCase(level, "warnings", len))
     {
         return LOG_LEVEL_WARNING;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "notices", len))
+    if (StringEqualN_IgnoreCase(level, "notices", len))
     {
         return LOG_LEVEL_NOTICE;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "information", len))
+    if (StringEqualN_IgnoreCase(level, "information", len))
     {
         return LOG_LEVEL_INFO;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "verbose", len))
+    if (StringEqualN_IgnoreCase(level, "verbose", len))
     {
         return LOG_LEVEL_VERBOSE;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "debug", len))
+    if (StringEqualN_IgnoreCase(level, "debug", len))
     {
         return LOG_LEVEL_DEBUG;
     }

--- a/libutils/map.c
+++ b/libutils/map.c
@@ -354,6 +354,6 @@ MapKeyValue *MapIteratorNext(MapIterator *i)
 
 TYPED_MAP_DEFINE(String, char *, char *,
                  StringHash_untyped,
-                 StringSafeEqual_untyped,
+                 StringEqual_untyped,
                  &free,
                  &free)

--- a/libutils/mustache.c
+++ b/libutils/mustache.c
@@ -560,8 +560,8 @@ static bool IsKeyExtensionVar(TagType tag_type, const char *tag_start,
         /* the special case of unescaped form using {{{@}}} iff "{{" and "}}" are
          * used as delimiters */
         if ((delim_start_len == 2) && (delim_end_len == 2) &&
-            StringSafeEqual(delim_start, "{{") &&
-            StringSafeEqual(delim_end, "}}") &&
+            StringEqual(delim_start, "{{") &&
+            StringEqual(delim_end, "}}") &&
             StringStartsWith(tag_start, "{{{@}}}"))
         {
             return true;

--- a/libutils/set.c
+++ b/libutils/set.c
@@ -29,7 +29,7 @@
 #include <buffer.h>
 
 TYPED_SET_DEFINE(String, char *,
-                 StringHash_untyped, StringSafeEqual_untyped, free)
+                 StringHash_untyped, StringEqual_untyped, free)
 
 Set *SetNew(MapHashFn element_hash_fn,
             MapKeyEqualFn element_equal_fn,

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -256,12 +256,12 @@ int StringSafeCompareN(const char *const a, const char *const b, const size_t n)
     return NullCompare(a, b);
 }
 
-bool StringSafeEqual(const char *const a, const char *const b)
+bool StringEqual(const char *const a, const char *const b)
 {
     return (StringSafeCompare(a, b) == 0);
 }
 
-bool StringSafeEqualN(const char *const a, const char *const b, const size_t n)
+bool StringEqualN(const char *const a, const char *const b, const size_t n)
 {
     return (StringSafeCompareN(a, b, n) == 0);
 }
@@ -296,19 +296,19 @@ int StringSafeCompareN_IgnoreCase(const char *const a, const char *const b, cons
     return NullCompare(a, b);
 }
 
-bool StringSafeEqual_IgnoreCase(const char *const a, const char *const b)
+bool StringEqual_IgnoreCase(const char *const a, const char *const b)
 {
     return (StringSafeCompare_IgnoreCase(a, b) == 0);
 }
 
-bool StringSafeEqualN_IgnoreCase(const char *const a, const char *const b, const size_t n)
+bool StringEqualN_IgnoreCase(const char *const a, const char *const b, const size_t n)
 {
     return (StringSafeCompareN_IgnoreCase(a, b, n) == 0);
 }
 
-bool StringSafeEqual_untyped(const void *a, const void *b)
+bool StringEqual_untyped(const void *a, const void *b)
 {
-    return StringSafeEqual(a, b);
+    return StringEqual(a, b);
 }
 
 /*********************************************************************/
@@ -1485,7 +1485,7 @@ bool StringMatchesOption(
     }
     else if (length == 2)
     {
-        return StringSafeEqual(supplied, shortopt);
+        return StringEqual(supplied, shortopt);
     }
-    return StringSafeEqualN_IgnoreCase(supplied, longopt, length);
+    return StringEqualN_IgnoreCase(supplied, longopt, length);
 }

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -110,18 +110,18 @@ char *SafeStringNDuplicate(const char *str, size_t size);
 int SafeStringLength(const char *str);
 
 int  StringSafeCompare(const char *a, const char *b);
-bool StringSafeEqual  (const char *a, const char *b);
+bool StringEqual  (const char *a, const char *b);
 
 int  StringSafeCompareN(const char *a, const char *b, size_t n);
-bool StringSafeEqualN  (const char *a, const char *b, size_t n);
+bool StringEqualN  (const char *a, const char *b, size_t n);
 
 int  StringSafeCompare_IgnoreCase(const char *a, const char *b);
-bool StringSafeEqual_IgnoreCase  (const char *a, const char *b);
+bool StringEqual_IgnoreCase  (const char *a, const char *b);
 
 int  StringSafeCompareN_IgnoreCase(const char *a, const char *b, size_t n);
-bool StringSafeEqualN_IgnoreCase  (const char *a, const char *b, size_t n);
+bool StringEqualN_IgnoreCase  (const char *a, const char *b, size_t n);
 
-bool StringSafeEqual_untyped(const void *a, const void *b);
+bool StringEqual_untyped(const void *a, const void *b);
 
 char *StringConcatenate(size_t count, const char *first, ...);
 char *StringSubstring(const char *source, size_t source_len, int start, int len);

--- a/tests/unit/logging_test.c
+++ b/tests/unit/logging_test.c
@@ -67,7 +67,7 @@ static void test_set_host(void)
 #define check_level(str, lvl) \
 {\
     assert_int_equal(LogLevelFromString(str), lvl);\
-    assert_true(StringSafeEqual_IgnoreCase(str, LogLevelToString(lvl)));\
+    assert_true(StringEqual_IgnoreCase(str, LogLevelToString(lvl)));\
 }
 
 static void test_log_level(void)

--- a/tests/unit/map_test.c
+++ b/tests/unit/map_test.c
@@ -28,13 +28,13 @@ static void test_new_destroy(void)
 static void test_new_hashmap_bad_size(void)
 {
     /* too small */
-    HashMap *hashmap = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *hashmap = HashMapNew(StringHash_untyped, StringEqual_untyped,
                                   free, free, MIN_HASHMAP_BUCKETS >> 1);
     assert_int_equal(hashmap->size, MIN_HASHMAP_BUCKETS);
     HashMapDestroy(hashmap);
 
     /* not a pow2 */
-    hashmap = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    hashmap = HashMapNew(StringHash_untyped, StringEqual_untyped,
                          free, free, 123);
     assert_int_equal(hashmap->size, 128);
     HashMapDestroy(hashmap);
@@ -101,7 +101,7 @@ static void test_insert_jumbo(void)
 
 static void test_remove(void)
 {
-    HashMap *hashmap = HashMapNew(ConstHash, StringSafeEqual_untyped, free, free,
+    HashMap *hashmap = HashMapNew(ConstHash, StringEqual_untyped, free, free,
                                   HASH_MAP_INIT_SIZE);
 
     HashMapInsert(hashmap, xstrdup("a"), xstrdup("b"));
@@ -159,7 +159,7 @@ static void assert_n_as_in_map(HashMap *hashmap, unsigned int i, bool in)
 static void test_grow(void)
 {
     unsigned int i = 0;
-    HashMap *hashmap = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *hashmap = HashMapNew(StringHash_untyped, StringEqual_untyped,
                                   free, free, HASH_MAP_INIT_SIZE);
 
     size_t orig_size = hashmap->size;
@@ -253,7 +253,7 @@ static void test_grow(void)
 static void test_shrink(void)
 {
     unsigned int i = 0;
-    HashMap *hashmap = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *hashmap = HashMapNew(StringHash_untyped, StringEqual_untyped,
                                   free, free, HASH_MAP_INIT_SIZE);
 
     size_t orig_size = hashmap->size;
@@ -311,7 +311,7 @@ static void test_shrink(void)
 
 static void test_no_shrink_below_init_size(void)
 {
-    HashMap *hashmap = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *hashmap = HashMapNew(StringHash_untyped, StringEqual_untyped,
                                   free, free, HASH_MAP_INIT_SIZE);
 
     assert_int_equal(hashmap->size, HASH_MAP_INIT_SIZE);
@@ -367,7 +367,7 @@ static void test_clear(void)
 
 static void test_clear_hashmap(void)
 {
-    HashMap *map = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *map = HashMapNew(StringHash_untyped, StringEqual_untyped,
                               free, free, HASH_MAP_INIT_SIZE);
 
     assert_false(HashMapInsert(map, xstrdup("one"), xstrdup("first")));
@@ -499,7 +499,7 @@ static void test_hashmap_new_destroy(void)
 
 static void test_hashmap_degenerate_hash_fn(void)
 {
-    HashMap *hashmap = HashMapNew(ConstHash, StringSafeEqual_untyped, free, free, HASH_MAP_INIT_SIZE);
+    HashMap *hashmap = HashMapNew(ConstHash, StringEqual_untyped, free, free, HASH_MAP_INIT_SIZE);
 
     for (int i = 0; i < 100; i++)
     {
@@ -528,7 +528,7 @@ typedef struct
  * any references in the new value are not invalid. */
 static void test_array_map_key_referenced_in_value(void)
 {
-    ArrayMap *m = ArrayMapNew(StringSafeEqual_untyped, free, free);
+    ArrayMap *m = ArrayMapNew(StringEqual_untyped, free, free);
 
     char      *key1 = xstrdup("blah");
     TestValue *val1 = xmalloc(sizeof(*val1));
@@ -574,7 +574,7 @@ static void test_array_map_key_referenced_in_value(void)
 /* Same purpose as the above test. */
 static void test_hash_map_key_referenced_in_value(void)
 {
-    HashMap *m = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *m = HashMapNew(StringHash_untyped, StringEqual_untyped,
                             free, free, HASH_MAP_INIT_SIZE);
     char      *key1 = xstrdup("blah");
     TestValue *val1 = xmalloc(sizeof(*val1));

--- a/tests/unit/string_lib_test.c
+++ b/tests/unit/string_lib_test.c
@@ -458,19 +458,19 @@ static void test_safe_compare(void)
 
 static void test_safe_equal(void)
 {
-    assert_true(StringSafeEqual(NULL, NULL));
-    assert_true(StringSafeEqual("a", "a"));
-    assert_true(StringSafeEqual("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"));
-    assert_true(StringSafeEqual("0123456789", "0123456789"));
-    assert_true(StringSafeEqual("CamelCase", "CamelCase"));
-    assert_true(StringSafeEqual("(){}[]<>", "(){}[]<>"));
-    assert_true(StringSafeEqual("+-*/%%^", "+-*/%%^"));
+    assert_true(StringEqual(NULL, NULL));
+    assert_true(StringEqual("a", "a"));
+    assert_true(StringEqual("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"));
+    assert_true(StringEqual("0123456789", "0123456789"));
+    assert_true(StringEqual("CamelCase", "CamelCase"));
+    assert_true(StringEqual("(){}[]<>", "(){}[]<>"));
+    assert_true(StringEqual("+-*/%%^", "+-*/%%^"));
 
-    assert_false(StringSafeEqual("", NULL));
-    assert_false(StringSafeEqual(NULL, ""));
-    assert_false(StringSafeEqual("a", "b"));
-    assert_false(StringSafeEqual("a", "A"));
-    assert_false(StringSafeEqual("abc def", "abc deF"));
+    assert_false(StringEqual("", NULL));
+    assert_false(StringEqual(NULL, ""));
+    assert_false(StringEqual("a", "b"));
+    assert_false(StringEqual("a", "A"));
+    assert_false(StringEqual("abc def", "abc deF"));
 }
 
 static void test_safe_compare_ignore_case(void)
@@ -506,31 +506,31 @@ static void test_safe_compare_ignore_case(void)
 
 static void test_safe_equal_ignore_case(void)
 {
-    assert_true(StringSafeEqual_IgnoreCase(NULL, NULL));
-    assert_true(StringSafeEqual_IgnoreCase("a", "a"));
-    assert_true(StringSafeEqual_IgnoreCase("a", "A"));
-    assert_true(StringSafeEqual_IgnoreCase(hi_alphabet, lo_alphabet));
-    assert_true(StringSafeEqual_IgnoreCase("0123456789", "0123456789"));
-    assert_true(StringSafeEqual_IgnoreCase("CamelCase", "camelcase"));
-    assert_true(StringSafeEqual_IgnoreCase("(){}[]<>", "(){}[]<>"));
-    assert_true(StringSafeEqual_IgnoreCase("+-*/%%^", "+-*/%%^"));
-    assert_true(StringSafeEqual_IgnoreCase("abc def", "abc deF"));
+    assert_true(StringEqual_IgnoreCase(NULL, NULL));
+    assert_true(StringEqual_IgnoreCase("a", "a"));
+    assert_true(StringEqual_IgnoreCase("a", "A"));
+    assert_true(StringEqual_IgnoreCase(hi_alphabet, lo_alphabet));
+    assert_true(StringEqual_IgnoreCase("0123456789", "0123456789"));
+    assert_true(StringEqual_IgnoreCase("CamelCase", "camelcase"));
+    assert_true(StringEqual_IgnoreCase("(){}[]<>", "(){}[]<>"));
+    assert_true(StringEqual_IgnoreCase("+-*/%%^", "+-*/%%^"));
+    assert_true(StringEqual_IgnoreCase("abc def", "abc deF"));
 
-    assert_false(StringSafeEqual_IgnoreCase("", NULL));
-    assert_false(StringSafeEqual_IgnoreCase(NULL, ""));
-    assert_false(StringSafeEqual_IgnoreCase("a", "b"));
+    assert_false(StringEqual_IgnoreCase("", NULL));
+    assert_false(StringEqual_IgnoreCase(NULL, ""));
+    assert_false(StringEqual_IgnoreCase("a", "b"));
 }
 
 static void test_safe_equal_n(void)
 {
-    assert_true(StringSafeEqualN("abcd", "abcX", 3));
-    assert_true(StringSafeEqualN_IgnoreCase("abcd", "ABCX", 3));
+    assert_true(StringEqualN("abcd", "abcX", 3));
+    assert_true(StringEqualN_IgnoreCase("abcd", "ABCX", 3));
 
-    assert_false(StringSafeEqualN("abcd", "abXX", 3));
-    assert_false(StringSafeEqualN_IgnoreCase("abcd", "ABXX", 3));
+    assert_false(StringEqualN("abcd", "abXX", 3));
+    assert_false(StringEqualN_IgnoreCase("abcd", "ABXX", 3));
 
-    assert_true(StringSafeEqualN("123abc", "123abc", 1000));
-    assert_true(StringSafeEqualN_IgnoreCase("123abc", "123ABC", 1000));
+    assert_true(StringEqualN("123abc", "123abc", 1000));
+    assert_true(StringEqualN_IgnoreCase("123abc", "123ABC", 1000));
 }
 
 static void test_match(void)


### PR DESCRIPTION
Backported commit:
a60798f53c0297277fe38c6e6b44952f29529b33

Merge together:
https://github.com/cfengine/core/pull/4232
https://github.com/cfengine/enterprise/pull/624
https://github.com/cfengine/nova/pull/1683