### PR TITLE
Protect classes and variables from CMDB data from being re-defined in augments

### DIFF
--- a/libpromises/cmdb.c
+++ b/libpromises/cmdb.c
@@ -189,7 +189,7 @@ static bool ReadCMDBVars(EvalContext *ctx, JsonElement *vars)
         }
 
         StringSet *tags = StringSetNew();
-        StringSetAdd(tags, xstrdup("source=cmdb"));
+        StringSetAdd(tags, xstrdup(CMDB_SOURCE_TAG));
         bool ret = AddCMDBVariable(ctx, key, ref, data, tags);
         VarRefDestroy(ref);
         if (!ret)
@@ -275,7 +275,7 @@ static bool ReadCMDBVariables(EvalContext *ctx, JsonElement *variables)
         {
             continue;
         }
-        StringSet *tags = GetTagsFromJsonTags("variable", key, json_tags, "source=cmdb");
+        StringSet *tags = GetTagsFromJsonTags("variable", key, json_tags, CMDB_SOURCE_TAG);
 
         bool ret = AddCMDBVariable(ctx, key, ref, data, tags);
         VarRefDestroy(ref);
@@ -351,7 +351,7 @@ static bool ReadCMDBClasses(EvalContext *ctx, JsonElement *classes)
             }
 
             StringSet *default_tags = StringSetNew();
-            StringSetAdd(default_tags, xstrdup("source=cmdb"));
+            StringSetAdd(default_tags, xstrdup(CMDB_SOURCE_TAG));
             bool ret = AddCMDBClass(ctx, key, default_tags);
             if (!ret)
             {
@@ -371,7 +371,7 @@ static bool ReadCMDBClasses(EvalContext *ctx, JsonElement *classes)
                 continue;
             }
             StringSet *default_tags = StringSetNew();
-            StringSetAdd(default_tags, xstrdup("source=cmdb"));
+            StringSetAdd(default_tags, xstrdup(CMDB_SOURCE_TAG));
             bool ret = AddCMDBClass(ctx, key, default_tags);
             if (!ret)
             {
@@ -408,7 +408,7 @@ static bool ReadCMDBClasses(EvalContext *ctx, JsonElement *classes)
                 continue;
             }
 
-            StringSet *tags = GetTagsFromJsonTags("class", key, json_tags, "source=cmdb");
+            StringSet *tags = GetTagsFromJsonTags("class", key, json_tags, CMDB_SOURCE_TAG);
             bool ret = AddCMDBClass(ctx, key, tags);
             if (!ret)
             {

--- a/libpromises/cmdb.h
+++ b/libpromises/cmdb.h
@@ -28,6 +28,8 @@
 #include <json.h>
 #include <logging.h>
 
+#define CMDB_SOURCE_TAG "source=cmdb"
+
 JsonElement *ReadJsonFile(const char *filename, LogLevel log_level, size_t size_max);
 bool LoadCMDBData(EvalContext *ctx);
 


### PR DESCRIPTION
Host-specific values should take precedence over possibly more generic values from augments.
