### PR TITLE
CFE-3438: Enabled `depends_on` for custom promise types (3.18.x)

### DIFF
--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -660,7 +660,8 @@ static void PromiseModule_AppendAllAttributes(
         if (IsClassesBodyConstraint(name)
             || StringEqual(name, "if")
             || StringEqual(name, "ifvarclass")
-            || StringEqual(name, "unless"))
+            || StringEqual(name, "unless")
+            || StringEqual(name, "depends_on"))
         {
             // Evaluated by agent and not sent to module, skip
             continue;

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2738,7 +2738,6 @@ static bool ValidateCustomPromise(const Promise *pp, Seq *errors)
             || StringEqual(name, "ifelapsed")
             || StringEqual(name, "expireafter")
             || StringEqual(name, "comment")
-            || StringEqual(name, "depends_on")
             || StringEqual(name, "meta")
             || StringEqual(name, "with"))
         {


### PR DESCRIPTION
`depends_on` attribute is handled by agent in
promises.c:ExpandDeRefPromise, which happens before any promises
are evaluated.

Cherry-picked from https://github.com/cfengine/core/pull/4827

Changelog: Title
Ticket: CFE-3438
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit ceaa0dfd7190b288834d2f7793f71f4f7c41c2cb)