### PR TITLE
ENT-7870 Remove inaccurate build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 [![Gitter chat](https://badges.gitter.im/cfengine/core.png)](https://gitter.im/cfengine/core)
 
-| Version    | [Core](https://github.com/cfengine/core)                                                                           | [MPF](https://github.com/cfengine/masterfiles)                                                                                  |
-|------------|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| master     | [![Core Build Status](https://travis-ci.com/cfengine/core.svg?branch=master)](https://app.travis-ci.com/github/cfengine/core) | [![MPF Build Status](https://travis-ci.com/cfengine/masterfiles.svg?branch=master)](https://app.travis-ci.com/github/cfengine/masterfiles) |
-| 3.18.x LTS | [![Core Build Status](https://travis-ci.com/cfengine/core.svg?branch=3.18.x)](https://app.travis-ci.com/github/cfengine/core) | [![MPF Build Status](https://travis-ci.com/cfengine/masterfiles.svg?branch=3.18.x)](https://app.travis-ci.com/github/cfengine/masterfiles) |
-| 3.15.x LTS | [![Core Build Status](https://travis-ci.com/cfengine/core.svg?branch=3.15.x)](https://app.travis-ci.com/github/cfengine/core) | [![MPF Build Status](https://travis-ci.com/cfengine/masterfiles.svg?branch=3.15.x)](https://app.travis-ci.com/github/cfengine/masterfiles) |
-| 3.12.x LTS | [![Core Build Status](https://travis-ci.com/cfengine/core.svg?branch=3.12.x)](https://app.travis-ci.com/github/cfengine/core) | [![MPF Build Status](https://travis-ci.com/cfengine/masterfiles.svg?branch=3.12.x)](https://app.travis-ci.com/github/cfengine/masterfiles) |
-
 [![Language grade: C](https://img.shields.io/lgtm/grade/cpp/g/cfengine/core.svg?logo=lgtm&logoWidth=18&label=code%20quality)](https://lgtm.com/projects/g/cfengine/core/)
 
 # CFEngine 3


### PR DESCRIPTION
Travis badges are for any PRs on the branches so not what we want.
Jenkins badges aren't accurate either due to lack of known
issue exceptions.

Ticket: ENT-7870
Changelog: none