### PR TITLE
Fix iteration over the 'extra_hashes' map in PolicyMerge

### DIFF
--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -428,7 +428,7 @@ Policy *PolicyMerge(Policy *a, Policy *b)
 
     if (extra_hashes != NULL)
     {
-        MapIterator it = MapIteratorInit((Map*) extra_hashes);
+        MapIterator it = MapIteratorInit(extra_hashes->impl);
         MapKeyValue *item;
         while ((item = MapIteratorNext(&it)) != NULL)
         {


### PR DESCRIPTION
'extra_hashes' is a StringMap which means the actual hash map is
in its 'impl' field.

(cherry picked from commit ee881fce018476f91914ca0d643fb00399f585d7)