### PR TITLE
CFE-3464: Added `--remote-download` argument to cf-remote

### DIFF
--- a/contrib/cf-remote/cf_remote/main.py
+++ b/contrib/cf-remote/cf_remote/main.py
@@ -35,9 +35,9 @@ def get_args():
     sp = subp.add_parser("install", help="Install CFEngine on the given hosts")
     sp.add_argument("--edition", "-E", choices=["community", "enterprise"],
                     help="Enterprise or community packages", type=str)
-    sp.add_argument("--package", help="Local path to package for transfer and install", type=str)
-    sp.add_argument("--hub-package", help="Local path to package for --hub", type=str)
-    sp.add_argument("--client-package", help="Local path to package for --clients", type=str)
+    sp.add_argument("--package", help="Local path to package or URL to download", type=str)
+    sp.add_argument("--hub-package", help="Local path to package or URL to download for --hub", type=str)
+    sp.add_argument("--client-package", help="Local path to package or URL to download for --clients", type=str)
     sp.add_argument("--bootstrap", "-B", help="cf-agent --bootstrap argument", type=str)
     sp.add_argument("--clients", "-c", help="Where to install client package", type=str)
     sp.add_argument("--hub", help="Where to install hub package", type=str)
@@ -45,6 +45,7 @@ def get_args():
         "--demo", help="Use defaults to make demos smoother (NOT secure)", action='store_true')
     sp.add_argument(
         "--call-collect", help="Enable call collect in --demo def.json", action='store_true')
+    sp.add_argument("--remote-download", help="Package will be downloaded directly to the target machine", action="store_true")
 
     sp = subp.add_parser("uninstall", help="Install CFEngine on the given hosts")
     sp.add_argument("--clients", "-c", help="Where to uninstall", type=str)
@@ -117,7 +118,8 @@ def run_command_with_args(command, args):
             version=args.version,
             demo=args.demo,
             call_collect=args.call_collect,
-            edition=args.edition)
+            edition=args.edition,
+            remote_download=args.remote_download)
     elif command == "uninstall":
         all_hosts = ((args.hosts or []) + (args.hub or []) + (args.clients or []))
         return commands.uninstall(all_hosts)

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -230,7 +230,8 @@ def install_host(
         call_collect=False,
         connection=None,
         edition=None,
-        show_info=True):
+        show_info=True,
+        remote_download=False):
 
     data = get_info(host, connection=connection)
     if show_info:
@@ -266,9 +267,15 @@ def install_host(
                     "hub" if hub else "client"))
             return 1
         artifact = artifacts[-1]
-        package = download_package(artifact.url)
+        if not remote_download:
+            package = download_package(artifact.url)
 
-    scp(package, host, connection=connection)
+    if remote_download:
+        print(f"Downloading '{package}' on '{host}' using curl")
+        ssh_cmd(cmd="curl -O {}".format(package), connection=connection)
+    else:
+        scp(package, host, connection=connection)
+
     package = basename(package)
     install_package(host, package, data, connection=connection)
     data = get_info(host, connection=connection)


### PR DESCRIPTION
Added `--remote-download` argument to the cf-remote that enables to download packages directly to the target machine with curl