### PR TITLE
CFE-3672: Fixed crash when attempting to put methods promises in bundles which are not agent bundles

### DIFF
--- a/tests/acceptance/00_basics/04_bundles/unsupported_promise_types_in_common.x.cf
+++ b/tests/acceptance/00_basics/04_bundles/unsupported_promise_types_in_common.x.cf
@@ -1,0 +1,26 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+}
+
+bundle common test
+{
+  meta:
+      "description" -> { "CFE-3672" }
+        string => "Test that cf-promises errors for incompatible promise types
+                   in common bundle and doesnt crash.";
+
+  methods:
+      "some_report" usebundle => reporter("123");
+
+  files:
+      "some_file";
+}
+
+bundle agent reporter(x)
+{
+  reports:
+      "${x}";
+}
+


### PR DESCRIPTION
Ticket: CFE-3672
Changelog: Title
