### PR TITLE
Change SINGLE_COPY_CACHE to be a StringSet

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -338,6 +338,8 @@ int main(int argc, char *argv[])
 
     GenericAgentFinalize(ctx, config);
 
+    StringSetDestroy(SINGLE_COPY_CACHE);
+
     StringSet *audited_files = NULL;
     if ((EVAL_MODE == EVAL_MODE_SIMULATE_MANIFEST) ||
         (EVAL_MODE == EVAL_MODE_SIMULATE_MANIFEST_FULL))
@@ -1087,6 +1089,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
             if (strcmp(cp->lval, CFA_CONTROLBODY[AGENT_CONTROL_FSINGLECOPY].lval) == 0)
             {
                 SINGLE_COPY_LIST = value;
+                SINGLE_COPY_CACHE = StringSetNew();
                 Log(LOG_LEVEL_VERBOSE, "Setting file single copy list");
                 continue;
             }

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -76,7 +76,7 @@ static const Rlist *AUTO_DEFINE_LIST = NULL; /* GLOBAL_P */
 static Item *VSETXIDLIST = NULL;
 
 const Rlist *SINGLE_COPY_LIST = NULL; /* GLOBAL_P */
-static Rlist *SINGLE_COPY_CACHE = NULL; /* GLOBAL_X */
+StringSet *SINGLE_COPY_CACHE = NULL; /* GLOBAL_X */
 
 static bool TransformFile(EvalContext *ctx, char *file, const Attributes *attr, const Promise *pp, PromiseResult *result);
 static PromiseResult VerifyName(EvalContext *ctx, char *path, const struct stat *sb, const Attributes *attr, const Promise *pp);
@@ -254,7 +254,7 @@ static PromiseResult CfCopyFile(EvalContext *ctx, char *sourcefile,
         return PROMISE_RESULT_NOOP;
     }
 
-    if (RlistIsInListOfRegex(SINGLE_COPY_CACHE, destfile))
+    if ((SINGLE_COPY_CACHE != NULL) && StringSetContains(SINGLE_COPY_CACHE, destfile))
     {
         RecordNoChange(ctx, pp, &attr, "Skipping single-copied file '%s'", destfile);
         return PROMISE_RESULT_NOOP;
@@ -408,7 +408,7 @@ static PromiseResult CfCopyFile(EvalContext *ctx, char *sourcefile,
 
                 if (SINGLE_COPY_LIST)
                 {
-                    RlistPrependScalarIdemp(&SINGLE_COPY_CACHE, destfile);
+                    StringSetAdd(SINGLE_COPY_CACHE, xstrdup(destfile));
                 }
 
                 if (MatchRlistItem(ctx, AUTO_DEFINE_LIST, destfile))
@@ -548,7 +548,7 @@ static PromiseResult CfCopyFile(EvalContext *ctx, char *sourcefile,
 
                     if (RlistIsInListOfRegex(SINGLE_COPY_LIST, destfile))
                     {
-                        RlistPrependScalarIdemp(&SINGLE_COPY_CACHE, destfile);
+                        StringSetAdd(SINGLE_COPY_CACHE, xstrdup(destfile));
                     }
                 }
                 else
@@ -579,7 +579,7 @@ static PromiseResult CfCopyFile(EvalContext *ctx, char *sourcefile,
 
             if (RlistIsInListOfRegex(SINGLE_COPY_LIST, destfile))
             {
-                RlistPrependScalarIdemp(&SINGLE_COPY_CACHE, destfile);
+                StringSetAdd(SINGLE_COPY_CACHE, xstrdup(destfile));
             }
 
             RecordNoChange(ctx, pp, &attr, "File '%s' is an up to date copy of source",

--- a/cf-agent/verify_files_utils.h
+++ b/cf-agent/verify_files_utils.h
@@ -30,6 +30,7 @@
 #include <comparray.h>
 
 extern const Rlist *SINGLE_COPY_LIST;
+extern StringSet *SINGLE_COPY_CACHE;
 
 void SetFileAutoDefineList(const Rlist *auto_define_list);
 


### PR DESCRIPTION
The SINGLE_COPY_CACHE is a helper structure to remember files
that were copied by the agent because they matched a regular
expression from the SINGLE_COPY_LIST ('files_single_copy' agent
control attribute). It should not be treated as a list of regular
expressions, it should be a list of simple strings (file
paths). And because ordering doesn't matter, it can be a set
which is optimized for fast presence checking.

Also make sure the structure is not leaked by the agent run.

Ticket: CFE-3621
Changelog: files_single_copy no longer treats paths of copied files as regular expressions