### PR TITLE
ENT-6941: Increased range of allowed values of number of processes (3.15)

### DIFF
--- a/tests/unit/mon_processes_test.c
+++ b/tests/unit/mon_processes_test.c
@@ -125,8 +125,8 @@ void test_processes_monitor(void)
         " the two numbers should be *about* the same since the 'ps'"
         " commands run very close to each other");
 
-    int upper = (int) ((double) usr*1.10);
-    int lower = (int) ((double) usr*0.90);
+    int upper = (int) ((double) usr*1.20);
+    int lower = (int) ((double) usr*0.80);
     assert_in_range((long long) cf_this[ob_users], lower, upper);
 }
 


### PR DESCRIPTION
Issue was that even with current ±10% allowed spread of number of processes
enumerated by CFEngine vs `ps` this test was failing sometimes, with errors
like this:

> 27 is not within the range 21-26

Changelog: None

(cherry picked from commit 2c90edf9678d825ea23a37353aa904797cbb71b1)