### PR TITLE
[3.18.x] Use StringEqual() in DefaultTemplateData()

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -3937,7 +3937,7 @@ JsonElement *DefaultTemplateData(const EvalContext *ctx, const char *wantbundle)
                     JsonObjectAppendObject(bundles, scope_key, scope_obj);
                 }
             }
-            else if (strcmp(scope_key, wantbundle) == 0)
+            else if (StringEqual(scope_key, wantbundle))
             {
                 scope_obj = hash;
             }


### PR DESCRIPTION
Otherwise static checkers complain that 'wantbundle' may be NULL.

(cherry picked from commit 8976b0c3826221d04e299c0c205a54dfa3366dbf)

Backport of https://github.com/cfengine/core/pull/4869.