### PR TITLE
Travis: Disabled MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ jobs:
       # filesystem in Travis; so change OS to Trusty, which uses ext4.
     - env: JOB_TYPE=acceptance_tests_unsafe_serial_network_etc
     - env: JOB_TYPE=serverd_multi_versions COVERAGE=no
-    - os: osx
-      env: JOB_TYPE=compile_only COVERAGE=no
 
 before_install:
   - chmod ug+x ./travis-scripts/*


### PR DESCRIPTION
Failing Mac builds have caused master to be red for some days.
This seems to be because Travis changed the installed packages
on their default image. Since we are already testing MacOS
on GitHub Actions, and they are much faster and more reliable,
I don't see a point in fixing the travis build, so I disabled it.