### PR TITLE
Handle 'null' as valid data for augments and CMDB items

### DIFF
--- a/libpromises/cmdb.c
+++ b/libpromises/cmdb.c
@@ -503,18 +503,21 @@ bool LoadCMDBData(EvalContext *ctx)
 
     bool success = true;
     JsonElement *vars = JsonObjectGet(data, "vars");
-    if ((vars != NULL) && !ReadCMDBVars(ctx, vars))
+    if ((vars != NULL) && (JsonGetType(vars) != JSON_TYPE_NULL) &&
+        !ReadCMDBVars(ctx, vars))
     {
         success = false;
     }
     /* Uses the new format allowing metadata (CFE-3633) */
     JsonElement *variables = JsonObjectGet(data, "variables");
-    if ((variables != NULL) && !ReadCMDBVariables(ctx, variables))
+    if ((variables != NULL) && (JsonGetType(variables) != JSON_TYPE_NULL) &&
+        !ReadCMDBVariables(ctx, variables))
     {
         success = false;
     }
     JsonElement *classes = JsonObjectGet(data, "classes");
-    if ((classes != NULL) && !ReadCMDBClasses(ctx, classes))
+    if ((classes != NULL) && (JsonGetType(classes) != JSON_TYPE_NULL) &&
+        !ReadCMDBClasses(ctx, classes))
     {
         success = false;
     }

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -361,7 +361,7 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
 
         /* load variables (if any) */
         JsonElement *element = JsonObjectGet(augment, "vars");
-        if (element != NULL)
+        if ((element != NULL) && (JsonGetType(element) != JSON_TYPE_NULL))
         {
             JsonElement* vars = JsonExpandElement(ctx, element);
 
@@ -483,7 +483,7 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
 
         /* Uses the new format allowing metadata (CFE-3633) */
         element = JsonObjectGet(augment, "variables");
-        if (element != NULL)
+        if ((element != NULL) && (JsonGetType(element) != JSON_TYPE_NULL))
         {
             JsonElement* variables = JsonExpandElement(ctx, element);
 
@@ -628,7 +628,7 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
 
         /* load classes (if any) */
         element = JsonObjectGet(augment, "classes");
-        if (element != NULL)
+        if ((element != NULL) && (JsonGetType(element) != JSON_TYPE_NULL))
         {
             JsonElement* classes = JsonExpandElement(ctx, element);
 
@@ -744,7 +744,7 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
 
         /* load inputs (if any) */
         element = JsonObjectGet(augment, "inputs");
-        if (element != NULL)
+        if ((element != NULL) && (JsonGetType(element) != JSON_TYPE_NULL))
         {
             JsonElement* inputs = JsonExpandElement(ctx, element);
 
@@ -772,7 +772,7 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
 
         /* load further def.json files (if any) */
         element = JsonObjectGet(augment, "augments");
-        if (element != NULL)
+        if ((element != NULL) && (JsonGetType(element) != JSON_TYPE_NULL))
         {
             JsonElement* further_augments = element;
             assert(further_augments != NULL);


### PR DESCRIPTION
Things like '"vars": null' should be valid and just noop.

Ticket: ENT-7201
Changelog: None