### PR TITLE
CFE-3723: Changed log level of message about reaching maximum recursion from ERROR to VERBOSE

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -736,8 +736,7 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
 
     if (maxrecurse == 0)        /* reached depth limit */
     {
-        RecordFailure(ctx, pp, attr, "Maximum recursion level reached at '%s'", from);
-        return PROMISE_RESULT_FAIL;
+        Log(LOG_LEVEL_VERBOSE, "Maximum recursion level reached at '%s'", from);
     }
 
     if (strlen(from) == 0)      /* Check for root dir */


### PR DESCRIPTION
If I promise to copy a directory recursively up to a depth of N and there are
levels deeper than N the promise should not error. Not promising enough depth to
reach the bottom isn't an error, at most it's a message more relevant for
verbose logs, if not debug logs.

Ticket: CFE-3723
Changelog: Title