### PR TITLE
ENT-7718: No longer possible to undefine reserved hard classes

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -2923,6 +2923,7 @@ static void DeleteAllClasses(EvalContext *ctx, const Rlist *list)
         {
             Log(LOG_LEVEL_ERR, "You cannot cancel a reserved hard class '%s' in post-condition classes",
                   RlistScalarValue(rp));
+            return;
         }
 
         const char *string = RlistScalarValue(rp);

--- a/tests/acceptance/02_classes/01_basic/cancel_hardclass.cf
+++ b/tests/acceptance/02_classes/01_basic/cancel_hardclass.cf
@@ -1,0 +1,46 @@
+#############################################################################
+#
+# Test that undefining hardclasses is not be permitted.
+#
+#############################################################################
+
+body common control
+{
+  bundlesequence => { "init", "test", "check" };
+}
+
+bundle agent init
+{
+
+}
+
+body classes undefine(class)
+{
+      cancel_kept => { "$(class)" };
+      cancel_repaired => { "$(class)" };
+      cancel_notkept => { "$(class)" };
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "ENT-7718" }
+        string => "Test that undefining hardclasses is not be permitted.";
+
+  commands:
+      "/bin/true"
+        classes => undefine("cfengine");
+}
+
+bundle agent check
+{
+  classes:
+      "passed"
+        expression => "cfengine";
+
+  reports:
+    passed::
+      "$(this.promise_filename) Pass";
+    !passed::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Fixed a bug allowing you to undefine a hard classes.