### PR TITLE
ENT-5348 Define 'RELEASE' macro based on the $RELEASE environment variable (3.12.x)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,10 @@ m4_undefine([cfversion])
 m4_undefine([cfversion_from_file])
 m4_undefine([cfversion_from_env])
 
+AS_IF([test -n "$RELEASE"],
+      [AC_DEFINE_UNQUOTED(RELEASE, ["$RELEASE"], [Release number])],
+      [AC_DEFINE(RELEASE, ["1"], [Release number])])
+
 AC_DEFINE(BUILD_YEAR, esyscmd([date +%Y | tr -d '\n']), "Software build year")
 
 AC_DEFINE_UNQUOTED(ABS_TOP_SRCDIR,

--- a/examples/variablesmatching.cf
+++ b/examples/variablesmatching.cf
@@ -44,5 +44,6 @@ bundle agent run
 #@ R: Variables matching 'default:sys.cf_version.*' = default:sys.cf_version_major
 #@ R: Variables matching 'default:sys.cf_version.*' = default:sys.cf_version_minor
 #@ R: Variables matching 'default:sys.cf_version.*' = default:sys.cf_version_patch
+#@ R: Variables matching 'default:sys.cf_version.*' = default:sys.cf_version_release
 #@ ```
 #+end_src

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -415,6 +415,9 @@ void DiscoverVersion(EvalContext *ctx)
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "cf_version_patch", "BAD VERSION " VERSION, CF_DATA_TYPE_STRING, "source=agent");
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "libdir", workdir, CF_DATA_TYPE_STRING, "source=agent");
     }
+
+    EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "cf_version_release", RELEASE, CF_DATA_TYPE_STRING, "source=agent");
+
 }
 
 static void GetNameInfo3(EvalContext *ctx)


### PR DESCRIPTION
This way we can propagate the environment variable to C
sources. If there is no such environment variable, or the value
is empty, we default to "1".

Ticket: ENT-5348
Changelog: None

merge together
https://github.com/cfengine/masterfiles/pull/1944
https://github.com/cfengine/core/pull/4548
