### PR TITLE
ENT-6947 Added FLAKEY/test_flakey_fail test result to acceptance test framework

### DIFF
--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -276,7 +276,7 @@ bundle agent collect_stories_metadata
 bundle agent test_precheck
 {
   vars:
-      "fail_types" slist => { "suppress", "soft" };
+      "fail_types" slist => { "suppress", "soft", "flakey" };
 
       "test_skip_unsupported" slist => variablesmatching(".*_meta\.test_skip_unsupported");
       "test_skip_needs_work" slist => variablesmatching(".*_meta\.test_skip_needs_work");
@@ -310,6 +310,10 @@ bundle agent test_precheck
     test_soft_fail_match.test_soft_fail_ticket_set::
       "$(this.promise_filename) SFAIL/$(test_soft_fail_ticket)";
     test_soft_fail_match.!test_soft_fail_ticket_set::
+      "$(this.promise_filename) FAIL/no_ticket_number";
+    test_flakey_fail_match.test_flakey_fail_ticket_set::
+      "$(this.promise_filename) FLAKEY/$(test_flakey_fail_ticket)";
+    test_flakey_fail_match.!test_flakey_fail_ticket_set::
       "$(this.promise_filename) FAIL/no_ticket_number";
 }
 

--- a/tests/acceptance/selftest.sh
+++ b/tests/acceptance/selftest.sh
@@ -5,7 +5,7 @@
 # failures there may be expected and will be checked by grep below
 clean ()
 {
-  rm test.xml
+  rm -f test.xml
 }
 check ()
 {
@@ -22,9 +22,9 @@ mkdir -p workdir
 
 ./testall selftest > workdir/selftest_normal.log
 ret=$?
-if [ "$ret" -ne "0" ]
+if [ "$ret" -ne "1" ]
 then
-  echo "error: exit code for selftest should be 0 but was $ret"
+  echo "error: exit code for selftest should be 1 but was $ret"
   clean
   exit 1
 fi
@@ -36,17 +36,20 @@ _pwd=$(pwd)
 
 for regex in \
 "./selftest/fail.cf FAIL (Suppressed, R: $_pwd/./selftest/fail.cf XFAIL)" \
+"./selftest/flakey_meta_fail.cf Flakey fail (ENT-6947)" \
+"./selftest/flakey_meta_no_ticket.cf FAIL (Tried to suppress failure, but no issue number is provided) (UNEXPECTED FAILURE)" \
 "./selftest/flaky_fail.cf Flakey fail (R: $_pwd/./selftest/flaky_fail.cf FLAKEY)" \
 "./selftest/flaky_pass.cf Pass" \
 "./selftest/pass.cf Pass" \
 "./selftest/skipped.cf Skipped (Test needs work)" \
 "./selftest/soft.cf Soft fail (R: $_pwd/./selftest/soft.cf SFAIL)" \
+"./selftest/soft_no_ticket.cf FAIL (Tried to suppress failure, but no issue number is provided) (UNEXPECTED FAILURE)" \
 "Passed tests:    2" \
-"Failed tests:    1 (1 are known and suppressed)" \
+"Failed tests:    3 (1 are known and suppressed)" \
 "Skipped tests:   1" \
 "Soft failures:   1" \
-"Flakey failures: 1" \
-"Total tests:     6"
+"Flakey failures: 2" \
+"Total tests:     9"
 do
   check "$regex" "$log" || errors=$((errors + 1))
 done
@@ -61,7 +64,7 @@ then
 fi
 
 
-FLAKEY_IS_FAIL=1 ./testall selftest > workdir/selftest_flakey_is_fail.log
+FLAKEY_IS_FAIL=1 ./testall selftest/flakey_meta_fail.cf selftest/flaky_fail.cf selftest/flaky_pass.cf > workdir/selftest_flakey_is_fail.log
 ret=$?
 if [ "$ret" -ne "4" ]
 then
@@ -74,18 +77,15 @@ errors=0
 log="workdir/selftest_flakey_is_fail.log"
 
 for regex in \
-"./selftest/fail.cf FAIL (Suppressed, R: $_pwd/./selftest/fail.cf XFAIL)" \
+"./selftest/flakey_meta_fail.cf Flakey fail (ENT-6947)" \
 "./selftest/flaky_fail.cf Flakey fail (R: $_pwd/./selftest/flaky_fail.cf FLAKEY)" \
 "./selftest/flaky_pass.cf Pass" \
-"./selftest/pass.cf Pass" \
-"./selftest/skipped.cf Skipped (Test needs work)" \
-"./selftest/soft.cf Soft fail (R: $_pwd/./selftest/soft.cf SFAIL)" \
-"Passed tests:    2" \
-"Failed tests:    1 (1 are known and suppressed)" \
-"Skipped tests:   1" \
-"Soft failures:   1" \
-"Flakey failures: 1" \
-"Total tests:     6"
+"Passed tests:    1" \
+"Failed tests:    0" \
+"Skipped tests:   0" \
+"Soft failures:   0" \
+"Flakey failures: 2" \
+"Total tests:     3"
 do
   check "$regex" "$log" || errors=$((errors + 1))
 done

--- a/tests/acceptance/selftest/flakey_meta_fail.cf
+++ b/tests/acceptance/selftest/flakey_meta_fail.cf
@@ -1,0 +1,19 @@
+body common control
+{
+      inputs => { "../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+    "test_flakey_fail" string => "any",
+      meta => { "ENT-6947" };
+}
+
+bundle agent check
+{
+  reports:
+    "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/selftest/flakey_meta_no_ticket.cf
+++ b/tests/acceptance/selftest/flakey_meta_no_ticket.cf
@@ -1,0 +1,18 @@
+body common control
+{
+      inputs => { "../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+    "test_flakey_fail" string => "any";
+}
+
+bundle agent check
+{
+  reports:
+    "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/selftest/soft_no_ticket.cf
+++ b/tests/acceptance/selftest/soft_no_ticket.cf
@@ -1,0 +1,18 @@
+body common control
+{
+      inputs => { "../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+    "test_soft_fail" string => "any";
+}
+
+bundle agent check
+{
+  reports:
+    "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Tests can now report FLAKEY or add test_flakey_fail meta promise similar to test_soft_fail.

In this way the test will report FLAKEY when failing, but Pass when passing.

Ticket: ENT-6947
Changelog: title

merge after https://github.com/cfengine/core/pull/4565 is merged and rebased here