### PR TITLE
Change comment in the pgsql_RA to mention RHEL 7 not 6

### DIFF
--- a/contrib/pgsql_RA
+++ b/contrib/pgsql_RA
@@ -13,7 +13,7 @@
 # License:      GNU General Public License (GPL)
 #
 # Note:         This is a modified version of the upstream RA that supports PostgreSQL 10-12
-#               on RHEL 6.
+#               on RHEL 7.
 ###############################################################################
 # Initialization:
 


### PR DESCRIPTION
The PostgreSQL resource agent we provide supports both RHEL 6 and
7, but RHEL 6 is EOL and we encourage users to use RHEL 7 for
their HA setups so we should not confuse them in the comment.

Ticket: ENT-6825
Changelog: None