### PR TITLE
[CFE-3754] Call cached functions every time if 'ifelapsed => "0"' is specified 

### DIFF
--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -134,12 +134,15 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
     /* Warn if promise locking was used with a promise that doesn't support it
      * (which applies to all of 'vars', 'meta' and 'defaults' promises handled
      * by this code).
+     * 'ifelapsed => "0"' (e.g. with 'action => immediate') can however be used
+     * to make sure cached functions are called every time. [ENT-7478]
      * (Only do this in the first pass in cf-promises, we don't have to repeat
      * the warning over and over.) */
     if (EvalContextGetPass(ctx) == 0 && THIS_AGENT_TYPE == AGENT_TYPE_COMMON)
     {
         int ifelapsed = PromiseGetConstraintAsInt(ctx, "ifelapsed", pp);
-        if (ifelapsed != CF_NOINT)
+        if ((ifelapsed != CF_NOINT) &&
+            ((ifelapsed != 0) || !StringEqual(PromiseGetPromiseType(pp), "vars")))
         {
             Log(LOG_LEVEL_WARNING,
                 "ifelapsed attribute specified in action body for %s promise '%s',"

--- a/tests/acceptance/01_vars/02_functions/execresult_action_immediate.cf
+++ b/tests/acceptance/01_vars/02_functions/execresult_action_immediate.cf
@@ -1,0 +1,58 @@
+# Test that execresult is called multiple times with the same command if
+# 'ifelapsed => "0"' is used.
+
+body common control
+{
+    inputs => { "../../default.cf.sub" };
+    bundlesequence => { default("$(this.promise_filename)") };
+    version => "1.0";
+}
+
+bundle agent check_date(x)
+{
+  vars:
+      "reports_file" string => "$(G.testdir)/execresult_action_immediate_report";
+
+      "date" string => execresult("date; sleep 1", "useshell"),
+        action => immediate;
+
+  reports:
+      "Date for ${x}: ${date}"
+        report_to_file => "$(reports_file)";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> {"ENT-7478"}
+        string => "If 'ifelapsed => 0' is used, execresult() should run the given command every time";
+
+  methods:
+      "foo" usebundle => check_date("foo");
+      "bar" usebundle => check_date("bar");
+}
+
+
+bundle agent check
+{
+  vars:
+      "content"
+        slist => readstringlist( "$(check_date.reports_file)",
+                                 "",
+                                 '$(const.n)',
+                                 inf,
+                                 inf);
+      "count"
+        int => length( content );
+
+  reports:
+    DEBUG|EXTRA::
+      "$(check_date.reports_file) contents:";
+      "$(content)";
+
+    any::
+      # Pass if there are 6 lines, 3 for each check_date bundle actuation,
+      # indicating that execresult is being called once for each pass.
+      "$(this.promise_filename) Pass" if => strcmp( $(count), 6 );
+      "$(this.promise_filename) FAIL" unless => strcmp( $(count), 6 );
+}


### PR DESCRIPTION
For cases where a fresh value is needed every time, for example:
```
  vars:
    "date"
      string => execresult("/bin/date", "noshell"),
      action => immediate;
```
Ticket: CFE-3754
Changelog: Cached functions are now always called inside promises with 'iflapsed => "0"'

Steps:
- [x] disable caching for `ifelapsed => "0"`
- [x] suppress warnings for `vars` promises with `ifelapsed => "0"`
- [x] acceptance test

Merge together:
https://github.com/cfengine/core/pull/4792
https://github.com/cfengine/masterfiles/pull/2085