### PR TITLE
CFE-3389 CFE-3409: Fixed compiler warnings for format truncation and pointer sign

### DIFF
--- a/cf-serverd/server_common.h
+++ b/cf-serverd/server_common.h
@@ -50,7 +50,7 @@ int CfOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *oldDirn
 int CfSecOpenDirectory(ServerConnectionState *conn, char *sendbuffer, char *dirname);
 void GetServerLiteral(EvalContext *ctx, ServerConnectionState *conn, char *sendbuffer, char *recvbuffer, int encrypted);
 bool GetServerQuery(ServerConnectionState *conn, char *recvbuffer, int encrypted);
-bool CompareLocalHash(const char *filename, const char digest[EVP_MAX_MD_SIZE + 1],
+bool CompareLocalHash(const char *filename, const unsigned char digest[EVP_MAX_MD_SIZE + 1],
                       char sendbuffer[CFD_FALSE_SIZE]);
 Item *ListPersistentClasses(void);
 

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -656,7 +656,7 @@ static bool EncryptCopyRegularFileNet(const char *source, const char *dest, off_
 
         EVP_DecryptInit_ex(crypto_ctx, CfengineCipher(CfEnterpriseOptions()), NULL, conn->session_key, iv);
 
-        if (!EVP_DecryptUpdate(crypto_ctx, workbuf, &plainlen, buf, cipherlen))
+        if (!EVP_DecryptUpdate(crypto_ctx, (unsigned char *) workbuf, &plainlen, (unsigned char *) buf, cipherlen))
         {
             close(dd);
             free(buf);
@@ -664,7 +664,7 @@ static bool EncryptCopyRegularFileNet(const char *source, const char *dest, off_
             return false;
         }
 
-        if (!EVP_DecryptFinal_ex(crypto_ctx, workbuf + plainlen, &finlen))
+        if (!EVP_DecryptFinal_ex(crypto_ctx, (unsigned char *) workbuf + plainlen, &finlen))
         {
             close(dd);
             free(buf);

--- a/libcfnet/client_protocol.c
+++ b/libcfnet/client_protocol.c
@@ -64,7 +64,7 @@ bool IdentifyAgent(ConnectionInfo *conn_info)
 {
     assert(conn_info != NULL);
 
-    char uname[CF_BUFSIZE], sendbuff[CF_BUFSIZE];
+    char uname[CF_MAXVARSIZE], sendbuff[CF_BUFSIZE];
     char dnsname[CF_MAXVARSIZE], localip[CF_MAX_IP_LEN];
     int ret;
 

--- a/libcfnet/client_protocol.h
+++ b/libcfnet/client_protocol.h
@@ -30,9 +30,9 @@
 
 bool IdentifyAgent(ConnectionInfo *connection);
 bool AuthenticateAgent(AgentConnection *conn, bool trust_key);
-bool BadProtoReply(char *buf);
-bool OKProtoReply(char *buf);
-bool FailedProtoReply(char *buf);
+bool BadProtoReply(const char *buf);
+bool OKProtoReply(const char *buf);
+bool FailedProtoReply(const char *buf);
 
 
 #endif

--- a/libcfnet/connection_info.c
+++ b/libcfnet/connection_info.c
@@ -153,7 +153,7 @@ const unsigned char *ConnectionInfoBinaryKeyHash(ConnectionInfo *info, unsigned 
     }
     Key *connection_key = info->remote_key;
     unsigned int real_length = 0;
-    const char *binary = KeyBinaryHash(connection_key, &real_length);
+    const unsigned char *binary = KeyBinaryHash(connection_key, &real_length);
     if (length)
     {
         *length = real_length;

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -490,7 +490,7 @@ X509 *TLSGenerateCertFromPrivKey(RSA *privkey)
 
     ret = 0;
     ret += X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
-                                      (const char *) "a",
+                                      (const unsigned char *) "a",
                                       -1, -1, 0);
     ret += X509_set_issuer_name(x509, name);
     ret += X509_set_pubkey(x509, pkey);

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -444,7 +444,7 @@ static void GetNameInfo3(EvalContext *ctx)
     };
     int have_component[COMPONENTS_SIZE];
     struct stat sb;
-    char name[CF_MAXVARSIZE], quoteName[CF_MAXVARSIZE], shortname[CF_MAXVARSIZE];
+    char name[CF_MAXVARSIZE], quoteName[CF_MAXVARSIZE + 2], shortname[CF_MAXVARSIZE];
 
     if (uname(&VSYSNAME) == -1)
     {

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2295,10 +2295,9 @@ static int Linux_Misc_Version(EvalContext *ctx)
 {
     char flavor[CF_MAXVARSIZE];
     char version[CF_MAXVARSIZE];
-    char os[CF_MAXVARSIZE];
     char buffer[CF_BUFSIZE];
 
-    *os = '\0';
+    const char *os = NULL;
     *version = '\0';
 
     FILE *fp = safe_fopen(LSB_RELEASE_FILENAME, "r");
@@ -2318,7 +2317,7 @@ static int Linux_Misc_Version(EvalContext *ctx)
             if (strstr(buffer, "Cumulus"))
             {
                 EvalContextClassPutHard(ctx, "cumulus", "inventory,attribute_name=none,source=agent");
-                strcpy(os, "cumulus");
+                os = "cumulus";
             }
 
             char *sp = strstr(buffer, "DISTRIB_RELEASE=");
@@ -2333,7 +2332,7 @@ static int Linux_Misc_Version(EvalContext *ctx)
     fclose(fp);
     }
 
-    if (*os && *version)
+    if (os != NULL && *version)
     {
         snprintf(flavor, CF_MAXVARSIZE, "%s_%s", os, version);
         SetFlavor(ctx, flavor);

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2294,11 +2294,11 @@ static void LinuxDebianSanitizeIssue(char *buffer)
 static int Linux_Misc_Version(EvalContext *ctx)
 {
     char flavor[CF_MAXVARSIZE];
-    char version[CF_MAXVARSIZE];
+    char version[256];
     char buffer[CF_BUFSIZE];
 
     const char *os = NULL;
-    *version = '\0';
+    version[0] = '\0';
 
     FILE *fp = safe_fopen(LSB_RELEASE_FILENAME, "r");
     if (fp != NULL)
@@ -2329,10 +2329,10 @@ static int Linux_Misc_Version(EvalContext *ctx)
                 CanonifyNameInPlace(version);
             }
         }
-    fclose(fp);
+        fclose(fp);
     }
 
-    if (os != NULL && *version)
+    if (os != NULL && version[0] != '\0')
     {
         snprintf(flavor, CF_MAXVARSIZE, "%s_%s", os, version);
         SetFlavor(ctx, flavor);
@@ -2349,7 +2349,8 @@ static int Linux_Debian_Version(EvalContext *ctx)
     int major = -1;
     int release = -1;
     int result;
-    char classname[CF_MAXVARSIZE], buffer[CF_MAXVARSIZE], os[CF_MAXVARSIZE], version[CF_MAXVARSIZE];
+    char classname[CF_MAXVARSIZE], buffer[CF_MAXVARSIZE], os[CF_MAXVARSIZE];
+    char version[256]; // Size must agree with sscanfs below
 
     Log(LOG_LEVEL_VERBOSE, "This appears to be a debian system.");
     EvalContextClassPutHard(
@@ -2426,9 +2427,8 @@ static int Linux_Debian_Version(EvalContext *ctx)
     else if (strcmp(os, "Ubuntu") == 0)
     {
         LinuxDebianSanitizeIssue(buffer);
-        char minor[CF_MAXVARSIZE] = {0};
+        char minor[256] = {0};
         assert((sizeof(version)) > 255); // TODO: static_assert()
-        assert((sizeof(minor)) > 255);   // TODO: static_assert()
         sscanf(buffer, "%*s %255[^.].%255s", version, minor);
         snprintf(buffer, CF_MAXVARSIZE, "ubuntu_%s", version);
         SetFlavor(ctx, buffer);
@@ -2655,11 +2655,10 @@ static int EOS_Version(EvalContext *ctx)
     {
         if (strstr(buffer, "EOS"))
         {
-            char version[CF_MAXVARSIZE], class[CF_MAXVARSIZE];
+            char version[256], class[CF_MAXVARSIZE];
             EvalContextClassPutHard(ctx, "eos", "inventory,attribute_name=none,source=agent");
             EvalContextClassPutHard(ctx, "arista", "source=agent");
             version[0] = '\0';
-            assert((sizeof(version)) > 255); // TODO: static_assert()
             sscanf(buffer, "%*s %*s %*s %255s", version);
             CanonifyNameInPlace(version);
             snprintf(class, CF_MAXVARSIZE, "eos_%s", version);
@@ -2682,10 +2681,8 @@ static int MiscOS(EvalContext *ctx)
     {
        if (strstr(buffer, "BIG-IP"))
        {
-           char version[CF_MAXVARSIZE], build[CF_MAXVARSIZE], class[CF_MAXVARSIZE];
+           char version[256], build[256], class[CF_MAXVARSIZE];
            EvalContextClassPutHard(ctx, "big_ip", "inventory,attribute_name=none,source=agent");
-           assert((sizeof(version)) > 255); // TODO: static_assert()
-           assert((sizeof(build)) > 255);   // TODO: static_assert()
            sscanf(buffer, "%*s %255s %*s %255s", version, build);
            CanonifyNameInPlace(version);
            CanonifyNameInPlace(build);
@@ -2704,7 +2701,7 @@ static int MiscOS(EvalContext *ctx)
 
 static int VM_Version(EvalContext *ctx)
 {
-    char *sp, buffer[CF_BUFSIZE], classbuf[CF_BUFSIZE], version[CF_BUFSIZE];
+    char *sp, buffer[CF_BUFSIZE], classbuf[CF_BUFSIZE], version[256];
     int major, minor, bug;
     int sufficient = 0;
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -514,7 +514,7 @@ static Rlist *GetHostsFromLastseenDB(Item *addresses, time_t horizon, bool retur
     Item *ip;
     time_t now = time(NULL);
     double entrytime;
-    char address[CF_MAXVARSIZE];
+    char address[CF_MAXVARSIZE]; // TODO: Could this be 1025 / NI_MAXHOST ?
 
     for (ip = addresses; ip != NULL; ip = ip->next)
     {
@@ -526,19 +526,19 @@ static Rlist *GetHostsFromLastseenDB(Item *addresses, time_t horizon, bool retur
 
         if (return_address)
         {
-            snprintf(address, sizeof(address), "%s", ip->name);
+            StringCopy(ip->name, address, sizeof(address));
         }
         else
         {
             char hostname[NI_MAXHOST];
             if (IPString2Hostname(hostname, ip->name, sizeof(hostname)) != -1)
             {
-                snprintf(address, sizeof(address), "%s", hostname);
+                StringCopy(hostname, address, sizeof(address));
             }
             else
             {
                 /* Not numeric address was requested, but IP was unresolvable. */
-                snprintf(address, sizeof(address), "%s", ip->name);
+                StringCopy(ip->name, address, sizeof(address));
             }
         }
 

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -87,7 +87,7 @@ void LastSaw1(const char *ipaddress, const char *hashstr,
     UpdateLastSawHost(hashstr, mapip, role == LAST_SEEN_ROLE_ACCEPT, time(NULL));
 }
 
-void LastSaw(const char *ipaddress, const char *digest, LastSeenRole role)
+void LastSaw(const char *ipaddress, const unsigned char *digest, LastSeenRole role)
 {
     char databuf[CF_HOSTKEY_STRING_SIZE];
 

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -43,7 +43,7 @@ typedef enum
 bool Address2Hostkey(char *dst, size_t dst_size, const char *address);
 
 void LastSaw1(const char *ipaddress, const char *hashstr, LastSeenRole role);
-void LastSaw(const char *ipaddress, const char *digest, LastSeenRole role);
+void LastSaw(const char *ipaddress, const unsigned char *digest, LastSeenRole role);
 
 bool DeleteIpFromLastSeen(const char *ip, char *digest, size_t digest_size);
 bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size);

--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -15,8 +15,7 @@ function check_with_clang() {
   rm -f config.cache
   make clean
   ./configure -C --enable-debug CC=clang
-  # no-pointer-sign => CFE-3389
-  make -j -l${n_procs} --keep-going CFLAGS="-Wno-pointer-sign -Werror"
+  make -j -l${n_procs} --keep-going CFLAGS="-Werror"
 }
 
 function check_with_cppcheck() {

--- a/travis-scripts/script.sh
+++ b/travis-scripts/script.sh
@@ -28,7 +28,7 @@ if [ "$TRAVIS_OS_NAME" = osx ]
 then
     ./autogen.sh --enable-debug --with-openssl="$(brew --prefix openssl)" --prefix=$INSTDIR --bindir=$INSTDIR/var/cfengine/bin
     gmake --version
-    gmake CFLAGS="-Werror -Wall -Wno-pointer-sign"
+    gmake CFLAGS="-Werror -Wall"
     # Tests are disabled on OS X, because they started hanging in travis,
     # for no apparent reason.
     # gmake --debug -C tests/unit check
@@ -46,16 +46,16 @@ export DIST_TARBALL
 
 if [ "$JOB_TYPE" = compile_only ]
 then
-    make CFLAGS="-Werror -Wno-pointer-sign" -k
+    make CFLAGS="-Werror" -k
 elif [ "$JOB_TYPE" = compile_and_unit_test ]
 then
-    make CFLAGS="-Wall -Wextra -Werror -Wno-pointer-sign -Wno-sign-compare"
+    make CFLAGS="-Wall -Wextra -Werror -Wno-sign-compare"
     make -C tests/unit check
     make -C tests/load check
     exit
 elif [ "$JOB_TYPE" = compile_and_unit_test_asan ]
 then
-    make CFLAGS="-Werror -Wall -Wno-pointer-sign -fsanitize=address" LDFLAGS="-fsanitize=address"
+    make CFLAGS="-Werror -Wall -fsanitize=address" LDFLAGS="-fsanitize=address"
     make -C tests/unit CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address" check
     make -C tests/load CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address" check
     exit


### PR DESCRIPTION
All of the pointer sign ones are fixed. Some format truncation remaining, but they are not trivial.