### PR TITLE
[3.15.x] Make sure program name is used as identifier in syslog

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -258,7 +258,10 @@ int main(int argc, char *argv[])
 
     GenericAgentConfigApply(ctx, config);
 
-    GenericAgentDiscoverContext(ctx, config);
+    const char *program_invocation_name = argv[0];
+    const char *last_dir_sep = strrchr(program_invocation_name, FILE_SEPARATOR);
+    const char *program_name = (last_dir_sep != NULL ? last_dir_sep + 1 : program_invocation_name);
+    GenericAgentDiscoverContext(ctx, config, program_name);
 
     /* FIXME: (CFE-2709) ALWAYS_VALIDATE will always be false here, since it can
      *        only change in KeepPromises(), five lines later on. */

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -145,7 +145,10 @@ int main(int argc, char *argv[])
     EvalContext *ctx = EvalContextNew();
     GenericAgentConfigApply(ctx, config);
 
-    GenericAgentDiscoverContext(ctx, config);
+    const char *program_invocation_name = argv[0];
+    const char *last_dir_sep = strrchr(program_invocation_name, FILE_SEPARATOR);
+    const char *program_name = (last_dir_sep != NULL ? last_dir_sep + 1 : program_invocation_name);
+    GenericAgentDiscoverContext(ctx, config, program_name);
 
     Policy *policy = SelectAndLoadPolicy(config, ctx, false, false);
 
@@ -671,7 +674,7 @@ static bool ScheduleRun(EvalContext *ctx, Policy **policy, GenericAgentConfig *c
         UpdateLastPolicyUpdateTime(ctx);
 
         DetectEnvironment(ctx);
-        GenericAgentDiscoverContext(ctx, config);
+        GenericAgentDiscoverContext(ctx, config, NULL);
 
         EvalContextClassPutHard(ctx, CF_AGENTTYPES[AGENT_TYPE_EXECUTOR], "cfe_internal,source=agent");
 

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -38,6 +38,7 @@
 #include <man.h>
 #include <signals.h>
 #include <string_lib.h>
+#include <file_lib.h>           /* FILE_SEPARATOR */
 #include <cleanup.h>
 
 #include <cf-key-functions.h>
@@ -145,7 +146,10 @@ int main(int argc, char *argv[])
     EvalContext *ctx = EvalContextNew();
     GenericAgentConfigApply(ctx, config);
 
-    GenericAgentDiscoverContext(ctx, config);
+    const char *program_invocation_name = argv[0];
+    const char *last_dir_sep = strrchr(program_invocation_name, FILE_SEPARATOR);
+    const char *program_name = (last_dir_sep != NULL ? last_dir_sep + 1 : program_invocation_name);
+    GenericAgentDiscoverContext(ctx, config, program_name);
 
     if (SHOWHOSTS)
     {

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -38,6 +38,7 @@
 #include <time_classes.h>
 #include <loading.h>
 #include <cleanup.h>
+#include <file_lib.h>           /* FILE_SEPARATOR */
 
 typedef enum
 {
@@ -120,7 +121,11 @@ int main(int argc, char *argv[])
     EvalContext *ctx = EvalContextNew();
     GenericAgentConfigApply(ctx, config);
 
-    GenericAgentDiscoverContext(ctx, config);
+    const char *program_invocation_name = argv[0];
+    const char *last_dir_sep = strrchr(program_invocation_name, FILE_SEPARATOR);
+    const char *program_name = (last_dir_sep != NULL ? last_dir_sep + 1 : program_invocation_name);
+    GenericAgentDiscoverContext(ctx, config, program_name);
+
     Policy *policy = LoadPolicy(ctx, config);
 
     GenericAgentPostLoadInit(ctx);

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -33,6 +33,7 @@
 #include <man.h>
 #include <bootstrap.h>
 #include <string_lib.h>
+#include <file_lib.h>                                     /* FILE_SEPARATOR */
 #include <loading.h>
 #include <regex.h>                                        /* CompileRegex */
 #include <match_scope.h>
@@ -135,7 +136,11 @@ int main(int argc, char *argv[])
     EvalContext *ctx = EvalContextNew();
     GenericAgentConfigApply(ctx, config);
 
-    GenericAgentDiscoverContext(ctx, config);
+    const char *program_invocation_name = argv[0];
+    const char *last_dir_sep = strrchr(program_invocation_name, FILE_SEPARATOR);
+    const char *program_name = (last_dir_sep != NULL ? last_dir_sep + 1 : program_invocation_name);
+    GenericAgentDiscoverContext(ctx, config, program_name);
+
     Policy *policy = LoadPolicy(ctx, config);
     if (!policy)
     {

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -207,7 +207,11 @@ int main(int argc, char *argv[])
     EvalContext *ctx = EvalContextNew();
     GenericAgentConfigApply(ctx, config);
 
-    GenericAgentDiscoverContext(ctx, config);
+    const char *program_invocation_name = argv[0];
+    const char *last_dir_sep = strrchr(program_invocation_name, FILE_SEPARATOR);
+    const char *program_name = (last_dir_sep != NULL ? last_dir_sep + 1 : program_invocation_name);
+    GenericAgentDiscoverContext(ctx, config, program_name);
+
     Policy *policy = LoadPolicy(ctx, config);
 
     GenericAgentPostLoadInit(ctx);

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -439,7 +439,7 @@ static void CheckFileChanges(EvalContext *ctx, Policy **policy, GenericAgentConf
             UpdateLastPolicyUpdateTime(ctx);
 
             DetectEnvironment(ctx);
-            GenericAgentDiscoverContext(ctx, config);
+            GenericAgentDiscoverContext(ctx, config, NULL);
 
             /* During startup this is done in GenericAgentDiscoverContext(). */
             EvalContextClassPutHard(ctx, CF_AGENTTYPES[AGENT_TYPE_SERVER], "cfe_internal,source=agent");

--- a/cf-serverd/cf-serverd.c
+++ b/cf-serverd/cf-serverd.c
@@ -56,7 +56,10 @@ int main(int argc, char *argv[])
     EvalContext *ctx = EvalContextNew();
     GenericAgentConfigApply(ctx, config);
 
-    GenericAgentDiscoverContext(ctx, config);
+    const char *program_invocation_name = argv[0];
+    const char *last_dir_sep = strrchr(program_invocation_name, FILE_SEPARATOR);
+    const char *program_name = (last_dir_sep != NULL ? last_dir_sep + 1 : program_invocation_name);
+    GenericAgentDiscoverContext(ctx, config, program_name);
 
     Policy *policy = SelectAndLoadPolicy(config, ctx, false, false);
 

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -77,6 +77,9 @@ static pthread_once_t pid_cleanup_once = PTHREAD_ONCE_INIT; /* GLOBAL_T */
 
 static char PIDFILE[CF_BUFSIZE] = ""; /* GLOBAL_C */
 
+/* Used for 'ident' argument to openlog() */
+static char CF_PROGRAM_NAME[256] = "";
+
 static void CheckWorkingDirectories(EvalContext *ctx);
 
 static void GetAutotagDir(char *dirname, size_t max_size, const char *maybe_dirname);
@@ -516,9 +519,14 @@ static void AddPolicyEntryVariables (EvalContext *ctx, const GenericAgentConfig 
     free(basename_path);
 }
 
-void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config)
+void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config,
+                                 const char *program_name)
 {
     strcpy(VPREFIX, "");
+    if (program_name != NULL)
+    {
+        strncpy(CF_PROGRAM_NAME, program_name, sizeof(CF_PROGRAM_NAME));
+    }
 
     Log(LOG_LEVEL_VERBOSE, " %s", NameVersion());
     Banner("Initialization preamble");
@@ -979,7 +987,7 @@ bool GenericAgentArePromisesValid(const GenericAgentConfig *config)
 #if !defined(__MINGW32__)
 static void OpenLog(int facility)
 {
-    openlog(NULL, LOG_PID | LOG_NOWAIT | LOG_ODELAY, facility);
+    openlog(CF_PROGRAM_NAME, LOG_PID | LOG_NOWAIT | LOG_ODELAY, facility);
 }
 #endif
 

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -106,7 +106,7 @@ typedef struct
 ENTERPRISE_VOID_FUNC_2ARG_DECLARE(void, GenericAgentSetDefaultDigest, HashMethod *, digest, int *, digest_len);
 const char *GenericAgentResolveInputPath(const GenericAgentConfig *config, const char *input_file);
 void MarkAsPolicyServer(EvalContext *ctx);
-void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config);
+void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config, const char *program_name);
 bool GenericAgentCheckPolicy(GenericAgentConfig *config, bool force_validation, bool write_validated_file);
 
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, GenericAgentAddEditionClasses, EvalContext *, ctx);


### PR DESCRIPTION
As man:openlog(3) says:

  The string pointed to by 'ident' is prepended to every message,
  and is typically set to the program name.  If 'ident' is NULL,
  the program name is used.  (POSIX.1-2008 does not specify the
  behavior when ident is NULL.)

And of course not all systems we support are nice and use program
name if we pass NULL as the 'ident' argument.

Ticket: ENT-7100
Changelog: CFEngine processes are now properly identified in syslog on non-GNU/Linux systems
(cherry picked from commit 5147f4a93a87b4ba651c6f2c3fbe1853ad1b0a86)