### PR TITLE
Use Fedora 34 as a base image for static checks

### DIFF
--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -333,8 +333,8 @@ static void MangleVarRefString(char *ref_str, size_t len)
     {
         *ns      = CF_MANGLED_NS;
         ref_str2 =  ns + 1;
+        assert(upto >= (ns + 1 - ref_str));
         upto    -= (ns + 1 - ref_str);
-        assert(upto >= 0);
     }
 
     bool mangled_scope = false;

--- a/tests/static-check/run.sh
+++ b/tests/static-check/run.sh
@@ -4,7 +4,7 @@ set -e
 trap "echo FAILURE" ERR
 
 set -x
-BASE_IMG="fedora:33"
+BASE_IMG="fedora:34"
 
 function create_image() {
   local c=$(buildah from -q $BASE_IMG)

--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -37,8 +37,10 @@ function check_with_cppcheck() {
 cd "$(dirname $0)"/../../
 
 failure=0
-check_with_gcc              || { echo "FAIL: GCC check failed"; failure=1; }
-check_with_clang            || { echo "FAIL: Clang check failed"; failure=1; }
-check_with_cppcheck         || { echo "FAIL: cppcheck failed"; failure=1; }
+failures=""
+check_with_gcc              || { failures="${failures}FAIL: GCC check failed\n"; failure=1; }
+check_with_clang            || { failures="${failures}FAIL: Clang check failed\n"; failure=1; }
+check_with_cppcheck         || { failures="${failures}FAIL: cppcheck failed\n"; failure=1; }
 
+echo -en "$failures"
 exit $failure


### PR DESCRIPTION
Revealed some new issues in our code right away:
https://github.com/cfengine/core/commit/acef0163ba8bdab1a8d13ea0ce7527acfee9d288
https://github.com/cfengine/libntech/pull/132
https://github.com/cfengine/libntech/pull/133