### PR TITLE
[3.12.x] Expand variables specifying data/list names in @() references

### DIFF
--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -1128,7 +1128,7 @@ bool IsExpandable(const char *str)
 
 /*********************************************************************/
 
-static char opposite(char c)
+static inline char opposite(char c)
 {
     switch (c)
     {

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -1149,7 +1149,7 @@ static inline char opposite(char c)
 bool IsNakedVar(const char *str, char vtype)
 {
     size_t len = strlen(str);
-    char last  = len > 0 ? str[len-1] : 0;
+    char last  = len > 0 ? str[len-1] : '\0';
 
     if (len < 3
         || str[0] != vtype

--- a/tests/acceptance/01_vars/04_containers/pass_variable_container.cf
+++ b/tests/acceptance/01_vars/04_containers/pass_variable_container.cf
@@ -44,6 +44,7 @@ bundle agent test
     # "found" variable, so we just use that instead.
 
     "bundle_name" string => "init";
+    "bundle_name_suffix" string => "it";
 
   methods:
   # These work.
@@ -54,7 +55,8 @@ bundle agent test
  # wouldn't be but thats a seperate issue.)
     "" usebundle => report_data("Pass by variable name:", "@($(bundle_name).d)");
     "" usebundle => report_data("Pass by variable name including namespace:", "@($(found).d)");
-
+    "" usebundle => report_data("Pass by variable name with prefix:", "@(in$(bundle_name_suffix).d)");
+    "" usebundle => report_data("Pass by variable name with namespace:", "@(default:$(bundle_name).d)");
 }
 
 bundle agent check

--- a/tests/acceptance/01_vars/04_containers/pass_variable_container.cf
+++ b/tests/acceptance/01_vars/04_containers/pass_variable_container.cf
@@ -35,17 +35,15 @@ bundle agent test
 {
 
   meta:
-    "description" string => "Test that variable data containers can be passed.";
-    "test_soft_fail"
-      string => "any",
-      meta => { "CFE-2434" };
+    "description" -> { "CFE-2434" }
+      string => "Test that variable data containers can be passed.";
 
   vars:
     "found" slist  => bundlesmatching(".*", "find");
     # "ns_bundle" string => "default:init"; # This is the same content as the
     # "found" variable, so we just use that instead.
 
-    "bundle" string => "init";
+    "bundle_name" string => "init";
 
   methods:
   # These work.
@@ -54,7 +52,7 @@ bundle agent test
 
  # These do not work. (Note: Quotes are required for this, ideally they
  # wouldn't be but thats a seperate issue.)
-    "" usebundle => report_data("Pass by variable name", "@($(bundle).d)");
+    "" usebundle => report_data("Pass by variable name:", "@($(bundle_name).d)");
     "" usebundle => report_data("Pass by variable name including namespace:", "@($(found).d)");
 
 }

--- a/tests/acceptance/01_vars/04_containers/pass_variable_container.cf.expected
+++ b/tests/acceptance/01_vars/04_containers/pass_variable_container.cf.expected
@@ -6,3 +6,7 @@ Pass by variable name: hosts=/etc/hosts
 Pass by variable name: auto_master=/etc/auto.master
 Pass by variable name including namespace: hosts=/etc/hosts
 Pass by variable name including namespace: auto_master=/etc/auto.master
+Pass by variable name with prefix: hosts=/etc/hosts
+Pass by variable name with prefix: auto_master=/etc/auto.master
+Pass by variable name with namespace: hosts=/etc/hosts
+Pass by variable name with namespace: auto_master=/etc/auto.master

--- a/tests/acceptance/01_vars/04_containers/pass_variable_container.cf.expected
+++ b/tests/acceptance/01_vars/04_containers/pass_variable_container.cf.expected
@@ -3,6 +3,6 @@ Pass by name: auto_master=/etc/auto.master
 Pass by namespace:name: hosts=/etc/hosts
 Pass by namespace:name: auto_master=/etc/auto.master
 Pass by variable name: hosts=/etc/hosts
-Pass by variable:name: auto_master=/etc/auto.master
+Pass by variable name: auto_master=/etc/auto.master
 Pass by variable name including namespace: hosts=/etc/hosts
 Pass by variable name including namespace: auto_master=/etc/auto.master

--- a/tests/unit/expand_test.c
+++ b/tests/unit/expand_test.c
@@ -62,6 +62,19 @@ static void test_extract_reference(void)
     test_extract_reference_("$(x${$(y)}) $(y) ${x${z}}", true, "$(x${$(y)})", "x${$(y)}");
 }
 
+static void test_isnakedvar()
+{
+    assert_true(IsNakedVar("$(whatever)", '$'));
+    assert_true(IsNakedVar("${whatever}", '$'));
+    assert_true(IsNakedVar("$(blah$(blue))", '$'));
+
+    assert_false(IsNakedVar("$(blah)blue", '$'));
+    assert_false(IsNakedVar("blah$(blue)", '$'));
+    assert_false(IsNakedVar("$(blah)$(blue)", '$'));
+    assert_false(IsNakedVar("$(blah}", '$'));
+}
+
+
 #if 0
 static void test_map_iterators_from_rval_empty(void **state)
 {
@@ -564,6 +577,7 @@ int main()
     {
         unit_test(test_extract_scalar_prefix),
         unit_test(test_extract_reference),
+        unit_test(test_isnakedvar),
 #if 0
         unit_test_setup_teardown(test_map_iterators_from_rval_empty, test_setup, test_teardown),
         unit_test_setup_teardown(test_map_iterators_from_rval_literal, test_setup, test_teardown),


### PR DESCRIPTION
Backported #4280 