### PR TITLE
ENT-6750/3.15: Stopped emitting warning and recording result when observing new SETGID files

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -3358,8 +3358,7 @@ static PromiseResult VerifySetUidGid(EvalContext *ctx, const char *file, const s
             {
                 if (amroot)
                 {
-                    cfPS(ctx, LOG_LEVEL_WARNING, PROMISE_RESULT_WARN, pp, attr, "NEW SETGID root PROGRAM '%s'", file);
-                    result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
+                    Log(LOG_LEVEL_NOTICE, "NEW SETGID root PROGRAM '%s' ", file);
                 }
 
                 PrependItem(&VSETXIDLIST, file, NULL);


### PR DESCRIPTION
Ticket: ENT-6750
Changelog: Title
(cherry picked from commit d34fd24dde3d83864bd5938813a4eb2b7beb0631)