### PR TITLE
ENT-7511 Skip update policy run with --skip-bootstrap-policy-run (3.18.x)

### DIFF
--- a/libpromises/failsafe.cf
+++ b/libpromises/failsafe.cf
@@ -383,7 +383,7 @@ bundle agent failsafe_cfe_internal_call_update
 
     # On Windows we need cf-execd to call update.cf, otherwise the daemons will
     # not run under the SYSTEM account.
-    !windows::
+    !windows.!skip_policy_on_bootstrap::
       "$(sys.cf_agent) -f $(sys.update_policy_path) --define $(mode)"
         handle => "failsafe_cfe_internal_call_update_commands_call_update_cf",
         if => fileexists( $(sys.update_policy_path) ),


### PR DESCRIPTION
Workaround for lmdb invalid argument issues in CI (ENT-7500)

Ticket: ENT-7511
Changelog: title
(cherry picked from commit ee529a5ca34e537ed00044b3bc7909b7bf9763d4)