### PR TITLE
CFE-3488 cf-remote: More clear failure when --remote-download encounters 404 and similar errors

### DIFF
--- a/contrib/cf-remote/cf_remote/commands.py
+++ b/contrib/cf-remote/cf_remote/commands.py
@@ -179,6 +179,11 @@ def install(
             hubs_install_pool.map(lambda job: job.run(), hub_jobs)
         errors = sum(job.errors for job in hub_jobs)
 
+    if errors > 0:
+        s = "s" if errors > 1 else ""
+        log.error(f"{errors} error{s} encountered while installing hub packages, aborting...")
+        return errors
+
     client_jobs = []
     show_host_info = (clients and (len(clients) == 1))
     for index, host in enumerate(clients or []):
@@ -204,6 +209,11 @@ def install(
             print(
                 "Your demo hub is ready: https://{}/ (Username: admin, Password: password)".
                 format(strip_user(hub)))
+
+    if errors > 0:
+        s = "s" if errors > 1 else ""
+        log.error(f"{errors} error{s} encountered while installing client packages")
+
     return errors
 
 def _iterate_over_packages(tags=None, version=None, edition=None, download=False):

--- a/contrib/cf-remote/cf_remote/remote.py
+++ b/contrib/cf-remote/cf_remote/remote.py
@@ -274,7 +274,9 @@ def install_host(
 
     if remote_download:
         print(f"Downloading '{package}' on '{host}' using curl")
-        ssh_cmd(cmd="curl -O {}".format(package), connection=connection)
+        r = ssh_cmd(cmd="curl --fail -O {}".format(package), connection=connection, errors=True)
+        if r is None:
+            return 1
     else:
         scp(package, host, connection=connection)
 


### PR DESCRIPTION
```
olehermanse@OH-WIN core $ cf-remote install --hub hub --bootstrap hub --demo --remote-download --package "https://example.com/blahblah.deb"

ubuntu@34.245.14.146
OS            : ubuntu (debian)
Architecture  : x86_64
CFEngine      : Not installed
Policy server : None
Binaries      : dpkg, apt

Downloading 'https://example.com/blahblah.deb' on 'ubuntu@34.245.14.146' using curl
Encountered a bad command exit code!

Command: 'curl --fail -O https://example.com/blahblah.deb'

Exit code: 22

Stdout:



Stderr:

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found


[ERROR] Non-sudo command unexpectedly exited: 'curl --fail -O https://example.com/blahblah.deb'
[ERROR] 1 error encountered while installing hub packages, aborting...
olehermanse@OH-WIN core $
```