### PR TITLE
CFE-3405 cf-remote: Added deploy command for deploying masterfiles

### DIFF
--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -15,17 +15,25 @@ from cf_remote import cloud_data
 def info(hosts, users=None):
     assert hosts
     log.debug("hosts='{}'".format(hosts))
+    errors = 0
     for host in hosts:
         data = get_info(host, users=users)
-        print_info(data)
+        if data:
+            print_info(data)
+        else:
+            errors += 1
+    return errors
 
 
 def run(hosts, command, users=None, sudo=False, raw=False):
     assert hosts
+    errors = 0
     for host in hosts:
         lines = run_command(host=host, command=command, users=users, sudo=sudo)
         if lines is None:
-            sys.exit("Command: '{}'\nFailed on host: '{}'".format(command, host))
+            log.error("Command: '{}'\nFailed on host: '{}'".format(command, host))
+            errors += 1
+            continue
         host_colon = (host + ":").ljust(16)
         if lines == "":
             if not raw:
@@ -42,16 +50,19 @@ def run(hosts, command, users=None, sudo=False, raw=False):
                 cmd = None
             else:
                 print("{}{}'{}'".format(host_colon, fill, line))
+    return errors
 
 
 def sudo(hosts, command, users=None, raw=False):
-    run(hosts, command, users, sudo=True, raw=raw)
+    return run(hosts, command, users, sudo=True, raw=raw)
 
 
 def scp(hosts, files, users=None):
+    errors = 0
     for host in hosts:
         for file in files:
-            transfer_file(host, file, users)
+            errors += transfer_file(host, file, users)
+    return errors
 
 
 def install(
@@ -78,12 +89,13 @@ def install(
         if type(bootstrap) is str:
             bootstrap = [bootstrap]
         save_file(os.path.join(cf_remote_dir(), "policy_server.dat"), "\n".join(bootstrap + [""]))
+    errors = 0
     if hubs:
         if type(hubs) is str:
             hubs = [hubs]
         for index, hub in enumerate(hubs):
             log.debug("Installing {} hub package on '{}'".format(edition, hub))
-            install_host(
+            errors += install_host(
                 hub,
                 hub=True,
                 package=hub_package,
@@ -94,7 +106,7 @@ def install(
                 edition=edition)
     for index, host in enumerate(clients or []):
         log.debug("Installing {} client package on '{}'".format(edition, host))
-        install_host(
+        errors += install_host(
             host,
             hub=False,
             package=client_package,
@@ -107,6 +119,7 @@ def install(
             print(
                 "Your demo hub is ready: https://{}/ (Username: admin, Password: password)".
                 format(strip_user(hub)))
+    return errors
 
 
 def packages(tags=None, version=None, edition=None):
@@ -124,6 +137,7 @@ def packages(tags=None, version=None, edition=None):
     else:
         for artifact in artifacts:
             download_package(artifact.url)
+    return 0
 
 def spawn(platform, count, role, group_name, provider=Providers.AWS, region=None):
     if os.path.exists(CLOUD_CONFIG_FPATH):
@@ -259,10 +273,13 @@ def init_cloud_config():
     }
     write_json(CLOUD_CONFIG_FPATH, empty_config)
     print("Config file %s created, please complete the configuration in it." % CLOUD_CONFIG_FPATH)
+    return 0
 
 def uninstall(hosts):
+    errors = 0
     for host in hosts:
-        uninstall_host(host)
+        errors += uninstall_host(host)
+    return errors
 
 def deploy(hubs, directory):
     assert(directory.endswith("/masterfiles"))
@@ -275,5 +292,7 @@ def deploy(hubs, directory):
     above = directory[0:-len("/masterfiles")]
     os.system(f"rm -rf {tarball}")
     os.system(f"tar -czf {tarball} -C {above} masterfiles")
+    errors = 0
     for hub in hubs:
-        deploy_masterfiles(hub, tarball)
+        errors += deploy_masterfiles(hub, tarball)
+    return errors

--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -93,9 +93,9 @@ def get_args():
 
 def run_command_with_args(command, args):
     if command == "info":
-        commands.info(args.hosts, None)
+        return commands.info(args.hosts, None)
     elif command == "install":
-        commands.install(
+        return commands.install(
             args.hub,
             args.clients,
             package=args.package,
@@ -108,34 +108,32 @@ def run_command_with_args(command, args):
             edition=args.edition)
     elif command == "uninstall":
         all_hosts = ((args.hosts or []) + (args.hub or []) + (args.clients or []))
-        commands.uninstall(all_hosts)
+        return commands.uninstall(all_hosts)
     elif command == "packages":
-        commands.packages(tags=args.tags, version=args.version, edition=args.edition)
+        return commands.packages(tags=args.tags, version=args.version, edition=args.edition)
     elif command == "run":
-        commands.run(hosts=args.hosts, raw=args.raw, command=args.remote_command)
+        return commands.run(hosts=args.hosts, raw=args.raw, command=args.remote_command)
     elif command == "sudo":
-        commands.sudo(hosts=args.hosts, raw=args.raw, command=args.remote_command)
+        return commands.sudo(hosts=args.hosts, raw=args.raw, command=args.remote_command)
     elif command == "scp":
-        commands.scp(hosts=args.hosts, files=args.args)
+        return commands.scp(hosts=args.hosts, files=args.args)
     elif command == "spawn":
         if args.list_platforms:
-            commands.list_platforms()
-            return
+            return commands.list_platforms()
         if args.init_config:
-            commands.init_cloud_config()
-            return
+            return commands.init_cloud_config()
         if args.name and "," in args.name:
             user_error("Group --name may not contain commas")
         # else
         if args.role.endswith("s"):
             # role should be singular
             args.role = args.role[:-1]
-        commands.spawn(args.platform, args.count, args.role, args.name)
+        return commands.spawn(args.platform, args.count, args.role, args.name)
     elif command == "destroy":
         group_name = args.name if args.name else None
-        commands.destroy(group_name)
+        return commands.destroy(group_name)
     elif command == "deploy":
-        commands.deploy(args.hub, args.directory)
+        return commands.deploy(args.hub, args.directory)
     else:
         user_error("Unknown command: '{}'".format(command))
 
@@ -321,7 +319,9 @@ def main():
         log.set_level(args.log_level)
     validate_args(args)
 
-    run_command_with_args(args.command, args)
+    exit_code = run_command_with_args(args.command, args)
+    assert(type(exit_code) is int)
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -83,6 +83,10 @@ def get_args():
     dp.add_argument("--all", help="Destroy all hosts spawned in the clouds", action='store_true')
     dp.add_argument("name", help="Name fo the group of hosts to destroy", nargs='?')
 
+    sp = subp.add_parser("deploy", help="Deploy masterfiles directory to hub")
+    sp.add_argument("--hub", help="Hub(s) to deploy to", type=str, required=True)
+    sp.add_argument("directory", help="Path to local masterfiles directory", type=str)
+
     args = ap.parse_args()
     return args
 
@@ -130,6 +134,8 @@ def run_command_with_args(command, args):
     elif command == "destroy":
         group_name = args.name if args.name else None
         commands.destroy(group_name)
+    elif command == "deploy":
+        commands.deploy(args.hub, args.directory)
     else:
         user_error("Unknown command: '{}'".format(command))
 
@@ -182,6 +188,14 @@ def validate_command(command, args):
     if command == "destroy":
         if not args.all and not args.name:
             user_error("One of --all or NAME required for destroy")
+
+    if command == "deploy":
+        if not args.directory:
+            user_error("Must specify a masterfiles directory")
+        if not args.hub:
+            user_error("Must specify at least one hub")
+        if not os.path.isdir(args.directory):
+            user_error(f"'{args.directory}' is not a directory")
 
 
 def is_in_cloud_state(name):

--- a/contrib/cf-remote/cf_remote/ssh.py
+++ b/contrib/cf-remote/cf_remote/ssh.py
@@ -64,6 +64,7 @@ def scp(file, remote, connection=None):
     else:
         print("Copying: '{}' to '{}'".format(file, remote))
         connection.put(file)
+    return 0
 
 
 def ssh_cmd(connection, cmd, errors=False):


### PR DESCRIPTION
```
olehermanse@OH-WIN core $ cf-remote deploy --hub hub /northern.tech/cfengine/masterfiles
ubuntu@34.250.47.156
OS            : ubuntu (debian)
Architecture  : x86_64
CFEngine      : 3.17.0a.ec47889f4 (Enterprise)
Policy server : None
Binaries      : dpkg, apt
Copying: '/home/olehermanse/.cfengine/cf-remote/masterfiles.tgz' to 'ubuntu@34.250.47.156'
Running: 'systemctl stop cfengine3 && rm -rf /var/cfengine/masterfiles && mv masterfiles /var/cfengine/masterfiles && systemctl start cfengine3 && cf-agent -Kf update.cf && cf-agent -K'
```