### PR TITLE
ENT-7870 Remove inaccurate build badges (3.15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,4 @@
 [![Gitter chat](https://badges.gitter.im/cfengine/core.png)](https://gitter.im/cfengine/core)
-
-| Version    | [Core](https://github.com/cfengine/core)                                                                           | [MPF](https://github.com/cfengine/masterfiles)                                                                                  |
-|------------|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| master     | [![Core Build Status](https://travis-ci.org/cfengine/core.svg?branch=master)](https://travis-ci.org/cfengine/core) | [![MPF Build Status](https://travis-ci.org/cfengine/masterfiles.svg?branch=master)](https://travis-ci.org/cfengine/masterfiles) |
-| 3.15.x LTS | [![Core Build Status](https://travis-ci.org/cfengine/core.svg?branch=3.15.x)](https://travis-ci.org/cfengine/core) | [![MPF Build Status](https://travis-ci.org/cfengine/masterfiles.svg?branch=3.15.x)](https://travis-ci.org/cfengine/masterfiles) |
-| 3.12.x LTS | [![Core Build Status](https://travis-ci.org/cfengine/core.svg?branch=3.12.x)](https://travis-ci.org/cfengine/core) | [![MPF Build Status](https://travis-ci.org/cfengine/masterfiles.svg?branch=3.12.x)](https://travis-ci.org/cfengine/masterfiles) |
-| 3.10.x LTS | [![Core Build Status](https://travis-ci.org/cfengine/core.svg?branch=3.10.x)](https://travis-ci.org/cfengine/core) | [![MPF Build Status](https://travis-ci.org/cfengine/masterfiles.svg?branch=3.10.x)](https://travis-ci.org/cfengine/masterfiles) |
-
 [![Language grade: C](https://img.shields.io/lgtm/grade/cpp/g/cfengine/core.svg?logo=lgtm&logoWidth=18&label=code%20quality)](https://lgtm.com/projects/g/cfengine/core/)
 
 # CFEngine 3


### PR DESCRIPTION
Travis badges are for any PRs on the branches so not what we want.
Jenkins badges aren't accurate either due to lack of known
issue exceptions.

Ticket: ENT-7870
Changelog: none
(cherry picked from commit cdfb560ffafe3211c685a2b6ec99c2812b69ef52)