### PR TITLE
ENT-5335 add workarounds for tests failing on SUSE - 3.15.x

### DIFF
--- a/tests/acceptance/17_users/unsafe/10_modify_user_with_many_attributes.cf
+++ b/tests/acceptance/17_users/unsafe/10_modify_user_with_many_attributes.cf
@@ -123,7 +123,13 @@ bundle agent check
                          "not_sgroup_success", "!not_sgroup_failure", };
     windows::
       "unix_ok" expression => "any";
-    any::
+    suse::
+      "ok" -> "CFE-3386"
+        and => { "pgroup_success", "!pgroup_failure", "!sgroup_success", "sgroup_failure",
+                 "hash_success", "!hash_failure",
+                 "home_success", "!home_failure", "desc_success", "!desc_failure",
+                 "unix_ok" };
+    !suse::
       "ok" and => { "pgroup_success", "!pgroup_failure", "sgroup_success", "!sgroup_failure",
                     "hash_success", "!hash_failure",
                     "home_success", "!home_failure", "desc_success", "!desc_failure",

--- a/tests/acceptance/17_users/unsafe/10_modify_user_with_many_attributes_warn.cf
+++ b/tests/acceptance/17_users/unsafe/10_modify_user_with_many_attributes_warn.cf
@@ -131,7 +131,13 @@ bundle agent check
                          "not_sgroup_success", "!not_sgroup_failure", };
     windows::
       "unix_ok" expression => "any";
-    any::
+    suse::
+      "ok" -> "CFE-3386"
+        and => { "pgroup_success", "!pgroup_failure", "!sgroup_success", "sgroup_failure",
+                 "hash_success", "!hash_failure",
+                 "home_success", "!home_failure", "desc_success", "!desc_failure",
+                 "unix_ok" };
+    !suse::
       "ok" and => { "pgroup_success", "!pgroup_failure", "sgroup_success", "!sgroup_failure",
                     "hash_success", "!hash_failure",
                     "home_success", "!home_failure", "desc_success", "!desc_failure",


### PR DESCRIPTION
Issue is that `usermod` on suse doesn't like editing secondary groups together
with any other attributes. In real life, this isn't a big issue - the promise
will be completely repaired on second run. However, this test failed.

This commit changes this behavior to expect secondary group to *not* be set
after first promise run. When this get fixed, this commit should be reverted :)

(cherry picked from commit 3d36de3949c0e4a5a1e7e7d3b3fabc1d6b822801)


----

#