### PR TITLE
CI: Fixed problems related to OpenSSL in mac builds

### DIFF
--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -14,9 +14,9 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: brew install lmdb automake
+      run: brew install lmdb automake openssl@1.1
     - name: Run autotools / configure
-      run: ./autogen.sh --enable-debug --with-openssl="$(brew --prefix openssl)"
+      run: ./autogen.sh --enable-debug --with-openssl="$(brew --prefix openssl@1.1)"
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests


### PR DESCRIPTION
Now that openssl in brew defaults to version 3.0,
we have to specify the old version to keep using that.