### PR TITLE
ENT-6098 fix init_script_test.sh failure of suse 12 and 15

### DIFF
--- a/misc/init.d/cfengine3.in
+++ b/misc/init.d/cfengine3.in
@@ -150,10 +150,11 @@ fi
 CURRENT_PS_UID=__none__
 INSIDE_CONTAINER=-1
 
-if ps --help 2>/dev/null | egrep -e '--cols\b' > /dev/null; then
+if ps --help 2>/dev/null | egrep -e '--cols\b' > /dev/null || ps --help output 2>/dev/null | egrep -e '--cols\b'; then
     # There is a bug in SUSE which means that ps output will be truncated even
     # when piped to grep, if the terminal size is small. However using --cols
-    # will override it.
+    # will override it. NOTE: On Suse 12 and 15, `ps` mentions `--cols` only
+    # in `ps --help output` only.
     PS_OPTIONS="--cols 200"
 else
     PS_OPTIONS=

--- a/tests/acceptance/17_users/unsafe/10_modify_user_with_many_attributes.cf
+++ b/tests/acceptance/17_users/unsafe/10_modify_user_with_many_attributes.cf
@@ -123,13 +123,13 @@ bundle agent check
                          "not_sgroup_success", "!not_sgroup_failure", };
     windows::
       "unix_ok" expression => "any";
-    suse::
+    sles_11::
       "ok" -> "CFE-3386"
         and => { "pgroup_success", "!pgroup_failure", "!sgroup_success", "sgroup_failure",
                  "hash_success", "!hash_failure",
                  "home_success", "!home_failure", "desc_success", "!desc_failure",
                  "unix_ok" };
-    !suse::
+    !sles_11::
       "ok" and => { "pgroup_success", "!pgroup_failure", "sgroup_success", "!sgroup_failure",
                     "hash_success", "!hash_failure",
                     "home_success", "!home_failure", "desc_success", "!desc_failure",

--- a/tests/acceptance/17_users/unsafe/10_modify_user_with_many_attributes_warn.cf
+++ b/tests/acceptance/17_users/unsafe/10_modify_user_with_many_attributes_warn.cf
@@ -131,13 +131,13 @@ bundle agent check
                          "not_sgroup_success", "!not_sgroup_failure", };
     windows::
       "unix_ok" expression => "any";
-    suse::
+    sles_11::
       "ok" -> "CFE-3386"
         and => { "pgroup_success", "!pgroup_failure", "!sgroup_success", "sgroup_failure",
                  "hash_success", "!hash_failure",
                  "home_success", "!home_failure", "desc_success", "!desc_failure",
                  "unix_ok" };
-    !suse::
+    !sles_11::
       "ok" and => { "pgroup_success", "!pgroup_failure", "sgroup_success", "!sgroup_failure",
                     "hash_success", "!hash_failure",
                     "home_success", "!home_failure", "desc_success", "!desc_failure",


### PR DESCRIPTION
fixes suse 12.

merge together:
https://github.com/cfengine/buildscripts/pull/762
