### PR TITLE
Wait for background processes before generating reports

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -159,6 +159,7 @@ static bool HasAvahiSupport(void);
 static int AutomaticBootstrap(GenericAgentConfig *config);
 static void BannerStatus(PromiseResult status, char *type, char *name);
 static PromiseResult DefaultVarPromise(EvalContext *ctx, const Promise *pp);
+static void WaitForBackgroundProcesses();
 
 /*******************************************************************/
 /* Command line options                                            */
@@ -294,6 +295,11 @@ int main(int argc, char *argv[])
 
     /* Update packages cache. */
     UpdatePackagesCache(ctx, false);
+
+    /* Wait for background processes before generating reports because
+     * GenerateReports() does nothing if it detects multiple cf-agent processes
+     * running. */
+    WaitForBackgroundProcesses();
 
     GenerateReports(config, ctx);
 
@@ -2126,3 +2132,25 @@ static int AutomaticBootstrap(ARG_UNUSED GenericAgentConfig *config)
 }
 
 #endif // Avahi
+
+static void WaitForBackgroundProcesses()
+{
+#ifdef __MINGW32__
+    /* no fork() on Windows */
+    return;
+#else
+    Log(LOG_LEVEL_VERBOSE, "Waiting for background processes");
+    bool have_children = true;
+    while (have_children)
+    {
+        pid_t child = wait(NULL);
+        if (child >= 0)
+        {
+            Log(LOG_LEVEL_VERBOSE, "Background process %ju terminated", (uintmax_t) child);
+        }
+        have_children = !((child == -1) && (errno == ECHILD));
+    }
+    Log(LOG_LEVEL_VERBOSE, "No more background processes to wait for");
+    return;
+#endif  /* __MINGW32__ */
+}


### PR DESCRIPTION
Reports generation only happens if there is exactly one
'cf-agent' process running (to avoid corruptions in the reporting
data). If some promise in the policy uses an action policy with
'background => true', there might still be a forked child process
evaluating the promise when the main process reaches the point
when it wants to generate reports. In such cases, it is important
that the main process waits for the forked child processes.

Ticket: ENT-6042
Changelog: Promises with 'action => bg()' no longer break reporting data