### PR TITLE
ENT-7709: Added support for cfbs managed policy set

### DIFF
--- a/contrib/masterfiles-stage/README.org
+++ b/contrib/masterfiles-stage/README.org
@@ -39,6 +39,7 @@ simple environments this will be =$(sys.masterdir)= (typically
 :END:
 - Supported upstreams
   - =VCS_TYPE="GIT"=
+  - =VCS_TYPE="GIT_CFBS"= :: Like GIT, but instead of deploying policy from the root of a git repo directly, cfbs is used to first build the policy.
   - =VCS_TYPE="GIT_POLICY_CHANNELS"=
   - =VCS_TYPE="SVN"=
 

--- a/contrib/masterfiles-stage/masterfiles-stage.sh
+++ b/contrib/masterfiles-stage/masterfiles-stage.sh
@@ -139,6 +139,9 @@ source "$PARAMS"
   # and additional vars set in PARAMS depending on the VCS_TYPE.
 
 case "${VCS_TYPE}" in
+    GIT_CFBS)
+        git_cfbs_masterstage
+        ;;
     GIT_POLICY_CHANNELS)
         git_stage_policy_channels
         ;;


### PR DESCRIPTION
This change adds support for cfbs managed policy sets. It mirrors the behavior
of the existing git behavior used my Mission Portal adding in the necessary
build step and tweaks the deployment source to comply with cfbs.

Note: This change does not do anything with respect to ensuring that cfbs and
any dependent tooling required for the build (like automake) are present.
Without necessary dependencies, the build will simply fail.

Ticket: ENT-7709
Changelog: Title