### PR TITLE
Install CFEngine to hosts in parallel

### DIFF
--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -135,6 +135,7 @@ def install(
 
     hub_jobs = []
     if hubs:
+        show_host_info = (len(hubs) == 1)
         if type(hubs) is str:
             hubs = [hubs]
         for index, hub in enumerate(hubs):
@@ -147,7 +148,8 @@ def install(
                 version=version,
                 demo=demo,
                 call_collect=call_collect,
-                edition=edition))
+                edition=edition,
+                show_info=show_host_info))
 
     errors = 0
     if hub_jobs:
@@ -156,6 +158,7 @@ def install(
         errors = sum(job.errors for job in hub_jobs)
 
     client_jobs = []
+    show_host_info = (clients and (len(clients) == 1))
     for index, host in enumerate(clients or []):
         log.debug("Installing {} client package on '{}'".format(edition, host))
         client_jobs.append(HostInstaller(
@@ -165,7 +168,8 @@ def install(
             bootstrap=bootstrap[index % len(bootstrap)] if bootstrap else None,
             version=version,
             demo=demo,
-            edition=edition))
+            edition=edition,
+            show_info=show_host_info))
 
     if client_jobs:
         with Pool(len(client_jobs)) as clients_install_pool:

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -287,6 +287,20 @@ def install_host(
     return 0
 
 
+class HostInstaller:
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+        self._errors = None
+
+    def run(self):
+        self._errors = install_host(*self._args, **self._kwargs)
+
+    @property
+    def errors(self):
+        return self._errors
+
+
 @auto_connect
 def uninstall_host(host, *, connection=None):
     data = get_info(host, connection=connection)

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -229,9 +229,12 @@ def install_host(
         demo=False,
         call_collect=False,
         connection=None,
-        edition=None):
+        edition=None,
+        show_info=True):
+
     data = get_info(host, connection=connection)
-    print_info(data)
+    if show_info:
+        print_info(data)
 
     if not package:
         tags = []


### PR DESCRIPTION
To speed things up.

Ticket: CFE-3003
Changelog: cf-remote now installs CFEngine to hosts in parallel