### PR TITLE
CFE-3409: Limited unqualified host and domain name to 511 characters

### DIFF
--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -44,9 +44,9 @@ extern struct utsname VSYSNAME;
 extern char VIPADDRESS[CF_MAX_IP_LEN];
 extern char VPREFIX[1024];
 
-extern char VDOMAIN[CF_MAXVARSIZE];
-extern char VFQNAME[];
-extern char VUQNAME[];
+extern char VFQNAME[CF_MAXVARSIZE];
+extern char VDOMAIN[CF_MAXVARSIZE / 2];
+extern char VUQNAME[CF_MAXVARSIZE / 2];
 
 typedef enum EvalMode {
     EVAL_MODE_NORMAL = 0,                 /* needs to be 'false' to work for DONTDO below */

--- a/libpromises/cf3globals.c
+++ b/libpromises/cf3globals.c
@@ -56,9 +56,14 @@ long LASTSEENEXPIREAFTER = SECONDS_PER_WEEK; /* GLOBAL_P */
 EvalMode EVAL_MODE = EVAL_MODE_NORMAL;
 
 /* NB! Check use before changing sizes */
-char VFQNAME[CF_MAXVARSIZE] = ""; /* GLOBAL_E GLOBAL_P */
-char VUQNAME[CF_MAXVARSIZE] = ""; /* GLOBAL_E */
-char VDOMAIN[CF_MAXVARSIZE] = ""; /* GLOBAL_E GLOBAL_P */
+// Note: These were previously all CF_MAXVARSIZE = 1024 size
+// However, to avoid problematic truncation, we changed the last 2 to 512,
+// thus they will fit into VFQNAME ("%s.%s").
+// This RFC indicates that DNS only supports up to 255 bytes, anyway:
+// https://tools.ietf.org/html/rfc2181#section-11
+char VFQNAME[CF_MAXVARSIZE] = "";     /* GLOBAL_E GLOBAL_P */
+char VUQNAME[CF_MAXVARSIZE / 2] = ""; /* GLOBAL_E */
+char VDOMAIN[CF_MAXVARSIZE / 2] = ""; /* GLOBAL_E GLOBAL_P */
 
 /*
   Default value for copytype attribute. Loaded by cf-agent from body control

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -936,7 +936,11 @@ static void ResolveControlBody(EvalContext *ctx, GenericAgentConfig *config,
 
             EvalContextVariableRemoveSpecial(ctx, SPECIAL_SCOPE_SYS, "domain");
             EvalContextVariableRemoveSpecial(ctx, SPECIAL_SCOPE_SYS, "fqhost");
-            snprintf(VFQNAME, CF_MAXVARSIZE, "%s.%s", VUQNAME, VDOMAIN);
+
+            // We don't expect hostname or domain name longer than 255,
+            // warnings are printed in sysinfo.c.
+            // Here we support up to 511 bytes, just in case, because we can:
+            snprintf(VFQNAME, CF_MAXVARSIZE, "%511s.%511s", VUQNAME, VDOMAIN);
             EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "fqhost",
                                           VFQNAME, CF_DATA_TYPE_STRING,
                                           "inventory,source=agent,attribute_name=Host name");

--- a/libpromises/verify_classes.c
+++ b/libpromises/verify_classes.c
@@ -156,9 +156,9 @@ static bool SelectClass(EvalContext *ctx, const Rlist *list, const Promise *pp)
 
     assert(list);
 
-    char splay[CF_MAXVARSIZE];
-    snprintf(splay, CF_MAXVARSIZE, "%s+%s+%ju",
-             VFQNAME, VIPADDRESS, (uintmax_t)getuid());
+    // Max:    (strlen of VFQNAME)   (strlen of VIPADDRESS)   (strlen of max 64 bit integer    )   '++\0'
+    char splay[sizeof(VFQNAME) - 1 + sizeof(VIPADDRESS) - 1 + sizeof("18446744073709551615") - 1 + 2 + 1];
+    snprintf(splay, sizeof(splay), "%s+%s+%ju", VFQNAME, VIPADDRESS, (uintmax_t)getuid());
     unsigned int hash = StringHash(splay, 0);
     int n = hash % count;
 

--- a/tests/static-check/cppcheck_suppressions.txt
+++ b/tests/static-check/cppcheck_suppressions.txt
@@ -2,7 +2,7 @@
 objectIndex:libntech/libutils/platform.h
 
 // cppcheck is not clever enough to see that if (i >= PLATFORM_CONTEXT_MAX) then 'found' is false
-arrayIndexOutOfBounds:libenv/sysinfo.c:563
+arrayIndexOutOfBounds:libenv/sysinfo.c:585
 
 // 'psin' is assigned to 'ai->ai_addr' and 'ai' is returned to the caller
 memleak:libntech/libcompat/getaddrinfo.c:153

--- a/tests/unit/set_domainname_test.c
+++ b/tests/unit/set_domainname_test.c
@@ -10,8 +10,8 @@
 /* Global variables we care about */
 
 char VFQNAME[CF_MAXVARSIZE];
-char VUQNAME[CF_MAXVARSIZE];
-char VDOMAIN[CF_MAXVARSIZE];
+char VUQNAME[CF_MAXVARSIZE / 2];
+char VDOMAIN[CF_MAXVARSIZE / 2];
 
 static struct hostent h = {
     .h_name = "laptop.intra.cfengine.com"


### PR DESCRIPTION
This is to make the truncation behavior consistent, since
fqhost is maximum 1023 characters. Thus, domain or host name
may in rare cases be truncated on their own, but fqhost will
never be truncated (compared to uqhost and domain).

Also introduced warning messages if you use host names or
domain names which are longer than 255 characters. The limit
for fqhost in DNS is 255 characters:
https://tools.ietf.org/html/rfc2181#section-11