### PR TITLE
ENT-6713 Update badges and travis config for 3.18.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ addons:
 branches:
   only:
     - master
-    - 3.10.x
     - 3.12.x
     - 3.15.x
+    - 3.18.x
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 | Version    | [Core](https://github.com/cfengine/core)                                                                           | [MPF](https://github.com/cfengine/masterfiles)                                                                                  |
 |------------|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
 | master     | [![Core Build Status](https://travis-ci.org/cfengine/core.svg?branch=master)](https://travis-ci.org/cfengine/core) | [![MPF Build Status](https://travis-ci.org/cfengine/masterfiles.svg?branch=master)](https://travis-ci.org/cfengine/masterfiles) |
+| 3.18.x LTS | [![Core Build Status](https://travis-ci.org/cfengine/core.svg?branch=3.18.x)](https://travis-ci.org/cfengine/core) | [![MPF Build Status](https://travis-ci.org/cfengine/masterfiles.svg?branch=3.18.x)](https://travis-ci.org/cfengine/masterfiles) |
 | 3.15.x LTS | [![Core Build Status](https://travis-ci.org/cfengine/core.svg?branch=3.15.x)](https://travis-ci.org/cfengine/core) | [![MPF Build Status](https://travis-ci.org/cfengine/masterfiles.svg?branch=3.15.x)](https://travis-ci.org/cfengine/masterfiles) |
 | 3.12.x LTS | [![Core Build Status](https://travis-ci.org/cfengine/core.svg?branch=3.12.x)](https://travis-ci.org/cfengine/core) | [![MPF Build Status](https://travis-ci.org/cfengine/masterfiles.svg?branch=3.12.x)](https://travis-ci.org/cfengine/masterfiles) |
 


### PR DESCRIPTION
Removed 3.10.x and added 3.18.x branch builds to travis config

Adjusted badges

Ticket: ENT-6713
Changelog: title