### PR TITLE
Report normal file editing mismatches as INFO not ERROR

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -429,8 +429,8 @@ static PromiseResult VerifyLineDeletions(EvalContext *ctx, const Promise *pp, Ed
              "Warnings encountered when actuating delete_lines promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating delete_lines promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating delete_lines promise '%s'", pp->promiser);
         break;
     }
 
@@ -520,8 +520,8 @@ static PromiseResult VerifyColumnEdits(EvalContext *ctx, const Promise *pp, Edit
              "Warnings encountered when actuating fields_edit promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating fields_edit promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating fields_edit promise '%s'", pp->promiser);
         break;
     }
 
@@ -600,8 +600,8 @@ static PromiseResult VerifyPatterns(EvalContext *ctx, const Promise *pp, EditCon
              "Warnings encountered when actuating replace_patterns promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating replace_patterns promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating replace_patterns promise '%s'", pp->promiser);
         break;
     }
 
@@ -812,6 +812,8 @@ static PromiseResult VerifyLineInsertions(EvalContext *ctx, const Promise *pp, E
         break;
     case PROMISE_RESULT_CHANGE:
         cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "insert_lines promise repaired");
+        cfPS(ctx, LOG_LEVEL_VERBOSE, result, pp, &a,
              "insert_lines promise '%s' repaired", pp->promiser);
         break;
     case PROMISE_RESULT_WARN:
@@ -819,8 +821,8 @@ static PromiseResult VerifyLineInsertions(EvalContext *ctx, const Promise *pp, E
              "Warnings encountered when actuating insert_lines promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating insert_lines promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating insert_lines promise '%s'", pp->promiser);
         break;
     }
 

--- a/cf-agent/files_editxml.c
+++ b/cf-agent/files_editxml.c
@@ -233,8 +233,8 @@ static PromiseResult KeepEditXmlPromise(EvalContext *ctx, const Promise *pp,
                  "Warnings encountered when actuating build_xpath promise '%s'", pp->promiser);
             break;
         default:
-            cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-                 "Errors encountered when actuating build_xpath promise '%s'", pp->promiser);
+            cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+                 "Mismatches encountered when actuating build_xpath promise '%s'", pp->promiser);
             break;
         }
         return result;
@@ -471,8 +471,8 @@ static PromiseResult VerifyTreeDeletions(EvalContext *ctx, const Attributes *att
              "Warnings encountered when actuating delete_tree promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating delete_tree promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating delete_tree promise '%s'", pp->promiser);
         break;
     }
 
@@ -565,8 +565,8 @@ static PromiseResult VerifyTreeInsertions(EvalContext *ctx, const Attributes *at
              "Warnings encountered when actuating insert_tree promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating insert_tree promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating insert_tree promise '%s'", pp->promiser);
         break;
     }
 
@@ -648,8 +648,8 @@ static PromiseResult VerifyAttributeDeletions(EvalContext *ctx, const Attributes
              "Warnings encountered when actuating delete_attribute promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating delete_attribute promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating delete_attribute promise '%s'", pp->promiser);
         break;
     }
 
@@ -731,8 +731,8 @@ static PromiseResult VerifyAttributeSet(EvalContext *ctx, const Attributes *attr
              "Warnings encountered when actuating set_attribute promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating set_attribute promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating set_attribute promise '%s'", pp->promiser);
         break;
     }
 
@@ -814,8 +814,8 @@ static PromiseResult VerifyTextDeletions(EvalContext *ctx, const Attributes *att
              "Warnings encountered when actuating delete_text promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating delete_text promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating delete_text promise '%s'", pp->promiser);
         break;
     }
 
@@ -897,8 +897,8 @@ static PromiseResult VerifyTextSet(EvalContext *ctx, const Attributes *attr, con
              "Warnings encountered when actuating set_text promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating set_text promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating set_text promise '%s'", pp->promiser);
         break;
     }
 
@@ -980,8 +980,8 @@ static PromiseResult VerifyTextInsertions(EvalContext *ctx, const Attributes *at
              "Warnings encountered when actuating insert_text promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating insert_text promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating insert_text promise '%s'", pp->promiser);
         break;
     }
 

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -600,8 +600,8 @@ exit:
              "Warnings encountered when actuating files promise '%s'", pp->promiser);
         break;
     default:
-        cfPS(ctx, LOG_LEVEL_ERR, result, pp, &a,
-             "Errors encountered when actuating files promise '%s'", pp->promiser);
+        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,
+             "Mismatches encountered when actuating files promise '%s'", pp->promiser);
         break;
     }
 


### PR DESCRIPTION
Mismatches while editing are common and should not be treated as errors.