### PR TITLE
Replace backticks with single quotes in changelogs - 3.18.x

### DIFF
--- a/misc/changelog-generator/changelog-generator
+++ b/misc/changelog-generator/changelog-generator
@@ -127,7 +127,8 @@ for repo in repos:
         log_entry_local = False
         log_entry = ""
         for line in blob.stdout:
-            line = line.decode().rstrip('\r\n')
+            # ENT-7979: we don't want to see backticks ` in our changelogs
+            line = line.decode().rstrip('\r\n').replace('`',"'")
 
             if line == "" and log_entry:
                 add_entry(sha, log_entry)


### PR DESCRIPTION
Issue was that backticks in changelogs break docs builds, and Nick had
to fix it manually. Quote from https://github.com/cfengine/core/pull/4863:

> The documentation pulls in changelogs and having markdown inside these files
> breaks when the doc build is unable to automatically resolve links.

Ticket: ENT-7979

Changelog: None
(cherry picked from commit 69d2537c55393e2e4771cb1af33f0a162aa233ba)