### PR TITLE
CFE-3441: Enabled `with` attribute for custom promise types (3.18.x)

### DIFF
--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -661,7 +661,8 @@ static void PromiseModule_AppendAllAttributes(
             || StringEqual(name, "if")
             || StringEqual(name, "ifvarclass")
             || StringEqual(name, "unless")
-            || StringEqual(name, "depends_on"))
+            || StringEqual(name, "depends_on")
+            || StringEqual(name, "with"))
         {
             // Evaluated by agent and not sent to module, skip
             continue;

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2738,8 +2738,7 @@ static bool ValidateCustomPromise(const Promise *pp, Seq *errors)
             || StringEqual(name, "ifelapsed")
             || StringEqual(name, "expireafter")
             || StringEqual(name, "comment")
-            || StringEqual(name, "meta")
-            || StringEqual(name, "with"))
+            || StringEqual(name, "meta"))
         {
             // TODO: Remove 1 attribute at a time, test and fix.
             //       https://tracker.mender.io/browse/CFE-3392


### PR DESCRIPTION
The `with` attribute is handled by the agent before custom promise types
are evaluated. Therefor it just works.

cherry-picked from https://github.com/cfengine/core/pull/4842

Ticket: CFE-3441
Changelog: Title
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit e5e3e76c5025f7aba0ca224c47efccc9a73d5d71)