### PR TITLE
[3.12.x] Do not assert namespace is not specified for 'def.' variables

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1999,10 +1999,15 @@ static VariableTable *GetVariableTableForScope(const EvalContext *ctx,
                                                const char *ns,
                                                const char *scope)
 {
+    assert(ctx != NULL);
+
     switch (SpecialScopeFromString(scope))
     {
-    case SPECIAL_SCOPE_SYS:
     case SPECIAL_SCOPE_DEF:
+        /* 'def.' is not as special as the other scopes below. (CFE-3668) */
+        return ctx->global_variables;
+
+    case SPECIAL_SCOPE_SYS:
     case SPECIAL_SCOPE_MON:
     case SPECIAL_SCOPE_CONST:
         assert(!ns || strcmp("default", ns) == 0);

--- a/tests/acceptance/00_basics/04_bundles/non_default_def.cf
+++ b/tests/acceptance/00_basics/04_bundles/non_default_def.cf
@@ -1,0 +1,45 @@
+# Test that 'def' bundle in a non-default namespace works
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+}
+
+body file control
+{
+        namespace => "my_ns";
+}
+
+bundle common def
+{
+  vars:
+      "some_var" string => "some value";
+}
+
+body file control
+{
+        namespace => "default";
+}
+
+bundle agent init
+{
+}
+
+bundle agent test
+{
+}
+
+bundle agent check
+{
+  classes:
+      "ok" expression => strcmp("$(my_ns:def.some_var)", "some value");
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok.DEBUG::
+      "my_ns:def.some_var: $(my_ns:def.some_var)";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
'def' is a pretty common name for a bundle and so using it
outside of the default namespace should be allowed. It doesn't
produce an error in PolicyCheckBundle() and referring to
variables from a 'def' bundle in a non-default namespace
should just work.

Ticket: CFE-3668
Changelog: None
(cherry picked from commit cfb55d6dd4f5f26ca6a9b89b9b5afe630aad7646)