### PR TITLE
CFE-3786: Added arclinux to list of expected os classes (3.18)

### DIFF
--- a/tests/acceptance/02_classes/01_basic/expected_os_classes.cf
+++ b/tests/acceptance/02_classes/01_basic/expected_os_classes.cf
@@ -25,6 +25,7 @@ bundle agent check
                          "aix",
                          "hpux",
                          "suse",
+                         "archlinux",
                          "windows",
                          "freebsd",
                          "macos",


### PR DESCRIPTION
Ticket: CFE-3786
Changelog: None
(cherry picked from commit d03b491deaafac4693d2ef28b458151a3b4b5c3d)