### PR TITLE
Associate comments with variables and classes

### DIFF
--- a/libpromises/class.c
+++ b/libpromises/class.c
@@ -68,8 +68,11 @@ struct ClassTableIterator_
 
 static void ClassInit(Class *cls,
                       const char *ns, const char *name,
-                      bool is_soft, ContextScope scope, StringSet *tags)
+                      bool is_soft, ContextScope scope, StringSet *tags,
+                      const char *comment)
 {
+    assert(cls != NULL);
+
     if (ns == NULL || strcmp(ns, "default") == 0)
     {
         cls->ns = NULL;
@@ -89,15 +92,17 @@ static void ClassInit(Class *cls,
     {
         StringSetAdd(cls->tags, xstrdup("hardclass"));
     }
+    cls->comment = SafeStringDuplicate(comment);
 }
 
 static void ClassDestroySoft(Class *cls)
 {
-    if (cls)
+    if (cls != NULL)
     {
         free(cls->ns);
         free(cls->name);
         StringSetDestroy(cls->tags);
+        free(cls->comment);
     }
 }
 
@@ -130,7 +135,7 @@ void ClassTableDestroy(ClassTable *table)
 
 bool ClassTablePut(ClassTable *table,
                    const char *ns, const char *name,
-                   bool is_soft, ContextScope scope, StringSet *tags)
+                   bool is_soft, ContextScope scope, StringSet *tags, const char *comment)
 {
     assert(name);
     assert(is_soft || (!ns || strcmp("default", ns) == 0)); // hard classes should have default namespace
@@ -142,7 +147,7 @@ bool ClassTablePut(ClassTable *table,
     }
 
     Class *cls = xmalloc(sizeof(*cls));
-    ClassInit(cls, ns, name, is_soft, scope, tags);
+    ClassInit(cls, ns, name, is_soft, scope, tags, comment);
 
     /* (cls->name != name) because canonification has happened. */
     char *fullname = StringConcatenate(3, ns, ":", cls->name);

--- a/libpromises/class.h
+++ b/libpromises/class.h
@@ -35,6 +35,7 @@ typedef struct
     ContextScope scope;
     bool is_soft;
     StringSet *tags;
+    char *comment;
 } Class;
 
 
@@ -44,7 +45,8 @@ typedef struct ClassTableIterator_ ClassTableIterator;
 ClassTable *ClassTableNew(void);
 void ClassTableDestroy(ClassTable *table);
 
-bool ClassTablePut(ClassTable *table, const char *ns, const char *name, bool is_soft, ContextScope scope, StringSet *tags);
+bool ClassTablePut(ClassTable *table, const char *ns, const char *name, bool is_soft, ContextScope scope,
+                   StringSet *tags, const char *comment);
 Class *ClassTableGet(const ClassTable *table, const char *ns, const char *name);
 Class *ClassTableMatch(const ClassTable *table, const char *regex);
 bool ClassTableRemove(ClassTable *table, const char *ns, const char *name);

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -2021,7 +2021,7 @@ static inline char *MangleScopedVarNameIntoSpecialScopeName(const char *scope, c
  */
 bool EvalContextVariablePutSpecial(EvalContext *ctx, SpecialScope scope, const char *lval, const void *value, DataType type, const char *tags)
 {
-    StringSet *tags_set = StringSetFromString(tags, ',');
+    StringSet *tags_set = (NULL_OR_EMPTY(tags) ? NULL : StringSetFromString(tags, ','));
     bool ret = EvalContextVariablePutSpecialTagsSet(ctx, scope, lval, value, type, tags_set);
     if (!ret)
     {
@@ -2267,7 +2267,7 @@ bool EvalContextVariablePut(EvalContext *ctx,
                             const VarRef *ref, const void *value,
                             DataType type, const char *tags)
 {
-    StringSet *tags_set = StringSetFromString(tags, ',');
+    StringSet *tags_set = (NULL_OR_EMPTY(tags) ? NULL : StringSetFromString(tags, ','));
     bool ret = EvalContextVariablePutTagsSet(ctx, ref, value, type, tags_set);
     if (!ret)
     {
@@ -2532,7 +2532,6 @@ StringSet *EvalContextVariableTags(const EvalContext *ctx, const VarRef *ref)
     }
 
     StringSet *var_tags = VariableGetTags(var);
-    assert(var_tags != NULL);
     return var_tags;
 }
 

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -455,7 +455,9 @@ static void EvalContextStackFrameAddSoft(EvalContext *ctx, const char *context, 
     }
 
     ClassTablePut(frame.classes, frame.owner->ns, context, true,
-                  CONTEXT_SCOPE_BUNDLE, StringSetFromString(tags, ','), NULL);
+                  CONTEXT_SCOPE_BUNDLE,
+                  NULL_OR_EMPTY(tags) ? NULL : StringSetFromString(tags, ','),
+                  NULL);
 
     if (!BundleAborted(ctx))
     {
@@ -1713,7 +1715,7 @@ static bool EvalContextClassPutTagsSet(EvalContext *ctx, const char *ns, const c
 static bool EvalContextClassPut(EvalContext *ctx, const char *ns, const char *name, bool is_soft,
                                 ContextScope scope, const char *tags, const char *comment)
 {
-    StringSet *tags_set = StringSetFromString(tags, ',');
+    StringSet *tags_set = (NULL_OR_EMPTY(tags) ? NULL : StringSetFromString(tags, ','));
     bool ret = EvalContextClassPutTagsSet(ctx, ns, name, is_soft, scope, tags_set, comment);
     if (!ret)
     {
@@ -1750,7 +1752,7 @@ bool EvalContextClassPutHard(EvalContext *ctx, const char *name, const char *tag
 
 bool EvalContextClassPutSoft(EvalContext *ctx, const char *name, ContextScope scope, const char *tags)
 {
-    StringSet *tags_set = StringSetFromString(tags, ',');
+    StringSet *tags_set = (NULL_OR_EMPTY(tags) ? NULL : StringSetFromString(tags, ','));
     bool ret = EvalContextClassPutSoftTagsSet(ctx, name, scope, tags_set);
     if (!ret)
     {

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -173,9 +173,17 @@ JsonElement *EvalContextGetPromiseCallers(EvalContext *ctx);
 
 bool EvalContextVariablePut(EvalContext *ctx, const VarRef *ref, const void *value, DataType type, const char *tags);
 bool EvalContextVariablePutTagsSet(EvalContext *ctx, const VarRef *ref, const void *value, DataType type, StringSet *tags);
+bool EvalContextVariablePutTagsSetWithComment(EvalContext *ctx,
+                                              const VarRef *ref, const void *value,
+                                              DataType type, StringSet *tags,
+                                              const char *comment);
 bool EvalContextVariablePutSpecial(EvalContext *ctx, SpecialScope scope, const char *lval, const void *value, DataType type, const char *tags);
 bool EvalContextVariablePutSpecialTagsSet(EvalContext *ctx, SpecialScope scope, const char *lval,
                                           const void *value, DataType type, StringSet *tags);
+bool EvalContextVariablePutSpecialTagsSetWithComment(EvalContext *ctx, SpecialScope scope,
+                                                     const char *lval, const void *value,
+                                                     DataType type, StringSet *tags,
+                                                     const char *comment);
 const void *EvalContextVariableGetSpecial(const EvalContext *ctx, const SpecialScope scope, const char *varname, DataType *type_out);
 const char *EvalContextVariableGetSpecialString(const EvalContext *ctx, const SpecialScope scope, const char *varname);
 const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *ref, DataType *type_out);

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -123,10 +123,14 @@ void EvalContextHeapPersistentLoadAll(EvalContext *ctx);
 
 bool EvalContextClassPutSoft(EvalContext *ctx, const char *name, ContextScope scope, const char *tags);
 bool EvalContextClassPutSoftTagsSet(EvalContext *ctx, const char *name, ContextScope scope, StringSet *tags);
+bool EvalContextClassPutSoftTagsSetWithComment(EvalContext *ctx, const char *name, ContextScope scope,
+                                               StringSet *tags, const char *comment);
 bool EvalContextClassPutSoftNS(EvalContext *ctx, const char *ns, const char *name,
                                ContextScope scope, const char *tags);
 bool EvalContextClassPutSoftNSTagsSet(EvalContext *ctx, const char *ns, const char *name,
                                       ContextScope scope, StringSet *tags);
+bool EvalContextClassPutSoftNSTagsSetWithComment(EvalContext *ctx, const char *ns, const char *name,
+                                                 ContextScope scope, StringSet *tags, const char *comment);
 bool EvalContextClassPutHard(EvalContext *ctx, const char *name, const char *tags);
 Class *EvalContextClassGet(const EvalContext *ctx, const char *ns, const char *name);
 Class *EvalContextClassMatch(const EvalContext *ctx, const char *regex);

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -2521,7 +2521,6 @@ void GenericAgentShowContextsFormatted(EvalContext *ctx, const char *regexp)
     assert(regexp != NULL);
 
     ClassTableIterator *iter = EvalContextClassTableIteratorNewGlobal(ctx, NULL, true, true);
-    Class *cls = NULL;
 
     Seq *seq = SeqNew(1000, free);
 
@@ -2533,7 +2532,7 @@ void GenericAgentShowContextsFormatted(EvalContext *ctx, const char *regexp)
         return;
     }
 
-    while ((cls = ClassTableIteratorNext(iter)))
+    while ((Class *cls = ClassTableIteratorNext(iter)) != NULL)
     {
         char *class_name = ClassRefToString(cls->ns, cls->name);
 
@@ -2543,7 +2542,7 @@ void GenericAgentShowContextsFormatted(EvalContext *ctx, const char *regexp)
             continue;
         }
 
-        StringSet *tagset = EvalContextClassTags(ctx, cls->ns, cls->name);
+        StringSet *tagset = cls->tags;
         Buffer *tagbuf = StringSetToBuffer(tagset, ',');
 
         char *line;

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -2621,7 +2621,7 @@ void GenericAgentShowVariablesFormatted(EvalContext *ctx, const char *regexp)
         }
 
 
-        StringSet *tagset = EvalContextVariableTags(ctx, VariableGetRef(v));
+        StringSet *tagset = VariableGetTags(v);
         Buffer *tagbuf = StringSetToBuffer(tagset, ',');
 
         char *line;

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -2623,9 +2623,11 @@ void GenericAgentShowVariablesFormatted(EvalContext *ctx, const char *regexp)
 
         StringSet *tagset = VariableGetTags(v);
         Buffer *tagbuf = StringSetToBuffer(tagset, ',');
+        const char *comment = VariableGetComment(v);
 
         char *line;
-        xasprintf(&line, "%-40s %-60s %-40s", varname, var_value, BufferData(tagbuf));
+        xasprintf(&line, "%-40s %-60s %-40s %-40s",
+                  varname, var_value, BufferData(tagbuf), NULL_TO_EMPTY_STRING(comment));
 
         SeqAppend(seq, line);
 
@@ -2638,7 +2640,7 @@ void GenericAgentShowVariablesFormatted(EvalContext *ctx, const char *regexp)
 
     SeqSort(seq, StrCmpWrapper, NULL);
 
-    printf("%-40s %-60s %-40s\n", "Variable name", "Variable value", "Meta tags");
+    printf("%-40s %-60s %-40s %-40s\n", "Variable name", "Variable value", "Meta tags", "Comment");
 
     for (size_t i = 0; i < SeqLength(seq); i++)
     {

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -2532,7 +2532,8 @@ void GenericAgentShowContextsFormatted(EvalContext *ctx, const char *regexp)
         return;
     }
 
-    while ((Class *cls = ClassTableIteratorNext(iter)) != NULL)
+    Class *cls = NULL;
+    while ((cls = ClassTableIteratorNext(iter)) != NULL)
     {
         char *class_name = ClassRefToString(cls->ns, cls->name);
 
@@ -2546,7 +2547,7 @@ void GenericAgentShowContextsFormatted(EvalContext *ctx, const char *regexp)
         Buffer *tagbuf = StringSetToBuffer(tagset, ',');
 
         char *line;
-        xasprintf(&line, "%-60s %-40s", class_name, BufferData(tagbuf));
+        xasprintf(&line, "%-60s %-40s %-40s", class_name, BufferData(tagbuf), NULL_TO_EMPTY_STRING(cls->comment));
         SeqAppend(seq, line);
 
         BufferDestroy(tagbuf);
@@ -2557,7 +2558,7 @@ void GenericAgentShowContextsFormatted(EvalContext *ctx, const char *regexp)
 
     SeqSort(seq, StrCmpWrapper, NULL);
 
-    printf("%-60s %-40s\n", "Class name", "Meta tags");
+    printf("%-60s %-40s %-40s\n", "Class name", "Meta tags", "Comment");
 
     for (size_t i = 0; i < SeqLength(seq); i++)
     {

--- a/libpromises/variable.c
+++ b/libpromises/variable.c
@@ -36,11 +36,13 @@ struct Variable_
     Rval rval;
     DataType type;
     StringSet *tags;
+    char *comment;
     const Promise *promise; // The promise that set the present value
 };
 
 static Variable *VariableNew(VarRef *ref, Rval rval, DataType type,
-                             StringSet *tags, const Promise *promise)
+                             StringSet *tags, char *comment,
+                             const Promise *promise)
 {
     Variable *var = xmalloc(sizeof(Variable));
 
@@ -48,6 +50,7 @@ static Variable *VariableNew(VarRef *ref, Rval rval, DataType type,
     var->rval = rval;
     var->type = type;
     var->tags = tags;
+    var->comment = comment;
     var->promise = promise;
 
     return var;
@@ -58,10 +61,11 @@ static Variable *VariableNew(VarRef *ref, Rval rval, DataType type,
  * by the Map implementation calling the key-destroy function. */
 static void VariableDestroy(Variable *var)
 {
-    if (var)
+    if (var != NULL)
     {
         RvalDestroy(var->rval);
         StringSetDestroy(var->tags);
+        free(var->comment);
         // Nothing to do for ->promise
 
         free(var);
@@ -95,6 +99,12 @@ StringSet *VariableGetTags(const Variable *var)
 {
     assert(var != NULL);
     return var->tags;
+}
+
+const char *VariableGetComment(const Variable *var)
+{
+    assert(var != NULL);
+    return var->comment;
 }
 
 const Promise *VariableGetPromise(const Variable *var)
@@ -222,7 +232,8 @@ bool VariableTableRemove(VariableTable *table, const VarRef *ref)
 
 bool VariableTablePut(VariableTable *table, const VarRef *ref,
                       const Rval *rval, DataType type,
-                      StringSet *tags, const Promise *promise)
+                      StringSet *tags, char *comment,
+                      const Promise *promise)
 {
     assert(VarRefIsQualified(ref));
 
@@ -242,7 +253,7 @@ bool VariableTablePut(VariableTable *table, const VarRef *ref,
               "Only iterables (Rlists) are allowed to be NULL");
 
     Variable *var = VariableNew(VarRefCopy(ref), RvalCopy(*rval), type,
-                                tags, promise);
+                                tags, comment, promise);
     return VarMapInsert(table->vars, var->ref, var);
 }
 

--- a/libpromises/variable.c
+++ b/libpromises/variable.c
@@ -47,14 +47,7 @@ static Variable *VariableNew(VarRef *ref, Rval rval, DataType type,
     var->ref = ref;
     var->rval = rval;
     var->type = type;
-    if (tags == NULL)
-    {
-        var->tags = StringSetFromString("", ',');
-    }
-    else
-    {
-        var->tags = tags;
-    }
+    var->tags = tags;
     var->promise = promise;
 
     return var;

--- a/libpromises/variable.h
+++ b/libpromises/variable.h
@@ -36,6 +36,7 @@ const VarRef *VariableGetRef(const Variable *var);
 DataType VariableGetType(const Variable *var);
 RvalType VariableGetRvalType(const Variable *var);
 StringSet *VariableGetTags(const Variable *var);
+const char *VariableGetComment(const Variable *var);
 const Promise *VariableGetPromise(const Variable *var);
 
 /**
@@ -65,7 +66,7 @@ void VariableTableDestroy(VariableTable *table);
 
 bool VariableTablePut(VariableTable *table, const VarRef *ref,
                       const Rval *rval, DataType type,
-                      StringSet *tags, const Promise *promise);
+                      StringSet *tags, char *comment, const Promise *promise);
 Variable *VariableTableGet(const VariableTable *table, const VarRef *ref);
 bool VariableTableRemove(VariableTable *table, const VarRef *ref);
 

--- a/libpromises/verify_classes.c
+++ b/libpromises/verify_classes.c
@@ -96,6 +96,8 @@ PromiseResult VerifyClassPromise(EvalContext *ctx, const Promise *pp, ARG_UNUSED
                 StringSetAdd(tags, xstrdup(RlistScalarValue(rp)));
             }
 
+            const char *comment = PromiseGetConstraintAsRval(pp, "comment", RVAL_TYPE_SCALAR);
+
             bool inserted = false;
             if (/* Persistent classes are always global: */
                 a.context.persistent > 0 ||
@@ -108,15 +110,17 @@ PromiseResult VerifyClassPromise(EvalContext *ctx, const Promise *pp, ARG_UNUSED
             {
                 Log(LOG_LEVEL_VERBOSE, "C:     +  Global class: %s",
                     pp->promiser);
-                inserted = EvalContextClassPutSoftTagsSet(ctx, pp->promiser,
-                                                          CONTEXT_SCOPE_NAMESPACE, tags);
+                inserted = EvalContextClassPutSoftTagsSetWithComment(ctx, pp->promiser,
+                                                                     CONTEXT_SCOPE_NAMESPACE,
+                                                                     tags, comment);
             }
             else
             {
                 Log(LOG_LEVEL_VERBOSE, "C:     +  Private class: %s",
                     pp->promiser);
-                inserted = EvalContextClassPutSoftTagsSet(ctx, pp->promiser,
-                                                          CONTEXT_SCOPE_BUNDLE, tags);
+                inserted = EvalContextClassPutSoftTagsSetWithComment(ctx, pp->promiser,
+                                                                     CONTEXT_SCOPE_BUNDLE,
+                                                                     tags, comment);
             }
 
             if (a.context.persistent > 0)

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -109,6 +109,8 @@ static bool IsLegalVariableName(EvalContext *ctx, const Promise *pp)
 PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
                                ARG_UNUSED void *param)
 {
+    assert(pp != NULL);
+
     ConvergeVariableOptions opts = CollectConvergeVariableOptions(ctx, pp);
 
     Log(LOG_LEVEL_DEBUG, "Evaluating vars promise: %s", pp->promiser);
@@ -455,8 +457,29 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
             return PROMISE_RESULT_FAIL;
         }
 
+        StringSet *tags = StringSetNew();
+        StringSetAdd(tags, xstrdup("source=promise"));
+
+        Rlist *promise_meta = PromiseGetConstraintAsList(ctx, "meta", pp);
+        if (promise_meta)
+        {
+            Buffer *print;
+            for (const Rlist *rp = promise_meta; rp; rp = rp->next)
+            {
+                StringSetAdd(tags, xstrdup(RlistScalarValue(rp)));
+                if (WouldLog(LOG_LEVEL_DEBUG))
+                {
+                    print = StringSetToBuffer(tags, ',');
+                    Log(LOG_LEVEL_DEBUG,
+                        "Added tag %s to variable %s tags (now [%s])",
+                        RlistScalarValue(rp), pp->promiser, BufferData(print));
+                    BufferDestroy(print);
+                }
+            }
+        }
+
         /* WRITE THE VARIABLE AT LAST. */
-        bool success = EvalContextVariablePut(ctx, ref, rval.item, required_datatype, "source=promise");
+        bool success = EvalContextVariablePutTagsSet(ctx, ref, rval.item, required_datatype, tags);
 
         if (!success)
         {
@@ -467,23 +490,8 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
 
             VarRefDestroy(ref);
             RvalDestroy(rval);
+            StringSetDestroy(tags);
             return PROMISE_RESULT_FAIL;
-        }
-
-        Rlist *promise_meta = PromiseGetConstraintAsList(ctx, "meta", pp);
-        if (promise_meta)
-        {
-            StringSet *class_meta = EvalContextVariableTags(ctx, ref);
-            Buffer *print;
-            for (const Rlist *rp = promise_meta; rp; rp = rp->next)
-            {
-                StringSetAdd(class_meta, xstrdup(RlistScalarValue(rp)));
-                print = StringSetToBuffer(class_meta, ',');
-                Log(LOG_LEVEL_DEBUG,
-                    "Added tag %s to class %s, tags now [%s]",
-                    RlistScalarValue(rp), pp->promiser, BufferData(print));
-                BufferDestroy(print);
-            }
         }
 
         result = PROMISE_RESULT_NOOP;

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -478,8 +478,11 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
             }
         }
 
+        const char *comment = PromiseGetConstraintAsRval(pp, "comment", RVAL_TYPE_SCALAR);
+
         /* WRITE THE VARIABLE AT LAST. */
-        bool success = EvalContextVariablePutTagsSet(ctx, ref, rval.item, required_datatype, tags);
+        bool success = EvalContextVariablePutTagsSetWithComment(ctx, ref, rval.item, required_datatype,
+                                                                tags, comment);
 
         if (!success)
         {

--- a/tests/acceptance/00_basics/def.json/classes_with_ns_tags.cf
+++ b/tests/acceptance/00_basics/def.json/classes_with_ns_tags.cf
@@ -23,5 +23,5 @@ bundle agent check
     "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf|$(G.grep) test_class";
 
   methods:
-      "" usebundle => dcs_passif_output("my_ns:test_class_29665402e2b4331f10b8d767b512cd916eeb5db9\s+test_tag,source=augments_file.+my_ns:test_class_29665402e2b4331f10b8d767b512cd916eeb5db9_2\s+test_tag,source=augments_file", "my_ns2:test_class_cfengine_and_cfengine_version\s+test_tag2,source=augments_file", $(command), $(this.promise_filename));
+      "" usebundle => dcs_passif_output("my_ns:test_class_29665402e2b4331f10b8d767b512cd916eeb5db9\s+test_tag,source=augments_file\s+comment1.+my_ns:test_class_29665402e2b4331f10b8d767b512cd916eeb5db9_2\s+test_tag,source=augments_file\s+comment2", "my_ns2:test_class_cfengine_and_cfengine_version\s+test_tag2,source=augments_file", $(command), $(this.promise_filename));
 }

--- a/tests/acceptance/00_basics/def.json/classes_with_ns_tags.cf.json
+++ b/tests/acceptance/00_basics/def.json/classes_with_ns_tags.cf.json
@@ -3,11 +3,14 @@
     {
         "my_ns:test_class_29665402e2b4331f10b8d767b512cd916eeb5db9": {
             "class_expressions": [ "one", "of", "these", "matches_classmatch", "any" ],
-            "tags": ["test_tag"]
+            "tags": ["test_tag"],
+            "comment": "comment1"
         },
         "my_ns:test_class_29665402e2b4331f10b8d767b512cd916eeb5db9_2":  {
             "regular_expressions": [ "cfengine" ],
-            "tags": ["test_tag"]
+            "tags": ["test_tag"],
+            "comment": "comment2"
+
         },
         "my_ns2:test_class_cfengine_and_cfengine_version":  {
             "class_expressions": [ "cfengine.cfengine_3" ],

--- a/tests/acceptance/00_basics/def.json/variables.cf
+++ b/tests/acceptance/00_basics/def.json/variables.cf
@@ -23,5 +23,5 @@ bundle agent check
     "command" string => "$(sys.cf_promises) --show-vars -f $(sys.inputdir)/promises.cf|$(G.grep) test_variable";
 
   methods:
-      "" usebundle => dcs_passif_output("default:def.test_variable\s+37bff81c825bd57a613ff4770b7a0679ff147bdf\s+test_tag,source=augments_file", "", $(command), $(this.promise_filename));
+      "" usebundle => dcs_passif_output("default:def.test_variable\s+37bff81c825bd57a613ff4770b7a0679ff147bdf\s+test_tag,source=augments_file\s+comment1", "", $(command), $(this.promise_filename));
 }

--- a/tests/acceptance/00_basics/def.json/variables.cf.json
+++ b/tests/acceptance/00_basics/def.json/variables.cf.json
@@ -2,7 +2,8 @@
  "variables": {
      "test_variable": {
          "value": "37bff81c825bd57a613ff4770b7a0679ff147bdf",
-         "tags": ["test_tag"]
+         "tags": ["test_tag"],
+         "comment": "comment1"
      }
  }
 }

--- a/tests/acceptance/01_vars/01_basic/vars_comments_emitted_in_show_vars.cf
+++ b/tests/acceptance/01_vars/01_basic/vars_comments_emitted_in_show_vars.cf
@@ -1,0 +1,22 @@
+# Test $(sys.inputdir), $(sys.masterdir), $(sys.libdir), $(sys.bindir), $(sys.failsafe_policy_path), $(sys.update_policy_path), $(sys.local_libdir)
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+    "description" string => "Test that comments on variables are emitted in --show-evaluated-vars output.";
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+    "" usebundle => dcs_passif_output(".*test_var.*test_var value.*This is a comment about test_var.*", "", "$(sys.cf_agent) -Kf $(this.promise_filename).sub --show-evaluated-vars", $(this.promise_filename));
+}

--- a/tests/acceptance/01_vars/01_basic/vars_comments_emitted_in_show_vars.cf.sub
+++ b/tests/acceptance/01_vars/01_basic/vars_comments_emitted_in_show_vars.cf.sub
@@ -1,0 +1,7 @@
+bundle agent main
+{
+  vars:
+    "test_var"
+      string => "test_var value",
+      comment => "This is a comment about test_var";
+}

--- a/tests/acceptance/02_classes/01_basic/classes_comments_emitted_in_show_classes.cf
+++ b/tests/acceptance/02_classes/01_basic/classes_comments_emitted_in_show_classes.cf
@@ -1,0 +1,22 @@
+# Test $(sys.inputdir), $(sys.masterdir), $(sys.libdir), $(sys.bindir), $(sys.failsafe_policy_path), $(sys.update_policy_path), $(sys.local_libdir)
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+    "description" string => "Test that comments on classes are emitted in --show-evaluated-classes output.";
+}
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+    "" usebundle => dcs_passif_output(".*test_class.*This is a comment about test_class.*", "", "$(sys.cf_agent) -Kf $(this.promise_filename).sub --show-evaluated-classes", $(this.promise_filename));
+}

--- a/tests/acceptance/02_classes/01_basic/classes_comments_emitted_in_show_classes.cf.sub
+++ b/tests/acceptance/02_classes/01_basic/classes_comments_emitted_in_show_classes.cf.sub
@@ -1,0 +1,8 @@
+bundle agent main
+{
+  classes:
+    "test_class"
+      expression => "any",
+      comment => "This is a comment about test_class",
+      scope => "namespace";
+}

--- a/tests/unit/class_test.c
+++ b/tests/unit/class_test.c
@@ -39,7 +39,7 @@ static void test_ns(void)
 {
     {
         ClassTable *t = ClassTableNew();
-        assert_false(ClassTablePut(t, "foo", "127.0.0.1", true, CONTEXT_SCOPE_BUNDLE, NULL));
+        assert_false(ClassTablePut(t, "foo", "127.0.0.1", true, CONTEXT_SCOPE_BUNDLE, NULL, NULL));
         Class *cls = ClassTableGet(t, "foo", "127_0_0_1");
         assert_string_equal("foo", cls->ns);
         assert_string_equal("127_0_0_1", cls->name);
@@ -60,7 +60,7 @@ static void test_default_ns(void)
 {
     {
         ClassTable *t = ClassTableNew();
-        assert_false(ClassTablePut(t, NULL, "127.0.0.1", false, CONTEXT_SCOPE_NAMESPACE, NULL));
+        assert_false(ClassTablePut(t, NULL, "127.0.0.1", false, CONTEXT_SCOPE_NAMESPACE, NULL, NULL));
         Class *cls = ClassTableGet(t, NULL, "127_0_0_1");
         assert_true(cls != NULL);
         assert_true(cls->ns == NULL);
@@ -79,7 +79,7 @@ static void test_default_ns(void)
 
     {
         ClassTable *t = ClassTableNew();
-        assert_false(ClassTablePut(t, "default", "127.0.0.1", false, CONTEXT_SCOPE_NAMESPACE, NULL));
+        assert_false(ClassTablePut(t, "default", "127.0.0.1", false, CONTEXT_SCOPE_NAMESPACE, NULL, NULL));
         Class *cls = ClassTableGet(t, NULL, "127_0_0_1");
         assert_true(cls->ns == NULL);
         cls = ClassTableGet(t, "default", "127_0_0_1");
@@ -93,12 +93,12 @@ static void test_default_ns(void)
 static void test_put_replace(void)
 {
     ClassTable *t = ClassTableNew();
-    assert_false(ClassTablePut(t, NULL, "test", false, CONTEXT_SCOPE_NAMESPACE, NULL));
+    assert_false(ClassTablePut(t, NULL, "test", false, CONTEXT_SCOPE_NAMESPACE, NULL, NULL));
     Class *cls = ClassTableGet(t, NULL, "test");
     assert_true(cls);
     assert_int_equal(CONTEXT_SCOPE_NAMESPACE, cls->scope);
 
-    assert_true(ClassTablePut(t, NULL, "test", true, CONTEXT_SCOPE_BUNDLE, NULL));
+    assert_true(ClassTablePut(t, NULL, "test", true, CONTEXT_SCOPE_BUNDLE, NULL, NULL));
     cls = ClassTableGet(t, NULL, "test");
     assert_true(cls);
     assert_int_equal(CONTEXT_SCOPE_BUNDLE, cls->scope);

--- a/tests/unit/variable_test.c
+++ b/tests/unit/variable_test.c
@@ -9,6 +9,7 @@ struct Variable_
     Rval rval;
     DataType type;
     StringSet *tags;
+    char *comment;
     const Promise *promise; // The promise that set the present value
 };
 
@@ -16,7 +17,7 @@ static bool PutVar(VariableTable *table, char *var_str)
 {
     VarRef *ref = VarRefParse(var_str);
     Rval rval = (Rval) { var_str, RVAL_TYPE_SCALAR };
-    bool ret = VariableTablePut(table, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL);
+    bool ret = VariableTablePut(table, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL, NULL);
     VarRefDestroy(ref);
     return ret;
 }
@@ -31,38 +32,38 @@ static VariableTable *ReferenceTable(void)
     {
         VarRef *ref = VarRefParse("scope1.array[one]");
         Rval rval = (Rval) { "scope1.array[one]", RVAL_TYPE_SCALAR };
-        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL));
+        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL, NULL));
         VarRefDestroy(ref);
     }
     {
         VarRef *ref = VarRefParse("scope1.array[two]");
         Rval rval = (Rval) { "scope1.array[two]", RVAL_TYPE_SCALAR };
-        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL));
+        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL, NULL));
         VarRefDestroy(ref);
     }
     {
         VarRef *ref = VarRefParse("scope1.array[two][three]");
         Rval rval = (Rval) { "scope1.array[two][three]", RVAL_TYPE_SCALAR };
-        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL));
+        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL, NULL));
         VarRefDestroy(ref);
     }
     {
         VarRef *ref = VarRefParse("scope1.array[two][four]");
         Rval rval = (Rval) { "scope1.array[two][four]", RVAL_TYPE_SCALAR };
-        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL));
+        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL, NULL));
         VarRefDestroy(ref);
     }
 
     {
         VarRef *ref = VarRefParse("scope3.array[te][st]");
         Rval rval = (Rval) { "scope3.array[te][st]", RVAL_TYPE_SCALAR };
-        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL));
+        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL, NULL));
         VarRefDestroy(ref);
     }
     {
         VarRef *ref = VarRefParse("scope3.array[t][e][s][t]");
         Rval rval = (Rval) { "scope3.array[t][e][s][t]", RVAL_TYPE_SCALAR };
-        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL));
+        assert_false(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL, NULL));
         VarRefDestroy(ref);
     }
 
@@ -133,7 +134,7 @@ static void test_replace(void)
     TestGet(t, "scope1.lval1");
 
     Rval rval = (Rval) { "foo", RVAL_TYPE_SCALAR };
-    assert_true(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL));
+    assert_true(VariableTablePut(t, ref, &rval, CF_DATA_TYPE_STRING, NULL, NULL, NULL));
 
     Variable *v = VariableTableGet(t, ref);
     assert_true(v != NULL);


### PR DESCRIPTION
Missing bits:
- [x] trivial acceptance tests checking the `comment` attribute propagation from `vars` and `classes` promises