### PR TITLE
Travis: Disabled MacOS (3.15)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,6 @@ matrix:
     - os: linux
       sudo: required
       env: JOB_TYPE=serverd_multi_versions COVERAGE=no
-    - os: osx
-      env: JOB_TYPE=compile_and_unit_test COVERAGE=no
-      sudo: false
-  allow_failures:
-    - os: osx
-      env: JOB_TYPE=compile_and_unit_test COVERAGE=no
-      sudo: false
 
 before_install:
   - chmod ug+x ./travis-scripts/*


### PR DESCRIPTION
Failing Mac builds have caused master to be red for some days.
This seems to be because Travis changed the installed packages
on their default image. Since we are already testing MacOS
on GitHub Actions, and they are much faster and more reliable,
I don't see a point in fixing the travis build, so I disabled it.

Had to resolve conflicts since this was already an allowed
failure on 3.15.x (but not on master).

(cherry picked from commit 1539824f12107a18652c4ce8a995f5fb269b6c7f)