### PR TITLE
Added debug message for promises skipped because of class guards

### DIFF
--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -257,8 +257,16 @@ static PromiseResult ExpandPromiseAndDo(EvalContext *ctx, PromiseIterator *iterc
 PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
                             PromiseActuator *act_on_promise, void *param)
 {
+    assert(pp != NULL);
+
     if (!IsDefinedClass(ctx, pp->classes))
     {
+        Log(LOG_LEVEL_DEBUG,
+            "Skipping %s promise expansion with promiser '%s' due to class guard '%s::' (pass %d)",
+            pp->parent_section->promise_type,
+            pp->promiser,
+            pp->classes,
+            EvalContextGetPass(ctx));
         return PROMISE_RESULT_SKIPPED;
     }
 

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -204,8 +204,8 @@ static void AppendExpandedBodies(EvalContext *ctx, Promise *pcopy,
  */
 Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
 {
-    Log(LOG_LEVEL_DEBUG, "DeRefCopyPromise(): "
-        "promiser:'%s'",
+    Log(LOG_LEVEL_DEBUG,
+        "DeRefCopyPromise(): promiser:'%s'",
         SAFENULL(pp->promiser));
 
     Promise *pcopy = xcalloc(1, sizeof(Promise));


### PR DESCRIPTION
Makes it a lot more clear to debug evaluation.

**Test policy:**

```
bundle agent __main__
{
  vars:
    (windows)::
      "A" string => "a";
    (windows.ubuntu)::
      "B" string => "b";
}
```

**Output:**

```
verbose: V: BEGIN variables (pass 1)
  debug: Skipping vars promise expansion with promiser 'A' due to class guard '(windows)::' (pass 1)
  debug: Skipping vars promise expansion with promiser 'B' due to class guard '(windows.ubuntu)::' (pass 1)
verbose: V: .........................................................
verbose: V: BEGIN variables (pass 2)
  debug: Skipping vars promise expansion with promiser 'A' due to class guard '(windows)::' (pass 2)
  debug: Skipping vars promise expansion with promiser 'B' due to class guard '(windows.ubuntu)::' (pass 2)
verbose: V: .........................................................
verbose: V: BEGIN variables (pass 3)
  debug: Skipping vars promise expansion with promiser 'A' due to class guard '(windows)::' (pass 3)
  debug: Skipping vars promise expansion with promiser 'B' due to class guard '(windows.ubuntu)::' (pass 3)
verbose: A: ...................................................
verbose: A: Bundle Accounting Summary for 'main' in namespace default
verbose: A: Zero promises executed for bundle 'main'
```

The biggest concern here is whether this will cause too many log messages.