### PR TITLE
[3.18.x] ENT-7724: Added test for --show-evaluated-vars not segfaulting when vars from module are not explicitly tagged

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -2816,13 +2816,19 @@ void GenericAgentShowVariablesFormatted(EvalContext *ctx, const char *regexp)
         }
 
 
+        Buffer *tagbuf = NULL;
         StringSet *tagset = VariableGetTags(v);
-        Buffer *tagbuf = StringSetToBuffer(tagset, ',');
+        if (tagset != NULL)
+        {
+            tagbuf = StringSetToBuffer(tagset, ',');
+        }
         const char *comment = VariableGetComment(v);
 
         char *line;
         xasprintf(&line, "%-40s %-60s %-40s %-40s",
-                  varname, var_value, BufferData(tagbuf), NULL_TO_EMPTY_STRING(comment));
+                  varname, var_value,
+                  tagbuf != NULL ? BufferData(tagbuf) : "",
+                  NULL_TO_EMPTY_STRING(comment));
 
         SeqAppend(seq, line);
 

--- a/tests/acceptance/00_basics/02_switches/show-evaluated-vars.cf
+++ b/tests/acceptance/00_basics/02_switches/show-evaluated-vars.cf
@@ -1,0 +1,38 @@
+#######################################################
+#
+# This is a special test - it exercises runtime switches
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "ENT-7724", "ENT-7678" }
+        string => "Test --show-evaluated-vars does not crash the agent when there are vars defined by the module protocol that do not have explicit tags defined.";
+
+      "test_skip_unsupported"
+        string => "windows",
+        comment => "The subtest policy uses /bin/echo";
+
+  commands:
+      "$(sys.cf_agent) -Kf $(this.promise_filename).sub --show-evaluated-vars"
+        classes => results( "namespace", "sub_agent" );
+}
+bundle agent check
+{
+  methods:
+
+      "Pass/Fail"
+        usebundle => dcs_passif_expected( "sub_agent_repaired", "sub_agent_not_kept",
+                                          "$(this.promise_filename)");
+}
+

--- a/tests/acceptance/00_basics/02_switches/show-evaluated-vars.cf.sub
+++ b/tests/acceptance/00_basics/02_switches/show-evaluated-vars.cf.sub
@@ -1,0 +1,11 @@
+# Here we execute echo as a module to define some variables that do not have /explicit/ tags.
+# As noted in ENT-7724, this can cause a segfault when the agent is run with --show-evaluated-vars
+bundle agent main
+{
+  commands:
+      `/bin/echo '=string_from_module= value of string from module
+@list_from_module= { "one", "two", "three" }
+%data1_from_module=[1,2,3]
+%data2_from_module={ "my_stuff": [1,2,3] }'`
+        module => "true";
+}

--- a/tests/acceptance/08_commands/01_modules/vars-from-module-have-source-and-derived_from-tags.cf
+++ b/tests/acceptance/08_commands/01_modules/vars-from-module-have-source-and-derived_from-tags.cf
@@ -1,0 +1,51 @@
+body common control
+{
+        inputs => { "../../default.cf.sub", "../../plucked.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "ENT-7725" }
+        string => "Test that vars defined by modules without explicit tags still have automatic tags identifying the source";
+
+      "test_skip_unsupported"
+        string => "windows",
+        comment => "The subtest policy uses /bin/echo";
+
+      "test_soft_fail"
+        string => "any",
+        meta => { "ENT-7725" };
+
+  commands:
+      "/bin/echo"
+        args => "=my_var_from_module= my val from module",
+        module => "true";
+}
+
+bundle agent check
+{
+  vars:
+      "my_var_from_module_tags"
+        slist => getvariablemetatags( "echo.my_var_from_module" );
+
+  reports:
+
+      # Every variable should have a source=SOMETHING tag
+      "Pass $(this.promise_filename)"
+        if => and(
+                   reglist( @(my_var_from_module_tags), "source=.*" ),
+                   reglist( @(my_var_from_module_tags), "derived_from=.*" )
+                   );
+      "FAIL $(this.promise_filename)"
+        unless => and(
+                   reglist( @(my_var_from_module_tags), "source=.*" ),
+                   reglist( @(my_var_from_module_tags), "derived_from=.*" )
+        );
+
+    EXTRA|DEBUG::
+      "my_var_from_module_tags == $(my_var_from_module_tags)";
+      "echo.my_var_from_module == $(echo.my_var_from_module)";
+}

--- a/tests/acceptance/08_commands/01_modules/vars-without-explicit-tags-do-not-segfault.cf
+++ b/tests/acceptance/08_commands/01_modules/vars-without-explicit-tags-do-not-segfault.cf
@@ -1,0 +1,33 @@
+body common control
+{
+        inputs => { "../../default.cf.sub", "../../plucked.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "ENT-7724", "ENT-7678" }
+        string => "Test that vars defined by modules without explicit tags does not crash the agent when there are vars defined by the module protocol that do not have explicit tags defined.";
+
+      "test_skip_unsupported"
+        string => "windows",
+        comment => "The subtest policy uses /bin/echo";
+
+  commands:
+      "$(sys.cf_agent) -Kvf $(this.promise_filename).sub"
+        classes => results( "namespace", "sub_agent");
+
+}
+bundle agent check
+{
+  methods:
+      "Pass/Fail"
+        usebundle => dcs_passif_expected( "sub_agent_repaired", "sub_agent_not_kept",
+                                          "$(this.promise_filename)");
+
+  reports:
+      EXTRA|DEBUG::
+        "sub_agent_.* classes: $(with)" with => join( ",", classesmatching( "sub_agent_.*" ));
+}

--- a/tests/acceptance/08_commands/01_modules/vars-without-explicit-tags-do-not-segfault.cf.sub
+++ b/tests/acceptance/08_commands/01_modules/vars-without-explicit-tags-do-not-segfault.cf.sub
@@ -1,0 +1,11 @@
+bundle agent main
+{
+  vars:
+    "my_var_in_policy" string => "my value in policy";
+    "tagged" slist => variablesmatching(".*", "my_tag");
+
+  commands:
+    "/bin/echo"
+      args => "=my_var_from_module= my val from module",
+      module => "true";
+}


### PR DESCRIPTION
_3.18.x_ version of #4826.