### PR TITLE
Include <platform.h> early in simulate_mode.c

### DIFF
--- a/cf-agent/simulate_mode.c
+++ b/cf-agent/simulate_mode.c
@@ -22,6 +22,8 @@
   included file COSL.txt.
 */
 
+#include <platform.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/libpromises/changes_chroot.c
+++ b/libpromises/changes_chroot.c
@@ -22,6 +22,7 @@
   included file COSL.txt.
 */
 
+#include <platform.h>
 #include <alloc.h>              /* xstrdup() */
 #include <dir.h>                /* DirOpen(), DirRead(), DirClose() */
 #include <eval_context.h>       /* ToChangesChroot() */

--- a/tests/acceptance/29_simulate_mode/diff_mode.cf
+++ b/tests/acceptance/29_simulate_mode/diff_mode.cf
@@ -19,13 +19,9 @@ bundle agent init
 bundle agent test
 {
   meta:
-    "test_soft_fail" string => "(solaris|aix|hpux)|(debian_7.i686)",
-      meta => { "ENT-6537", "ENT-6540" };
-      # ENT-6537 debian 7 dirent has extra ',' entry
+    "test_soft_fail" string => "(solaris|aix|hpux)",
+      meta => { "ENT-6540" };
       # ENT-6540 exotics fail to delete chroot
-    "test_skip_needs_work" string => "(redhat_5|centos_5)",
-      meta => { "ENT-6569" };
-      # ENT-6569 on RHEL/CentOS 5, dirlisting consists of two unprintable characters
 
     "description" -> { "ENT-5302" }
       string => "Test that files promises in --simulate=diff mode produce proper output and only make changes in chroot";

--- a/tests/acceptance/29_simulate_mode/manifest_full_mode.cf
+++ b/tests/acceptance/29_simulate_mode/manifest_full_mode.cf
@@ -19,13 +19,9 @@ bundle agent init
 bundle agent test
 {
   meta:
-    "test_soft_fail" string => "(solaris|aix|hpux)|(debian_7.i686)",
-      meta => { "ENT-6537", "ENT-6540" };
-      # ENT-6537 debian 7 dirent has extra ',' entry
+    "test_soft_fail" string => "(solaris|aix|hpux)",
+      meta => { "ENT-6540" };
       # ENT-6540 exotics fail to delete chroot
-    "test_skip_needs_work" string => "(redhat_5|centos_5)",
-      meta => { "ENT-6569" };
-      # ENT-6569 on RHEL/CentOS 5, dirlisting consists of two unprintable characters
 
     "description" -> { "ENT-5301" }
       string => "Test that files promises in --simulate=manifest-full mode produce proper output and only make changes in chroot";

--- a/tests/acceptance/29_simulate_mode/manifest_mode.cf
+++ b/tests/acceptance/29_simulate_mode/manifest_mode.cf
@@ -19,13 +19,9 @@ bundle agent init
 bundle agent test
 {
   meta:
-    "test_soft_fail" string => "(solaris|aix|hpux)|(debian_7.i686)",
-      meta => { "ENT-6537", "ENT-6540" };
-      # ENT-6537 debian 7 dirent has extra ',' entry
+    "test_soft_fail" string => "(solaris|aix|hpux)",
+      meta => { "ENT-6540" };
       # ENT-6540 exotics fail to delete chroot
-    "test_skip_needs_work" string => "(redhat_5|centos_5)",
-      meta => { "ENT-6569" };
-      # ENT-6569 on RHEL/CentOS 5, dirlisting consists of two unprintable characters
 
     "description" -> { "ENT-5301" }
       string => "Test that files promises in --simulate=manifest mode produce proper output and only make changes in chroot";


### PR DESCRIPTION
As the file says::
  * INCLUDE THIS HEADER ALWAYS FIRST in order to define appropriate macros for
  * including system headers (such as _FILE_OFFSET_BITS).

_FILE_OFFSET_BITS (and others) determine offsets of fields in
various structures that we use, for example 'struct
dirent'. Accessing fields at wrong offsets means we get garbage
data.

Ticket: ENT-6537
Changelog: None