### PR TITLE
ENT-6935 Added flakey test result handling to testall

### DIFF
--- a/tests/acceptance/Makefile.am
+++ b/tests/acceptance/Makefile.am
@@ -87,6 +87,7 @@ endif
 # to run in parallel; TODO fix "make -n" not working:
 check-local:
 	+ $(TESTS_ENVIRONMENT) MAKE=$(MAKE) $(srcdir)/testall
+	+ $(srcdir)/selftest.sh
 
 
 EXTRA_DIST = default.cf.sub dcs.cf.sub plucked.cf.sub run_with_server.cf.sub \
@@ -96,6 +97,9 @@ EXTRA_DIST = default.cf.sub dcs.cf.sub plucked.cf.sub run_with_server.cf.sub \
 
 # Recursively include all tests in the dist tarball and set proper permissions
 EXTRA_DIST += $(wildcard [0-9]*)
+
+# Include selftest.sh and selftest directory contents in dist tarball
+EXTRA_DIST += selftest.sh selftest
 
 dist-hook:
 	chmod -R go-w $(distdir)

--- a/tests/acceptance/README
+++ b/tests/acceptance/README
@@ -15,6 +15,11 @@ In case you find a bug you are encouraged to create tests in format of testsuite
 which demonstrate bug found, so the test could be added to this testsuite and
 checked for in the future.
 
+Note that the testall script generates JUnit style XML output for parsing by CI systems.
+
+https://llg.cubic.org/docs/junit/
+
+
 ------------------------------------------------------------------------------
 Preparing for running tests
 ------------------------------------------------------------------------------
@@ -204,16 +209,20 @@ possible variable names:
 
   - test_soft_fail
   - test_suppress_fail
+  - test_flakey_fail
       Runs the test, but will accept failure. Use this when there is a
       real failure, but it is acceptable for the time being. This
       variable requires a meta tag on the variable set to
       "redmine<number>", where <number> is a Redmine issue number.
-      There is a subtle difference between the two. Soft failures will
+      There is a subtle difference between the three. Soft failures will
       not be reported as a failure in the XML output, and is
       appropriate for test cases that document incoming bug reports.
       Suppressed failures will count as a failure, but it won't block
       the build, and is appropriate for regressions or bad test
       failures.
+      Flakey failures count in a category by themselves and won't block
+      the build. If any are present then a different exit code will be
+      produced from the test run so that CI runners can react accordingly.
 
 Additionally, a *description* meta variable can be added to the test to describe
 its function.

--- a/tests/acceptance/selftest.sh
+++ b/tests/acceptance/selftest.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+
+# because results in test.xml should not be parsed by CI or otherwise
+# failures there may be expected and will be checked by grep below
+clean ()
+{
+  rm test.xml
+}
+check ()
+{
+  expect=$1
+  log=$2
+  if ! grep "$expect" "$log" >/dev/null
+  then
+    echo "error: failed to match regex \"$expect\" in log file $log"
+    return 1
+  fi
+}
+
+mkdir -p workdir
+
+./testall selftest > workdir/selftest_normal.log
+ret=$?
+if [ "$ret" -ne "0" ]
+then
+  echo "error: exit code for selftest should be 0 but was $ret"
+  clean
+  exit 1
+fi
+
+log="workdir/selftest_normal.log"
+
+errors=0
+_pwd=$(pwd)
+
+for regex in \
+"./selftest/fail.cf FAIL (Suppressed, R: $_pwd/./selftest/fail.cf XFAIL)" \
+"./selftest/flaky_fail.cf Flakey fail (R: $_pwd/./selftest/flaky_fail.cf FLAKEY)" \
+"./selftest/flaky_pass.cf Pass" \
+"./selftest/pass.cf Pass" \
+"./selftest/skipped.cf Skipped (Test needs work)" \
+"./selftest/soft.cf Soft fail (R: $_pwd/./selftest/soft.cf SFAIL)" \
+"Passed tests:    2" \
+"Failed tests:    1 (1 are known and suppressed)" \
+"Skipped tests:   1" \
+"Soft failures:   1" \
+"Flakey failures: 1" \
+"Total tests:     6"
+do
+  check "$regex" "$log" || errors=$((errors + 1))
+done
+if [ "$errors" -ne "0" ]
+then
+  echo "error: $errors error(s) occurred for selftest (flakey is not fail)"
+  echo "=== BEGIN $log ==="
+  cat $log
+  echo "=== END $log ==="
+  clean
+  exit 1
+fi
+
+
+FLAKEY_IS_FAIL=1 ./testall selftest > workdir/selftest_flakey_is_fail.log
+ret=$?
+if [ "$ret" -ne "4" ]
+then
+  echo "error: exit code for testall with FLAKEY_IS_FAIL=1 should be 4 but was $ret"
+  clean
+  exit 1
+fi
+
+errors=0
+log="workdir/selftest_flakey_is_fail.log"
+
+for regex in \
+"./selftest/fail.cf FAIL (Suppressed, R: $_pwd/./selftest/fail.cf XFAIL)" \
+"./selftest/flaky_fail.cf Flakey fail (R: $_pwd/./selftest/flaky_fail.cf FLAKEY)" \
+"./selftest/flaky_pass.cf Pass" \
+"./selftest/pass.cf Pass" \
+"./selftest/skipped.cf Skipped (Test needs work)" \
+"./selftest/soft.cf Soft fail (R: $_pwd/./selftest/soft.cf SFAIL)" \
+"Passed tests:    2" \
+"Failed tests:    1 (1 are known and suppressed)" \
+"Skipped tests:   1" \
+"Soft failures:   1" \
+"Flakey failures: 1" \
+"Total tests:     6"
+do
+  check "$regex" "$log" || errors=$((errors + 1))
+done
+if [ "$errors" -ne "0" ]
+then
+  echo "error: $errors error(s) occurred for selftest (flakey is fail)"
+  echo "=== BEGIN $log ==="
+  cat $log
+  echo "=== END $log ==="
+  clean
+  exit 1
+fi

--- a/tests/acceptance/selftest/fail.cf
+++ b/tests/acceptance/selftest/fail.cf
@@ -1,0 +1,5 @@
+bundle agent main
+{
+  reports:
+    "$(this.promise_filename) XFAIL";
+}

--- a/tests/acceptance/selftest/flaky_fail.cf
+++ b/tests/acceptance/selftest/flaky_fail.cf
@@ -1,0 +1,5 @@
+bundle agent main
+{
+  reports:
+    "$(this.promise_filename) FLAKEY";
+}

--- a/tests/acceptance/selftest/flaky_pass.cf
+++ b/tests/acceptance/selftest/flaky_pass.cf
@@ -1,0 +1,5 @@
+bundle agent main
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}

--- a/tests/acceptance/selftest/pass.cf
+++ b/tests/acceptance/selftest/pass.cf
@@ -1,0 +1,5 @@
+bundle agent main
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}

--- a/tests/acceptance/selftest/skipped.cf
+++ b/tests/acceptance/selftest/skipped.cf
@@ -1,0 +1,18 @@
+body common control
+{
+      inputs => { "../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+    "test_skip_needs_work" string => "any";
+}
+
+bundle agent check
+{
+  reports:
+    "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/selftest/soft.cf
+++ b/tests/acceptance/selftest/soft.cf
@@ -1,0 +1,5 @@
+bundle agent main
+{
+  reports:
+    "$(this.promise_filename) SFAIL";
+}

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -155,6 +155,7 @@ FAILED_TESTS=0
 SUPPRESSED_FAILURES=0
 SOFT_FAILURES=0
 SKIPPED_TESTS=0
+FLAKEY_FAILURES=0
 
 #
 # Many older platforms don't support date +%s, so check for compatibility
@@ -617,6 +618,12 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
             then
                 RESULT=Skip
                 RESULT_MSG="${COLOR_WARNING}Skipped (Test needs work)${COLOR_NORMAL}"
+            elif egrep "R: .*$ESCAPED_TEST FLAKEY" $OUTFILE > /dev/null
+            then
+                RESULT=FLAKEY
+                TICKET="$(egrep "R: .*$ESCAPED_TEST FLAKEY" $OUTFILE | sed -e "s,.*FLAKEY/\(.*\),\1,")"
+                RESULT_MSG="${COLOR_WARNING}Flakey fail ($TICKET)${COLOR_NORMAL}"
+
             else
                 RESULT=FAIL
                 RESULT_MSG="${COLOR_FAILURE}FAIL${COLOR_NORMAL}"
@@ -1032,7 +1039,7 @@ then
         fi
     done
 else
-    ALL_TESTS="$ALL_TESTS${ALL_TESTS:+ }$(find . -name workdir -prune -o -name '*.cf' -print | sort)"
+    ALL_TESTS="$ALL_TESTS${ALL_TESTS:+ }$(find . \( -name selftest -o -name workdir \) -prune -o -name '*.cf' -print | sort)"
 fi
 
 for addtest in $ALL_TESTS
@@ -1099,6 +1106,7 @@ print_footer() {
     FAILED_TESTS=`egrep '^(FAIL|XFAIL) ' $SUMMARY | wc -l | tr -d ' '`
     SUPPRESSED_FAILURES=`egrep '^XFAIL ' $SUMMARY | wc -l | tr -d ' '`
     SOFT_FAILURES=`egrep '^SFAIL ' $SUMMARY | wc -l | tr -d ' '`
+    FLAKEY_FAILURES=`egrep '^FLAKEY ' $SUMMARY | wc -l | tr -d ' '`
     SKIPPED_TESTS=`egrep '^Skip ' $SUMMARY | wc -l | tr -d ' '`
 
     ( echo
@@ -1107,17 +1115,18 @@ print_footer() {
     ) | tee -a "$LOG" | tee -a "$SUMMARY" >&7
 
     ( echo
-      echo   "Passed tests:  $PASSED_TESTS"
-      printf "Failed tests:  $FAILED_TESTS"
+      echo   "Passed tests:    $PASSED_TESTS"
+      printf "Failed tests:    $FAILED_TESTS"
       if [ $SUPPRESSED_FAILURES -gt 0 ]
       then
           echo " ($SUPPRESSED_FAILURES are known and suppressed)"
       else
           echo
       fi
-      echo   "Skipped tests: $SKIPPED_TESTS"
-      echo   "Soft failures: $SOFT_FAILURES"
-      echo   "Total tests:   $TESTS_COUNT"
+      echo   "Skipped tests:   $SKIPPED_TESTS"
+      echo   "Soft failures:   $SOFT_FAILURES"
+      echo   "Flakey failures: $FLAKEY_FAILURES"
+      echo   "Total tests:     $TESTS_COUNT"
     ) | tee -a "$LOG" | tee -a "$SUMMARY"
 
     if [ -n "$PRINTLOG" ]
@@ -1362,7 +1371,7 @@ then
     finish_xml
 fi
 
-if [ $(($PASSED_TESTS+$FAILED_TESTS+$SOFT_FAILURES+$SKIPPED_TESTS)) -ne $TESTS_COUNT ]
+if [ $(($PASSED_TESTS+$FAILED_TESTS+$SOFT_FAILURES+$SKIPPED_TESTS+$FLAKEY_FAILURES)) -ne $TESTS_COUNT ]
 then
     echo "WARNING: Number of test results does not match number of tests!"
     echo "Did something go wrong during execution?"
@@ -1371,6 +1380,9 @@ fi
 if [ "$FAILED_TESTS" -gt "$SUPPRESSED_FAILURES" ]
 then
     exit 1
+elif [ "$FLAKEY_FAILURES" -gt "0" ] && [ -n "$FLAKEY_IS_FAIL" ]
+then
+    exit 4
 else
     exit 0
 fi


### PR DESCRIPTION
If a tests/acceptance test outputs FLAKEY, testall
will consider it a flakey failure and not fail the
test run.

Ticket: ENT-6935
Changelog: title