### PR TITLE
[3.15.x] Fix '-N/--negate' preventing persistent classes from being defined

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@
 	- cf-check dump now shows measurement names (ENT-7452)
 	- The value of '$(with)' is now expanded even if it contains unresolved variable references
 	  (CFE-3776)
+	- '-N/--negate' now prevents persistent classes from being defined (ENT-5886)
 
 3.15.4:
 	- cf-runagent now exits with a code reflecting remote agent run status(es)

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -121,6 +121,13 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
 void EvalContextHeapPersistentRemove(const char *context);
 void EvalContextHeapPersistentLoadAll(EvalContext *ctx);
 
+/**
+ * Sets negated classes (persistent classes that should not be defined).
+ *
+ * @note Takes ownership of #negated_classes
+ */
+void EvalContextSetNegatedClasses(EvalContext *ctx, StringSet *negated_classes);
+
 bool EvalContextClassPutSoft(EvalContext *ctx, const char *name, ContextScope scope, const char *tags);
 bool EvalContextClassPutHard(EvalContext *ctx, const char *name, const char *tags);
 Class *EvalContextClassGet(const EvalContext *ctx, const char *ns, const char *name);

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -2070,6 +2070,8 @@ void GenericAgentConfigDestroy(GenericAgentConfig *config)
 
 void GenericAgentConfigApply(EvalContext *ctx, const GenericAgentConfig *config)
 {
+    assert(config != NULL);
+
     if (config->heap_soft)
     {
         StringSetIterator it = StringSetIteratorInit(config->heap_soft);
@@ -2084,6 +2086,13 @@ void GenericAgentConfigApply(EvalContext *ctx, const GenericAgentConfig *config)
 
             EvalContextClassPutSoft(ctx, context, CONTEXT_SCOPE_NAMESPACE, "source=environment");
         }
+    }
+
+    if (config->heap_negated != NULL)
+    {
+        /* Takes ownership of heap_negated. */
+        EvalContextSetNegatedClasses(ctx, config->heap_negated);
+        ((GenericAgentConfig *)config)->heap_negated = NULL;
     }
 
     switch (LogGetGlobalLevel())

--- a/tests/acceptance/02_classes/01_basic/persistent_negate.cf
+++ b/tests/acceptance/02_classes/01_basic/persistent_negate.cf
@@ -1,0 +1,50 @@
+#######################################################
+#
+# ENT-5886 -- -N/--negate should prevent persistent classes from being defined
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  vars:
+      "dflags" string => ifelse("EXTRA", "-DDEBUG,EXTRA", "-DDEBUG");
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> {"ENT-5886"}
+        string => "-N/--negate should prevent persistent classes from being defined";
+
+  commands:
+      "$(sys.cf_agent) -K $(init.dflags) -f $(this.promise_filename).sub"
+        classes => test_always("done_persisting");
+}
+
+body classes test_always(x)
+{
+    promise_repaired => { "$(x)" };
+    promise_kept => { "$(x)" };
+    repair_failed => { "$(x)" };
+    repair_denied => { "$(x)" };
+    repair_timeout => { "$(x)" };
+}
+
+bundle agent check
+{
+  vars:
+    done_persisting::
+      "subout" string => execresult("$(sys.cf_agent) -N test_class -K $(init.dflags) -f $(this.promise_filename).sub2", "noshell");
+
+  methods:
+      "" usebundle => dcs_check_strcmp($(subout), "R: Pass",
+                                       $(this.promise_filename),
+                                       "no");
+}

--- a/tests/acceptance/02_classes/01_basic/persistent_negate.cf.sub
+++ b/tests/acceptance/02_classes/01_basic/persistent_negate.cf.sub
@@ -1,0 +1,12 @@
+body common control
+{
+      bundlesequence => { run };
+}
+
+bundle common run
+{
+  classes:
+      "test_class"
+        expression => "any",
+        persistence => "120"; # 2 hours.
+}

--- a/tests/acceptance/02_classes/01_basic/persistent_negate.cf.sub2
+++ b/tests/acceptance/02_classes/01_basic/persistent_negate.cf.sub2
@@ -1,0 +1,20 @@
+body common control
+{
+      bundlesequence => { run };
+}
+
+bundle agent run
+{
+  classes:
+      "ok" expression => "!test_class";
+
+  reports:
+    ok::
+      "Pass";
+
+    !ok.DEBUG::
+      "test_class defined";
+
+    !ok::
+      "FAIL";
+}


### PR DESCRIPTION
Ticket: ENT-5886
Changelog: '-N/--negate now prevents persistent classes from being defined'
(cherry picked from commit 3e3a744743adc6e554013699aad0839a1cde461c)

Conflicts:
  libpromises/eval_context.c