### PR TITLE
[3.18.x] Fix the log message for remote copies

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -1558,7 +1558,7 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, con
             return false;
         }
         RecordChange(ctx, pp, attr, "Copied file '%s' from '%s' to '%s'",
-                     source, new, conn->remoteip);
+                     source, conn->remoteip, new);
         *result = PromiseResultUpdate(*result, PROMISE_RESULT_CHANGE);
     }
     else


### PR DESCRIPTION
This, for example, is clearly wrong:

  info: Copied file 'hub_cmdb/host_specific.json' from '/var/cfengine/data/./host_specific.json.cfnew' to '63.33.55.11'

should say "... from '63.33.55.11' to '/var/cfengine...'".

(cherry picked from commit 94d1d3b778af5243bc1c4048077b0ae4ed50fd7e)