### PR TITLE
CFE-3675: Bugfix in policy function `selectservers`

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -4114,7 +4114,7 @@ static FnCallResult FnCallSelectServers(EvalContext *ctx,
                 char recvbuf[CF_BUFSIZE];
                 ssize_t n_read = recv(sd, recvbuf, maxbytes, 0);
 
-                if (n_read < 0)
+                if (n_read >= 0)
                 {
                     /* maxbytes was checked earlier, but just make sure... */
                     assert((size_t) n_read < sizeof(recvbuf));


### PR DESCRIPTION
Bad logic causes writing array out of bounds.

No need to backport, see ticket CFE-3675

Ticket: CFE-3675
Changelog: None
Signed-off-by: larsewi <lars.erik.wik@northern.tech>