### PR TITLE
ENT-6205 add ifelapsed locks test without abort

### DIFF
--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/locks.cf
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/locks.cf
@@ -1,0 +1,63 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  vars:
+      "first"
+        string =>
+          execresult("$(sys.cf_agent) -KIf $(this.promise_filename).sub -b example -Dfirst",
+                     "noshell"),
+        comment => "Ignore locks in this first run - it will still write the locks!";
+
+      "second"
+        string =>
+          execresult("$(sys.cf_agent) -If $(this.promise_filename).sub -b example -Dsecond",
+                     "noshell"),
+        comment => "Don't ignore locks here so for pass_only_first_test_second case";
+}
+
+bundle agent check
+{
+  vars:
+      "pass_strings" slist => { "test", "call_report_now", "only_first" };
+      "activations" slist => { "test.first", "test.second" };
+
+# we want to see all of those in either "test.first" or "test.second"
+      "pass_classes" slist => {
+                              "pass_test_test_first",
+                              "pass_call_report_now_test_first",
+                              "pass_test_test_second",
+                              "pass_call_report_now_test_second",
+                              "pass_only_first_test_first",
+                              };
+
+# we don't want to any of those in neither "test.first" nor "test.second"
+      "fail_classes" slist => {
+                              "pass_only_first_test_second"
+                              };
+
+  classes:
+      "pass_$(pass_strings)_$(activations)" expression => regcmp(".*R: Called from $(pass_strings).*",
+                                                                 "$($(activations))");
+
+      "ok_pass" and => { @(pass_classes) };
+      "fail_pass" or => { @(fail_classes) };
+
+      "ok" expression => "ok_pass.!fail_pass";
+
+  reports:
+    DEBUG.!ok::
+      "Failed activation $(activations): '$($(activations))'";
+    DEBUG::
+      "expected  : $(pass_classes)" if => not("$(pass_classes)");
+      "unexpected: $(fail_classes)" if => "$(fail_classes)";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/locks.cf.sub
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/locks.cf.sub
@@ -1,0 +1,52 @@
+# Test that locking works
+# Called twice from main.cf
+
+bundle agent example
+{
+  methods:
+      "test" usebundle => test, action => now;
+}
+
+bundle agent test
+{
+  vars:
+    first::                                                      
+       "count" string => "first";
+    second::
+       "count" string => "second";
+
+  methods:
+# should print "Called from test" for both runs
+      "Report"
+      usebundle => report_now($(this.bundle)),
+      action => now;
+
+# should print "Called from call_report_now" for both runs
+      "Nested Report"
+      usebundle => call_report_now,
+      action => now;
+
+# should print "Called from only_first" only for the first run
+      "Only first"
+      usebundle => report_now("only_first");
+}
+
+bundle agent call_report_now
+{
+  methods:
+      "Call Report"
+      usebundle => report_now($(this.bundle)),
+      action => now;
+}
+
+bundle agent report_now(caller)
+{
+  reports:
+      "Called from $(caller) ($(test.count))"
+      action => now;
+}
+
+body action now
+{
+    ifelapsed => "0";
+}


### PR DESCRIPTION
Goal is to merge this test and let it run in CI for a while (a week?) and hope that the new test fails on solaris sparc at some point, or that the test passes in a run where the original redmine test fails.