### PR TITLE
CFE-3424 cf-remote: Added new command to list available packages

### DIFF
--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -122,7 +122,7 @@ def install(
     return errors
 
 
-def packages(tags=None, version=None, edition=None):
+def download(tags=None, version=None, edition=None):
     releases = Releases(edition)
     print("Available releases: {}".format(releases))
 

--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -121,8 +121,7 @@ def install(
                 format(strip_user(hub)))
     return errors
 
-
-def download(tags=None, version=None, edition=None):
+def _iterate_over_packages(tags=None, version=None, edition=None, download=False):
     releases = Releases(edition)
     print("Available releases: {}".format(releases))
 
@@ -136,8 +135,18 @@ def download(tags=None, version=None, edition=None):
         print("No suitable packages found")
     else:
         for artifact in artifacts:
-            download_package(artifact.url)
+            if download:
+                download_package(artifact.url)
+            else:
+                print(artifact.url)
     return 0
+
+# named list_command to not conflict with list()
+def list_command(tags=None, version=None, edition=None):
+    return _iterate_over_packages(tags, version, edition, False)
+
+def download(tags=None, version=None, edition=None):
+    return _iterate_over_packages(tags, version, edition, True)
 
 def spawn(platform, count, role, group_name, provider=Providers.AWS, region=None):
     if os.path.exists(CLOUD_CONFIG_FPATH):

--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -33,7 +33,8 @@ def get_args():
     sp.add_argument("--hosts", "-H", help="Which hosts to get info for", type=str, required=True)
 
     sp = subp.add_parser("install", help="Install CFEngine on the given hosts")
-    sp.add_argument("--edition", "-E", help="Enterprise or community packages", type=str)
+    sp.add_argument("--edition", "-E", choices=["community", "enterprise"],
+                    help="Enterprise or community packages", type=str)
     sp.add_argument("--package", help="Local path to package for transfer and install", type=str)
     sp.add_argument("--hub-package", help="Local path to package for --hub", type=str)
     sp.add_argument("--client-package", help="Local path to package for --clients", type=str)
@@ -51,15 +52,18 @@ def get_args():
     sp.add_argument("--hosts", "-H", help="Where to uninstall", type=str)
 
     sp = subp.add_parser("packages", help="Get info about available packages")
-    sp.add_argument("--edition", "-E", help="Enterprise or community packages", type=str)
+    sp.add_argument("--edition", "-E", choices=["community", "enterprise"],
+                    help="Enterprise or community packages", type=str)
     sp.add_argument("tags", metavar="TAG", nargs="*")
 
     sp = subp.add_parser("list", help="List CFEngine packages available for download")
-    sp.add_argument("--edition", "-E", help="Enterprise or community packages", type=str)
+    sp.add_argument("--edition", "-E", choices=["community", "enterprise"],
+                    help="Enterprise or community packages", type=str)
     sp.add_argument("tags", metavar="TAG", nargs="*")
 
     sp = subp.add_parser("download", help="Download CFEngine packages")
-    sp.add_argument("--edition", "-E", help="Enterprise or community packages", type=str)
+    sp.add_argument("--edition", "-E", choices=["community", "enterprise"],
+                    help="Enterprise or community packages", type=str)
     sp.add_argument("tags", metavar="TAG", nargs="*")
 
     sp = subp.add_parser("run", help="Run the command given as arguments on the given hosts")

--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -54,6 +54,10 @@ def get_args():
     sp.add_argument("--edition", "-E", help="Enterprise or community packages", type=str)
     sp.add_argument("tags", metavar="TAG", nargs="*")
 
+    sp = subp.add_parser("list", help="List CFEngine packages available for download")
+    sp.add_argument("--edition", "-E", help="Enterprise or community packages", type=str)
+    sp.add_argument("tags", metavar="TAG", nargs="*")
+
     sp = subp.add_parser("download", help="Download CFEngine packages")
     sp.add_argument("--edition", "-E", help="Enterprise or community packages", type=str)
     sp.add_argument("tags", metavar="TAG", nargs="*")
@@ -116,6 +120,8 @@ def run_command_with_args(command, args):
     elif command == "packages":
         log.warning("packages command is deprecated, please use the new command: download")
         return commands.download(tags=args.tags, version=args.version, edition=args.edition)
+    elif command == "list":
+        return commands.list_command(tags=args.tags, version=args.version, edition=args.edition)
     elif command == "download":
         return commands.download(tags=args.tags, version=args.version, edition=args.edition)
     elif command == "run":
@@ -146,7 +152,7 @@ def run_command_with_args(command, args):
 
 
 def validate_command(command, args):
-    if command in ["install", "packages", "download"]:
+    if command in ["install", "packages", "list", "download"]:
         if args.edition:
             args.edition = args.edition.lower()
             if args.edition == "core":
@@ -299,7 +305,7 @@ def validate_args(args):
         print_version_info()
         exit_success()
 
-    if args.version and args.command not in ["install", "packages", "download"]:
+    if args.version and args.command not in ["install", "packages", "list", "download"]:
         user_error("Cannot specify version number in '{}' command".format(args.command))
 
     if "hosts" in args and args.hosts:

--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -54,6 +54,10 @@ def get_args():
     sp.add_argument("--edition", "-E", help="Enterprise or community packages", type=str)
     sp.add_argument("tags", metavar="TAG", nargs="*")
 
+    sp = subp.add_parser("download", help="Download CFEngine packages")
+    sp.add_argument("--edition", "-E", help="Enterprise or community packages", type=str)
+    sp.add_argument("tags", metavar="TAG", nargs="*")
+
     sp = subp.add_parser("run", help="Run the command given as arguments on the given hosts")
     sp.add_argument("--hosts", "-H", help="Which hosts to run the command on", type=str, required=True)
     sp.add_argument("--raw", help="Print only output of command itself", action='store_true')
@@ -110,7 +114,10 @@ def run_command_with_args(command, args):
         all_hosts = ((args.hosts or []) + (args.hub or []) + (args.clients or []))
         return commands.uninstall(all_hosts)
     elif command == "packages":
-        return commands.packages(tags=args.tags, version=args.version, edition=args.edition)
+        log.warning("packages command is deprecated, please use the new command: download")
+        return commands.download(tags=args.tags, version=args.version, edition=args.edition)
+    elif command == "download":
+        return commands.download(tags=args.tags, version=args.version, edition=args.edition)
     elif command == "run":
         return commands.run(hosts=args.hosts, raw=args.raw, command=args.remote_command)
     elif command == "sudo":
@@ -139,7 +146,7 @@ def run_command_with_args(command, args):
 
 
 def validate_command(command, args):
-    if command in ["install", "packages"]:
+    if command in ["install", "packages", "download"]:
         if args.edition:
             args.edition = args.edition.lower()
             if args.edition == "core":
@@ -292,7 +299,7 @@ def validate_args(args):
         print_version_info()
         exit_success()
 
-    if args.version and args.command not in ["install", "packages"]:
+    if args.version and args.command not in ["install", "packages", "download"]:
         user_error("Cannot specify version number in '{}' command".format(args.command))
 
     if "hosts" in args and args.hosts:


### PR DESCRIPTION
Demo:

```
olehermanse@OHMBP core $ cf-remote list deb
Available releases: 3.16.0, 3.15.x, 3.15.2, 3.15.1, 3.15.0, 3.15.0b1, 3.12.x, 3.12.5, 3.12.4, 3.12.3, 3.12.2, 3.12.1, 3.12.0
Using 3.15.2 LTS (default):
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/debian_7_x86_64/cfengine-nova-hub_3.15.2-1.debian7_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/debian_8_x86_64/cfengine-nova-hub_3.15.2-1.debian8_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/debian_9_x86_64/cfengine-nova-hub_3.15.2-1.debian9_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/debian_10_x86_64/cfengine-nova-hub_3.15.2-1.debian10_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/ubuntu_14_x86_64/cfengine-nova-hub_3.15.2-1.ubuntu14_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/ubuntu_16_x86_64/cfengine-nova-hub_3.15.2-1.ubuntu16_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/ubuntu_18_x86_64/cfengine-nova-hub_3.15.2-1.ubuntu18_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/agent/agent_deb_i386/cfengine-nova_3.15.2-1.debian7_i386.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/agent/agent_deb_x86_64/cfengine-nova_3.15.2-1.debian7_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/agent/agent_debian8_x86_64/cfengine-nova_3.15.2-1.debian8_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/agent/agent_debian9_x86_64/cfengine-nova_3.15.2-1.debian9_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/agent/agent_debian10_x86_64/cfengine-nova_3.15.2-1.debian10_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/agent/agent_ubuntu14_x86_64/cfengine-nova_3.15.2-1.ubuntu14_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/agent/agent_ubuntu16_x86_64/cfengine-nova_3.15.2-1.ubuntu16_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/agent/agent_ubuntu18_x86_64/cfengine-nova_3.15.2-1.ubuntu18_amd64.deb
olehermanse@OHMBP core $ cf-remote list hub
Available releases: 3.16.0, 3.15.x, 3.15.2, 3.15.1, 3.15.0, 3.15.0b1, 3.12.x, 3.12.5, 3.12.4, 3.12.3, 3.12.2, 3.12.1, 3.12.0
Using 3.15.2 LTS (default):
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/debian_7_x86_64/cfengine-nova-hub_3.15.2-1.debian7_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/debian_8_x86_64/cfengine-nova-hub_3.15.2-1.debian8_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/debian_9_x86_64/cfengine-nova-hub_3.15.2-1.debian9_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/debian_10_x86_64/cfengine-nova-hub_3.15.2-1.debian10_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/redhat_6_x86_64/cfengine-nova-hub-3.15.2-1.el6.x86_64.rpm
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/redhat_7_x86_64/cfengine-nova-hub-3.15.2-1.el7.x86_64.rpm
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/ubuntu_14_x86_64/cfengine-nova-hub_3.15.2-1.ubuntu14_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/ubuntu_16_x86_64/cfengine-nova-hub_3.15.2-1.ubuntu16_amd64.deb
https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.2/hub/ubuntu_18_x86_64/cfengine-nova-hub_3.15.2-1.ubuntu18_amd64.deb
```