### PR TITLE
Enabled non-object bare values inside augments variables key

### DIFF
--- a/libpromises/cmdb.c
+++ b/libpromises/cmdb.c
@@ -308,6 +308,7 @@ static bool ReadCMDBVariables(EvalContext *ctx, JsonElement *variables)
             if (data == NULL)
             {
                 Log(LOG_LEVEL_ERR, "Missing value in '%s' variable specification in CMDB data (value field is required)", key);
+                VarRefDestroy(ref);
                 continue;
             }
 

--- a/libpromises/cmdb.c
+++ b/libpromises/cmdb.c
@@ -288,6 +288,13 @@ static bool ReadCMDBVariables(EvalContext *ctx, JsonElement *variables)
     while (JsonIteratorHasMore(&iter))
     {
         const char *key = JsonIteratorNextKey(&iter);
+
+        VarRef *ref = GetCMDBVariableRef(key);
+        if (ref == NULL)
+        {
+            continue;
+        }
+
         JsonElement *const var_info = JsonObjectGet(variables, key);
 
         JsonElement *data;
@@ -317,12 +324,6 @@ static bool ReadCMDBVariables(EvalContext *ctx, JsonElement *variables)
 
         assert(tags != NULL);
         assert(data != NULL);
-
-        VarRef *ref = GetCMDBVariableRef(key);
-        if (ref == NULL)
-        {
-            continue;
-        }
 
         bool ret = AddCMDBVariable(ctx, key, ref, data, tags, comment);
         VarRefDestroy(ref);

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -532,6 +532,7 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
                     {
                         Log(LOG_LEVEL_ERR, "Missing value for the augments variable '%s' in '%s' (value field is required)",
                             vkey, filename);
+                        VarRefDestroy(ref);
                         continue;
                     }
 

--- a/tests/acceptance/00_basics/def.json/variables_bare_array.cf
+++ b/tests/acceptance/00_basics/def.json/variables_bare_array.cf
@@ -1,0 +1,27 @@
+# basic test of the def.json facility: variables
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) --show-vars -f $(sys.inputdir)/promises.cf | $(G.grep) bare_test";
+
+  methods:
+      "" usebundle => dcs_passif_output("default:def.bare_test_array\s+.*bare_test_array_element.*", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/variables_bare_array.cf.json
+++ b/tests/acceptance/00_basics/def.json/variables_bare_array.cf.json
@@ -1,0 +1,5 @@
+{
+  "variables": {
+    "bare_test_array": ["bare_test_array_element"]
+  }
+}

--- a/tests/acceptance/00_basics/def.json/variables_bare_string.cf
+++ b/tests/acceptance/00_basics/def.json/variables_bare_string.cf
@@ -1,0 +1,27 @@
+# basic test of the def.json facility: variables
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+      "" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+      "" usebundle => file_copy("$(this.promise_filename).json", "$(sys.inputdir)/def.json");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    "command" string => "$(sys.cf_promises) --show-vars -f $(sys.inputdir)/promises.cf | $(G.grep) bare_test";
+
+  methods:
+      "" usebundle => dcs_passif_output("default:def.bare_test_string\s+bare_test_string_value\s.*", "", $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/def.json/variables_bare_string.cf.json
+++ b/tests/acceptance/00_basics/def.json/variables_bare_string.cf.json
@@ -1,0 +1,5 @@
+{
+  "variables": {
+    "bare_test_string": "bare_test_string_value"
+  }
+}


### PR DESCRIPTION
When discussing this feature, we mentioned that the new
format was only a problem/incompatibility for objects.
If the value is something like a string (or list)
the old structure "just works". This also means that
in the future, when 3.18.0+ is common, we can tell users
to just rename "vars" to "variables". As long as they
don't have any objects they don't have to make further
changes. This can be added as a warning, even.

Looking at our examples it seems quite common that
augments variables are strings or lists, and quite
rare that they are objects (data containers), so for
most users, they can just rename "vars" to "variables".
(With this change).

Without this change, the code crashes (abort assertion
error) if you try to do this.