### PR TITLE
Fixed segfaults on Solaris 10 caused by NULL as argument in string format functions (3.15.x)  

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -675,7 +675,13 @@ static PromiseResult RenderTemplateMustache(EvalContext *ctx, const Promise *pp,
     }
     else
     {
-        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, &a, "Error rendering mustache template '%s'", a.edit_template);
+        /* Use `edit_template` attribute when template method is "mustache".
+         * Use `edit_template_string` attribute when template method is
+         * "inline_mustache".
+         */
+        char *tmpl = StringEqual(attr->template_method, "mustache")
+                   ? attr->edit_template : attr->edit_template_string;
+        cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, &a, "Error rendering mustache template '%s'", tmpl);
         result = PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
         BufferDestroy(output_buffer);
         JsonDestroy(destroy_this);


### PR DESCRIPTION
cherry-picked from https://github.com/cfengine/core/pull/4923