### PR TITLE
Changed python version check in promise module tests

### DIFF
--- a/tests/acceptance/30_custom_promise_types/07_python_library.cf
+++ b/tests/acceptance/30_custom_promise_types/07_python_library.cf
@@ -15,13 +15,14 @@ body common control
 bundle common python_check
 {
   classes:
-    "python_f_string_support" expression => returnszero("/usr/bin/python3 -c 'f\"string\"'", "useshell");
+    "python_version_compatible_with_cfengine_library"
+      expression => returnszero("/usr/bin/python3 -c 'import sys; assert sys.version_info >= (3,6)'", "useshell");
 }
 
 bundle agent init
 {
   meta:
-      "test_skip_unsupported" string => "!python_f_string_support";
+      "test_skip_unsupported" string => "!python_version_compatible_with_cfengine_library";
 
   vars:
     "test_string"

--- a/tests/acceptance/30_custom_promise_types/08_slist_attrs.cf
+++ b/tests/acceptance/30_custom_promise_types/08_slist_attrs.cf
@@ -15,13 +15,14 @@ body common control
 bundle common python_check
 {
   classes:
-      "python_f_string_support" expression => returnszero("/usr/bin/python3 -c 'f\"string\"'", "useshell");
+      "python_version_compatible_with_cfengine_library"
+        expression => returnszero("/usr/bin/python3 -c 'import sys; assert sys.version_info >= (3,6)'", "useshell");
 }
 
 bundle agent init
 {
   meta:
-      "test_skip_unsupported" string => "!python_f_string_support";
+      "test_skip_unsupported" string => "!python_version_compatible_with_cfengine_library";
 
   files:
       "$(this.promise_dirname)/cfengine.py"

--- a/tests/acceptance/30_custom_promise_types/09_log_level.cf
+++ b/tests/acceptance/30_custom_promise_types/09_log_level.cf
@@ -15,13 +15,14 @@ body common control
 bundle common python_check
 {
   classes:
-    "python_f_string_support" expression => returnszero("/usr/bin/python3 -c 'f\"string\"'", "useshell");
+    "python_version_compatible_with_cfengine_library"
+      expression => returnszero("/usr/bin/python3 -c 'import sys; assert sys.version_info >= (3,6)'", "useshell");
 }
 
 bundle agent init
 {
   meta:
-      "test_skip_unsupported" string => "!python_f_string_support";
+      "test_skip_unsupported" string => "!python_version_compatible_with_cfengine_library";
 
   vars:
     "test_string"

--- a/tests/acceptance/30_custom_promise_types/10_log_level_bad_module.cf
+++ b/tests/acceptance/30_custom_promise_types/10_log_level_bad_module.cf
@@ -15,13 +15,14 @@ body common control
 bundle common python_check
 {
   classes:
-    "python_f_string_support" expression => returnszero("/usr/bin/python3 -c 'f\"string\"'", "useshell");
+    "python_version_compatible_with_cfengine_library"
+      expression => returnszero("/usr/bin/python3 -c 'import sys; assert sys.version_info >= (3,6)'", "useshell");
 }
 
 bundle agent init
 {
   meta:
-      "test_skip_unsupported" string => "!python_f_string_support";
+      "test_skip_unsupported" string => "!python_version_compatible_with_cfengine_library";
 
   vars:
     "test_string"

--- a/tests/acceptance/30_custom_promise_types/16_data_attrs.cf
+++ b/tests/acceptance/30_custom_promise_types/16_data_attrs.cf
@@ -15,13 +15,14 @@ body common control
 bundle common python_check
 {
   classes:
-      "python_f_string_support" expression => returnszero("/usr/bin/python3 -c 'f\"string\"'", "useshell");
+      "python_version_compatible_with_cfengine_library"
+        expression => returnszero("/usr/bin/python3 -c 'import sys; assert sys.version_info >= (3,6)'", "useshell");
 }
 
 bundle agent init
 {
   meta:
-      "test_skip_unsupported" string => "!python_f_string_support";
+      "test_skip_unsupported" string => "!python_version_compatible_with_cfengine_library";
 
   files:
       "$(this.promise_dirname)/cfengine.py"

--- a/tests/acceptance/30_custom_promise_types/17_early_module_failure.cf
+++ b/tests/acceptance/30_custom_promise_types/17_early_module_failure.cf
@@ -15,13 +15,14 @@ body common control
 bundle common python_check
 {
   classes:
-    "python_f_string_support" expression => returnszero("/usr/bin/python3 -c 'f\"string\"'", "useshell");
+    "python_version_compatible_with_cfengine_library"
+      expression => returnszero("/usr/bin/python3 -c 'import sys; assert sys.version_info >= (3,6)'", "useshell");
 }
 
 bundle agent init
 {
   meta:
-      "test_skip_unsupported" string => "!python_f_string_support";
+      "test_skip_unsupported" string => "!python_version_compatible_with_cfengine_library";
 
   files:
     "$(this.promise_dirname)/cfengine.py"

--- a/tests/acceptance/30_custom_promise_types/18_early_module_failure_classes.cf
+++ b/tests/acceptance/30_custom_promise_types/18_early_module_failure_classes.cf
@@ -15,13 +15,14 @@ body common control
 bundle common python_check
 {
   classes:
-    "python_f_string_support" expression => returnszero("/usr/bin/python3 -c 'f\"string\"'", "useshell");
+    "python_version_compatible_with_cfengine_library"
+      expression => returnszero("/usr/bin/python3 -c 'import sys; assert sys.version_info >= (3,6)'", "useshell");
 }
 
 bundle agent init
 {
   meta:
-      "test_skip_unsupported" string => "!python_f_string_support";
+      "test_skip_unsupported" string => "!python_version_compatible_with_cfengine_library";
 
   files:
     "$(this.promise_dirname)/cfengine.py"


### PR DESCRIPTION
This allows us to change to version 3.5 more easily soon.