### PR TITLE
libpromises: Fix compilation of qdbm and tokycabinet backends

### DIFF
--- a/libpromises/dbm_quick.c
+++ b/libpromises/dbm_quick.c
@@ -249,8 +249,8 @@ bool DBPrivWrite(DBPriv *db, const void *key, int key_size, const void *value, i
     return true;
 }
 
-bool DBPrivOverwrite(DBPriv *db, const void *key, int key_size, const void *value, int value_size,
-                     OverwriteCondition *Condition, void *data)
+bool DBPrivOverwrite(DBPriv *db, const char *key, int key_size, const void *value, size_t value_size,
+                     OverwriteCondition Condition, void *data)
 {
     if (!Lock(db))
     {

--- a/libpromises/dbm_tokyocab.c
+++ b/libpromises/dbm_tokyocab.c
@@ -307,8 +307,8 @@ bool DBPrivWrite(DBPriv *db, const void *key, int key_size, const void *value, i
     return ret;
 }
 
-bool DBPrivOverwrite(DBPriv *db, const void *key, int key_size, const void *value, int value_size,
-                     OverwriteCondition *Condition, void *data)
+bool DBPrivOverwrite(DBPriv *db, const char *key, int key_size, const void *value, size_t value_size,
+                     OverwriteCondition Condition, void *data)
 {
     ssize_t cur_val_size = tchdbvsiz(db->hdb, key, key_size);
     void *cur_val = NULL;
@@ -318,7 +318,7 @@ bool DBPrivOverwrite(DBPriv *db, const void *key, int key_size, const void *valu
     {
         assert(cur_val_size > 0);
         cur_val = xmalloc(cur_val_size);
-        if (tchdbget3(db->hdb, key, key_size, dest, dest_size) == -1)
+        if (tchdbget3(db->hdb, key, key_size, cur_val, cur_val_size) == -1)
         {
             /* If exists, we should never get the TCENOREC error. */
             assert(tchdbecode(db->hdb) != TCENOREC);


### PR DESCRIPTION
With commit 032bda408 (Add a new function for overwriting a value in
local DB, 2020-05-27), a new function `DBPrivOverwrite()` has been
introduced with implementations for the various database backends. As it
turns out, both the implementation for qdbm and for tokyocabinet are
broken and don't compile out of the box: both use a different signature
compared to the declared one, and the tokyocabinet implementation uses
wrong variable names.

Fix both issues by adapting the implementations' function signatures and
by using the correct set of variables in case of tokyocabinet.