### PR TITLE
Fix '-N/--negate' preventing persistent classes from being defined

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -178,6 +178,9 @@ struct EvalContext_
     /* List if all classes set during policy evaluation */
     StringSet *all_classes;
 
+    /* Negated classes (persistent classes that should not be defined). */
+    StringSet *negated_classes;
+
     /* These following two fields are needed for remote variable injection
      * detection (CFE-1915) */
     /* Names of all bundles */
@@ -741,6 +744,8 @@ void EvalContextHeapPersistentRemove(const char *context)
 
 void EvalContextHeapPersistentLoadAll(EvalContext *ctx)
 {
+    assert(ctx != NULL);
+
     time_t now = time(NULL);
 
     Log(LOG_LEVEL_VERBOSE, "Loading persistent classes");
@@ -793,23 +798,38 @@ void EvalContextHeapPersistentLoadAll(EvalContext *ctx)
         {
             Log(LOG_LEVEL_VERBOSE, "Persistent class '%s' for %jd more minutes",
                 key, (intmax_t) ((info.expires - now) / 60));
-            Log(LOG_LEVEL_DEBUG, "Adding persistent class '%s'", key);
+            if ((ctx->negated_classes != NULL) && StringSetContains(ctx->negated_classes, key))
+            {
+                Log(LOG_LEVEL_VERBOSE,
+                    "Not adding persistent class '%s' due to match in -N/--negate", key);
+            }
+            else
+            {
+                Log(LOG_LEVEL_DEBUG, "Adding persistent class '%s'", key);
 
-            ClassRef ref = ClassRefParse(key);
-            EvalContextClassPut(ctx, ref.ns, ref.name, true, CONTEXT_SCOPE_NAMESPACE, tags, NULL);
+                ClassRef ref = ClassRefParse(key);
+                EvalContextClassPut(ctx, ref.ns, ref.name, true, CONTEXT_SCOPE_NAMESPACE, tags, NULL);
 
-            StringSet *tag_set = EvalContextClassTags(ctx, ref.ns, ref.name);
-            assert(tag_set);
+                StringSet *tag_set = EvalContextClassTags(ctx, ref.ns, ref.name);
+                assert(tag_set);
 
-            StringSetAdd(tag_set, xstrdup("source=persistent"));
+                StringSetAdd(tag_set, xstrdup("source=persistent"));
 
-            ClassRefDestroy(ref);
+                ClassRefDestroy(ref);
+            }
         }
     }
 
     DeleteDBCursor(dbcp);
     CloseDB(dbp);
 }
+
+void EvalContextSetNegatedClasses(EvalContext *ctx, StringSet *negated_classes)
+{
+    assert(ctx != NULL);
+    ctx->negated_classes = negated_classes;
+}
+
 
 bool BundleAbort(EvalContext *ctx)
 {
@@ -1041,6 +1061,7 @@ EvalContext *EvalContextNew(void)
     ctx->package_promise_context = PackagePromiseConfigNew();
 
     ctx->all_classes = NULL;
+    ctx->negated_classes = NULL;
     ctx->bundle_names = StringSetNew();
     ctx->remote_var_promises = NULL;
 
@@ -1087,6 +1108,7 @@ void EvalContextDestroy(EvalContext *ctx)
         FreePackagePromiseContext(ctx->package_promise_context);
 
         StringSetDestroy(ctx->all_classes);
+        StringSetDestroy(ctx->negated_classes);
         StringSetDestroy(ctx->bundle_names);
         if (ctx->remote_var_promises != NULL)
         {

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -121,6 +121,13 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
 void EvalContextHeapPersistentRemove(const char *context);
 void EvalContextHeapPersistentLoadAll(EvalContext *ctx);
 
+/**
+ * Sets negated classes (persistent classes that should not be defined).
+ *
+ * @note Takes ownership of #negated_classes
+ */
+void EvalContextSetNegatedClasses(EvalContext *ctx, StringSet *negated_classes);
+
 bool EvalContextClassPutSoft(EvalContext *ctx, const char *name, ContextScope scope, const char *tags);
 bool EvalContextClassPutSoftTagsSet(EvalContext *ctx, const char *name, ContextScope scope, StringSet *tags);
 bool EvalContextClassPutSoftTagsSetWithComment(EvalContext *ctx, const char *name, ContextScope scope,

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -2563,6 +2563,8 @@ void GenericAgentConfigDestroy(GenericAgentConfig *config)
 
 void GenericAgentConfigApply(EvalContext *ctx, const GenericAgentConfig *config)
 {
+    assert(config != NULL);
+
     if (config->heap_soft)
     {
         StringSetIterator it = StringSetIteratorInit(config->heap_soft);
@@ -2577,6 +2579,13 @@ void GenericAgentConfigApply(EvalContext *ctx, const GenericAgentConfig *config)
 
             EvalContextClassPutSoft(ctx, context, CONTEXT_SCOPE_NAMESPACE, "source=environment");
         }
+    }
+
+    if (config->heap_negated != NULL)
+    {
+        /* Takes ownership of heap_negated. */
+        EvalContextSetNegatedClasses(ctx, config->heap_negated);
+        ((GenericAgentConfig *)config)->heap_negated = NULL;
     }
 
     switch (LogGetGlobalLevel())

--- a/tests/acceptance/02_classes/01_basic/persistent_negate.cf
+++ b/tests/acceptance/02_classes/01_basic/persistent_negate.cf
@@ -1,0 +1,50 @@
+#######################################################
+#
+# ENT-5886 -- -N/--negate should prevent persistent classes from being defined
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  vars:
+      "dflags" string => ifelse("EXTRA", "-DDEBUG,EXTRA", "-DDEBUG");
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> {"ENT-5886"}
+        string => "-N/--negate should prevent persistent classes from being defined";
+
+  commands:
+      "$(sys.cf_agent) -K $(init.dflags) -f $(this.promise_filename).sub"
+        classes => test_always("done_persisting");
+}
+
+body classes test_always(x)
+{
+    promise_repaired => { "$(x)" };
+    promise_kept => { "$(x)" };
+    repair_failed => { "$(x)" };
+    repair_denied => { "$(x)" };
+    repair_timeout => { "$(x)" };
+}
+
+bundle agent check
+{
+  vars:
+    done_persisting::
+      "subout" string => execresult("$(sys.cf_agent) -N test_class -K $(init.dflags) -f $(this.promise_filename).sub2", "noshell");
+
+  methods:
+      "" usebundle => dcs_check_strcmp($(subout), "R: Pass",
+                                       $(this.promise_filename),
+                                       "no");
+}

--- a/tests/acceptance/02_classes/01_basic/persistent_negate.cf.sub
+++ b/tests/acceptance/02_classes/01_basic/persistent_negate.cf.sub
@@ -1,0 +1,12 @@
+body common control
+{
+      bundlesequence => { run };
+}
+
+bundle common run
+{
+  classes:
+      "test_class"
+        expression => "any",
+        persistence => "120"; # 2 hours.
+}

--- a/tests/acceptance/02_classes/01_basic/persistent_negate.cf.sub2
+++ b/tests/acceptance/02_classes/01_basic/persistent_negate.cf.sub2
@@ -1,0 +1,20 @@
+body common control
+{
+      bundlesequence => { run };
+}
+
+bundle agent run
+{
+  classes:
+      "ok" expression => "!test_class";
+
+  reports:
+    ok::
+      "Pass";
+
+    !ok.DEBUG::
+      "test_class defined";
+
+    !ok::
+      "FAIL";
+}


### PR DESCRIPTION
Ticket: ENT-5886
Changelog: '-N/--negate now prevents persistent classes from being defined'