### PR TITLE
Use a newer version of RHEL 8 in 'cf-remote spawn'

### DIFF
--- a/contrib/cf-remote/cf_remote/cloud_data.py
+++ b/contrib/cf-remote/cf_remote/cloud_data.py
@@ -59,7 +59,7 @@ aws_platforms = {
         "xlsize": "t2.large"
     },
     "rhel-8-x64": {
-        "ami": "ami-04facb3ed127a2eb6",
+        "ami": "ami-08f4717d06813bf00",
         "size": "t3a.micro",
         "user": "ec2-user",
         "xlsize": "m3.xlarge"


### PR DESCRIPTION
It's RHEL 8.2 and it already has the updated SELinux policy that
we require.

Ticket: ENT-6103
Changelog: None