### PR TITLE
Use Fedora 33 as the base image for static checks

### DIFF
--- a/tests/static-check/run.sh
+++ b/tests/static-check/run.sh
@@ -4,7 +4,7 @@ set -e
 trap "echo FAILURE" ERR
 
 set -x
-BASE_IMG="fedora:32"
+BASE_IMG="fedora:33"
 
 function create_image() {
   local c=$(buildah from -q $BASE_IMG)


### PR DESCRIPTION
Freshly released with newer versions of compilers and static
checkers.