### PR TITLE
[3.12.x] Allow spaces inside square brackets in class expressions

### DIFF
--- a/libpromises/string_expressions.c
+++ b/libpromises/string_expressions.c
@@ -135,8 +135,10 @@ static StringParseResult ParseVarRef(const char *expr, int start, int end)
 
 /* <token> */
 
-static bool ValidTokenCharacter(char c)
+static inline bool ValidTokenCharacter(char c, bool *inside_index)
 {
+    assert(inside_index != NULL);
+
     if (c >= 'a' && c <= 'z')
     {
         return true;
@@ -152,7 +154,27 @@ static bool ValidTokenCharacter(char c)
         return true;
     }
 
-    if (c == '_' || c == '[' || c == ']' || c == ':')
+    if (c == '_' || c == ':')
+    {
+        return true;
+    }
+
+    if (c == '[')
+    {
+        *inside_index = true;
+        return true;
+    }
+
+    if (c == ']')
+    {
+        if (*inside_index)
+        {
+            *inside_index = false;
+        }
+        return true;
+    }
+
+    if ((c == ' ') && *inside_index)
     {
         return true;
     }
@@ -164,7 +186,8 @@ static StringParseResult ParseToken(const char *expr, int start, int end)
 {
     int endlit = start;
 
-    while (endlit < end && ValidTokenCharacter(expr[endlit]))
+    bool inside_index = false;
+    while (endlit < end && ValidTokenCharacter(expr[endlit], &inside_index))
     {
         endlit++;
     }

--- a/tests/acceptance/00_basics/01_compiler/no_error_when_key_contains_space.cf
+++ b/tests/acceptance/00_basics/01_compiler/no_error_when_key_contains_space.cf
@@ -1,0 +1,61 @@
+# This test should be renamed from .x.cf to .cf when the bug is fixed.
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-3320" }
+      string => "Test that data container keys can contain spaces";
+
+  vars:
+      "d" data => '{
+  "thing s": [
+    {
+      "Title": "ExpectedPick",
+      "classexpr": "$(sys.class)"
+    }
+  ]
+      }';
+
+      "selected"
+        string => "$(d[thing s][0][Title])",
+        if => "$(d[thing s][0][classexpr])";
+      # Note: wrapping with concat or classify prevents the error
+      #        if => concat("$(d[thing s][$(di)][classexpr])");
+      #        if => classify("$(d[thing s][$(di)][classexpr])");
+
+      "sanity_check"
+        string => "You are sane",
+        if => "$(sys.class)";
+
+  reports:
+    EXTRA|DEBUG::
+      "See iteration/expansion: $(d[thing s][ExpectedPick][Title]) has classexpr $(d[thing s][ExpectedPick][classexpr])";
+      "See sanity_check: $(sanity_check) because $(sys.class) is a defined class";
+
+      "Picked: $(d[thing s][ExpectedPick][Title]) has classexpr $(d[thing s][ExpectedPick][classexpr])"
+        if => "$(d[thing s][ExpectedPick][classexpr])";
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "expected_selection" string => "ExpectedPick";
+
+  methods:
+      "Pass/Fail"
+        usebundle => dcs_check_strcmp($(expected_selection), $(test.selected),
+                                      $(this.promise_filename), "no");
+
+}
+


### PR DESCRIPTION
Ticket: CFE-3320
Changelog: Spaces inside square brackets (slist/data index) are now allowed in class expressions
(cherry picked from commit 53e21fdc713783dcc1690e5cbfbf54e9e2fb388e)