### PR TITLE
Allow spaces inside square brackets in class expressions

### DIFF
--- a/libpromises/string_expressions.c
+++ b/libpromises/string_expressions.c
@@ -135,8 +135,10 @@ static StringParseResult ParseVarRef(const char *expr, int start, int end)
 
 /* <token> */
 
-static bool ValidTokenCharacter(char c)
+static inline bool ValidTokenCharacter(char c, bool *inside_index)
 {
+    assert(inside_index != NULL);
+
     if (c >= 'a' && c <= 'z')
     {
         return true;
@@ -152,7 +154,27 @@ static bool ValidTokenCharacter(char c)
         return true;
     }
 
-    if (c == '_' || c == '[' || c == ']' || c == ':')
+    if (c == '_' || c == ':')
+    {
+        return true;
+    }
+
+    if (c == '[')
+    {
+        *inside_index = true;
+        return true;
+    }
+
+    if (c == ']')
+    {
+        if (*inside_index)
+        {
+            *inside_index = false;
+        }
+        return true;
+    }
+
+    if ((c == ' ') && *inside_index)
     {
         return true;
     }
@@ -164,7 +186,8 @@ static StringParseResult ParseToken(const char *expr, int start, int end)
 {
     int endlit = start;
 
-    while (endlit < end && ValidTokenCharacter(expr[endlit]))
+    bool inside_index = false;
+    while (endlit < end && ValidTokenCharacter(expr[endlit], &inside_index))
     {
         endlit++;
     }

--- a/tests/acceptance/00_basics/01_compiler/no_error_when_key_contains_space.cf
+++ b/tests/acceptance/00_basics/01_compiler/no_error_when_key_contains_space.cf
@@ -26,8 +26,8 @@ bundle agent test
       }';
 
       "selected"
-        string => "$(d[thing s][ExpectedPick][Title])",
-        if => "$(d[thing s][ExpectedPick][classexpr])";
+        string => "$(d[thing s][0][Title])",
+        if => "$(d[thing s][0][classexpr])";
       # Note: wrapping with concat or classify prevents the error
       #        if => concat("$(d[thing s][$(di)][classexpr])");
       #        if => classify("$(d[thing s][$(di)][classexpr])");


### PR DESCRIPTION
Ticket: CFE-3320
Changelog: Spaces inside square brackets (slist/data index) are now allowed in class expressions