### PR TITLE
ENT-6519/master: Stopped updating files promise result with WARN (notkept) when setuid files are encountered

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -3764,7 +3764,6 @@ static PromiseResult VerifySetUidGid(EvalContext *ctx, const char *file, const s
                 if (amroot)
                 {
                     RecordWarning(ctx, pp, attr, "NEW SETUID root PROGRAM '%s'", file);
-                    result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
                 }
 
                 PrependItem(&VSETXIDLIST, file, NULL);

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -3763,7 +3763,7 @@ static PromiseResult VerifySetUidGid(EvalContext *ctx, const char *file, const s
             {
                 if (amroot)
                 {
-                    RecordWarning(ctx, pp, attr, "NEW SETUID root PROGRAM '%s'", file);
+                    Log(LOG_LEVEL_NOTICE, "NEW SETUID root PROGRAM '%s' ", file);
                 }
 
                 PrependItem(&VSETXIDLIST, file, NULL);


### PR DESCRIPTION

When cf-agent encounters SETUID files that are not present in the setuid log
file ( $(sys.workdir)/cfagent.$(sys.fqhost).log ) a WARNING is emitted. Until
now the promise result was also updated in a way making the promise seem to be
not kept. This change removes the updating of the promise result so that the
real promise outcome is un-altered. The warning will still be emitted and the
file will be added to the log if it is not already there.

Ticket: ENT-6519
Changelog: Title
