### PR TITLE
[3.15.x] Fixed locking of promises using log_repaired / log_string with timestamps

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -648,7 +648,7 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt,
     Rlist *rp;
     FnCall *fp;
 
-    char *noRvalHash[] = { "mtime", "atime", "ctime", "stime_range", "ttime_range", NULL };
+    char *noRvalHash[] = { "mtime", "atime", "ctime", "stime_range", "ttime_range", "log_string", NULL };
     int doHash;
 
     md = HashDigestFromId(type);


### PR DESCRIPTION
log_string in action bodies is no longer used in promise hashing.

Promise hashes are used to track a promise between agent runs,
so anything which changes every run (like time) should be excluded.

Log messages very commonly have timestamps, and our default from
standard library does.

Changelog: Title
Ticket: CFE-3376
Signed-off-by: Ole Herman Schumacher Elgesem <ole@northern.tech>
(cherry picked from commit a18ad4e92b50bc3d119f4cee3523dbb5f3e41694)