### PR TITLE
CFE-3510: Custom promise types can now be declared in separate files

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -89,8 +89,9 @@
 #include <sys/stat.h>                   /* checking umask on writing setxid log */
 #include <simulate_mode.h>              /* ManifestChangedFiles(), DiffChangedFiles() */
 
+#include <syntax.h>                     /* IsBuiltInPromiseType() */
 #include <mod_common.h>
-#include <mod_custom.h>                 /* IsCustomPromiseType() */
+#include <mod_custom.h>                 /* EvaluateCustomPromise() */
 
 #ifdef HAVE_AVAHI_CLIENT_CLIENT_H
 #ifdef HAVE_AVAHI_COMMON_ADDRESS_H
@@ -1737,6 +1738,8 @@ static void LogVariableValue(const EvalContext *ctx, const Promise *pp)
 static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_UNUSED void *param)
 {
     assert(param == NULL);
+    assert(pp != NULL);
+
     struct timespec start = BeginMeasure();
     PromiseResult result = PROMISE_RESULT_NOOP;
 
@@ -1852,7 +1855,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
     {
         result = VerifyReportPromise(ctx, pp);
     }
-    else if (IsCustomPromiseType(pp))
+    else if (!IsBuiltInPromiseType(pp->parent_section->promise_type))
     {
         result = EvaluateCustomPromise(ctx, pp);
     }

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -481,19 +481,19 @@ constraint_id:         IDENTIFIER                        /* BUNDLE ONLY */
                        {
                            ParserDebug("\tP:%s:%s:%s:%s:%s:%s attribute = %s\n", ParserBlockString(P.block), P.blocktype, P.blockid, P.currenttype, P.currentclasses ? P.currentclasses : "any", P.promiser, P.currentid);
 
-                           if (!PolicyHasCustomPromiseType(P.policy, P.currenttype))
+                           const PromiseTypeSyntax *promise_type_syntax = PromiseTypeSyntaxGet(P.blocktype, P.currenttype);
+                           if (promise_type_syntax == NULL)
                            {
-                               const PromiseTypeSyntax *promise_type_syntax = PromiseTypeSyntaxGet(P.blocktype, P.currenttype);
-                               if (!promise_type_syntax)
-                               {
-                                   ParseError("Invalid promise type '%s' in bundle '%s' of type '%s'", P.currenttype, P.blockid, P.blocktype);
-                                   INSTALL_SKIP = true;
-                               }
-                               else if (!PromiseTypeSyntaxGetConstraintSyntax(promise_type_syntax, P.currentid))
-                               {
-                                   ParseError("Unknown attribute '%s' for promise type '%s' in bundle with type '%s'", P.currentid, P.currenttype, P.blocktype);
-                                   INSTALL_SKIP = true;
-                               }
+                               // This promise type might be defined in another Policy object.
+                               // There is no way to distinguish a custom promise type
+                               // from a wrong (misspelled) promise type while parsing
+                               // since the Policy objects will be merged later.
+                           }
+                           else if (!PromiseTypeSyntaxGetConstraintSyntax(promise_type_syntax, P.currentid))
+                           {
+                               // Built in promise type with bad attribute
+                               ParseError("Unknown attribute '%s' for promise type '%s' in bundle with type '%s'", P.currentid, P.currenttype, P.blocktype);
+                               INSTALL_SKIP = true;
                            }
 
                            strncpy(P.lval,P.currentid,CF_MAXVARSIZE);

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -153,6 +153,10 @@ promisecomponent_values: typeid
 
 promiseid:             promiseid_values
                        {
+                          if (IsBuiltInPromiseType(P.blockid))
+                          {
+                             ParseError("'%s' promises are built in and cannot be custom", yytext);
+                          }
                           ParserDebug("\tP:promise:%s:%s\n", P.blocktype, P.blockid);
                           CURRENT_BLOCKID_LINE = P.line_no;
                        }

--- a/libpromises/cf3parse_logic.h
+++ b/libpromises/cf3parse_logic.h
@@ -660,6 +660,7 @@ static inline void ParserHandleBundlePromiseRval()
 
     if (PolicyHasCustomPromiseType(P.policy, P.currenttype))
     {
+        // Definitely custom promise type, just add the constraint and move on
         MagicRvalTransformations(NULL);
         ParserAppendCurrentConstraint();
         goto cleanup;
@@ -676,12 +677,10 @@ static inline void ParserHandleBundlePromiseRval()
 
     if (promise_type_syntax == NULL)
     {
-        ParseError(
-            "Invalid promise type '%s' in bundle '%s' of type '%s'",
-            P.currenttype,
-            P.blockid,
-            P.blocktype);
-        INSTALL_SKIP = true;
+        // Assume custom promise type, but defined in another policy file
+        MagicRvalTransformations(NULL);
+        ParserAppendCurrentConstraint();
+        goto cleanup;
     }
     else if (constraint_syntax == NULL)
     {
@@ -803,8 +802,10 @@ static inline void ParserHandlePromiseGuard()
             break;
         }
     }
-    else if (PolicyHasCustomPromiseType(P.policy, P.currenttype))
+    else
     {
+        // Unrecognized promise type, assume it is custom
+        // no way to know while parsing, let's check later:
         if (!INSTALL_SKIP)
         {
             P.currentstype =
@@ -816,11 +817,6 @@ static inline void ParserHandlePromiseGuard()
         {
             P.currentstype = NULL;
         }
-    }
-    else
-    {
-        ParseError("Unknown promise type '%s'", P.currenttype);
-        INSTALL_SKIP = true;
     }
 }
 

--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -43,17 +43,7 @@ static const ConstraintSyntax promise_constraints[] = {
 const BodySyntax CUSTOM_PROMISE_BLOCK_SYNTAX =
     BodySyntaxNew("promise", promise_constraints, NULL, SYNTAX_STATUS_NORMAL);
 
-bool IsCustomPromiseType(const Promise *pp)
-{
-    assert(pp != NULL);
-
-    Policy *policy = pp->parent_section->parent_bundle->parent_policy;
-
-    return PolicyHasCustomPromiseType(
-        policy, pp->parent_section->promise_type);
-}
-
-static Body *FindCustomPromiseType(const Promise *promise)
+Body *FindCustomPromiseType(const Promise *promise)
 {
     assert(promise != NULL);
 
@@ -821,6 +811,14 @@ PromiseResult EvaluateCustomPromise(EvalContext *ctx, const Promise *pp)
     assert(pp != NULL);
 
     Body *promise_block = FindCustomPromiseType(pp);
+    if (promise_block == NULL)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Undefined promise type '%s'",
+            pp->parent_section->promise_type);
+        return PROMISE_RESULT_FAIL;
+    }
+
     char *interpreter = NULL;
     char *path = NULL;
 

--- a/libpromises/mod_custom.h
+++ b/libpromises/mod_custom.h
@@ -50,7 +50,7 @@ typedef struct PromiseModule
     JsonElement *message;
 } PromiseModule;
 
-bool IsCustomPromiseType(const Promise *pp);
+Body *FindCustomPromiseType(const Promise *promise);
 PromiseResult EvaluateCustomPromise(ARG_UNUSED EvalContext *ctx, const Promise *pp);
 
 #endif

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -73,6 +73,26 @@ static const PromiseTypeSyntax *PromiseTypeSyntaxGetStrict(const char *bundle_ty
     return NULL;
 }
 
+bool IsBuiltInPromiseType(const char *const promise_type)
+{
+    // Any built in promise type, regardless of bundle (agent) type
+    assert(promise_type != NULL);
+
+    for (int module_index = 0; module_index < CF3_MODULES; module_index++)
+    {
+        const PromiseTypeSyntax *const module = CF_ALL_PROMISE_TYPES[module_index];
+        for (int promise_type_index = 0; module[promise_type_index].promise_type; promise_type_index++)
+        {
+            const PromiseTypeSyntax *promise_type_syntax = &(module[promise_type_index]);
+            if (StringEqual(promise_type, promise_type_syntax->promise_type))
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 const PromiseTypeSyntax *PromiseTypeSyntaxGet(const char *bundle_type, const char *promise_type)
 {
     const PromiseTypeSyntax *pts = PromiseTypeSyntaxGetStrict(bundle_type, promise_type);

--- a/libpromises/syntax.h
+++ b/libpromises/syntax.h
@@ -80,6 +80,7 @@ SyntaxTypeMatch CheckParseContext(const char *context, const char *range);
 DataType StringDataType(EvalContext *ctx, const char *string);
 DataType ExpectedDataType(const char *lvalname);
 
+bool IsBuiltInPromiseType(const char *const promise_type);
 const PromiseTypeSyntax *PromiseTypeSyntaxGet(const char *bundle_type, const char *promise_type);
 const ConstraintSyntax *PromiseTypeSyntaxGetConstraintSyntax(const PromiseTypeSyntax *promise_type_syntax, const char *lval);
 

--- a/tests/acceptance/30_custom_promise_types/04_unknown_promise_type.error.cf
+++ b/tests/acceptance/30_custom_promise_types/04_unknown_promise_type.error.cf
@@ -1,0 +1,5 @@
+bundle agent main
+{
+  unknown:
+    "promise";
+}

--- a/tests/unit/data/bundle_custom_promise_type.cf
+++ b/tests/unit/data/bundle_custom_promise_type.cf
@@ -1,0 +1,7 @@
+# This policy should be parseable since the promise type might be
+# defined in another policy file
+bundle agent foo
+{
+custom_promise_type:
+  "var" string => "test";
+}

--- a/tests/unit/data/bundle_invalid_promise_type.cf
+++ b/tests/unit/data/bundle_invalid_promise_type.cf
@@ -1,5 +1,0 @@
-bundle agent foo
-{
-invalid:
-  "var" string => "test";
-}

--- a/tests/unit/parser_test.c
+++ b/tests/unit/parser_test.c
@@ -55,9 +55,9 @@ void test_bundle_body_forgot_ob(void)
     assert_false(TestParsePolicy("bundle_body_forgot_ob.cf"));
 }
 
-void test_bundle_invalid_promise_type(void)
+void test_bundle_custom_promise_type(void)
 {
-    assert_false(TestParsePolicy("bundle_invalid_promise_type.cf"));
+    assert_true(TestParsePolicy("bundle_custom_promise_type.cf"));
 }
 
 void test_bundle_body_wrong_promise_type_token(void)
@@ -226,7 +226,7 @@ int main()
         unit_test(test_bundle_args_invalid_type),
         unit_test(test_bundle_args_forgot_cp),
         unit_test(test_bundle_body_forgot_ob),
-        unit_test(test_bundle_invalid_promise_type),
+        unit_test(test_bundle_custom_promise_type),
         unit_test(test_bundle_body_wrong_promise_type_token),
         unit_test(test_bundle_body_wrong_statement),
         unit_test(test_bundle_body_forgot_semicolon),


### PR DESCRIPTION
Since inputs are parsed one by one, and then merged later,
there is no way to know when parsing a file whether a promise
type has already been declared. Thus we must assume that
anything which is not a built in promise type, is a custom
promise type and perform error checking later.