### PR TITLE
CFE-3562 Refactor custom_promise_binary.c to be more portable

### DIFF
--- a/tests/acceptance/30_custom_promise_types/custom_promise_binary.c
+++ b/tests/acceptance/30_custom_promise_types/custom_promise_binary.c
@@ -1,29 +1,25 @@
 #include <stdio.h>
 
+static inline void eatline(FILE *stream)
+{
+    int c;
+    while ((c = getc(stream)) != EOF && c != '\n')
+        ;
+}
+
 int main()
 {
-    char *line = NULL;
-    size_t len = 0;
-
     printf("binary 0.0.1 v1 line_based\n");
     printf("\n");
 
-    if (getline(&line, &len, stdin) == -1)
-    {
-        perror("Couldn't read from stdin");
-        return 1;
-    }
+    eatline(stdin);
 
     printf("operation=validate_promise\n");
     printf("promiser=foobar\n");
     printf("result=valid\n");
     printf("\n");
 
-    if (getline(&line, &len, stdin) == -1)
-    {
-        perror("Couldn't read from stdin");
-        return 1;
-    }
+    eatline(stdin);
 
     printf("operation=evaluate_promise\n");
     printf("promiser=foobar\n");


### PR DESCRIPTION
 The `getline` function is not well supported on exotic
platforms like solaris, hpux so change to small custom
function `eatline`.

Ticket: CFE-3562
Changelog: none