### PR TITLE
Support slist attributes with custom promise modules using JSON protocol

### DIFF
--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -68,7 +68,7 @@ static const char *const POLICY_ERROR_PROMISE_ATTRIBUTE_NOT_IMPLEMENTED =
 static const char *const POLICY_ERROR_PROMISE_ATTRIBUTE_NOT_SUPPORTED =
     "Common attribute '%s' not supported for custom promises, use '%s' instead (%s promises)";
 static const char *const POLICY_ERROR_PROMISE_CUSTOM_CONTAINERS_NOT_IMPLEMENTED =
-    "Container / string list attributes not implemented for custom promises (%s promise, '%s' promiser, '%s' attribute)";
+    "Container attributes not implemented for custom promises (%s promise, '%s' promiser, '%s' attribute)";
 
 static const char *const POLICY_ERROR_CONSTRAINT_TYPE_MISMATCH =
     "Type mismatch in constraint: %s";
@@ -2758,11 +2758,8 @@ static bool ValidateCustomPromise(const Promise *pp, Seq *errors)
                     promise_type));
             valid = false;
         }
-        else if ((attribute->rval.type == RVAL_TYPE_CONTAINER)
-            || (attribute->rval.type == RVAL_TYPE_LIST))
+        else if (attribute->rval.type == RVAL_TYPE_CONTAINER)
         {
-            // TODO - Implement slists for custom promises:
-            // https://tracker.mender.io/browse/CFE-3444
             SeqAppend(
                 errors,
                 PolicyErrorNew(

--- a/tests/acceptance/30_custom_promise_types/08_slist_attrs.cf
+++ b/tests/acceptance/30_custom_promise_types/08_slist_attrs.cf
@@ -1,0 +1,67 @@
+######################################################
+#
+#  Basic test of promise module using the Python library and an slist attribute
+#
+#####################################################
+body common control
+{
+        inputs => { "../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+#######################################################
+
+bundle common python_check
+{
+  classes:
+      "python_f_string_support" expression => returnszero("/usr/bin/python3 -c 'f\"string\"'", "useshell");
+}
+
+bundle agent init
+{
+  meta:
+      "test_skip_unsupported" string => "!python_f_string_support";
+
+  files:
+      "$(this.promise_dirname)/cfengine.py"
+        copy_from => local_cp("$(this.promise_dirname)/../../../misc/custom_promise_types/cfengine.py");
+}
+
+#######################################################
+
+promise agent multiline_insert
+{
+        interpreter => "/usr/bin/python3";
+        path => "$(this.promise_dirname)/multiline_insert.py";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-3444" }
+        string => "Test a simple promise module which uses the Python library and an slist attribute";
+
+  vars:
+      "lines" slist => { "hello", "from", "modules" };
+
+  multiline_insert:
+      "$(G.testfile)"
+        lines => @(lines);
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok"
+        expression => strcmp(join("$(const.n)", "test.lines"), readfile("$(G.testfile)")),
+        if => fileexists("$(G.testfile)");
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/30_custom_promise_types/multiline_insert.py
+++ b/tests/acceptance/30_custom_promise_types/multiline_insert.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+#
+# Sample custom promise type, uses cfengine.py library located in same dir.
+#
+# Use it in the policy like this:
+# promise agent multiline_insert
+# {
+#     interpreter => "/usr/bin/python3";
+#     path => "$(sys.inputdir)/multiline_insert.py";
+# }
+# bundle agent main
+# {
+#   multiline_insert:
+#     "/home/vagrant/output"
+#       lines => { "line1", "line2", "line3" };
+# }
+
+from cfengine import PromiseModule, ValidationError, Result
+
+
+def _file_content_is(fpath, contents):
+    try:
+        with open(fpath, "r") as f:
+            return f.read() == contents
+    except:
+        return False
+
+
+class MultilineInsertPromiseTypeModule(PromiseModule):
+    def __init__(self):
+        super().__init__("multiline_insert_promise_module", "0.0.1")
+
+    def validate_promise(self, promiser, attributes):
+        if ("lines" not in attributes or
+            type(attributes["lines"]) not in (list, tuple) or
+            any(type(item) != str for item in attributes["lines"])):
+            raise ValidationError("'lines' attribute of type slist required")
+
+    def evaluate_promise(self, promiser, attributes):
+        dst = promiser
+        lines = attributes["lines"]
+        lines_str = "\n".join(lines)
+        if _file_content_is(dst, lines_str):
+            return Result.KEPT
+
+        try:
+            with open(dst, "w") as f:
+                f.write(lines_str)
+        except:
+            return Result.NOT_KEPT
+
+        if _file_content_is(dst, lines_str):
+            return Result.REPAIRED
+        else:
+            return Result.NOT_KEPT
+
+
+if __name__ == "__main__":
+    MultilineInsertPromiseTypeModule().start()


### PR DESCRIPTION
Just pass the slists as JSON arrays with strings.

Ticket: CFE-3444
Changelog: Custom promise modules using JSON protocol now support slist attributes

TODO:
- [x] implementation
- [x] manual testing
- [x] new acceptance test
- [x] documentation