### PR TITLE
[3.18.x] ENT-8289: Only replace the dot after the scope in MangleScopedVarNameIntoSpecia…

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -2063,8 +2063,10 @@ static inline char *MangleScopedVarNameIntoSpecialScopeName(const char *scope, c
     char *scope_with_dot = StringConcatenate(2, scope, ".");
     char *scope_with_underscores = StringConcatenate(2, scope, NESTED_SCOPE_SEP);
 
-    NDEBUG_UNUSED ssize_t ret = StringReplace(new_var_name, var_name_len + sizeof(NESTED_SCOPE_SEP),
-                                              scope_with_dot, scope_with_underscores);
+    /* Only replace the first "scope." occurrence (there might be "scope."
+     * inside square brackets). */
+    NDEBUG_UNUSED ssize_t ret = StringReplaceN(new_var_name, var_name_len + sizeof(NESTED_SCOPE_SEP),
+                                               scope_with_dot, scope_with_underscores, 1);
     assert(ret == (var_name_len + sizeof(NESTED_SCOPE_SEP) - 2));
 
     free(scope_with_dot);


### PR DESCRIPTION
…lScopeName()

In very rare cases where a scoped variable which has the same
string as "scope." inside square brackets (classic array index)
needs to be put into a special scope,
MangleScopedVarNameIntoSpecialScopeName() has to be more careful
and only replace the dot after the scope, not in the same string
inside the square brackets.

Ticket: ENT-8289
Changelog: None
(cherry picked from commit d4e7a40e2006714251b16648c2aba0e095a59057)

Conflicts:
  libntech