### PR TITLE
CFE-3453 cf-remote: packages can now be specified with URLs

### DIFF
--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -169,10 +169,9 @@ def validate_command(command, args):
     if command in ["uninstall"] and not (args.hosts or args.hub or args.clients):
         user_error("Use --hosts, --hub or --clients to specify remote hosts")
 
-    if command == "install" and (args.call_collect and not args.demo):
-        user_error("--call-collect must be used with --demo")
-
     if command == "install":
+        if args.call_collect and not args.demo:
+            user_error("--call-collect must be used with --demo")
         if not args.clients and not args.hub:
             user_error("Specify hosts using --hub and --clients")
         if args.hub and args.clients and args.package:
@@ -181,7 +180,15 @@ def validate_command(command, args):
         if args.package and (args.hub_package or args.client_package):
             user_error(
                 "--package cannot be used in combination with --hub-package / --client-package")
-            # TODO: Find this automatically
+        if args.package:
+            if not os.path.isfile(args.package):
+                user_error(f"Package '{args.package}' does not exist")
+        if args.hub_package:
+            if not os.path.isfile(args.hub_package):
+                user_error(f"Hub package '{args.hub_package}' does not exist")
+        if args.client_package:
+            if not os.path.isfile(args.client_package):
+                user_error(f"Client package '{args.client_package}' does not exist")
 
     if command in ["sudo", "run"]:
         if len(args.remote_command) != 1:

--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -5,7 +5,7 @@ import sys
 from cf_remote import log
 from cf_remote import commands, paths
 from cf_remote.utils import user_error, exit_success, expand_list_from_file, is_file_string
-from cf_remote.utils import strip_user, read_json
+from cf_remote.utils import strip_user, read_json, is_package_url
 from cf_remote.packages import Releases
 
 
@@ -180,13 +180,13 @@ def validate_command(command, args):
         if args.package and (args.hub_package or args.client_package):
             user_error(
                 "--package cannot be used in combination with --hub-package / --client-package")
-        if args.package:
+        if args.package and not is_package_url(args.package):
             if not os.path.isfile(args.package):
                 user_error(f"Package '{args.package}' does not exist")
-        if args.hub_package:
+        if args.hub_package and not is_package_url(args.hub_package):
             if not os.path.isfile(args.hub_package):
                 user_error(f"Hub package '{args.hub_package}' does not exist")
-        if args.client_package:
+        if args.client_package and not is_package_url(args.client_package):
             if not os.path.isfile(args.client_package):
                 user_error(f"Client package '{args.client_package}' does not exist")
 

--- a/contrib/cf-remote/cf_remote/utils.py
+++ b/contrib/cf-remote/cf_remote/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import re
 import json
 import getpass
 from collections import OrderedDict
@@ -72,6 +73,15 @@ def package_path():
 def above_package_path():
     path = package_path() + "/../"
     return os.path.abspath(path)
+
+
+def is_package_url(string):
+    return bool(re.match("https?://.+/.+\.(rpm|deb|msi)", string))
+
+
+def get_package_name(url):
+    assert(is_package_url(url))
+    return url.rsplit("/", 1)[-1]
 
 
 def read_json(path):

--- a/contrib/cf-remote/cf_remote/utils.py
+++ b/contrib/cf-remote/cf_remote/utils.py
@@ -98,7 +98,7 @@ def os_release(inp):
             continue
         key, sep, value = line.partition("=")
         assert "=" not in key
-        if (len(value) > 1 and value[0] == value[-1] and value[0] in ["'", '"']):
+        if len(value) > 1 and value[0] == value[-1] and value[0] in ["'", '"']:
             value = value[1:-1]
         d[key] = value
     return d
@@ -167,9 +167,9 @@ def expand_list_from_file(string):
 
 def strip_user(host):
     """Strips the 'user@' info from a host spec"""
-    idx = host.find('@')
+    idx = host.find("@")
     if idx != -1:
-        return host[(idx + 1):]
+        return host[(idx + 1) :]
     return host
 
 

--- a/contrib/cf-remote/cf_remote/web.py
+++ b/contrib/cf-remote/cf_remote/web.py
@@ -19,14 +19,15 @@ def get_json(url):
     return data
 
 
-def download_package(url):
-    filename = os.path.basename(url)
-    dir = cf_remote_packages_dir()
-    mkdir(dir)
-    location = os.path.join(dir, filename)
-    if os.path.exists(location):
-        print("Package already downloaded: '{}'".format(location))
-        return location
-    print("Downloading package: '{}'".format(location))
-    os.system("curl --silent -L '{}' -o '{}'".format(url, location))
-    return location
+def download_package(url, path=None):
+    if not path:
+        filename = os.path.basename(url)
+        directory = cf_remote_packages_dir()
+        mkdir(directory)
+        path = os.path.join(directory, filename)
+    if os.path.exists(path):
+        print("Package already downloaded: '{}'".format(path))
+        return path
+    print("Downloading package: '{}'".format(path))
+    os.system("curl --silent -L '{}' -o '{}'".format(url, path))
+    return path


### PR DESCRIPTION
For example:

```
$ cf-remote install --hub hub --bootstrap hub --package 'http://buildcache.cfengine.com/packages/testing-pr/jenkins-pr-pipeline-5735/PACKAGES_HUB_x86_64_linux_ubuntu_16/cfengine-nova-hub_3.17.0a.e29846823~11116.ubuntu16_amd64.deb' --demo
Downloading package: '/home/olehermanse/.cfengine/cf-remote/packages/url_specified/cfengine-nova-hub_3.17.0a.e29846823~11116.ubuntu16_amd64.deb'

ubuntu@18.202.174.100
OS            : ubuntu (debian)
Architecture  : x86_64
CFEngine      : Not installed
Policy server : None
Binaries      : dpkg, apt

Copying: '/home/olehermanse/.cfengine/cf-remote/packages/url_specified/cfengine-nova-hub_3.17.0a.e29846823~11116.ubuntu16_amd64.deb' to 'ubuntu@18.202.174.100'
Installing: 'cfengine-nova-hub_3.17.0a.e29846823~11116.ubuntu16_amd64.deb' on 'ubuntu@18.202.174.100'
CFEngine 3.17.0a.e29846823 (Enterprise) was successfully installed on 'ubuntu@18.202.174.100'
Bootstrapping: '18.202.174.100' -> '172.31.29.145'
Bootstrap successful: '18.202.174.100' -> '172.31.29.145'
Transferring def.json to hub: 'ubuntu@18.202.174.100'
Copying: '/home/olehermanse/.cfengine/cf-remote/json/def.json' to 'ubuntu@18.202.174.100'
Triggering an agent run on: '18.202.174.100'
Disabling password change on hub: 'ubuntu@18.202.174.100'
Triggering an agent run on: '18.202.174.100'
Your demo hub is ready: https://18.202.174.100/ (Username: admin, Password: password)
```