### PR TITLE
CFE-3417: Added DefaultVarPromise wrapper and used StrCmpWrapper in sequence fuctions

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -240,6 +240,15 @@ static const char *const HINTS[] =
     NULL
 };
 
+/**
+ @brief
+ Wrapper around DefaultVarPromise to silence cast-function-type compiler warning in ScheduleAgentOperations
+ */
+static PromiseResult DefaultVarPromiseWrapper(EvalContext *ctx, const Promise *pp, void *param) {
+    UNUSED(param);
+    return DefaultVarPromise(ctx, pp);
+}
+
 /*******************************************************************/
 
 int main(int argc, char *argv[])
@@ -1548,7 +1557,7 @@ PromiseResult ScheduleAgentOperations(EvalContext *ctx, const Bundle *bp)
             if (type == TYPE_SEQUENCE_CONTEXTS)
             {
                 BundleResolve(ctx, bp);
-                BundleResolvePromiseType(ctx, bp, "defaults", (PromiseActuator*)DefaultVarPromise);
+                BundleResolvePromiseType(ctx, bp, "defaults", DefaultVarPromiseWrapper);
             }
         }
 

--- a/cf-agent/files_changes.c
+++ b/cf-agent/files_changes.c
@@ -194,10 +194,10 @@ static void AddMigratedFileToDirectoryList(CF_DB *changes_db, const char *file, 
         return;
     }
 
-    if (SeqBinaryIndexOf(files, basefile, (SeqItemComparator)strcmp) == -1)
+    if (SeqBinaryIndexOf(files, basefile, StrCmpWrapper) == -1)
     {
         SeqAppend(files, xstrdup(basefile));
-        SeqSort(files, (SeqItemComparator)strcmp, NULL);
+        SeqSort(files, StrCmpWrapper, NULL);
         bool changes;
         if (!FileChangesSetDirectoryList(changes_db, dir, files, &changes))
         {
@@ -567,7 +567,7 @@ void FileChangesCheckAndUpdateDirectory(EvalContext *ctx, const Attributes *attr
         return;
     }
 
-    Seq *disk_file_set = SeqSoftSort(file_set, (SeqItemComparator)strcmp, NULL);
+    Seq *disk_file_set = SeqSoftSort(file_set, StrCmpWrapper, NULL);
 
     // We'll traverse the union of disk_file_set and db_file_set in merged order.
 

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -2861,7 +2861,7 @@ bool DepthSearch(EvalContext *ctx, char *name, const struct stat *sb, int rlevel
         {
             if (attr->havechange)
             {
-                if (!SeqBinaryLookup(db_file_set, dirp->d_name, (SeqItemComparator)strcmp))
+                if (!SeqBinaryLookup(db_file_set, dirp->d_name, StrCmpWrapper))
                 {
                     // See comments in FileChangesCheckAndUpdateDirectory(),
                     // regarding this function call.

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -2207,7 +2207,7 @@ void GenericAgentShowContextsFormatted(EvalContext *ctx, const char *regexp)
 
     pcre_free(rx);
 
-    SeqSort(seq, (SeqItemComparator)strcmp, NULL);
+    SeqSort(seq, StrCmpWrapper, NULL);
 
     printf("%-60s %-40s\n", "Class name", "Meta tags");
 
@@ -2287,7 +2287,7 @@ void GenericAgentShowVariablesFormatted(EvalContext *ctx, const char *regexp)
 
     pcre_free(rx);
 
-    SeqSort(seq, (SeqItemComparator)strcmp, NULL);
+    SeqSort(seq, StrCmpWrapper, NULL);
 
     printf("%-40s %-60s %-40s\n", "Variable name", "Variable value", "Meta tags");
 

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -228,8 +228,8 @@ static void ShowContext(EvalContext *ctx)
         ClassTableIteratorDestroy(iter);
     }
 
-    SeqSort(soft_contexts, (SeqItemComparator)strcmp, NULL);
-    SeqSort(hard_contexts, (SeqItemComparator)strcmp, NULL);
+    SeqSort(soft_contexts, StrCmpWrapper, NULL);
+    SeqSort(hard_contexts, StrCmpWrapper, NULL);
 
     Log(LOG_LEVEL_VERBOSE, "----------------------------------------------------------------");
 

--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -8,7 +8,7 @@ function check_with_gcc() {
   rm -f config.cache
   make clean
   ./configure -C --enable-debug CC=gcc
-  local gcc_exceptions="-Wno-sign-compare -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-type-limits"
+  local gcc_exceptions="-Wno-sign-compare -Wno-implicit-fallthrough -Wno-type-limits"
   make -j -l${n_procs} --keep-going CFLAGS="-Werror -Wall -Wextra $gcc_exceptions"
 }
 


### PR DESCRIPTION
DefaultVarPromiseWrapper was created to silence
cast-function-type warning in ScheduleAgentOperations.
StrCmpWrapper can be found in libntech #128.

Ticket: CFE-3417
Changelog: None