### PR TITLE
ENT-7556 ifelse() not falling back in case of undefined vars (3.15)

### DIFF
--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -352,12 +352,11 @@ FnCallResult FnCallEvaluate(EvalContext *ctx, const Policy *policy, FnCall *fp, 
     if ( ! (fp_type->options & FNCALL_OPTION_DELAYED_EVALUATION) &&
          RlistIsUnresolved(expargs))
     {
-        // Special case: ifelse(isvariable("x"), $(x), "default")
-        // (the first argument will come down expanded as "!any")
+        // Special case where a three argument ifelse call must
+        // be allowed to have undefined variables.
         if (strcmp(fp->name, "ifelse") == 0 &&
-            RlistLen(expargs) == 3 &&
-            strcmp("!any", RlistScalarValueSafe(expargs)) == 0 &&
-            !RlistIsUnresolved(expargs->next->next))
+            expargs->val.type != RVAL_TYPE_FNCALL &&
+            RlistLen(expargs) == 3) 
         {
                 Log(LOG_LEVEL_DEBUG, "Allowing ifelse() function evaluation even"
                     " though its arguments contain unresolved variables: %s",

--- a/tests/acceptance/01_vars/02_functions/ifelse_undefined.cf
+++ b/tests/acceptance/01_vars/02_functions/ifelse_undefined.cf
@@ -1,0 +1,37 @@
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "ENT-4653" }
+        string => "Test that ifelse works with undefined variables in the second or third arguments";
+
+  vars:
+    "test_one" string => ifelse( "no_such_class", "$(no_such_var)", "test_one_expected_value" );
+    "test_two" string => ifelse( "any", "test_two_expected_value", "$(no_such_var)" );
+}
+
+bundle agent check
+{
+
+  reports:
+      '$(this.promise_filename) Pass'
+        if => and(
+                  strcmp( "test_one_expected_value", $(test.test_one) ),
+                  strcmp( "test_two_expected_value", $(test.test_two) ) );
+
+      '$(this.promise_filename) FAIL'
+        if => or(
+                 not( isvariable( "test.test_one" ) ),
+                 not( isvariable( "test.test_two" ) ) );
+
+      '$(this.propmise_filename) FAIL'
+        if => or(
+                 not(strcmp( "test_one_expected_value", $(test.test_one) ) ),
+                 not(strcmp( "test_two_expected_value", $(test.test_two) ) ) );
+}


### PR DESCRIPTION
The existing test case apparently wasn't sufficient to
catch a regression that may have occurred.

Ticket: ENT-7556
Changelog: none
(cherry picked from commit 8550de2be3042e6236f292e63620123c2cc675a7)