### PR TITLE
CFE-3525: Fixed buffer overflow vulnerabillity in policy function format() (3.15.x)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -5187,7 +5187,7 @@ static FnCallResult FnCallFormat(EvalContext *ctx, ARG_UNUSED const Policy *poli
                     if (strrchr(format_piece, 'd') != NULL || strrchr(format_piece, 'o') != NULL || strrchr(format_piece, 'x') != NULL)
                     {
                         long x = 0;
-                        sscanf(data, "%ld%s", &x, piece); // we don't care about the remainder and will overwrite it
+                        sscanf(data, "%ld", &x);
                         snprintf(piece, CF_BUFSIZE, format_piece, x);
                         BufferAppend(buf, piece, strlen(piece));
                     }
@@ -5199,7 +5199,7 @@ static FnCallResult FnCallFormat(EvalContext *ctx, ARG_UNUSED const Policy *poli
                     else if (strrchr(format_piece, 'f') != NULL)
                     {
                         double x = 0;
-                        sscanf(data, "%lf%s", &x, piece); // we don't care about the remainder and will overwrite it
+                        sscanf(data, "%lf", &x);
                         snprintf(piece, CF_BUFSIZE, format_piece, x);
                         BufferAppend(buf, piece, strlen(piece));
                     }


### PR DESCRIPTION
Fixed vulnerabillity where malformed input could trigger buffer overflow in
policy function format.

Changelog: Body
Ticket: CFE-3525
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 3fb57366017715f0b91031909350fed9b07d3224)