### PR TITLE
Added a new --simulate=manifest-full mode

### DIFF
--- a/cf-agent/simulate_mode.h
+++ b/cf-agent/simulate_mode.h
@@ -27,9 +27,12 @@
 #ifndef _SIMULATE_H_
 #define _SIMULATE_H_
 
+#include <set.h>                /* StringSet */
+
 bool ManifestFile(const char *path, bool chrooted);
 bool ManifestRename(const char *orig_name, const char *new_name);
-bool ManifestChangedFiles();
-bool DiffChangedFiles();
+bool ManifestChangedFiles(StringSet **audited_files);
+bool ManifestAllFiles(StringSet **audited_files);
+bool DiffChangedFiles(StringSet **audited_files);
 
 #endif  /* _SIMULATE_H_ */

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -582,6 +582,12 @@ exit:
     case PROMISE_RESULT_NOOP:
         cfPS(ctx, LOG_LEVEL_VERBOSE, result, pp, &a,
              "No changes done for the files promise '%s'", pp->promiser);
+
+        if (EVAL_MODE == EVAL_MODE_SIMULATE_MANIFEST_FULL)
+        {
+            RecordFileEvaluatedInChroot(path);
+        }
+
         break;
     case PROMISE_RESULT_CHANGE:
         cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a,

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -2723,6 +2723,12 @@ bool DepthSearch(EvalContext *ctx, char *name, const struct stat *sb, int rlevel
         }
         if (!attr->haveselect || SelectLeaf(ctx, name, sb, &(attr->select)))
         {
+            /* Renames are handled separately. */
+            if ((EVAL_MODE == EVAL_MODE_SIMULATE_MANIFEST_FULL) && !attr->haverename)
+            {
+                RecordFileEvaluatedInChroot(name);
+            }
+
             VerifyFileLeaf(ctx, name, sb, attr, pp, result);
             return true;
         }
@@ -2865,6 +2871,12 @@ bool DepthSearch(EvalContext *ctx, char *name, const struct stat *sb, int rlevel
             }
 
             VerifyFileLeaf(ctx, path, &lsb, attr, pp, result);
+
+            /* Renames are handled separately. */
+            if ((EVAL_MODE == EVAL_MODE_SIMULATE_MANIFEST_FULL) && !attr->haverename)
+            {
+                RecordFileEvaluatedInChroot(path);
+            }
             if (ChrootChanges() && (*result == PROMISE_RESULT_CHANGE))
             {
                 RecordFileChangedInChroot(path);

--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -53,6 +53,7 @@ typedef enum EvalMode {
     EVAL_MODE_DRY_RUN = 1,
     EVAL_MODE_SIMULATE_DIFF = 2,
     EVAL_MODE_SIMULATE_MANIFEST = 3,
+    EVAL_MODE_SIMULATE_MANIFEST_FULL = 4,
 } EvalMode;
 
 extern EvalMode EVAL_MODE;

--- a/libpromises/changes_chroot.c
+++ b/libpromises/changes_chroot.c
@@ -251,3 +251,14 @@ bool RecordFileRenamedInChroot(const char *old_name, const char *new_name)
     WriterClose(writer);
     return ret;
 }
+
+bool RecordFileEvaluatedInChroot(const char *path)
+{
+    FILE *chroot_changes = safe_fopen(ToChangesChroot(CHROOT_KEPT_LIST_FILE), "a");
+    Writer *writer = FileWriter(chroot_changes);
+
+    bool ret = WriteLenPrefixedString(writer, path);
+
+    WriterClose(writer);
+    return ret;
+}

--- a/libpromises/changes_chroot.h
+++ b/libpromises/changes_chroot.h
@@ -27,9 +27,11 @@
 
 #define CHROOT_CHANGES_LIST_FILE "/changed_files"
 #define CHROOT_RENAMES_LIST_FILE "/renamed_files"
+#define CHROOT_KEPT_LIST_FILE "/kept_files"
 
 void PrepareChangesChroot(const char *path);
 bool RecordFileChangedInChroot(const char *path);
 bool RecordFileRenamedInChroot(const char *old_name, const char *new_name);
+bool RecordFileEvaluatedInChroot(const char *path);
 
 #endif /* CFENGINE_CHANGES_CHROOT_H */

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -295,7 +295,9 @@ bool MakingInternalChanges(EvalContext *ctx, const Promise *pp, const Attributes
  */
 static inline bool ChrootChanges()
 {
-    return ((EVAL_MODE == EVAL_MODE_SIMULATE_DIFF) || (EVAL_MODE == EVAL_MODE_SIMULATE_MANIFEST));
+    return ((EVAL_MODE == EVAL_MODE_SIMULATE_DIFF) ||
+            (EVAL_MODE == EVAL_MODE_SIMULATE_MANIFEST) ||
+            (EVAL_MODE == EVAL_MODE_SIMULATE_MANIFEST_FULL));
 }
 
 /**

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -337,6 +337,7 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
     }
 
     const bool skip_unsafe_function_calls = ((EVAL_MODE == EVAL_MODE_SIMULATE_MANIFEST) ||
+                                             (EVAL_MODE == EVAL_MODE_SIMULATE_MANIFEST_FULL) ||
                                              (EVAL_MODE == EVAL_MODE_SIMULATE_DIFF));
 
     Rlist *caller_meta = PromiseGetConstraintAsList(ctx, "meta", caller);

--- a/tests/acceptance/29_simulate_mode/manifest_full_mode.cf
+++ b/tests/acceptance/29_simulate_mode/manifest_full_mode.cf
@@ -1,0 +1,48 @@
+body common control
+{
+      inputs => {
+        "../default.cf.sub",
+        "./prepare_files_for_simulate_tests.cf.sub",
+        "./normalize_agent_output.cf.sub"
+      };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+
+bundle agent init
+{
+  methods:
+    "prepare_files_for_simulate_tests";
+}
+
+bundle agent test
+{
+  meta:
+    "test_soft_fail" string => "(solaris|aix|hpux)|(debian_7.i686)",
+      meta => { "ENT-6537", "ENT-6540" };
+      # ENT-6537 debian 7 dirent has extra ',' entry
+      # ENT-6540 exotics fail to delete chroot
+    "test_skip_needs_work" string => "(redhat_5|centos_5)",
+      meta => { "ENT-6569" };
+      # ENT-6569 on RHEL/CentOS 5, dirlisting consists of two unprintable characters
+
+    "description" -> { "ENT-5301" }
+      string => "Test that files promises in --simulate=manifest-full mode produce proper output and only make changes in chroot";
+
+  commands:
+    # add --verbose here and look at the .actual log for debugging sub policy runs
+    "$(sys.cf_agent) -Kf $(this.promise_dirname)$(const.dirsep)promises.cf.sub --simulate=manifest-full > $(this.promise_filename).temp 2>&1"
+      contain => in_shell,
+      comment => "Run sub policy in manifest mode and capture output to $(this.promise_filename).actual file.";
+}
+
+bundle agent check
+{
+  methods:
+    "normalize_agent_results" usebundle => normalize_agent_results("$(this.promise_filename).temp",
+                                                                   "$(this.promise_filename).actual");
+    "check" usebundle => dcs_check_diff("$(this.promise_filename).actual",
+                                        "$(this.promise_filename).expected",
+                                        "$(this.promise_filename)");
+}

--- a/tests/acceptance/29_simulate_mode/manifest_full_mode.cf.expected
+++ b/tests/acceptance/29_simulate_mode/manifest_full_mode.cf.expected
@@ -1,0 +1,170 @@
+ warning: All changes in files will be made in the 'WORKDIR/state/PID.changes' chroot
+===========================================================================
+'WORKDIR/tmp/rename-newname' is the new name of 'WORKDIR/tmp/rename-me'
+===========================================================================
+'WORKDIR/tmp/source-file' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+These are my source file contents.
+\no newline at the end of file
+===========================================================================
+'WORKDIR/tmp/create-true' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+===========================================================================
+'WORKDIR/tmp/insert-lines' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+foobar
+===========================================================================
+'WORKDIR/tmp/SUBDIR' is a directory
+Size: SIZE
+Access: (0755/rwxr-xr-x)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Directory contents:
+===========================================================================
+'WORKDIR/tmp/copy-from' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+These are my source file contents.
+\no newline at the end of file
+===========================================================================
+'WORKDIR/tmp/delete-me' no longer exists
+===========================================================================
+'WORKDIR/tmp/sub-dir/./sub-file' no longer exists
+===========================================================================
+'WORKDIR/tmp/sub-dir/.' is a directory
+Size: SIZE
+Access: (0755/rwxr-xr-x)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Directory contents:
+===========================================================================
+'WORKDIR/tmp/set-colon-field' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+me:x:1001:1001::/my/new/shell:/bin/sh
+===========================================================================
+'WORKDIR/tmp/delete-lines-matching' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+
+bar 2
+baz 3
+me:x:101:doo
+===========================================================================
+'WORKDIR/tmp/regex-replace' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+I dare you to change my policy FOO!
+===========================================================================
+'WORKDIR/tmp/edit-template-string' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+Darth Vader killed your father
+\no newline at the end of file
+===========================================================================
+'WORKDIR/tmp/build-xpath' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+<?xml version="1.0"?>
+<Server><Service><Engine><Host/></Engine></Service></Server>
+===========================================================================
+'WORKDIR/tmp/xml-insert-tree' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+<?xml version="1.0"?>
+<Root><x foo="bar">y</x></Root>
+===========================================================================
+'WORKDIR/tmp/perms' is a regular file
+Size: SIZE
+Access: (0000/---------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+===========================================================================
+'WORKDIR/tmp/transformer' no longer exists
+===========================================================================
+'WORKDIR/tmp/hardlink' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:
+===========================================================================
+'WORKDIR/tmp/link' is a symbolic link
+Size: SIZE
+Access: (0777/rwxrwxrwx)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Target: 'WORKDIR/tmp/already-created'
+===========================================================================
+'WORKDIR/tmp/already-created' is a regular file
+Size: SIZE
+Access: (0600/rw-------)  Uid: (0/root)   Gid: (0/root)
+Access: TIMESTAMP
+Modify: TIMESTAMP
+Change: TIMESTAMP
+
+Contents of the file:


### PR DESCRIPTION
New simulation mode that manifests all changed files as well as
all other files evaluated by the agent run which were not skipped
(by file selection rules).

Ticket: CFE-3506
Changelog: Commit