### PR TITLE
CFE-3640: Don't try to backup files with an empty name

### DIFF
--- a/libpromises/files_repository.c
+++ b/libpromises/files_repository.c
@@ -91,6 +91,11 @@ bool ArchiveToRepository(const char *file, const Attributes *attr)
     char destination[CF_BUFSIZE];
     struct stat sb, dsb;
 
+    // Skip empty file name
+    if (file[0] == '\0') {
+        return false;
+    }
+
     if (!GetRepositoryPath(file, attr, destination))
     {
         return false;


### PR DESCRIPTION
Fixes https://tracker.mender.io/browse/CFE-3640.