### PR TITLE
[3.15.x] Add a new 'a_entry_required' parameter to DeleteDigestFromLastSeen()

### DIFF
--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -510,9 +510,11 @@ clean:
  * @param[in,out] ip  : return the key corresponding host.
  *                      If NULL, return nothing
  * @param[in] ip_size : length of ip parameter
+ * @param[in] a_entry_required : whether 'aIP_ADDR' entry is required for
+ *                               the 'kHOSTKEY' entry deletion
  * @retval true if entry was deleted, false otherwise
  */
-bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size)
+bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size, bool a_entry_required)
 {
     DBHandle *db;
     bool res = false;
@@ -535,7 +537,7 @@ bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size)
     {
         strcpy(bufhost, "a");
         strlcat(bufhost, host, CF_BUFSIZE);
-        if (HasKeyDB(db, bufhost, strlen(bufhost) + 1) == false)
+        if (a_entry_required && !HasKeyDB(db, bufhost, strlen(bufhost) + 1))
         {
             res = false;
             goto clean;
@@ -710,7 +712,7 @@ int RemoveKeysFromLastSeen(const char *input, bool must_be_coherent,
     if (is_digest == true)
     {
         Log(LOG_LEVEL_VERBOSE, "Removing digest '%s' from lastseen database\n", input);
-        if (DeleteDigestFromLastSeen(input, equivalent, equivalent_size) == false)
+        if (!DeleteDigestFromLastSeen(input, equivalent, equivalent_size, must_be_coherent))
         {
             Log(LOG_LEVEL_ERR, "Unable to remove digest from lastseen database.");
             return 252;

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -46,7 +46,7 @@ void LastSaw1(const char *ipaddress, const char *hashstr, LastSeenRole role);
 void LastSaw(const char *ipaddress, const char *digest, LastSeenRole role);
 
 bool DeleteIpFromLastSeen(const char *ip, char *digest, size_t digest_size);
-bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size);
+bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size, bool a_entry_required);
 
 /*
  * Return false in order to stop iteration

--- a/tests/unit/lastseen_test.c
+++ b/tests/unit/lastseen_test.c
@@ -178,7 +178,7 @@ static void test_remove(void)
     UpdateLastSawHost("SHA-12345", "127.0.0.64", false, 556);
 
     //RemoveHostFromLastSeen("SHA-12345");
-    DeleteDigestFromLastSeen("SHA-12345", NULL, 0);
+    DeleteDigestFromLastSeen("SHA-12345", NULL, 0, true);
 
     DBHandle *db;
     OpenDB(&db, dbid_lastseen);
@@ -187,6 +187,28 @@ static void test_remove(void)
     assert_int_equal(HasKeyDB(db, "qoSHA-12345", strlen("qoSHA-12345") + 1), false);
     assert_int_equal(HasKeyDB(db, "kSHA-12345", strlen("kSHA-12345") + 1), false);
     assert_int_equal(HasKeyDB(db, "a127.0.0.64", strlen("a127.0.0.64") + 1), false);
+
+    CloseDB(db);
+}
+
+static void test_remove_no_a_entry(void)
+{
+    setup();
+
+    UpdateLastSawHost("SHA-12345", "127.0.0.64", true, 555);
+    UpdateLastSawHost("SHA-12345", "127.0.0.64", false, 556);
+
+    DBHandle *db;
+    OpenDB(&db, dbid_lastseen);
+
+    assert_true(DeleteDB(db, "a127.0.0.64"));
+    assert_false(DeleteDigestFromLastSeen("SHA-12345", NULL, 0, true));
+    assert_true(DeleteDigestFromLastSeen("SHA-12345", NULL, 0, false));
+
+    assert_false(HasKeyDB(db, "qiSHA-12345", strlen("qiSHA-12345") + 1));
+    assert_false(HasKeyDB(db, "qoSHA-12345", strlen("qoSHA-12345") + 1));
+    assert_false(HasKeyDB(db, "kSHA-12345", strlen("kSHA-12345") + 1));
+    assert_false(HasKeyDB(db, "a127.0.0.64", strlen("a127.0.0.64") + 1));
 
     CloseDB(db);
 }
@@ -588,6 +610,7 @@ int main()
             unit_test(test_reverse_conflict),
             unit_test(test_reverse_missing_forward),
             unit_test(test_remove),
+            unit_test(test_remove_no_a_entry),
             unit_test(test_remove_ip),
 
             unit_test_setup_teardown(test_consistent_1a, begin, end),


### PR DESCRIPTION
The lastseen local DB has entries of multiple types. In
particular, there are k-entries mapping hostkeys to IP addresses
and a-entries for the reverse mapping of IP addresses to
hostkeys. The ideal state is to have the entries of those two
types coherent (bijective), but it's not always possible. For
this reason, we need to be able to delete k-entries even if there
is no matching a-entry.

Do not require a-entries when deleting digests in
RemoveKeysFromLastSeen() if must_be_coherent is false.

Ticket: ENT-6490
Changelog: None
(cherry picked from commit 93b778ca3aa60e130fc5d063dee9744d398a683d)