### PR TITLE
CFE-3304: Removed restriction on bootstrap to loopback interface (3.15)

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -371,8 +371,7 @@ static void ConfigureBootstrap(GenericAgentConfig *config, const char *argument)
 
     if(IsLoopbackAddress(argument))
     {
-        Log(LOG_LEVEL_ERR, "Cannot bootstrap to a loopback address");
-        DoCleanupAndExit(EXIT_FAILURE);
+        Log(LOG_LEVEL_WARNING, "Bootstrapping to loopback interface (localhost), other hosts will not be able to bootstrap to this server");
     }
 
     // temporary assure that network functions are working


### PR DESCRIPTION
The exit blocked effective use in a development environment
without a stable non-loopback interface, such as a phone (android/termux).

(cherry picked from commit 5b00565454195b0b79f420c5abeca764b1476ff0)