### PR TITLE
ENT-6750/master: Stopped emitting warning and recording result when observing new SETGID files

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -3830,8 +3830,7 @@ static PromiseResult VerifySetUidGid(EvalContext *ctx, const char *file, const s
             {
                 if (amroot)
                 {
-                    RecordWarning(ctx, pp, attr, "NEW SETGID root PROGRAM '%s'", file);
-                    result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
+                    Log(LOG_LEVEL_NOTICE, "NEW SETGID root PROGRAM '%s' ", file);
                 }
 
                 PrependItem(&VSETXIDLIST, file, NULL);


### PR DESCRIPTION
Ticket: ENT-6750
Changelog: Title