### PR TITLE
Send promise type to custom promise modules

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -160,7 +160,7 @@ static int NoteBundleCompliance(const Bundle *bundle, int save_pr_kept, int save
 static void AllClassesReport(const EvalContext *ctx);
 static bool HasAvahiSupport(void);
 static int AutomaticBootstrap(GenericAgentConfig *config);
-static void BannerStatus(PromiseResult status, char *type, char *name);
+static void BannerStatus(PromiseResult status, const char *type, char *name);
 static PromiseResult DefaultVarPromise(EvalContext *ctx, const Promise *pp);
 static void WaitForBackgroundProcesses();
 
@@ -1770,8 +1770,8 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
     struct timespec start = BeginMeasure();
     PromiseResult result = PROMISE_RESULT_NOOP;
 
-    if (strcmp("meta", pp->parent_section->promise_type) == 0 ||
-        strcmp("vars", pp->parent_section->promise_type) == 0)
+    if (strcmp("meta", PromiseGetPromiseType(pp)) == 0 ||
+        strcmp("vars", PromiseGetPromiseType(pp)) == 0)
     {
         Log(LOG_LEVEL_VERBOSE, "V:     Computing value of '%s'", pp->promiser);
 
@@ -1784,15 +1784,15 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
             }
         }
     }
-    else if (strcmp("defaults", pp->parent_section->promise_type) == 0)
+    else if (strcmp("defaults", PromiseGetPromiseType(pp)) == 0)
     {
         result = DefaultVarPromise(ctx, pp);
     }
-    else if (strcmp("classes", pp->parent_section->promise_type) == 0)
+    else if (strcmp("classes", PromiseGetPromiseType(pp)) == 0)
     {
         result = VerifyClassPromise(ctx, pp, NULL);
     }
-    else if (strcmp("processes", pp->parent_section->promise_type) == 0)
+    else if (strcmp("processes", PromiseGetPromiseType(pp)) == 0)
     {
         if (!LoadProcessTable())
         {
@@ -1805,7 +1805,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
             EndMeasurePromise(start, pp);
         }
     }
-    else if (strcmp("storage", pp->parent_section->promise_type) == 0)
+    else if (strcmp("storage", PromiseGetPromiseType(pp)) == 0)
     {
         result = FindAndVerifyStoragePromises(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
@@ -1813,7 +1813,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
             EndMeasurePromise(start, pp);
         }
     }
-    else if (strcmp("packages", pp->parent_section->promise_type) == 0)
+    else if (strcmp("packages", PromiseGetPromiseType(pp)) == 0)
     {
         result = VerifyPackagesPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
@@ -1821,7 +1821,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
             EndMeasurePromise(start, pp);
         }
     }
-    else if (strcmp("users", pp->parent_section->promise_type) == 0)
+    else if (strcmp("users", PromiseGetPromiseType(pp)) == 0)
     {
         result = VerifyUsersPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
@@ -1830,7 +1830,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         }
     }
 
-    else if (strcmp("files", pp->parent_section->promise_type) == 0)
+    else if (strcmp("files", PromiseGetPromiseType(pp)) == 0)
     {
         result = ParallelFindAndVerifyFilesPromises(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
@@ -1838,7 +1838,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
             EndMeasurePromise(start, pp);
         }
     }
-    else if (strcmp("commands", pp->parent_section->promise_type) == 0)
+    else if (strcmp("commands", PromiseGetPromiseType(pp)) == 0)
     {
         result = VerifyExecPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
@@ -1846,7 +1846,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
             EndMeasurePromise(start, pp);
         }
     }
-    else if (strcmp("databases", pp->parent_section->promise_type) == 0)
+    else if (strcmp("databases", PromiseGetPromiseType(pp)) == 0)
     {
         result = VerifyDatabasePromises(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
@@ -1854,7 +1854,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
             EndMeasurePromise(start, pp);
         }
     }
-    else if (strcmp("methods", pp->parent_section->promise_type) == 0)
+    else if (strcmp("methods", PromiseGetPromiseType(pp)) == 0)
     {
         result = VerifyMethodsPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
@@ -1862,7 +1862,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
             EndMeasurePromise(start, pp);
         }
     }
-    else if (strcmp("services", pp->parent_section->promise_type) == 0)
+    else if (strcmp("services", PromiseGetPromiseType(pp)) == 0)
     {
         result = VerifyServicesPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
@@ -1870,7 +1870,7 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
             EndMeasurePromise(start, pp);
         }
     }
-    else if (strcmp("guest_environments", pp->parent_section->promise_type) == 0)
+    else if (strcmp("guest_environments", PromiseGetPromiseType(pp)) == 0)
     {
         result = VerifyEnvironmentsPromise(ctx, pp);
         if (result != PROMISE_RESULT_SKIPPED)
@@ -1878,11 +1878,11 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
             EndMeasurePromise(start, pp);
         }
     }
-    else if (strcmp("reports", pp->parent_section->promise_type) == 0)
+    else if (strcmp("reports", PromiseGetPromiseType(pp)) == 0)
     {
         result = VerifyReportPromise(ctx, pp);
     }
-    else if (!IsBuiltInPromiseType(pp->parent_section->promise_type))
+    else if (!IsBuiltInPromiseType(PromiseGetPromiseType(pp)))
     {
         result = EvaluateCustomPromise(ctx, pp);
     }
@@ -1891,13 +1891,13 @@ static PromiseResult KeepAgentPromise(EvalContext *ctx, const Promise *pp, ARG_U
         result = PROMISE_RESULT_NOOP;
     }
 
-    BannerStatus(result, pp->parent_section->promise_type, pp->promiser);
+    BannerStatus(result, PromiseGetPromiseType(pp), pp->promiser);
     EvalContextLogPromiseIterationOutcome(ctx, pp, result);
     return result;
 }
 
 
-static void BannerStatus(PromiseResult status, char *type, char *name)
+static void BannerStatus(PromiseResult status, const char *type, char *name)
 {
     if ((strcmp(type, "vars") == 0) || (strcmp(type, "classes") == 0))
     {

--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -317,27 +317,27 @@ static PromiseResult KeepEditLinePromise(EvalContext *ctx, const Promise *pp, vo
 
     PromiseBanner(ctx, pp);
 
-    if (strcmp("classes", pp->parent_section->promise_type) == 0)
+    if (strcmp("classes", PromiseGetPromiseType(pp)) == 0)
     {
         return VerifyClassPromise(ctx, pp, NULL);
     }
-    else if (strcmp("delete_lines", pp->parent_section->promise_type) == 0)
+    else if (strcmp("delete_lines", PromiseGetPromiseType(pp)) == 0)
     {
         return VerifyLineDeletions(ctx, pp, edcontext);
     }
-    else if (strcmp("field_edits", pp->parent_section->promise_type) == 0)
+    else if (strcmp("field_edits", PromiseGetPromiseType(pp)) == 0)
     {
         return VerifyColumnEdits(ctx, pp, edcontext);
     }
-    else if (strcmp("insert_lines", pp->parent_section->promise_type) == 0)
+    else if (strcmp("insert_lines", PromiseGetPromiseType(pp)) == 0)
     {
         return VerifyLineInsertions(ctx, pp, edcontext);
     }
-    else if (strcmp("replace_patterns", pp->parent_section->promise_type) == 0)
+    else if (strcmp("replace_patterns", PromiseGetPromiseType(pp)) == 0)
     {
         return VerifyPatterns(ctx, pp, edcontext);
     }
-    else if (strcmp("reports", pp->parent_section->promise_type) == 0)
+    else if (strcmp("reports", PromiseGetPromiseType(pp)) == 0)
     {
         return VerifyReportPromise(ctx, pp);
     }

--- a/cf-agent/files_editxml.c
+++ b/cf-agent/files_editxml.c
@@ -207,11 +207,11 @@ static PromiseResult KeepEditXmlPromise(EvalContext *ctx, const Promise *pp,
 {
     PromiseBanner(ctx, pp);
 
-    if (strcmp("classes", pp->parent_section->promise_type) == 0)
+    if (strcmp("classes", PromiseGetPromiseType(pp)) == 0)
     {
         return VerifyClassPromise(ctx, pp, NULL);
     }
-    else if (strcmp("build_xpath", pp->parent_section->promise_type) == 0)
+    else if (strcmp("build_xpath", PromiseGetPromiseType(pp)) == 0)
     {
         Attributes a = GetInsertionAttributes(ctx, pp);
 #ifdef HAVE_LIBXML2
@@ -243,7 +243,7 @@ static PromiseResult KeepEditXmlPromise(EvalContext *ctx, const Promise *pp,
         return PROMISE_RESULT_FAIL;
 #endif
     }
-    else if (strcmp("delete_tree", pp->parent_section->promise_type) == 0)
+    else if (strcmp("delete_tree", PromiseGetPromiseType(pp)) == 0)
     {
         Attributes a = GetDeletionAttributes(ctx, pp);
 #ifdef HAVE_LIBXML2
@@ -255,7 +255,7 @@ static PromiseResult KeepEditXmlPromise(EvalContext *ctx, const Promise *pp,
         return PROMISE_RESULT_FAIL;
 #endif
     }
-    else if (strcmp("insert_tree", pp->parent_section->promise_type) == 0)
+    else if (strcmp("insert_tree", PromiseGetPromiseType(pp)) == 0)
     {
         Attributes a = GetInsertionAttributes(ctx, pp);
 #ifdef HAVE_LIBXML2
@@ -267,7 +267,7 @@ static PromiseResult KeepEditXmlPromise(EvalContext *ctx, const Promise *pp,
         return PROMISE_RESULT_FAIL;
 #endif
     }
-    else if (strcmp("delete_attribute", pp->parent_section->promise_type) == 0)
+    else if (strcmp("delete_attribute", PromiseGetPromiseType(pp)) == 0)
     {
         Attributes a = GetDeletionAttributes(ctx, pp);
 #ifdef HAVE_LIBXML2
@@ -279,7 +279,7 @@ static PromiseResult KeepEditXmlPromise(EvalContext *ctx, const Promise *pp,
         return PROMISE_RESULT_FAIL;
 #endif
     }
-    else if (strcmp("set_attribute", pp->parent_section->promise_type) == 0)
+    else if (strcmp("set_attribute", PromiseGetPromiseType(pp)) == 0)
     {
         Attributes a = GetInsertionAttributes(ctx, pp);
 #ifdef HAVE_LIBXML2
@@ -291,7 +291,7 @@ static PromiseResult KeepEditXmlPromise(EvalContext *ctx, const Promise *pp,
         return PROMISE_RESULT_FAIL;
 #endif
     }
-    else if (strcmp("delete_text", pp->parent_section->promise_type) == 0)
+    else if (strcmp("delete_text", PromiseGetPromiseType(pp)) == 0)
     {
         Attributes a = GetDeletionAttributes(ctx, pp);
 #ifdef HAVE_LIBXML2
@@ -303,7 +303,7 @@ static PromiseResult KeepEditXmlPromise(EvalContext *ctx, const Promise *pp,
         return PROMISE_RESULT_FAIL;
 #endif
     }
-    else if (strcmp("set_text", pp->parent_section->promise_type) == 0)
+    else if (strcmp("set_text", PromiseGetPromiseType(pp)) == 0)
     {
         Attributes a = GetInsertionAttributes(ctx, pp);
 #ifdef HAVE_LIBXML2
@@ -315,7 +315,7 @@ static PromiseResult KeepEditXmlPromise(EvalContext *ctx, const Promise *pp,
         return PROMISE_RESULT_FAIL;
 #endif
     }
-    else if (strcmp("insert_text", pp->parent_section->promise_type) == 0)
+    else if (strcmp("insert_text", PromiseGetPromiseType(pp)) == 0)
     {
         Attributes a = GetInsertionAttributes(ctx, pp);
 #ifdef HAVE_LIBXML2
@@ -327,7 +327,7 @@ static PromiseResult KeepEditXmlPromise(EvalContext *ctx, const Promise *pp,
         return PROMISE_RESULT_FAIL;
 #endif
     }
-    else if (strcmp("reports", pp->parent_section->promise_type) == 0)
+    else if (strcmp("reports", PromiseGetPromiseType(pp)) == 0)
     {
         return VerifyReportPromise(ctx, pp);
     }
@@ -1833,7 +1833,7 @@ static bool SanityCheckXPathBuild(EvalContext *ctx, const Attributes *a, const P
         strcpy(rawxpath, pp->promiser);
     }
 
-    if ((strcmp("build_xpath", pp->parent_section->promise_type) == 0) && (a->xml.havebuildxpath))
+    if ((strcmp("build_xpath", PromiseGetPromiseType(pp)) == 0) && (a->xml.havebuildxpath))
     {
         Log(LOG_LEVEL_ERR, "Attribute: build_xpath is not allowed within bundle: build_xpath");
         return false;

--- a/cf-agent/retcode.c
+++ b/cf-agent/retcode.c
@@ -48,7 +48,7 @@ bool VerifyCommandRetcode(EvalContext *ctx, int retcode, const Attributes *a, co
         // inform constraint is only for commands promises,
         // a->inform is actually false for other promise types, so
         // checking the promise type here is important:
-        if (StringEqual("commands", pp->parent_section->promise_type) && (!a->inform))
+        if (StringEqual("commands", PromiseGetPromiseType(pp)) && (!a->inform))
         {
             // for commands promises which don't make changes to the system,
             // you can use this to make the log messages verbose:

--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -1175,20 +1175,20 @@ static PromiseResult KeepMonitorPromise(EvalContext *ctx, const Promise *pp, ARG
 {
     assert(param == NULL);
 
-    if (strcmp("vars", pp->parent_section->promise_type) == 0)
+    if (strcmp("vars", PromiseGetPromiseType(pp)) == 0)
     {
         return PROMISE_RESULT_NOOP;
     }
-    else if (strcmp("classes", pp->parent_section->promise_type) == 0)
+    else if (strcmp("classes", PromiseGetPromiseType(pp)) == 0)
     {
         return VerifyClassPromise(ctx, pp, NULL);
     }
-    else if (strcmp("measurements", pp->parent_section->promise_type) == 0)
+    else if (strcmp("measurements", PromiseGetPromiseType(pp)) == 0)
     {
         PromiseResult result = VerifyMeasurementPromise(ctx, CF_THIS, pp);
         return result;
     }
-    else if (strcmp("reports", pp->parent_section->promise_type) == 0)
+    else if (strcmp("reports", PromiseGetPromiseType(pp)) == 0)
     {
         return PROMISE_RESULT_NOOP;
     }

--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -686,12 +686,12 @@ static PromiseResult KeepServerPromise(EvalContext *ctx, const Promise *pp, ARG_
     assert(!param);
     PromiseBanner(ctx, pp);
 
-    if (strcmp(pp->parent_section->promise_type, "vars") == 0)
+    if (strcmp(PromiseGetPromiseType(pp), "vars") == 0)
     {
         return VerifyVarPromise(ctx, pp, NULL);
     }
 
-    if (strcmp(pp->parent_section->promise_type, "classes") == 0)
+    if (strcmp(PromiseGetPromiseType(pp), "classes") == 0)
     {
         return VerifyClassPromise(ctx, pp, NULL);
     }
@@ -705,8 +705,8 @@ static PromiseResult KeepServerPromise(EvalContext *ctx, const Promise *pp, ARG_
         Log(LOG_LEVEL_WARNING,
             "ifelapsed attribute specified in action body for %s promise '%s',"
             " but %s promises do not support promise locking",
-            pp->parent_section->promise_type, pp->promiser,
-            pp->parent_section->promise_type);
+            PromiseGetPromiseType(pp), pp->promiser,
+            PromiseGetPromiseType(pp));
     }
     int expireafter = PromiseGetConstraintAsInt(ctx, "expireafter", pp);
     if (expireafter != CF_NOINT)
@@ -714,11 +714,11 @@ static PromiseResult KeepServerPromise(EvalContext *ctx, const Promise *pp, ARG_
         Log(LOG_LEVEL_WARNING,
             "expireafter attribute specified in action body for %s promise '%s',"
             " but %s promises do not support promise locking",
-            pp->parent_section->promise_type, pp->promiser,
-            pp->parent_section->promise_type);
+            PromiseGetPromiseType(pp), pp->promiser,
+            PromiseGetPromiseType(pp));
     }
 
-    if (strcmp(pp->parent_section->promise_type, "access") == 0)
+    if (strcmp(PromiseGetPromiseType(pp), "access") == 0)
     {
         const char *resource_type =
             PromiseGetConstraintAsRval(pp, "resource_type", RVAL_TYPE_SCALAR);
@@ -757,7 +757,7 @@ static PromiseResult KeepServerPromise(EvalContext *ctx, const Promise *pp, ARG_
             return PROMISE_RESULT_NOOP;
         }
     }
-    else if (strcmp(pp->parent_section->promise_type, "roles") == 0)
+    else if (strcmp(PromiseGetPromiseType(pp), "roles") == 0)
     {
         KeepServerRolePromise(ctx, pp);
         return PROMISE_RESULT_NOOP;

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -684,28 +684,28 @@ TransactionContext GetTransactionConstraints(const EvalContext *ctx, const Promi
 
     /* Warn if promise locking was used with a promise that doesn't support it.
      * XXX: EvalContextGetPass() takes 'EvalContext *' instead of 'const EvalContext *'*/
-    if ((strcmp("access", pp->parent_section->promise_type) == 0 ||
-         strcmp("classes", pp->parent_section->promise_type) == 0 ||
-         strcmp("defaults", pp->parent_section->promise_type) == 0 ||
-         strcmp("meta", pp->parent_section->promise_type) == 0 ||
-         strcmp("roles", pp->parent_section->promise_type) == 0 ||
-         strcmp("vars", pp->parent_section->promise_type) == 0))
+    if ((strcmp("access", PromiseGetPromiseType(pp)) == 0 ||
+         strcmp("classes", PromiseGetPromiseType(pp)) == 0 ||
+         strcmp("defaults", PromiseGetPromiseType(pp)) == 0 ||
+         strcmp("meta", PromiseGetPromiseType(pp)) == 0 ||
+         strcmp("roles", PromiseGetPromiseType(pp)) == 0 ||
+         strcmp("vars", PromiseGetPromiseType(pp)) == 0))
     {
         if (t.ifelapsed != CF_NOINT)
         {
             Log(LOG_LEVEL_WARNING,
                 "ifelapsed attribute specified in action body for %s promise '%s',"
                 " but %s promises do not support promise locking",
-                pp->parent_section->promise_type, pp->promiser,
-                pp->parent_section->promise_type);
+                PromiseGetPromiseType(pp), pp->promiser,
+                PromiseGetPromiseType(pp));
         }
         if (t.expireafter != CF_NOINT)
         {
             Log(LOG_LEVEL_WARNING,
                 "expireafter attribute specified in action body for %s promise '%s',"
                 " but %s promises do not support promise locking",
-                pp->parent_section->promise_type, pp->promiser,
-                pp->parent_section->promise_type);
+                PromiseGetPromiseType(pp), pp->promiser,
+                PromiseGetPromiseType(pp));
         }
     }
 

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -2598,7 +2598,7 @@ static const char *const NO_LOG_TYPES[] =
  */
 static bool IsPromiseValuableForStatus(const Promise *pp)
 {
-    return pp && (pp->parent_section->promise_type != NULL) && (!IsStrIn(pp->parent_section->promise_type, NO_STATUS_TYPES));
+    return pp && (PromiseGetPromiseType(pp) != NULL) && (!IsStrIn(PromiseGetPromiseType(pp), NO_STATUS_TYPES));
 }
 
 /*
@@ -2608,7 +2608,7 @@ static bool IsPromiseValuableForStatus(const Promise *pp)
 
 static bool IsPromiseValuableForLogging(const Promise *pp)
 {
-    return pp && (pp->parent_section->promise_type != NULL) && (!IsStrIn(pp->parent_section->promise_type, NO_LOG_TYPES));
+    return pp && (PromiseGetPromiseType(pp) != NULL) && (!IsStrIn(PromiseGetPromiseType(pp), NO_LOG_TYPES));
 }
 
 static void AddAllClasses(EvalContext *ctx, const Rlist *list, unsigned int persistence_ttl,

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -236,8 +236,8 @@ static PromiseResult ExpandPromiseAndDo(EvalContext *ctx, PromiseIterator *iterc
         /* EVALUATE VARS PROMISES again, allowing redefinition of
          * variables. The theory behind this is that the "sampling rate" of
          * vars promise needs to be double than the rest. */
-        if (strcmp(pexp->parent_section->promise_type, "vars") == 0 ||
-            strcmp(pexp->parent_section->promise_type, "meta") == 0)
+        if (strcmp(PromiseGetPromiseType(pexp), "vars") == 0 ||
+            strcmp(PromiseGetPromiseType(pexp), "meta") == 0)
         {
             if (act_on_promise != &VerifyVarPromise)
             {
@@ -263,7 +263,7 @@ PromiseResult ExpandPromise(EvalContext *ctx, const Promise *pp,
     {
         Log(LOG_LEVEL_DEBUG,
             "Skipping %s promise expansion with promiser '%s' due to class guard '%s::' (pass %d)",
-            pp->parent_section->promise_type,
+            PromiseGetPromiseType(pp),
             pp->promiser,
             pp->classes,
             EvalContextGetPass(ctx));

--- a/libpromises/instrumentation.c
+++ b/libpromises/instrumentation.c
@@ -73,7 +73,7 @@ void EndMeasurePromise(struct timespec start, const Promise *pp)
 
     if (mid)
     {
-        snprintf(id, CF_BUFSIZE, "%s:%s:%.100s", mid, pp->parent_section->promise_type, pp->promiser);
+        snprintf(id, CF_BUFSIZE, "%s:%s:%.100s", mid, PromiseGetPromiseType(pp), pp->promiser);
         Chop(id, CF_EXPANDSIZE);
         EndMeasure(id, start);
     }

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -507,7 +507,7 @@ static void RegisterLockCleanup(void)
  */
 static void PromiseTypeString(char *dst, size_t dst_size, const Promise *pp)
 {
-    char *sp       = pp->parent_section->promise_type;
+    const char *sp = PromiseGetPromiseType(pp);
     size_t sp_len  = strlen(sp);
 
     dst[0]         = '\0';

--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -632,9 +632,13 @@ static bool PromiseModule_Validate(PromiseModule *module, const Promise *pp)
     assert(module != NULL);
     assert(pp != NULL);
 
+    const char *const promise_type = PromiseGetPromiseType(pp);
+    const char *const promiser = pp->promiser;
+
     PromiseModule_AppendString(module, "operation", "validate_promise");
     PromiseModule_AppendString(module, "log_level", LogLevelToRequestFromModule());
-    PromiseModule_AppendString(module, "promiser", pp->promiser);
+    PromiseModule_AppendString(module, "promise_type", promise_type);
+    PromiseModule_AppendString(module, "promiser", promiser);
     PromiseModule_AppendAllAttributes(module, pp);
     PromiseModule_Send(module);
 
@@ -654,8 +658,6 @@ static bool PromiseModule_Validate(PromiseModule *module, const Promise *pp)
     if (!valid)
     {
         // Detailed error messages from module should already have been printed
-        const char *const promise_type = pp->parent_section->promise_type;
-        const char *const promiser = pp->promiser;
         const char *const filename =
             pp->parent_section->parent_bundle->source_path;
         const size_t line = pp->offset.line;
@@ -676,10 +678,14 @@ static PromiseResult PromiseModule_Evaluate(
     assert(module != NULL);
     assert(pp != NULL);
 
+    const char *const promise_type = PromiseGetPromiseType(pp);
+    const char *const promiser = pp->promiser;
+
     PromiseModule_AppendString(module, "operation", "evaluate_promise");
     PromiseModule_AppendString(
         module, "log_level", LogLevelToRequestFromModule());
-    PromiseModule_AppendString(module, "promiser", pp->promiser);
+    PromiseModule_AppendString(module, "promise_type", promise_type);
+    PromiseModule_AppendString(module, "promiser", promiser);
 
     PromiseModule_AppendAllAttributes(module, pp);
     PromiseModule_Send(module);
@@ -714,8 +720,8 @@ static PromiseResult PromiseModule_Evaluate(
             pp,
             &a,
             "Promise module did not return a result for promise evaluation (%s promise, promiser: '%s' module: '%s')",
-            pp->parent_section->promise_type,
-            pp->promiser,
+            promise_type,
+            promiser,
             module->path);
     }
     else if (StringEqual(result_str, "kept"))
@@ -728,7 +734,7 @@ static PromiseResult PromiseModule_Evaluate(
             pp,
             &a,
             "Promise with promiser '%s' was kept by promise module '%s'",
-            pp->promiser,
+            promiser,
             module->path);
     }
     else if (StringEqual(result_str, "not_kept"))
@@ -741,7 +747,7 @@ static PromiseResult PromiseModule_Evaluate(
             pp,
             &a,
             "Promise with promiser '%s' was not kept by promise module '%s'",
-            pp->promiser,
+            promiser,
             module->path);
     }
     else if (StringEqual(result_str, "repaired"))
@@ -754,7 +760,7 @@ static PromiseResult PromiseModule_Evaluate(
             pp,
             &a,
             "Promise with promiser '%s' was repaired by promise module '%s'",
-            pp->promiser,
+            promiser,
             module->path);
     }
     else if (StringEqual(result_str, "error"))
@@ -767,8 +773,8 @@ static PromiseResult PromiseModule_Evaluate(
             pp,
             &a,
             "An unexpected error occured in promise module (%s promise, promiser: '%s' module: '%s')",
-            pp->parent_section->promise_type,
-            pp->promiser,
+            promise_type,
+            promiser,
             module->path);
     }
     else
@@ -782,8 +788,8 @@ static PromiseResult PromiseModule_Evaluate(
             &a,
             "Promise module returned unacceptable result: '%s' (%s promise, promiser: '%s' module: '%s')",
             result_str,
-            pp->parent_section->promise_type,
-            pp->promiser,
+            promise_type,
+            promiser,
             module->path);
     }
 

--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -47,7 +47,7 @@ Body *FindCustomPromiseType(const Promise *promise)
 {
     assert(promise != NULL);
 
-    const char *const promise_type = promise->parent_section->promise_type;
+    const char *const promise_type = PromiseGetPromiseType(promise);
     const Policy *const policy =
         promise->parent_section->parent_bundle->parent_policy;
     Seq *custom_promise_types = policy->custom_promise_types;
@@ -815,7 +815,7 @@ PromiseResult EvaluateCustomPromise(EvalContext *ctx, const Promise *pp)
     {
         Log(LOG_LEVEL_ERR,
             "Undefined promise type '%s'",
-            pp->parent_section->promise_type);
+            PromiseGetPromiseType(pp));
         return PROMISE_RESULT_FAIL;
     }
 
@@ -853,7 +853,7 @@ PromiseResult EvaluateCustomPromise(EvalContext *ctx, const Promise *pp)
         {
             Log(LOG_LEVEL_ERR,
                 "%s promise with promiser '%s' has unresolved/unexpanded variables",
-                pp->parent_section->promise_type,
+                PromiseGetPromiseType(pp),
                 pp->promiser);
         }
     }
@@ -867,7 +867,7 @@ PromiseResult EvaluateCustomPromise(EvalContext *ctx, const Promise *pp)
         // PromiseModule_Validate() already printed an error
         Log(LOG_LEVEL_VERBOSE,
             "%s promise with promiser '%s' will be skipped because it failed validation",
-            pp->parent_section->promise_type,
+            PromiseGetPromiseType(pp),
             pp->promiser);
         result = PROMISE_RESULT_FAIL; // TODO: Investigate if DENIED is more
                                       // appropriate

--- a/libpromises/ornaments.c
+++ b/libpromises/ornaments.c
@@ -148,11 +148,11 @@ void PromiseBanner(EvalContext *ctx, const Promise *pp)
 
     if (strlen(handle) > 0)
     {
-        Log(LOG_LEVEL_VERBOSE, "P: BEGIN promise '%s' of type \"%s\" (pass %d)", handle, pp->parent_section->promise_type, EvalContextGetPass(ctx));
+        Log(LOG_LEVEL_VERBOSE, "P: BEGIN promise '%s' of type \"%s\" (pass %d)", handle, PromiseGetPromiseType(pp), EvalContextGetPass(ctx));
     }
     else
     {
-        Log(LOG_LEVEL_VERBOSE, "P: BEGIN un-named promise of type \"%s\" (pass %d)", pp->parent_section->promise_type, EvalContextGetPass(ctx));
+        Log(LOG_LEVEL_VERBOSE, "P: BEGIN un-named promise of type \"%s\" (pass %d)", PromiseGetPromiseType(pp), EvalContextGetPass(ctx));
     }
 
     const size_t n = 2*CF_MAXFRAGMENT + 3;

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2713,7 +2713,7 @@ static bool ValidateCustomPromise(const Promise *pp, Seq *errors)
     assert(pp->parent_section != NULL);
     assert(errors != NULL);
 
-    const char *const promise_type = pp->parent_section->promise_type;
+    const char *const promise_type = PromiseGetPromiseType(pp);
     const char *const promiser = pp->promiser;
     bool valid = true;
     Seq *attributes = pp->conlist;
@@ -2796,7 +2796,7 @@ static bool PromiseCheck(const Promise *pp, Seq *errors)
         success = false;
     }
 
-    const bool is_builtin = IsBuiltInPromiseType(pp->parent_section->promise_type);
+    const bool is_builtin = IsBuiltInPromiseType(PromiseGetPromiseType(pp));
 
     if (is_builtin)
     {
@@ -2809,7 +2809,7 @@ static bool PromiseCheck(const Promise *pp, Seq *errors)
     }
 
     const PromiseTypeSyntax *pts = PromiseTypeSyntaxGet(pp->parent_section->parent_bundle->type,
-                                                        pp->parent_section->promise_type);
+                                                        PromiseGetPromiseType(pp));
 
 
     if (pts == NULL)
@@ -3265,7 +3265,7 @@ void PromiseRecheckAllConstraints(const EvalContext *ctx, const Promise *pp)
     /* Check and warn for non-convergence, see commits
        4f8c19b84327b8f3c2e269173196282ccedfdad9 and
        30c109d22e170a781a647b04b4b0a4a2f7244871. */
-    if (strcmp(pp->parent_section->promise_type, "insert_lines") == 0)
+    if (strcmp(PromiseGetPromiseType(pp), "insert_lines") == 0)
     {
         /* TODO without static var, actually remove this check from here
          * completely, do it at the end of PRE-EVAL promise iterations

--- a/libpromises/policy.h
+++ b/libpromises/policy.h
@@ -194,6 +194,12 @@ const char *PromiseGetNamespace(const Promise *pp);
 const Bundle *PromiseGetBundle(const Promise *pp);
 const Policy *PromiseGetPolicy(const Promise *pp);
 
+static inline const char *PromiseGetPromiseType(const Promise *pp)
+{
+    assert(pp != NULL);
+    return pp->parent_section->promise_type;
+}
+
 void PromisePath(Writer *w, const Promise *pp);
 const char *PromiseGetHandle(const Promise *pp);
 int PromiseGetConstraintAsInt(const EvalContext *ctx, const char *lval, const Promise *pp);

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -421,7 +421,7 @@ Promise *DeRefCopyPromise(EvalContext *ctx, const Promise *pp)
 
     // Add default body for promise body types that are not present
     char *bundle_type = pcopy->parent_section->parent_bundle->type;
-    char *promise_type = pcopy->parent_section->promise_type;
+    const char *promise_type = PromiseGetPromiseType(pcopy);
     const PromiseTypeSyntax *syntax = PromiseTypeSyntaxGet(bundle_type, promise_type);
     AddDefaultBodiesToPromise(ctx, pcopy, syntax);
 
@@ -450,7 +450,7 @@ static void AddDefaultBodiesToPromise(EvalContext *ctx, Promise *promise, const 
             if(!PromiseBundleOrBodyConstraintExists(ctx, constraint_type, promise)) {
                 const Policy *policy = PolicyFromPromise(promise);
                 // default format is <promise_type>_<body_type>
-                char* default_body_name = StringConcatenate(3, promise->parent_section->promise_type, "_", constraint_type);
+                char* default_body_name = StringConcatenate(3, PromiseGetPromiseType(promise), "_", constraint_type);
                 const Body *bp = EvalContextFindFirstMatchingBody(policy, constraint_type, "bodydefault", default_body_name);
                 if(bp) {
                     Log(LOG_LEVEL_VERBOSE, "Using the default body: %60s", default_body_name);
@@ -586,8 +586,8 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
     pcopy->promiser = RvalScalarValue(returnval);
 
     /* TODO remove the conditions here for fixing redmine#7880. */
-    if ((strcmp("files", pp->parent_section->promise_type) != 0) &&
-        (strcmp("storage", pp->parent_section->promise_type) != 0))
+    if ((strcmp("files", PromiseGetPromiseType(pp)) != 0) &&
+        (strcmp("storage", PromiseGetPromiseType(pp)) != 0))
     {
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promiser", pcopy->promiser,
                                       CF_DATA_TYPE_STRING, "source=promise");
@@ -610,7 +610,7 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
     pcopy->org_pp = pp->org_pp;
 
     // if this is a class promise, check if it is already set, if so, skip
-    if (strcmp("classes", pp->parent_section->promise_type) == 0)
+    if (strcmp("classes", PromiseGetPromiseType(pp)) == 0)
     {
         if (IsDefinedClass(ctx, CanonifyName(pcopy->promiser)))
         {
@@ -685,7 +685,7 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
                 // We default to NOT skipping (since if would skip).
                 Log(LOG_LEVEL_VERBOSE,
                     "Not skipping %s promise '%s' with constraint '%s => %s' in last evaluation pass (since if would skip)",
-                    pp->parent_section->promise_type,
+                    PromiseGetPromiseType(pp),
                     pp->promiser,
                     unless->lval,
                     unless_string);

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -142,8 +142,8 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
             Log(LOG_LEVEL_WARNING,
                 "ifelapsed attribute specified in action body for %s promise '%s',"
                 " but %s promises do not support promise locking",
-                pp->parent_section->promise_type, pp->promiser,
-                pp->parent_section->promise_type);
+                PromiseGetPromiseType(pp), pp->promiser,
+                PromiseGetPromiseType(pp));
         }
         int expireafter = PromiseGetConstraintAsInt(ctx, "expireafter", pp);
         if (expireafter != CF_NOINT)
@@ -151,15 +151,15 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
             Log(LOG_LEVEL_WARNING,
                 "expireafter attribute specified in action body for %s promise '%s',"
                 " but %s promises do not support promise locking",
-                pp->parent_section->promise_type, pp->promiser,
-                pp->parent_section->promise_type);
+                PromiseGetPromiseType(pp), pp->promiser,
+                PromiseGetPromiseType(pp));
         }
     }
 
     a.classes = GetClassDefinitionConstraints(ctx, pp);
 
     VarRef *ref = VarRefParseFromBundle(pp->promiser, PromiseGetBundle(pp));
-    if (strcmp("meta", pp->parent_section->promise_type) == 0)
+    if (strcmp("meta", PromiseGetPromiseType(pp)) == 0)
     {
         VarRefSetMeta(ref, true);
     }


### PR DESCRIPTION
Custom promise modules can potentially implement multiple promise types so they need to know the type of the promise they are asked to validate or evaluate.