### PR TITLE
cf-remote: Replaced os.getlogin() with whoami()

### DIFF
--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -6,7 +6,7 @@ from cf_remote.remote import get_info, print_info, install_host, uninstall_host,
 from cf_remote.packages import Releases
 from cf_remote.web import download_package
 from cf_remote.paths import cf_remote_dir, CLOUD_CONFIG_FPATH, CLOUD_STATE_FPATH
-from cf_remote.utils import save_file, strip_user, read_json, write_json
+from cf_remote.utils import save_file, strip_user, read_json, write_json, whoami
 from cf_remote.spawn import VM, VMRequest, Providers, AWSCredentials
 from cf_remote.spawn import spawn_vms, destroy_vms, dump_vms_info, get_cloud_driver
 from cf_remote import log
@@ -154,7 +154,7 @@ def spawn(platform, count, role, group_name, provider=Providers.AWS, region=None
 
     requests = []
     for i in range(count):
-        vm_name = os.getlogin()[0:2] + group_name + "-" + platform + role + str(i)
+        vm_name = whoami()[0:2] + group_name + "-" + platform + role + str(i)
         requests.append(VMRequest(platform=platform,
                                   name=vm_name,
                                   size=None))

--- a/contrib/cf-remote/cf_remote/spawn.py
+++ b/contrib/cf-remote/cf_remote/spawn.py
@@ -9,6 +9,7 @@ from libcloud.compute.providers import get_driver
 from libcloud.compute.base import NodeSize, NodeImage
 
 from cf_remote.cloud_data import aws_platforms
+from cf_remote.utils import whoami
 from cf_remote import log
 
 
@@ -232,7 +233,7 @@ def spawn_vm_in_aws(platform, aws_creds, key_pair, security_groups, region, name
         ex_security_groups=security_groups,
         ex_metadata={
             "created-by": "cf-remote",
-            "owner": os.getlogin(),
+            "owner": whoami(),
         }
     )
 


### PR DESCRIPTION
Fixes error on my Ubuntu / WSL setup:

```
>>> os.getlogin()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
FileNotFoundError: [Errno 2] No such file or directory
>>> getpass.getuser()
  'olehermanse'
```

See:
https://github.com/parmentelat/apssh/issues/1