### PR TITLE
WIP: DEBUG ENT-5752: https://github.com/cfengine/masterfiles/pull/1981

### DIFF
--- a/tests/acceptance/dcs.cf.sub
+++ b/tests/acceptance/dcs.cf.sub
@@ -214,6 +214,11 @@ bundle agent default(filename)
 
   vars:
 
+      "stuff_in_workdir_modules" -> { "ENT-5752" }
+        slist => findfiles( "$(sys.workdir)/modules" ),
+        comment => "ENT-5752, debugging";
+
+
       "tests" slist => { "default:init",
                          "default:test",
                          "default:check",
@@ -233,6 +238,9 @@ bundle agent default(filename)
       "any" usebundle => test_run("$(filename)"), inherit => "true";
 
   reports:
+    "Stuff under workdir/modules"; # ENT-5752, debugging
+    "$(stuff_in_workdir_modules)"; # ENT-5752, debugging
+
     EXTRA.verbose_mode::
       "$(this.bundle): found runnable bundle $(bundles)";
 }


### PR DESCRIPTION
Trying to figure out why this PR https://github.com/cfengine/masterfiles/pull/1981
fails the_great_package_test.cf
https://ci.cfengine.com/job/testing-pr/label=PACKAGES_x86_64_linux_redhat_7/14350/testReport/junit/._17_packages_10_new_unsafe_the_great_package_test/cf/the_great_package_test_cf/
with many error: Unsupported package module wrapper API version: -1

Ticket: ENT-5752