### PR TITLE
ENT-7048 Marked acceptance tests flakey for appropriate platforms (3.12.x)

### DIFF
--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/redmine_6334.cf
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/redmine_6334.cf
@@ -7,6 +7,10 @@ body common control
 
 bundle agent test
 {
+  meta:
+    "test_flakey_fail" string => "sunos_5_11.sparc",
+      meta => { "ENT-7068" };
+
   vars:
       "first"
         string =>

--- a/tests/acceptance/05_processes/01_matching/inverse_ttime_inverse_found.cf
+++ b/tests/acceptance/05_processes/01_matching/inverse_ttime_inverse_found.cf
@@ -28,6 +28,9 @@ bundle agent test
       "test_suppress_fail" string => "windows",
         meta => { "redmine4747" };
 
+      "test_flakey_fail" string => "aix_7_1",
+        meta => { "CFE-3313" };
+
   processes:
       ".*"
       process_count => test_range,


### PR DESCRIPTION
00_basics/ifelapsed_and_expireafter/locks.cf for solaris11sparc
00_basics/ifelapsed_and_expireafter/redmine_6334.cf for solaris11sparc
01_vars/01_basic/os_version_major.cf for centos5
05_processes/01_matching/inverse_ttime_inverse_found.cf for aix 7.1

Changelog: none
Ticket: ENT-7048
(cherry picked from commit 001130f3facb2c6a0df331d05b2c745fbcc7cbc4)

Conflicts:
	tests/acceptance/00_basics/ifelapsed_and_expireafter/locks.cf
	tests/acceptance/01_vars/01_basic/os_version_major.cf