### PR TITLE
[3.18.x] ENT-7898: Label /opt/cfengine as cfengine_var_lib_t

### DIFF
--- a/misc/selinux/cfengine-enterprise.fc
+++ b/misc/selinux/cfengine-enterprise.fc
@@ -6,3 +6,4 @@
 /var/cfengine/bin/pg.*		    --	gen_context(system_u:object_r:cfengine_postgres_exec_t,s0)
 /var/cfengine/httpd/bin/.*      --	gen_context(system_u:object_r:cfengine_httpd_exec_t,s0)
 /var/cfengine/httpd/php/bin/.*  --	gen_context(system_u:object_r:cfengine_httpd_exec_t,s0)
+/opt/cfengine(/.*)?             --	gen_context(system_u:object_r:cfengine_var_lib_t,s0)


### PR DESCRIPTION
Same as /var/cfengine so that our daemons and processes can
access it.

Ticket: ENT-7898
Changelog: None
(cherry picked from commit 41a873d2d14d6e6c2d798f20475da3b0f7d0e778)