### PR TITLE
SELinux: Allow cf-serverd getattr on cfengine_log_t:lnk_file

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -289,6 +289,7 @@ allow cfengine_serverd_t ssh_port_t:tcp_socket name_connect;
 allow cfengine_serverd_t cfengine_execd_exec_t:file getattr;
 allow cfengine_serverd_t cfengine_monitord_exec_t:file getattr;
 allow cfengine_serverd_t cfengine_hub_exec_t:file getattr;
+allow cfengine_serverd_t cfengine_log_t:lnk_file getattr;
 
 allow cfengine_serverd_t crontab_exec_t:file getattr;
 allow cfengine_serverd_t dmidecode_exec_t:file getattr;


### PR DESCRIPTION
Discovered while working on ENT-6735.

(cherry picked from commit 01b3bf0cf62ba7c1857ee84af63dd4391328f366)