### PR TITLE
Acceptance tests for host-specific data loading

### DIFF
--- a/tests/acceptance/00_basics/06_host_specific_data/01-vars.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/01-vars.cf
@@ -1,0 +1,59 @@
+# basic test of the host_specific.json functionality: 'vars' object
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "result"
+        data => execresult_as_data("$(sys.cf_agent) -Kf $(this.promise_filename).sub",
+                                   "noshell", "both"),
+        depends_on => { "prepare_host_specific_data" }; # ensure the sub-agent execution doesn't happen too early
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "exit_code_ok" expression => strcmp("$(test.result[exit_code])", "0");
+      "output_ok" expression => strcmp("$(test.result[output])",
+'R: 4hfcattz2607yfksllzpf73eg7nmqprl
+R: { "496btq4wxqs6rf07anbx95cj74ftdyhy" }
+R: {"key":"tiyl4z5nybvlp8npd2faso4ctxhknpvk"}');
+
+      "ok" and => {"exit_code_ok", "output_ok"};
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+
+    !ok.DEBUG::
+      "exit code: $(test.result[exit_code])";
+      "output: $(test.result[output])";
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/01-vars.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/01-vars.cf.json
@@ -1,0 +1,7 @@
+{
+    "vars" : {
+        "test_variable": "4hfcattz2607yfksllzpf73eg7nmqprl",
+        "scope1.test_variable": ["496btq4wxqs6rf07anbx95cj74ftdyhy"],
+        "ns1:scope1.test_variable": { "key" : "tiyl4z5nybvlp8npd2faso4ctxhknpvk" }
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/01-vars.cf.sub
+++ b/tests/acceptance/00_basics/06_host_specific_data/01-vars.cf.sub
@@ -1,0 +1,6 @@
+bundle agent __main__ {
+  reports:
+      "$(data:variables.test_variable)";
+      "$(with)" with => format("%S", "data:scope1.test_variable");
+      "$(with)" with => format("%S", "ns1:scope1.test_variable");
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/02-variables.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/02-variables.cf
@@ -1,0 +1,58 @@
+# basic test of the host_specific.json functionality: 'variables' object
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "result"
+        data => execresult_as_data("$(sys.cf_agent) -Kf $(this.promise_filename).sub",
+                                   "noshell", "both"),
+        depends_on => { "prepare_host_specific_data" }; # ensure the sub-agent execution doesn't happen too early
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "exit_code_ok" expression => strcmp("$(test.result[exit_code])", "0");
+      "output_ok" expression => strcmp("$(test.result[output])",
+'R: 4hfcattz2607yfksllzpf73eg7nmqprl
+R: { "496btq4wxqs6rf07anbx95cj74ftdyhy" }');
+
+      "ok" and => {"exit_code_ok", "output_ok"};
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+
+    !ok.DEBUG::
+      "exit code: $(test.result[exit_code])";
+      "output: $(test.result[output])";
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/02-variables.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/02-variables.cf.json
@@ -1,0 +1,6 @@
+{
+    "variables" : {
+        "test_variable": "4hfcattz2607yfksllzpf73eg7nmqprl",
+        "scope1.test_variable": ["496btq4wxqs6rf07anbx95cj74ftdyhy"]
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/02-variables.cf.sub
+++ b/tests/acceptance/00_basics/06_host_specific_data/02-variables.cf.sub
@@ -1,0 +1,5 @@
+bundle agent __main__ {
+  reports:
+      "$(data:variables.test_variable)";
+      "$(with)" with => format("%S", "data:scope1.test_variable");
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/03-variables-value.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/03-variables-value.cf
@@ -1,0 +1,59 @@
+# basic test of the host_specific.json functionality: 'variables' object with the 'value' field
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "result"
+        data => execresult_as_data("$(sys.cf_agent) -Kf $(this.promise_filename).sub",
+                                   "noshell", "both"),
+        depends_on => { "prepare_host_specific_data" }; # ensure the sub-agent execution doesn't happen too early
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "exit_code_ok" expression => strcmp("$(test.result[exit_code])", "0");
+      "output_ok" expression => strcmp("$(test.result[output])",
+'R: 4hfcattz2607yfksllzpf73eg7nmqprl
+R: { "496btq4wxqs6rf07anbx95cj74ftdyhy" }
+R: {"key":"tiyl4z5nybvlp8npd2faso4ctxhknpvk"}');
+
+      "ok" and => {"exit_code_ok", "output_ok"};
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+
+    !ok.DEBUG::
+      "exit code: $(test.result[exit_code])";
+      "output: $(test.result[output])";
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/03-variables-value.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/03-variables-value.cf.json
@@ -1,0 +1,7 @@
+{
+    "variables" : {
+        "test_variable": { "value": "4hfcattz2607yfksllzpf73eg7nmqprl" },
+        "scope1.test_variable": { "value": ["496btq4wxqs6rf07anbx95cj74ftdyhy"] },
+        "ns1:scope1.test_variable": { "value": { "key" : "tiyl4z5nybvlp8npd2faso4ctxhknpvk" } }
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/03-variables-value.cf.sub
+++ b/tests/acceptance/00_basics/06_host_specific_data/03-variables-value.cf.sub
@@ -1,0 +1,6 @@
+bundle agent __main__ {
+  reports:
+      "$(data:variables.test_variable)";
+      "$(with)" with => format("%S", "data:scope1.test_variable");
+      "$(with)" with => format("%S", "ns1:scope1.test_variable");
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/04-classes.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/04-classes.cf
@@ -1,0 +1,64 @@
+# basic test of the host_specific.json functionality: 'classes' object
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+}
+
+#######################################################
+
+bundle agent test
+{
+  vars:
+      "result"
+        data => execresult_as_data("$(sys.cf_agent) -Kf $(this.promise_filename).sub",
+                                   "noshell", "both"),
+        depends_on => { "prepare_host_specific_data" }; # ensure the sub-agent execution doesn't happen too early
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "exit_code_ok" expression => strcmp("$(test.result[exit_code])", "0");
+      "output_ok" expression => strcmp("$(test.result[output])",
+'R: test_class1 defined as expected
+R: test_class2 defined as expected
+R: test_class3 defined as expected
+R: test_class4 defined as expected
+R: test_class5 defined as expected
+R: test_class6 defined as expected
+R: test_class7 defined as expected
+R: test_class8 defined as expected');
+
+      "ok" and => {"exit_code_ok", "output_ok"};
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+
+    !ok.DEBUG::
+      "exit code: $(test.result[exit_code])";
+      "output: $(test.result[output])";
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/04-classes.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/04-classes.cf.json
@@ -1,0 +1,12 @@
+{
+    "classes" : {
+        "test_class1": "any::",
+        "test_class2": ["any::"],
+        "ns1:test_class3": "any::",
+        "ns2:test_class4" : { "class_expressions": ["any::"] },
+        "ns2:test_class5" : { "regular_expressions": ["any"] },
+        "ns3:test_class6" : { "class_expressions": [] },
+        "ns3:test_class7" : { "regular_expressions": [] },
+        "test_class8" : {}
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/04-classes.cf.sub
+++ b/tests/acceptance/00_basics/06_host_specific_data/04-classes.cf.sub
@@ -1,0 +1,19 @@
+bundle agent __main__ {
+  reports:
+    data:test_class1::
+      "test_class1 defined as expected";
+    data:test_class2::
+      "test_class2 defined as expected";
+    ns1:test_class3::
+      "test_class3 defined as expected";
+    ns2:test_class4::
+      "test_class4 defined as expected";
+    ns2:test_class5::
+      "test_class5 defined as expected";
+    ns3:test_class6::
+      "test_class6 defined as expected";
+    ns3:test_class7::
+      "test_class7 defined as expected";
+    data:test_class8::
+      "test_class8 defined as expected";
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/05-variables-tag-comment.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/05-variables-tag-comment.cf
@@ -1,0 +1,38 @@
+# basic test of the host_specific.json functionality: 'variables' object with a tag and a comment
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+      "empty_promises_cf" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "command" string => "$(sys.cf_promises) --show-vars -f $(sys.inputdir)/promises.cf | $(G.grep) test_variable";
+
+  methods:
+      "" usebundle => dcs_passif_output("data:variables.test_variable\s+4hfcattz2607yfksllzpf73eg7nmqprl\s+test_tag,source=cmdb\s+comment1",
+                                        "",
+                                        $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/05-variables-tag-comment.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/05-variables-tag-comment.cf.json
@@ -1,0 +1,9 @@
+{
+    "variables" : {
+        "test_variable": {
+            "value" : "4hfcattz2607yfksllzpf73eg7nmqprl",
+            "comment" : "comment1",
+            "tags" : ["test_tag"]
+        }
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/06-classes-tag-comment.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/06-classes-tag-comment.cf
@@ -1,0 +1,38 @@
+# basic test of the host_specific.json functionality: 'classes' object with a tag and a comment
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+      "empty_promises_cf" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf|$(G.grep) test_class";
+
+  methods:
+      "" usebundle => dcs_passif_output("ns1:test_class\s+test_tag,source=cmdb\s+comment1.*ns2:test_class2\s+test_tag2,source=cmdb\s+comment2",
+                                        "",
+                                        $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/06-classes-tag-comment.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/06-classes-tag-comment.cf.json
@@ -1,0 +1,13 @@
+{
+    "classes" : {
+        "ns1:test_class": {
+            "class_expressions" : [],
+            "tags": ["test_tag"],
+            "comment" : "comment1"
+        },
+        "ns2:test_class2": {
+            "tags": ["test_tag2"],
+            "comment" : "comment2"
+        }
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/07-invalid-data.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/07-invalid-data.cf
@@ -1,0 +1,38 @@
+# basic test of the host_specific.json functionality: 'classes' object with a tag and a comment
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+      "empty_promises_cf" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf";
+
+  methods:
+      "" usebundle => dcs_passif_output("\s*warning: Invalid key 'clses'.*\s+ns1:test_class\s+.*",
+                                        "",
+                                        $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/07-invalid-data.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/07-invalid-data.cf.json
@@ -1,0 +1,16 @@
+{
+    "clses" : {
+        "ns1:test_class": {
+            "class_expressions" : [],
+            "tags": ["test_tag"],
+            "comment" : "comment1"
+        }
+    },
+    "classes" : {
+        "ns1:test_class": {
+            "class_expressions" : [],
+            "tags": ["test_tag"],
+            "comment" : "comment1"
+        }
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/08-class-expression.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/08-class-expression.cf
@@ -1,0 +1,38 @@
+# basic test of the host_specific.json functionality: 'classes' object with a tag and a comment
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+      "empty_promises_cf" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf";
+
+  methods:
+      "" usebundle => dcs_passif_output("\s*error: Invalid class expression rules for class 'ns1:test_class1'.*\s+ns2:test_class2\s+.*",
+                                        "",
+                                        $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/08-class-expression.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/08-class-expression.cf.json
@@ -1,0 +1,14 @@
+{
+    "classes" : {
+        "ns1:test_class1": {
+            "class_expressions" : ["cfengine"],
+            "tags": ["test_tag"],
+            "comment" : "comment1"
+        },
+       "ns2:test_class2": {
+            "class_expressions" : [],
+            "tags": ["test_tag"],
+            "comment" : "comment1"
+       }
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/09-class-reg-expression.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/09-class-reg-expression.cf
@@ -1,0 +1,38 @@
+# basic test of the host_specific.json functionality: 'classes' object with a tag and a comment
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+      "empty_promises_cf" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf";
+
+  methods:
+      "" usebundle => dcs_passif_output("\s*error: Invalid regular expression rules for class 'ns1:test_class1'.*\s+ns2:test_class2\s+.*",
+                                        "",
+                                        $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/09-class-reg-expression.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/09-class-reg-expression.cf.json
@@ -1,0 +1,14 @@
+{
+    "classes" : {
+        "ns1:test_class1": {
+            "regular_expressions" : ["cfengine"],
+            "tags": ["test_tag"],
+            "comment" : "comment1"
+        },
+       "ns2:test_class2": {
+            "class_expressions" : [],
+            "tags": ["test_tag"],
+            "comment" : "comment1"
+       }
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/10-variable-references.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/10-variable-references.cf
@@ -1,0 +1,38 @@
+# basic test of the host_specific.json functionality: 'classes' object with a tag and a comment
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+      "empty_promises_cf" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "command" string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf";
+
+  methods:
+      "" usebundle => dcs_passif_output("\s*error: Invalid 'variables' CMDB data.*",
+                                        "test_variable2?",
+                                        $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/10-variable-references.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/10-variable-references.cf.json
@@ -1,0 +1,14 @@
+{
+    "variables" : {
+        "test_variable": {
+            "value" : "$(sys.uptime)",
+            "comment" : "comment1",
+            "tags" : ["test_tag"]
+        },
+        "test_variable2": {
+            "value" : "4hfcattz2607yfksllzpf73eg7nmqprl",
+            "comment" : "comment2",
+            "tags" : ["test_tag2"]
+        }
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/11-augments-no-override.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/11-augments-no-override.cf
@@ -1,0 +1,41 @@
+# basic test of the host_specific.json functionality: 'variables' object with a tag and a comment
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+        create => "true",
+        perms => mog("0700", "$(sys.user_data[username])", "$(sys.user_data[username])");
+
+  methods:
+      "prepare_host_specific_data"
+        usebundle => file_copy("$(this.promise_filename).json",
+                               "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"),
+        handle => "prepare_host_specific_data";
+
+      "def_json" usebundle => file_copy("$(this.promise_filename).def.json", "$(sys.inputdir)/def.json");
+
+      "empty_promises_cf" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+      "command" string => "$(sys.cf_promises) --verbose --show-vars -f $(sys.inputdir)/promises.cf | $(G.grep) test_variable";
+
+  methods:
+      "" usebundle => dcs_passif_output(concat(".*Cannot set variable ns1:scope1.test_variable from augments, already defined from host-specific data",
+                                               ".*ns1:scope1.test_variable\s+4hfcattz2607yfksllzpf73eg7nmqprl\s+test_tag,source=cmdb\s+comment1.*"),
+                                        "override_value",
+                                        $(command), $(this.promise_filename));
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/11-augments-no-override.cf.def.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/11-augments-no-override.cf.def.json
@@ -1,0 +1,9 @@
+{
+    "variables" : {
+        "ns1:scope1.test_variable": {
+            "value" : "override_value",
+            "comment" : "comment2",
+            "tags" : ["test_tag2"]
+        }
+    }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/11-augments-no-override.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/11-augments-no-override.cf.json
@@ -1,0 +1,9 @@
+{
+    "variables" : {
+        "ns1:scope1.test_variable": {
+            "value" : "4hfcattz2607yfksllzpf73eg7nmqprl",
+            "comment" : "comment1",
+            "tags" : ["test_tag"]
+        }
+    }
+}


### PR DESCRIPTION
TODO:
- [x] CMDB data is loaded by cf-promises and cf-agent
- [x] vars, variables and classes are loaded
- [x] other top-level child objects trigger errors
- [x] variable expressions cause errors
- [x] classes only support any:: as expression
- [x] default namespace for variables and classes from CMDB data is data, default bundle for variables is variables
- [x] vars, variables can specify namespace and budle and classes can specify namespace
- [x] tags and comment are properly applied from variables and classes
- [x] variables support the direct value specification compatible with vars except for data variables
- [x] variables and classes from CMDB data cannot be re-defined in augments
