### PR TITLE
ENT-5879: Fixed log level for failure to stat remote files without missing_ok (3.15)

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -2685,7 +2685,7 @@ static PromiseResult CopyFileSources(EvalContext *ctx, char *destination, const 
         }
         else
         {
-            cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_FAIL, pp, attr,
+            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, attr,
                  "Can't stat file '%s' on '%s' in files.copy_from promise",
                  BufferData(source), conn ? conn->remoteip : "localhost");
             BufferDestroy(source);


### PR DESCRIPTION
In versions before 3.12.0 it was not possible to suppress errors generated from
promises to copy remote files that did not exist. Because of this limitation,
this specific log message was moved from ERROR to INFO as it could generate many
logs that were impossible to avoid, whereas INFO log messages are not always
emitted, especially by regularly scheduled runs.

Version 3.12.0 introduced the missing_ok attribute which allows for clients to
avoid considering a missing remote file as an error.

This change restores the log level for the message to ERROR. Users should
instrument their policy with missing_ok if they are promising copies of files
that may not exist.

Ticket: ENT-5879
Changelog: Restored log level for failure to state remote files without missing_ok to ERROR