### PR TITLE
SELinux: Allow cf-serverd getattr on cfengine_log_t:lnk_file

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -292,6 +292,7 @@ allow cfengine_serverd_t proc_xen_t:dir search;
 allow cfengine_serverd_t cfengine_execd_exec_t:file getattr;
 allow cfengine_serverd_t cfengine_monitord_exec_t:file getattr;
 allow cfengine_serverd_t cfengine_hub_exec_t:file getattr;
+allow cfengine_serverd_t cfengine_log_t:lnk_file getattr;
 
 allow cfengine_serverd_t crontab_exec_t:file getattr;
 allow cfengine_serverd_t dmidecode_exec_t:file getattr;


### PR DESCRIPTION
Discovered while working on ENT-6735.