### PR TITLE
Make the ActionAttributeLogLevelFromString function be nicer on users

### DIFF
--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -649,16 +649,22 @@ LogLevel ActionAttributeLogLevelFromString(const char *log_level)
         return LOG_LEVEL_ERR;
     }
 
-    if (strcmp("inform", log_level) == 0)
+    if (StringEqual(log_level, "inform") || StringEqual(log_level, "info"))
     {
         return LOG_LEVEL_INFO;
     }
-    else if (strcmp("verbose", log_level) == 0)
+    else if (StringEqual(log_level, "verbose"))
     {
         return LOG_LEVEL_VERBOSE;
     }
+    else if (StringEqual(log_level, "error") || StringEqual(log_level, "log"))
+    {
+        /* XXX: what is 'log' and why is it the same as 'error'? */
+        return LOG_LEVEL_ERR;
+    }
     else
     {
+        Log(LOG_LEVEL_WARNING, "Unrecognized 'log_level' attribute value: %s", log_level);
         return LOG_LEVEL_ERR;
     }
 }


### PR DESCRIPTION
Recognize both 'info' and 'inform' as LOG_LEVEL_INFO log level
and produce a warning if the log level is not recognized.

Also use StringEqual() instead of strcmp() == 0.