### PR TITLE
[3.15.x] SELinux fixes

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -137,7 +137,7 @@ require {
 	class dccp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
 	class ib_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
 	class mpls_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
-	class process { setrlimit transition dyntransition execstack execheap execmem };
+	class process { setrlimit transition dyntransition execstack execheap execmem signull };
 	class file { execute execute_no_trans getattr ioctl map open read unlink write entrypoint lock link rename append setattr create relabelfrom relabelto };
 	class fifo_file { create open getattr setattr read write append rename link unlink ioctl lock relabelfrom relabelto };
 	class dir { getattr read search open write add_name remove_name lock ioctl create };
@@ -496,7 +496,7 @@ allow cfengine_httpd_t cfengine_postgres_t:unix_stream_socket connectto;
 
 # allow httpd to use our custom compiled module
 allow cfengine_httpd_t cfengine_var_lib_t:file map;
-allow cfengine_httpd_t cfengine_var_lib_t:file { append create execute getattr ioctl lock open read setattr unlink write };
+allow cfengine_httpd_t cfengine_var_lib_t:file { append create execute getattr ioctl lock open read setattr unlink write rename };
 
 allow cfengine_httpd_t cfengine_var_lib_t:dir { add_name getattr open read remove_name search write create };
 allow cfengine_httpd_t cfengine_var_lib_t:lnk_file read;
@@ -513,6 +513,7 @@ allow cfengine_httpd_t node_t:tcp_socket node_bind;
 allow cfengine_httpd_t self:capability { dac_override dac_read_search kill net_bind_service setgid setuid };
 allow cfengine_httpd_t self:netlink_route_socket { bind create getattr nlmsg_read };
 allow cfengine_httpd_t self:process execmem;
+allow cfengine_httpd_t unconfined_t:process signull;
 allow cfengine_httpd_t self:tcp_socket { accept bind connect create getattr getopt listen setopt shutdown };
 allow cfengine_httpd_t self:udp_socket { connect create getattr };
 allow cfengine_httpd_t self:unix_dgram_socket { connect create };

--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -349,7 +349,7 @@ allow cfengine_hub_t unreserved_port_t:tcp_socket name_connect;
 
 allow cfengine_hub_t cfengine_log_t:dir getattr;
 allow cfengine_hub_t cfengine_var_lib_t:dir { add_name getattr open read search write remove_name };
-allow cfengine_hub_t cfengine_var_lib_t:file { create ioctl lock write };
+allow cfengine_hub_t cfengine_var_lib_t:file { create ioctl lock write unlink };
 allow cfengine_hub_t cfengine_var_lib_t:lnk_file { getattr read };
 allow cfengine_hub_t cfengine_var_lib_t:sock_file { create unlink };
 
@@ -460,8 +460,8 @@ allow cfengine_postgres_t tmpfs_t:filesystem getattr;
 allow cfengine_postgres_t var_log_t:file { append open };
 
 # Needed for systemd to be able to check PostgreSQL's PID file
-allow init_t cfengine_var_lib_t:dir read;
-allow init_t cfengine_var_lib_t:file { getattr open read };
+allow init_t cfengine_var_lib_t:dir { read remove_name write };
+allow init_t cfengine_var_lib_t:file { getattr open read unlink };
 
 # TODO: these should not be needed
 allow cfengine_postgres_t shell_exec_t:file map;


### PR DESCRIPTION
Backport of https://github.com/cfengine/core/pull/4698 and cfengine/core@8a61693 which wasn't backported before for some reason.