### PR TITLE
[3.18.x] Don't try to backup files with an empty name

### DIFF
--- a/libpromises/files_repository.c
+++ b/libpromises/files_repository.c
@@ -91,6 +91,11 @@ bool ArchiveToRepository(const char *file, const Attributes *attr)
     char destination[CF_BUFSIZE];
     struct stat sb, dsb;
 
+    // Skip empty file name
+    if (file[0] == '\0') {
+        return false;
+    }
+
     if (!GetRepositoryPath(file, attr, destination))
     {
         return false;


### PR DESCRIPTION
When creating new files (for example with a copy_from when the destination
does not exist), if backups are enabled, the agent would try to backup the
previous state of the (non-existent) destination. It makes the promise
fail and logs errors about the backup of an empty file name.

Changelog: Don't fail on new file creation when backups are enabled
Ticket: CFE-3640
(cherry picked from commit dc07dc879d1c1ec7d5b1686b5647019940e4feb1)