### PR TITLE
Check if result from evaluate_promise() is a string in custom_promise…

### DIFF
--- a/docs/custom_promise_types/cfengine.py
+++ b/docs/custom_promise_types/cfengine.py
@@ -146,7 +146,7 @@ class PromiseModule:
             results = self.evaluate_promise(promiser, attributes)
 
             # evaluate_promise should return either a result or a (result, result_classes) pair
-            if type(results) == Result:
+            if type(results) == str:
                 self._result = results
             else:
                 assert len(results) == 2


### PR DESCRIPTION
…_types/cfengine.py

'class Result' only defines attributes that are strings, it's not
an Enum. So things like 'Result.KEPT' are actually just strings
with no special type.

Changelog: None