### PR TITLE
Support the 'handle' attribute in custom promises

### DIFF
--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2739,7 +2739,6 @@ static bool ValidateCustomPromise(const Promise *pp, Seq *errors)
             || StringEqual(name, "expireafter")
             || StringEqual(name, "comment")
             || StringEqual(name, "depends_on")
-            || StringEqual(name, "handle")
             || StringEqual(name, "meta")
             || StringEqual(name, "with"))
         {


### PR DESCRIPTION
It just works, '$(this.handle)' is properly replaced by the value
of the attribute.

Ticket: CFE-3439
Changelog: Custom promises can now use the 'handle' attribute

Merge together:
https://github.com/cfengine/core/pull/4795
https://github.com/cfengine/masterfiles/pull/2087