### PR TITLE
Do not report no action for 'content => "something"' in files promises

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -197,7 +197,8 @@ static bool AttrHasNoAction(const Attributes *attr)
     if (!(attr->transformer || attr->haverename || attr->havedelete ||
           attr->havecopy || attr->create || attr->touch || attr->havelink ||
           attr->haveperms || attr->havechange || attr->acl.acl_entries ||
-          attr->haveedit || attr->haveeditline || attr->haveeditxml))
+          attr->haveedit || attr->haveeditline || attr->haveeditxml ||
+          (attr->content != NULL)))
     {
         return true;
     }


### PR DESCRIPTION
Promising the exact content of a file is an action.

Ticket: CFE-3507
Changelog: "No action for file" warning is no longer triggered when only 'content => "something"' is used