### PR TITLE
CFE-3934: Moved Skipping loading of duplicate policy file messages from VERBOSE to DEBUG

### DIFF
--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -326,12 +326,12 @@ static Policy *LoadPolicyFile(EvalContext *ctx, GenericAgentConfig *config, cons
 
     if (StringMapHasKey(policy_files_hashes, policy_file))
     {
-        Log(LOG_LEVEL_VERBOSE, "Skipping loading of duplicate policy file %s", policy_file);
+        Log(LOG_LEVEL_DEBUG, "Skipping loading of duplicate policy file %s", policy_file);
         return NULL;
     }
     else if (StringSetContains(parsed_files_checksums, hashbuffer))
     {
-        Log(LOG_LEVEL_VERBOSE, "Skipping loading of duplicate (detected by hash) policy file %s",
+        Log(LOG_LEVEL_DEBUG, "Skipping loading of duplicate (detected by hash) policy file %s",
             policy_file);
         return NULL;
     }


### PR DESCRIPTION
These messages clutter up the verbose log for something that I do not think we
have had tickets about, so it's really just noise in most cases of reading a
verbose log. Many of these are generated by the MPF itself, so it's rather
expected.

Ticket: CFE-3934
Changelog: Title