### PR TITLE
ENT-7502: Fixed Windows version unknown in MP

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1092,7 +1092,7 @@ static void SetFlavor(EvalContext *ctx, const char *flavor)
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "flavor", flavor, CF_DATA_TYPE_STRING, "inventory,source=agent,attribute_name=none");
 }
 
-#ifdef __linux__
+#if defined __linux__ || __MINGW32__
 
 /**
  * @brief Combines OS and version string to define flavor variable and class
@@ -1113,6 +1113,10 @@ static void SetFlavor2(
     SetFlavor(ctx, flavor);
     free(flavor);
 }
+
+#endif
+
+#ifdef __linux__
 
 /**
  * @brief Combines OS and version string to define multiple hard classes

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -150,6 +150,8 @@ static time_t GetBootTimeFromUptimeCommand(time_t now);
 
 /*****************************************************/
 
+static char *FindNextInteger(char *str, char **num);
+
 void CalculateDomainName(const char *nodename, const char *dnsname,
                          char *fqname, size_t fqname_size,
                          char *uqname, size_t uqname_size,
@@ -1558,7 +1560,18 @@ static void OSClasses(EvalContext *ctx)
         EvalContextClassPutHard(ctx, "unknown_ostype", "source=agent,derived-from=sys.sysname");
     }
 
-    SetFlavor(ctx, "windows");
+    char *release = SafeStringDuplicate(VSYSNAME.release);
+    char *major = NULL;
+    FindNextInteger(release, &major);
+    if (NULL_OR_EMPTY(major))
+    {
+        SetFlavor(ctx, "windows");
+    }
+    else
+    {
+        SetFlavor2(ctx, "windows", major);
+    }
+    free(release);
 
 #endif /* __MINGW32__ */
 

--- a/tests/static-check/cppcheck_suppressions.txt
+++ b/tests/static-check/cppcheck_suppressions.txt
@@ -2,7 +2,7 @@
 objectIndex:libntech/libutils/platform.h
 
 // cppcheck is not clever enough to see that if (i >= PLATFORM_CONTEXT_MAX) then 'found' is false
-arrayIndexOutOfBounds:libenv/sysinfo.c:585
+arrayIndexOutOfBounds:libenv/sysinfo.c:587
 
 // 'psin' is assigned to 'ai->ai_addr' and 'ai' is returned to the caller
 memleak:libntech/libcompat/getaddrinfo.c:153


### PR DESCRIPTION
Tested:
 - [x] Windows 2012
 - [x] Windows 2016
 - [x] Windows 2019
 - [x] Windows 10

cherry-picked to 3.18.x - https://github.com/cfengine/core/pull/4762

Ticket: ENT-7502
Changelog: None
Signed-off-by: larsewi <lars.erik.wik@northern.tech>