### PR TITLE
Fixed segfaults on Solaris 10 caused by NULL as argument in string format functions (3.18.x)

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -823,7 +823,14 @@ static PromiseResult RenderTemplateMustache(EvalContext *ctx, const Promise *pp,
     }
     else
     {
-        RecordFailure(ctx, pp, attr, "Error rendering mustache template '%s'", attr->edit_template);
+        /* Use `edit_template` attribute when template method is "mustache".
+         * Use `edit_template_string` attribute when template method is
+         * "inline_mustache".
+         */
+        char *tmpl = StringEqual(attr->template_method, "mustache")
+                   ? attr->edit_template : attr->edit_template_string;
+        RecordFailure(ctx, pp, attr, "Error rendering mustache template '%s'",
+                      tmpl);
         result = PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
     }
     BufferDestroy(output_buffer);

--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -1108,8 +1108,10 @@ PromiseResult EvaluateCustomPromise(EvalContext *ctx, const Promise *pp)
     /* Used below, constructed here while path and interpreter are definitely
      * valid pointers. */
     char custom_promise_id[CF_BUFSIZE];
-    NDEBUG_UNUSED size_t ret = snprintf(custom_promise_id, sizeof(custom_promise_id),
-                                        "%s-%s-%s", pp->promiser, path, interpreter);
+    NDEBUG_UNUSED size_t ret = snprintf(custom_promise_id,
+                                        sizeof(custom_promise_id),
+                                        "%s-%s-%s", pp->promiser, path,
+                                        interpreter ? interpreter : "(null)");
     assert((ret > 0) && (ret < sizeof(custom_promise_id)));
 
     PromiseModule *module = MapGet(custom_modules, path);


### PR DESCRIPTION
cherry-picked from https://github.com/cfengine/core/pull/4923