### PR TITLE
CFE-3410 Codecov: Disabled PR statuses

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -6,15 +6,7 @@ coverage:
   precision: 2
   round: down
   range: 50..75
-
-  status:
-    project: yes
-    patch: yes
-    changes: yes
-
-# comment:
-#   layout: "header, diff, tree, changes, reach, footer"
-#   behavior: default
+  status: false
 
 comment: off
 


### PR DESCRIPTION
Since we have fluctuations in test coverage, codecov is
currently not useful, and in some cases creating extra noise in
PRs / diffs etc.

First attempt is to disable the status / PR interactions:
https://community.codecov.io/t/disable-all-intereactions-on-prs/1218/10

Then, we should still be able to go to codecov.io to see coverage info
but it won't create noise in PRs. If this doesn't work, I'll rip it all
out.