### PR TITLE
Use StringEqual() in DefaultTemplateData()

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -3991,7 +3991,7 @@ JsonElement *DefaultTemplateData(const EvalContext *ctx, const char *wantbundle)
                     JsonObjectAppendObject(bundles, scope_key, scope_obj);
                 }
             }
-            else if (strcmp(scope_key, wantbundle) == 0)
+            else if (StringEqual(scope_key, wantbundle))
             {
                 scope_obj = hash;
             }


### PR DESCRIPTION
Otherwise static checkers complain that 'wantbundle' may be NULL.