### PR TITLE
CFE-3434: Custom promise locking and ifelapsed

### DIFF
--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -648,7 +648,7 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt,
     Rlist *rp;
     FnCall *fp;
 
-    char *noRvalHash[] = { "mtime", "atime", "ctime", "stime_range", "ttime_range", "log_string", NULL };
+    char *noRvalHash[] = { "mtime", "atime", "ctime", "stime_range", "ttime_range", "log_string", "template_data", NULL };
     int doHash;
 
     md = HashDigestFromId(type);
@@ -741,6 +741,16 @@ void PromiseRuntimeHash(const Promise *pp, const char *salt,
                     RvalDigestUpdate(context, rp);
                 }
                 break;
+
+            case RVAL_TYPE_CONTAINER:
+                {
+                    const JsonElement *rval_json = RvalContainerValue(cp->rval);
+                    Writer *writer = StringWriter();
+                    JsonWriteCompact(writer, rval_json); /* sorts elements and produces canonical form */
+                    EVP_DigestUpdate(context, StringWriterData(writer), StringWriterLength(writer));
+                    WriterClose(writer);
+                    break;
+                }
 
             case RVAL_TYPE_FNCALL:
 

--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -1138,18 +1138,17 @@ PromiseResult EvaluateCustomPromise(EvalContext *ctx, const Promise *pp)
     }
 
     // TODO: Do validation earlier (cf-promises --full-check)
-    bool valid = PromiseModule_Validate(module, ctx, pp);
-
+    bool valid = CustomPromise_IsFullyResolved(ctx, pp, module->json);
+    if ((!valid) && (EvalContextGetPass(ctx) == CF_DONEPASSES - 1))
+    {
+        Log(LOG_LEVEL_ERR,
+            "%s promise with promiser '%s' has unresolved/unexpanded variables",
+            PromiseGetPromiseType(pp),
+            pp->promiser);
+    }
     if (valid)
     {
-        valid = CustomPromise_IsFullyResolved(ctx, pp, module->json);
-        if ((!valid) && (EvalContextGetPass(ctx) == CF_DONEPASSES - 1))
-        {
-            Log(LOG_LEVEL_ERR,
-                "%s promise with promiser '%s' has unresolved/unexpanded variables",
-                PromiseGetPromiseType(pp),
-                pp->promiser);
-        }
+        valid = PromiseModule_Validate(module, ctx, pp);
     }
 
     PromiseResult result;

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2733,9 +2733,7 @@ static bool ValidateCustomPromise(const Promise *pp, Seq *errors)
                     "if",
                     promise_type));
             valid = false;
-        } else if (StringEqual(name, "action")
-            || StringEqual(name, "action_policy")
-            || StringEqual(name, "ifelapsed")
+        } else if (StringEqual(name, "action_policy")
             || StringEqual(name, "expireafter")
             || StringEqual(name, "comment")
             || StringEqual(name, "meta"))


### PR DESCRIPTION
steps:
- [x] shuffle validation and unresolved variables check
- [x] include container attributes in promise hash
- [x] enable promise locking for custom promises
- [x] acceptance test(s)

Merge together:
https://github.com/cfengine/core/pull/4905
https://github.com/cfengine/masterfiles/pull/2223