### PR TITLE
[3.18.x] Support the 'handle' attribute in custom promises

### DIFF
--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2739,7 +2739,6 @@ static bool ValidateCustomPromise(const Promise *pp, Seq *errors)
             || StringEqual(name, "expireafter")
             || StringEqual(name, "comment")
             || StringEqual(name, "depends_on")
-            || StringEqual(name, "handle")
             || StringEqual(name, "meta")
             || StringEqual(name, "with"))
         {


### PR DESCRIPTION
It just works, '$(this.handle)' is properly replaced by the value
of the attribute.

Ticket: CFE-3439
Changelog: Custom promises can now use the 'handle' attribute
(cherry picked from commit 660723e770c140ee99a2b5b0d6cf5090ddcdb0dc)