### PR TITLE
Run cf-agent for localhost requests on the runagent.socket

### DIFF
--- a/cf-execd/cf-execd-runagent.h
+++ b/cf-execd/cf-execd-runagent.h
@@ -25,6 +25,6 @@
 #ifndef CFENGINE_CF_EXECD_RUNAGENT_H
 #define CFENGINE_CF_EXECD_RUNAGENT_H
 
-void HandleRunagentRequest(int conn_fd);
+void HandleRunagentRequest(int conn_fd, const char *local_run_command);
 
 #endif

--- a/cf-execd/execd-config.h
+++ b/cf-execd/execd-config.h
@@ -36,6 +36,7 @@ typedef struct ExecdConfig
     int splay_time;
     char *log_facility;
     StringSet *runagent_allow_users;
+    char *local_run_command;
 } ExecdConfig;
 
 ExecdConfig *ExecdConfigNew(const EvalContext *ctx, const Policy *policy);


### PR DESCRIPTION
cf-execd should run cf-agent locally if 'localhost' (or a
localhost IP address) agent run is requested via the
runagent.socket.

Ticket: ENT-7090
Changelog: cf-execd now executes cf-agent for "localhost" requests via the runagent.socket