### PR TITLE
ENT-6200 Disable flaky test on whole Solaris and older suse, also - 3.15.x

### DIFF
--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/defaults.cf
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/timed/defaults.cf
@@ -30,9 +30,9 @@ bundle agent init
   meta:
       # Backgrounding doesn't work properly on Windows or with fakeroot.
       # In addition, RHEL4 seems to have some problem killing the test
-      # afterwards, and HP-UX and Solaris 9 and 10 are too slow for timing
-      # to be accurate.
-      "test_skip_needs_work" string => "windows|using_fakeroot|redhat_4|hpux|sunos_5_9|sunos_5_10";
+      # afterwards, and HP-UX and Solaris are too slow for timing
+      # to be accurate. Also, this test randomly fails on SUSE 11 and 12.
+      "test_skip_needs_work" string => "windows|using_fakeroot|redhat_4|hpux|sunos|suse_11|suse_12";
 
   methods:
     test_pass_1::


### PR DESCRIPTION
(cherry picked from commit a7fa95211ff4fdad0c735ab8d6c394d13e5132b5)


----

#