### PR TITLE
CFE-3560: Changed log message about whitespace in class expressions to be error (3.12.x)

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -546,7 +546,7 @@ bool IsDefinedClass(const EvalContext *ctx, const char *context)
 
     if (StringMatchFullWithPrecompiledRegex(context_expression_whitespace_rx, context))
     {
-        Log(LOG_LEVEL_INFO, "class names can't be separated by whitespace without an intervening operator in expression '%s'", context);
+        Log(LOG_LEVEL_ERR, "class expressions can't be separated by whitespace without an intervening operator in expression '%s'", context);
         return false;
     }
 


### PR DESCRIPTION
Output string was changed from:
`"class names [...]"`
to:
`"class expressions [...]"`

Ticket: CFE-3560
Changelog: Title
(cherry picked from commit eb9dd6c5d315d5a7daebc50610529f306ed56a04)