### PR TITLE
CFE-3609: Hard class with OS- name & version major on HP-UX (3.12.x)

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1394,6 +1394,36 @@ static void OSClasses(EvalContext *ctx)
     snprintf(context, CF_BUFSIZE, "%s_%s", VSYSNAME.sysname, vbuff);
     SetFlavor(ctx, context);
 
+
+#ifdef __hpux
+    /*
+     * Define a hard class with just the version major number of HP-UX
+     *
+     * For example, when being run on HP-UX B.11.23 the following class will
+     * be defined: hpux_11
+     */
+
+    // Extract major version number
+    char *major = NULL;
+    for (char *sp = vbuff; *sp != '\0'; sp++)
+    {
+        if (major == NULL && isdigit(*sp))
+        {
+            major = sp;
+        }
+        else if (!isdigit(*sp))
+        {
+            *sp = '\0';
+        }
+    }
+
+    if (major != NULL)
+    {
+        snprintf(context, CF_BUFSIZE, "hpux_%s", major);
+        EvalContextClassPutHard(ctx, context, "source=agent,derived-from=sys.flavor");
+    }
+#endif
+
 #ifdef __FreeBSD__
     /*
      * Define a hard class with just the version major number on FreeBSD

--- a/tests/acceptance/02_classes/01_basic/hp_ux_major.cf
+++ b/tests/acceptance/02_classes/01_basic/hp_ux_major.cf
@@ -1,0 +1,38 @@
+body common control
+{
+  bundlesequence => { "test", "check" };
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-3609" }
+        string => "Make sure the class 'hpux_<major>' is defined on HP-UX";
+
+  vars:
+    DEBUG::
+      "defined_classes" string => join("$(const.n)", classesmatching(".*"));
+}
+
+bundle agent check
+{
+  classes:
+    # if 'hpux': make sure 'hpux_10' or 'hpux_11' is defined
+    hpux::
+      "passed" expression => "hpux_10|hpux_11";
+    # if not 'hpux': make sure neither 'hpux_10' nor 'hpux_11' is defined
+    !hpux::
+      "passed" expression => "!(hpux_10|hpux_11)";
+
+  reports:
+    DEBUG&hpux&!passed::
+      "No class containing OS- name & version major is defined on HP-UX.";
+      "Here is a list of defined classes:";
+      "$(test.defined_classes)";
+    DEBUG&!hpux&!passed::
+      "A class containing 'hpux_<major>' was defined on a non HP-UX system";
+    passed::
+      "$(this.promise_filename) Pass";
+    !passed::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Make sure hard class with OS- name & version major is defined on HP-UX.

Ticket: CFE-3609
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 701cbaf2a1e353a4f1a959dc03780052863e4524)