### PR TITLE
SELinux: Allow access to /opt/cfengine for commands over SSH

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -84,6 +84,7 @@ require {
 	type postfix_public_t;
 	type postfix_spool_t;
 	type sendmail_exec_t;
+	type sshd_t;
 	class tcp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown name_connect accept listen name_bind node_bind };
 	class udp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown node_bind };
 	class sock_file { create write getattr setattr unlink };
@@ -636,3 +637,7 @@ allow cfengine_httpd_t cfengine_action_script_t:process siginh;
 
 allow cfengine_action_script_t cfengine_action_script_exec_t:file entrypoint;
 allow cfengine_action_script_t cfengine_action_script_exec_t:file { ioctl read getattr lock map execute open };
+
+#============= special rules for Federated Reporting =============
+# sshd needs access to files in /opt/cfengine
+allow sshd_t cfengine_var_lib_t:file { getattr open read };

--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -85,6 +85,7 @@ require {
 	type postfix_spool_t;
 	type sendmail_exec_t;
 	type sshd_t;
+	type rpm_script_t;
 	class tcp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown name_connect accept listen name_bind node_bind };
 	class udp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown node_bind };
 	class sock_file { create write getattr setattr unlink };
@@ -186,6 +187,8 @@ role object_r types cfengine_agent_exec_t;
 allow cfengine_agent_t cfengine_agent_exec_t:file entrypoint;
 allow cfengine_agent_t cfengine_agent_exec_t:file { ioctl read getattr lock map execute open };
 
+# cf-agent needs to be able to transition into the domain of RPM scriplets
+allow cfengine_agent_t rpm_script_t:process transition;
 
 #============= cfengine_execd_t ==============
 # allow cf-execd to run cf-agent and make sure the forked process run in the


### PR DESCRIPTION
Needed for Federated Reporting.

Ticket: ENT-7493
Changelog: Federated Reporting is now supported on RHEL 8 hubs