### PR TITLE
ENT-6789: Add a feature class for host-specific data loading

### DIFF
--- a/libpromises/feature.c
+++ b/libpromises/feature.c
@@ -26,6 +26,7 @@ static const char* features[] = {
     "tls_1_3",
 #endif
     "def_json_preparse",
+    "host_specific_data_load",
     NULL
 };
 


### PR DESCRIPTION
So that some policy can be omitted on hosts that cannot load
host-specific data.