### PR TITLE
Add a function for getting IP address for hostkey from LMDB

### DIFF
--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -241,6 +241,37 @@ bool Address2Hostkey(char *dst, size_t dst_size, const char *address)
     return retval;
 }
 
+char *HostkeyToAddress(const char *hostkey)
+{
+    DBHandle *db;
+    if (OpenDB(&db, dbid_lastseen))
+    {
+        char hostkey_key[CF_HOSTKEY_STRING_SIZE + 1];
+        char address[CF_BUFSIZE];
+
+        /* Hostkey key: "k" + hostkey */
+        snprintf(hostkey_key, sizeof(hostkey_key), "k%s", hostkey);
+
+        if (ReadDB(db, hostkey_key, &address, sizeof(address)))
+        {
+            CloseDB(db);
+            Log(LOG_LEVEL_DEBUG, "Found hostkey '%s' in lastseen LMDB", hostkey);
+            return xstrdup(address);
+        }
+        else
+        {
+            CloseDB(db);
+            Log(LOG_LEVEL_VERBOSE, "Could not find hostkey '%s' in lastseen LMDB", hostkey);
+            return NULL;
+        }
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR, "Failed to open lastseen DB");
+        return NULL;
+    }
+}
+
 /**
  * @brief detects whether input is a host/ip name or a key digest
  *

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -41,6 +41,7 @@ typedef enum
 
 
 bool Address2Hostkey(char *dst, size_t dst_size, const char *address);
+char *HostkeyToAddress(const char *hostkey);
 
 void LastSaw1(const char *ipaddress, const char *hashstr, LastSeenRole role);
 void LastSaw(const char *ipaddress, const unsigned char *digest, LastSeenRole role);

--- a/tests/unit/lastseen_test.c
+++ b/tests/unit/lastseen_test.c
@@ -111,6 +111,16 @@ static void test_update(void)
     CloseDB(db);
 }
 
+static void test_HostkeyToAddress(void)
+{
+    setup();
+
+    UpdateLastSawHost("SHA-12345", "127.0.0.64", true, 555);
+    char *address = HostkeyToAddress("SHA-12345");
+    assert_string_equal(address, "127.0.0.64");
+    free(address);
+}
+
 static void test_reverse_missing(void)
 {
     setup();
@@ -584,6 +594,7 @@ int main()
         {
             unit_test(test_newentry),
             unit_test(test_update),
+            unit_test(test_HostkeyToAddress),
             unit_test(test_reverse_missing),
             unit_test(test_reverse_conflict),
             unit_test(test_reverse_missing_forward),


### PR DESCRIPTION
Logical counterpart to Adress2Hostkey.

Ticket: ENT-6181
Changelog: None