### PR TITLE
ENT-6383: Reverted log level change for old package promises

### DIFF
--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -195,7 +195,7 @@ PromiseResult VerifyPackagesPromise(EvalContext *ctx, const Promise *pp)
             break;
 
         case PACKAGE_PROMISE_TYPE_OLD:
-            Log(LOG_LEVEL_NOTICE,
+            Log(LOG_LEVEL_VERBOSE,
                 "Using old package promise. Please note that this old "
                 "implementation is being phased out. The old "
                 "implementation will continue to work, but forward development "


### PR DESCRIPTION
Changed here:

https://github.com/cfengine/core/commit/47223e7112243b183cb7a14aa8e0ecd2729720e6#diff-2c933bcbb521c8e7dae80f608cfd69e5a1657354a13c94874525de66cd1bdfe1R198

Causes failures in deployment tests.

Big thanks to @craigcomstock for the forensics.