### PR TITLE
Fixed segmentation fault when custom promise sends invalid response

### DIFF
--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -909,6 +909,11 @@ static PromiseResult PromiseModule_Evaluate(
     PromiseModule_Send(module);
 
     JsonElement *response = PromiseModule_Receive(module, pp);
+    if (response == NULL)
+    {
+        // Log from PromiseModule_Receive
+        return PROMISE_RESULT_FAIL;
+    }
 
     JsonElement *result_classes = JsonObjectGetAsArray(response, "result_classes");
     if (result_classes != NULL)


### PR DESCRIPTION
There are two possible ways for `PromiseModule_receive` to return NULL.
These lines are 285 and 302 in `mod_custom.c`. By adding this check we
can at least ensure that the promise evaluation fails and the agent continues.
    
The manual testing consisted of a custom promise
and a simple policy file:

```python
from cfengine import PromiseModule, Result

class CustomPromiseTypeModule(PromiseModule):
    def __init__(self, **kwargs):
        super().__init__('custom_promise', '0.0.1', **kwargs)
        self.add_attribute('attribute', str)

    def evaluate_promise(self, promiser, attribute):
        #print('blah')  # Would segfault because of NULL from line 285
        #print()  # Would segfault because of NULL from line 302
        return Result.KEPT, None
```
```cfengine3
promise agent custom
{
    path => "$(sys.workdir)/modules/promises/custom.py";
    interpreter => "/usr/bin/python3";
}

body common control
{
    bundlesequence => {"first", "second"};
}

bundle agent first
# bad responses from `evaluate_promise` make sure it fails
{
  custom:
    "custom_promiser"
      attribute => "value";
}

bundle agent second
# Must be evaluated even if `first` fails
{
  files:
    "/tmp/delete_me"
      create => "true";

  commands:
    "/usr/bin/echo 123";
}
```
