### PR TITLE
CFE-3432: Enable comment-attribute for custom promise types

### DIFF
--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2737,7 +2737,6 @@ static bool ValidateCustomPromise(const Promise *pp, Seq *errors)
             || StringEqual(name, "action_policy")
             || StringEqual(name, "ifelapsed")
             || StringEqual(name, "expireafter")
-            || StringEqual(name, "comment")
             || StringEqual(name, "meta"))
         {
             // TODO: Remove 1 attribute at a time, test and fix.


### PR DESCRIPTION
Acceptance test: https://github.com/cfengine/masterfiles/pull/2222