### PR TITLE
CFE-3414 static-check: Added -Wall and -Wextra flags

### DIFF
--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -8,14 +8,15 @@ function check_with_gcc() {
   rm -f config.cache
   make clean
   ./configure -C --enable-debug CC=gcc
-  make -j -l${n_procs} --keep-going CFLAGS="-Werror"
+  local gcc_exceptions="-Wno-sign-compare -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-type-limits"
+  make -j -l${n_procs} --keep-going CFLAGS="-Werror -Wall -Wextra $gcc_exceptions"
 }
 
 function check_with_clang() {
   rm -f config.cache
   make clean
   ./configure -C --enable-debug CC=clang
-  make -j -l${n_procs} --keep-going CFLAGS="-Werror"
+  make -j -l${n_procs} --keep-going CFLAGS="-Werror -Wall -Wextra -Wno-sign-compare"
 }
 
 function check_with_cppcheck() {


### PR DESCRIPTION
Not too many exceptions were necessary, and we can work on
getting rid of those over time.