### PR TITLE
CFE-3906: Fix wrong use of log level in users promises log messages

### DIFF
--- a/cf-agent/verify_users.c
+++ b/cf-agent/verify_users.c
@@ -68,10 +68,10 @@ PromiseResult VerifyUsersPromise(EvalContext *ctx, const Promise *pp)
     case PROMISE_RESULT_TIMEOUT:
     case PROMISE_RESULT_INTERRUPTED:
     case PROMISE_RESULT_WARN:
-        cfPS(ctx, LOG_LEVEL_INFO, result, pp, &a, "User promise not kept");
+        cfPS(ctx, LOG_LEVEL_VERBOSE, result, pp, &a, "User promise not kept");
         break;
     case PROMISE_RESULT_CHANGE:
-        cfPS(ctx, LOG_LEVEL_INFO, PROMISE_RESULT_CHANGE, pp, &a, "User promise repaired");
+        cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_CHANGE, pp, &a, "User promise repaired");
         break;
     default:
         ProgrammingError("Unknown promise result");

--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -1851,7 +1851,7 @@ void VerifyOneUsersPromise (const char *puser, const User *u, PromiseResult *res
     bool res;
     if (u->policy == USER_STATE_PRESENT || u->policy == USER_STATE_LOCKED)
     {
-        if (passwd_info)
+        if (passwd_info != NULL)
         {
             StringSet *groups_to_set = StringSetNew();
             StringSet *current_secondary_groups = StringSetNew();
@@ -1865,10 +1865,12 @@ void VerifyOneUsersPromise (const char *puser, const User *u, PromiseResult *res
                     res = DoModifyUser (puser, u, passwd_info, cmap, action, groups_to_set);
                     if (res)
                     {
+                        Log(LOG_LEVEL_INFO, "Modified user '%s'", puser);
                         *result = PROMISE_RESULT_CHANGE;
                     }
                     else
                     {
+                        Log(LOG_LEVEL_ERR, "Failed to modify user '%s'", puser);
                         *result = PROMISE_RESULT_FAIL;
                     }
                 }
@@ -1890,25 +1892,29 @@ void VerifyOneUsersPromise (const char *puser, const User *u, PromiseResult *res
             res = DoCreateUser (puser, u, action, ctx, a, pp);
             if (res)
             {
+                Log(LOG_LEVEL_INFO, "Created user '%s'", puser);
                 *result = PROMISE_RESULT_CHANGE;
             }
             else
             {
+                Log(LOG_LEVEL_ERR, "Failed to create user '%s'", puser);
                 *result = PROMISE_RESULT_FAIL;
             }
         }
     }
     else if (u->policy == USER_STATE_ABSENT)
     {
-        if (passwd_info)
+        if (passwd_info != NULL)
         {
             res = DoRemoveUser (puser, action);
             if (res)
             {
+                Log(LOG_LEVEL_INFO, "Removed user '%s'", puser);
                 *result = PROMISE_RESULT_CHANGE;
             }
             else
             {
+                Log(LOG_LEVEL_ERR, "Failed to remove user '%s'", puser);
                 *result = PROMISE_RESULT_FAIL;
             }
         }


### PR DESCRIPTION
Log messages at log level info should state what the actual changes on
the system are, not the promise outcome. The promise outcome should be
logged at log level verbose.

Ticket: CFE-3906
Changelog: Title
Signed-off-by: larsewi <lars.erik.wik@northern.tech>