### PR TITLE
Do not record 'packages' promises skipped due to locking

### DIFF
--- a/cf-agent/verify_new_packages.c
+++ b/cf-agent/verify_new_packages.c
@@ -85,9 +85,6 @@ PromiseResult HandleNewPackagePromiseType(EvalContext *ctx, const Promise *pp, c
     if (global_lock.g_lock.lock == NULL)
     {
         Log(LOG_LEVEL_DEBUG, "Skipping promise execution due to global packaging locking.");
-        PromiseRef(LOG_LEVEL_VERBOSE, pp);
-        cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_SKIPPED, pp, a,
-             "Can not acquire global lock for package promises. Skipping promise evaluation");
         return PROMISE_RESULT_SKIPPED;
     }
 
@@ -99,10 +96,6 @@ PromiseResult HandleNewPackagePromiseType(EvalContext *ctx, const Promise *pp, c
         YieldGlobalPackagePromiseLock(global_lock);
 
         Log(LOG_LEVEL_DEBUG, "Skipping promise execution due to promise-specific package locking.");
-        PromiseRef(LOG_LEVEL_VERBOSE, pp);
-        cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_SKIPPED, pp, a,
-             "Can not acquire lock for '%s' package promise. Skipping promise evaluation",
-             pp->promiser);
         return PROMISE_RESULT_SKIPPED;
     }
 


### PR DESCRIPTION
For other promise types, promises skipped due to locking only
result in 'debug' log messages being emitted and cfPS() is not
called. There's no reason why 'packages' promises should behave
differently.

Ticket: ENT-6553
Changelog: Reduced the noise caused by packages promises being skipped in evaluation passes 2 and 3