### PR TITLE
CFE-3418: Fixed type-limits compiler warnings

### DIFF
--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -334,7 +334,6 @@ static void MangleVarRefString(char *ref_str, size_t len)
         *ns      = CF_MANGLED_NS;
         ref_str2 =  ns + 1;
         upto    -= (ns + 1 - ref_str);
-        assert(upto >= 0);
     }
 
     bool mangled_scope = false;

--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -8,7 +8,7 @@ function check_with_gcc() {
   rm -f config.cache
   make clean
   ./configure -C --enable-debug CC=gcc
-  local gcc_exceptions="-Wno-sign-compare -Wno-type-limits"
+  local gcc_exceptions="-Wno-sign-compare"
   make -j -l${n_procs} --keep-going CFLAGS="-Werror -Wall -Wextra $gcc_exceptions"
 }
 


### PR DESCRIPTION
As `upto` is `size_t` its impossible for it to be less than 0.
At the same time the current algorithm doesnt allow any
underflowing to occur since it uses `ref_str` as an anchor.

The lowest upto can go is 0 if the bracket is found at the start,
at which point all subsequent `memchr` will result in `NULL`.

Ticket: CFE-3418
Changelog: None
