### PR TITLE
Fixed segmentation fault when custom promise sends invalid response (3.18.x)

### DIFF
--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -909,6 +909,11 @@ static PromiseResult PromiseModule_Evaluate(
     PromiseModule_Send(module);
 
     JsonElement *response = PromiseModule_Receive(module, pp);
+    if (response == NULL)
+    {
+        // Log from PromiseModule_Receive
+        return PROMISE_RESULT_FAIL;
+    }
 
     JsonElement *result_classes = JsonObjectGetAsArray(response, "result_classes");
     if (result_classes != NULL)


### PR DESCRIPTION
Mark custom promise as failed if module doesn't send valid JSON

Ticket: None
Changelog: None
(cherry picked from commit 2a6c302a5f343794ed9b4931de351c35bfa56dec)
