### PR TITLE
Add a reference to the Northern.tech AS Contributor statement to CONT…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,9 @@ When submitting your pull request, please make sure you:
 
 * Add one or more [ChangeLog Entries](#changelog) to the commit(s).
 
+* Become familiar with the *Northern.tech AS Contributor statement* as described
+  in the [*AUTHORS*](./AUTHORS) file.
+
 
 ### Pull request title and description
 


### PR DESCRIPTION
…RIBUTING.md

So that people can become familiar with our policies before
submitting a PR instead of the CLA signing request coming as a
surprise to them afterwards.