### PR TITLE
ENT-6626: Filtered error about unknown binary data from Valgrind test for cf-check dump (master)

### DIFF
--- a/tests/valgrind-check/valgrind.sh
+++ b/tests/valgrind-check/valgrind.sh
@@ -37,7 +37,7 @@ function check_valgrind_output {
     fi
     echo "Looking for problems in $1:"
     grep -i "ERROR SUMMARY: 0 errors" "$1"
-    cat $1 | sed -e "/ 0 errors/d" -e "/and suppressed error/d" -e "/a memory error detector/d" > filtered.txt
+    cat $1 | sed -e "/ 0 errors/d" -e "/and suppressed error/d" -e "/a memory error detector/d" -e "/This database contains unknown binary data/d" > filtered.txt
     no_errors filtered.txt
     set +e
     grep -i "at 0x" filtered.txt

--- a/travis-scripts/valgrind.sh
+++ b/travis-scripts/valgrind.sh
@@ -73,7 +73,7 @@ function check_output {
     fi
     echo "Looking for problems in $1:"
     grep -i "ERROR SUMMARY: 0 errors" "$1"
-    cat $1 | sed -e "/ 0 errors/d" -e "/and suppressed error/d" -e "/a memory error detector/d" > filtered.txt
+    cat $1 | sed -e "/ 0 errors/d" -e "/and suppressed error/d" -e "/a memory error detector/d" -e "/This database contains unknown binary data/d" > filtered.txt
     no_errors filtered.txt
     set +e
     grep -i "at 0x" filtered.txt


### PR DESCRIPTION
Recently a measurement tracking entropy available was added to the MPF. The
measurement causes cf-check dump to emit an error when dumping the
nova_static.lmdb database which in turn causes the Valigrind check to fail.

    cf-check dump ./nova_static.lmdb
    {
        "available_entropy/proc/sys/kernel/random/entropy_avail": "
    Error: This database contains unknown binary data - use --simple to print anyway

This change filters lines including "This database contains unknown binary data"
from consideration as an error by the Valgrind check.

Ticket: ENT-6626
Changelog: None