### PR TITLE
Verbose-log comments associated with 'vars' and 'classes' promises

### DIFF
--- a/libpromises/verify_classes.c
+++ b/libpromises/verify_classes.c
@@ -54,6 +54,7 @@ static bool ValidClassName(const char *str)
 
 PromiseResult VerifyClassPromise(EvalContext *ctx, const Promise *pp, ARG_UNUSED void *param)
 {
+    assert(pp != NULL);
     assert(param == NULL);
 
     Log(LOG_LEVEL_DEBUG, "Evaluating classes promise: %s", pp->promiser);
@@ -133,6 +134,11 @@ PromiseResult VerifyClassPromise(EvalContext *ctx, const Promise *pp, ARG_UNUSED
                                               CONTEXT_STATE_POLICY_RESET, BufferData(buf));
                 BufferDestroy(buf);
             }
+            if (inserted && (comment != NULL))
+            {
+                Log(LOG_LEVEL_VERBOSE, "Added class '%s' with comment '%s'", pp->promiser, comment);
+            }
+
 
             if (!inserted)
             {

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -483,6 +483,11 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
         /* WRITE THE VARIABLE AT LAST. */
         bool success = EvalContextVariablePutTagsSetWithComment(ctx, ref, rval.item, required_datatype,
                                                                 tags, comment);
+        if (success && (comment != NULL))
+        {
+            Log(LOG_LEVEL_VERBOSE, "Added variable '%s' with comment '%s'",
+                pp->promiser, comment);
+        }
 
         if (!success)
         {

--- a/tests/acceptance/01_vars/01_basic/vars_comments_emitted_in_verbose.cf
+++ b/tests/acceptance/01_vars/01_basic/vars_comments_emitted_in_verbose.cf
@@ -10,11 +10,9 @@ body common control
 bundle agent test
 {
   meta:
-    "description" string => "Test that comments on variables are emitted in verbose output.";
-
-    "test_soft_fail"
-      string => "any",
-      meta => { "CFE-2442" };
+      "description"
+        string => "Test that comments on variables are emitted in verbose output.",
+        meta => { "CFE-2442" };
 }
 
 #######################################################

--- a/tests/acceptance/02_classes/01_basic/classes_comments_emitted_in_verbose.cf
+++ b/tests/acceptance/02_classes/01_basic/classes_comments_emitted_in_verbose.cf
@@ -10,11 +10,9 @@ body common control
 bundle agent test
 {
   meta:
-    "description" string => "Test that comments on classes are emitted in verbose output.";
-
-    "test_soft_fail"
-      string => "any",
-      meta => { "CFE-2443" };
+      "description"
+        string => "Test that comments on classes are emitted in verbose output.",
+        meta => { "CFE-2443" };
 }
 
 #######################################################


### PR DESCRIPTION
Ticket: CFE-2442
Ticket: CFE-2443
    
Changelog: Verbose log now contains comments associated with 'vars' and 'classes' promises