### PR TITLE
CFE-3683: Made filename and line number available to promise module

### DIFF
--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -525,6 +525,18 @@ static void PromiseModule_AppendString(
     JsonObjectAppendString(module->message, key, value);
 }
 
+static void PromiseModule_AppendInteger(
+    PromiseModule *module, const char *key, int64_t value)
+{
+    assert(module != NULL);
+
+    if (module->message == NULL)
+    {
+        module->message = JsonObjectCreate(10);
+    }
+    JsonObjectAppendInteger64(module->message, key, value);
+}
+
 static void PromiseModule_AppendAttribute(
     PromiseModule *module, const char *key, JsonElement *value)
 {
@@ -817,6 +829,8 @@ static bool PromiseModule_Validate(PromiseModule *module, const EvalContext *ctx
     PromiseModule_AppendString(module, "log_level", LogLevelToRequestFromModule(pp));
     PromiseModule_AppendString(module, "promise_type", promise_type);
     PromiseModule_AppendString(module, "promiser", promiser);
+    PromiseModule_AppendInteger(module, "line_number", pp->offset.line);
+    PromiseModule_AppendString(module, "filename", PromiseGetBundle(pp)->source_path);
     PromiseModule_AppendAllAttributes(module, ctx, pp);
     PromiseModule_Send(module);
 
@@ -864,6 +878,8 @@ static PromiseResult PromiseModule_Evaluate(
         module, "log_level", LogLevelToRequestFromModule(pp));
     PromiseModule_AppendString(module, "promise_type", promise_type);
     PromiseModule_AppendString(module, "promiser", promiser);
+    PromiseModule_AppendInteger(module, "line_number", pp->offset.line);
+    PromiseModule_AppendString(module, "filename", PromiseGetBundle(pp)->source_path);
 
     PromiseModule_AppendAllAttributes(module, ctx, pp);
     PromiseModule_Send(module);

--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -839,7 +839,7 @@ static bool PromiseModule_Validate(PromiseModule *module, const EvalContext *ctx
         const char *const filename =
             pp->parent_section->parent_bundle->source_path;
         const size_t line = pp->offset.line;
-        Log(LOG_LEVEL_ERR,
+        Log(LOG_LEVEL_VERBOSE,
             "%s:%zu: %s promise with promiser '%s' failed validation",
             filename,
             line,

--- a/misc/custom_promise_types/cfengine.py
+++ b/misc/custom_promise_types/cfengine.py
@@ -227,7 +227,7 @@ class PromiseModule:
         # Check for missing required attributes:
         for name, attribute in self._validator_attributes.items():
             if attribute["required"] and name not in attributes:
-                raise ValidationError(f"Missing required attribute '{a}'")
+                raise ValidationError(f"Missing required attribute '{name}'")
 
         # Check for unknown attributes:
         for name in attributes:

--- a/misc/custom_promise_types/cfengine.py
+++ b/misc/custom_promise_types/cfengine.py
@@ -146,6 +146,9 @@ class PromiseModule:
             if type(value) is not str:
                 # If something is not string, assume it is correct type
                 continue
+            if name not in self._validator_attributes:
+                # Unknown attribute, this will cause a validation error later
+                continue
             # Only known conversion needed: "true"/"false" -> True/False
             if self._validator_attributes[name]["typing"] is bool:
                 if value == "true":


### PR DESCRIPTION
TL;DR of this PR is that error messages from promise modules now look like this:

```
   error: Unknown attribute 'versionss' for git promise with promiser 'starter_pack_repo' (example.cf:11)
```