### PR TITLE
complicated_cpu_bound_benchmark.cf: Made default range lower to reduce runtime

### DIFF
--- a/examples/complicated_cpu_bound_benchmark.cf
+++ b/examples/complicated_cpu_bound_benchmark.cf
@@ -7,7 +7,7 @@ bundle agent benchmark
 {
   vars:
     # Determines how many times each example is run
-      "n" int => "100";
+      "n" int => "10";
 
     # Range: 1, 2, 3, ..., n
       "i" slist => { expandrange("[1-$(n)]", "1") };


### PR DESCRIPTION
This makes the policy take around 1 second instead of 10 on my
machine. Users can always change this range, but having it
somewhat fast by default makes sense.