### PR TITLE
Only respect 'ifelapsed' if there is a previous promise evaluation

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -867,7 +867,7 @@ CfLock AcquireLock(EvalContext *ctx, const char *operand, const char *host,
 
     // For promises/locks with ifelapsed == 0, skip all detection logic of
     // previously acquired locks, whether in this agent or a parallel one.
-    if (ifelapsed != 0)
+    if ((ifelapsed != 0) && (lastcompleted != 0))
     {
         if (elapsedtime < 0)
         {


### PR DESCRIPTION
If the promise is being evaluated for the first time (no records
in the locks LMDB), it doesn't make sense to check 'ifelapsed'
for it.