### PR TITLE
CFE-3569: Make sure hard class suse is defined on SUSE (3.15.x)

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1143,6 +1143,11 @@ static void OSReleaseParse(EvalContext *ctx, const char *file_path)
             {
                 alias = "redhat";
             }
+            else if (StringEqual(os_release_id, "opensuse") || 
+                     StringEqual(os_release_id, "sles"))
+            {
+                alias = "suse";
+            }
 
             if (os_release_version_id == NULL)
             {

--- a/tests/acceptance/02_classes/01_basic/expected_os_classes.cf
+++ b/tests/acceptance/02_classes/01_basic/expected_os_classes.cf
@@ -1,0 +1,42 @@
+body common control
+{
+  bundlesequence => { "test", "check" };
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-3608" }
+        string => "Make sure at least one of the expected os hard classes are defined";
+
+  vars:
+    DEBUG::
+      "defined_classes" string => join("$(const.n)", classesmatching(".*"));
+}
+
+bundle agent check
+{
+    classes:
+        "passed" or => { "debian",
+                         "ubuntu",
+                         "redhat",
+                         "centos",
+                         "fedora",
+                         "aix",
+                         "hpux",
+                         "suse",
+                         "windows",
+                         "freebsd",
+                         "macos",
+                         "solaris" };
+    
+    reports:
+      DEBUG&!passed::
+        "None of the expected classes were defined.";
+        "Here is a list of defined classes:";
+        "$(test.defined_classes)";
+      passed::
+        "$(this.promise_filename) Pass";
+      !passed::
+        "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Ticket: CFE-3569
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 2d0c678df5b9b64e792ad6b96ff14e9efcb45fac)