### PR TITLE
ENT-7099: Fixed bad assertion parsing promise agent blocks

### DIFF
--- a/libpromises/cf3parse_logic.h
+++ b/libpromises/cf3parse_logic.h
@@ -825,9 +825,8 @@ static inline void ParserBeginBlockBody()
 {
     const BodySyntax *body_syntax = BodySyntaxGet(P.block, P.blocktype);
 
-    if (P.block == PARSER_BLOCK_PROMISE)
+    if (P.block == PARSER_BLOCK_PROMISE && body_syntax != NULL)
     {
-        assert(body_syntax != NULL);
         P.currentbody = PolicyAppendPromiseBlock(
             P.policy,
             P.current_namespace,

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -171,7 +171,10 @@ const BodySyntax *BodySyntaxGet(ARG_UNUSED ParserBlock block, const char *body_t
     if (block == PARSER_BLOCK_PROMISE)
     {
         // Required: promise agent <id>
-        assert(StringEqual(body_type, "agent"));
+        if (!StringEqual(body_type, "agent"))
+        {
+            return NULL;
+        }
         return &CUSTOM_PROMISE_BLOCK_SYNTAX;
     }
 


### PR DESCRIPTION
The code for parsing custom promises assumed body type is always agent.
This is not the case, and here is why:

The parser calls `ParseError` when encountering a non-agent body type.
But the parser continues parsing until a limit of 13 errors have been
encountered. Thus one cannot assume the body type is always agent.
Instead we have to handle the cases when it's not.

Ticket: ENT-7099
Changelog: None
Signed-off-by: larsewi <lars.erik.wik@northern.tech>