### PR TITLE
CFE-3818: Moved errors from data_sysctlvalues from inform to verbose

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1022,7 +1022,7 @@ static FnCallResult FnCallSysctlValue(ARG_UNUSED EvalContext *ctx,
 
         if (w == NULL)
         {
-            Log(LOG_LEVEL_INFO, "Error while reading file '%s' (%s)",
+            Log(LOG_LEVEL_VERBOSE, "Error while reading file '%s' (%s)",
                 BufferData(filenamebuf), GetErrorStr());
             BufferDestroy(filenamebuf);
             return FnFailure();


### PR DESCRIPTION
Inform level logging is intended for messages about changes that CFEngine is
making. These messages are about errors reading files in proc. Prior to this
change you would see errors like this while running as a privileged user:

    info: Error while reading file '/proc/sys/net/ipv6/conf/lo/stable_secret' (Input/output error)
    info: Error while reading file '/proc/sys/fs/binfmt_misc/register' (Invalid argument)
    info: Error while reading file '/proc/sys/net/ipv6/route/flush' (Permission denied)
    info: Error while reading file '/proc/sys/net/ipv6/conf/default/stable_secret' (Input/output error)
    info: Error while reading file '/proc/sys/net/ipv6/conf/enp0s25/stable_secret' (Input/output error)
    info: Error while reading file '/proc/sys/net/ipv6/conf/all/stable_secret' (Input/output error)
    info: Error while reading file '/proc/sys/vm/compact_memory' (Permission denied)
    info: Error while reading file '/proc/sys/net/ipv6/conf/wlp3s0/stable_secret' (Input/output error)
    info: Error while reading file '/proc/sys/net/ipv4/route/flush' (Permission denied)
    info: Error while reading file '/proc/sys/vm/drop_caches' (Permission denied)

When running as an unprivledged user you will see many more.

This change moves these messages from inform to verbose log level so as not to
dirty up output logs.

Ticket: CFE-3818
Changelog: Title