### PR TITLE
ENT-6975 update 'bin' gid for suse 15 in tests - 3.12.x

### DIFF
--- a/tests/acceptance/17_users/unsafe/user_queries.cf.sub
+++ b/tests/acceptance/17_users/unsafe/user_queries.cf.sub
@@ -5,9 +5,9 @@ bundle common user_tests
       "group1" string => "bin";
       "group2" string => "sys";
       "gid2" string => "3";
-    redhat|suse::
+    redhat|suse.!suse_15::
       "gid1" string => "1";
-    !redhat.!suse.!windows::
+    !redhat.(!suse|suse_15).!windows::
       "gid1" string => "2";
 
     windows::


### PR DESCRIPTION
Issue was that since recently, it changed from 1 (like on RHEL) to 2 (like on
other Linuxes).

Changelog: none
(cherry picked from commit e54da26fb0dbfb46816779ac7cc6acfab36106ec)


----

#