### PR TITLE
ENT-8430: Fixed default for ignore_missing_bundles and ignore_missing_inputs 

### DIFF
--- a/cf-agent/verify_methods.c
+++ b/cf-agent/verify_methods.c
@@ -25,6 +25,7 @@
 #include <verify_methods.h>
 
 #include <actuator.h>
+#include <audit.h> // FatalError()
 #include <eval_context.h>
 #include <vars.h>
 #include <expand.h>
@@ -227,6 +228,10 @@ PromiseResult VerifyMethod(EvalContext *ctx, const Rval call, const Attributes *
              "A method attempted to use a bundle '%s' that was apparently not defined",
              BufferData(method_name));
         result = PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
+        if (!EvalContextGetConfig(ctx)->ignore_missing_bundles)
+        {
+            FatalError(ctx, "Aborting due to missing bundle '%s'", BufferData(method_name));
+        }
     }
 
     YieldCurrentLock(thislock);

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -378,6 +378,55 @@ bool BooleanFromString(const char *s)
     }
 }
 
+bool StringIsBoolean(const char *s)
+{
+    assert(s != NULL);
+
+    if (s[0] == '\0')
+    {
+        // Empty string is not one of the accepted values in CF_BOOL.
+        // We have to check for this, because strstr() would return a "match"
+        // at the beginning of CF_BOOL. The C std library takes the
+        // mathematical view that all strings contain the empty string.
+        return false;
+    }
+
+    if (strchr(s, ',') != NULL)
+    {
+        // If there is a comma in the string,
+        // it is not one of the boolean values we have in a comma-separated
+        // list (CF_BOOL).
+        return false;
+    }
+
+    // The length of the match is the length of what we searched for:
+    const size_t match_length = strlen(s);
+    const char *match = strstr(CF_BOOL, s);
+    while (match != NULL)
+    {
+        // We found a match, but we also have to check that it matched
+        // everything between commas or start or end of string.
+
+        const char* after_match = match + match_length;
+        if (*after_match != '\0' && *after_match != ',')
+        {
+            match = strstr(match + 1, s);
+            continue; // There was something more, not a complete match.
+        }
+        const size_t offset = match - CF_BOOL;
+        if (offset == 0)
+        {
+            return true; // We matched the beginning, so a complete match.
+        }
+        if (CF_BOOL[offset - 1] == ',')
+        {
+            return true; // Previous character was comma, so a complete match.
+        }
+        match = strstr(match + 1, s);
+    }
+    return false;
+}
+
 /****************************************************************************/
 
 /**

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -351,80 +351,41 @@ DataType ConstraintSyntaxGetDataType(const ConstraintSyntax *body_syntax, const 
 
 /****************************************************************************/
 
+// Warning: Defaults to true on unexpected (non-bool) input
 bool BooleanFromString(const char *s)
 {
-    Item *list = SplitString(CF_BOOL, ','), *ip;
-    int count = 0;
+    assert(StringEqual(CF_BOOL, "true,false,yes,no,on,off"));
+    assert(s != NULL);
 
-    for (ip = list; ip != NULL; ip = ip->next)
-    {
-        if (strcmp(s, ip->name) == 0)
-        {
-            break;
-        }
-
-        count++;
-    }
-
-    DeleteItemList(list);
-
-    if (count % 2)
+    if (StringEqual(s, "false")
+        || StringEqual(s, "no")
+        || StringEqual(s, "off"))
     {
         return false;
     }
-    else
-    {
-        return true;
-    }
+    // Unnecessary to check here because the default is true anyway:
+    // if (StringEqual(s, "true")
+    //     || StringEqual(s, "yes")
+    //     || StringEqual(s, "on"))
+    // {
+    //     return true;
+    // }
+
+    // Default to true to preserve old behavior:
+    return true;
 }
 
 bool StringIsBoolean(const char *s)
 {
+    assert(StringEqual(CF_BOOL, "true,false,yes,no,on,off"));
     assert(s != NULL);
 
-    if (s[0] == '\0')
-    {
-        // Empty string is not one of the accepted values in CF_BOOL.
-        // We have to check for this, because strstr() would return a "match"
-        // at the beginning of CF_BOOL. The C std library takes the
-        // mathematical view that all strings contain the empty string.
-        return false;
-    }
-
-    if (strchr(s, ',') != NULL)
-    {
-        // If there is a comma in the string,
-        // it is not one of the boolean values we have in a comma-separated
-        // list (CF_BOOL).
-        return false;
-    }
-
-    // The length of the match is the length of what we searched for:
-    const size_t match_length = strlen(s);
-    const char *match = strstr(CF_BOOL, s);
-    while (match != NULL)
-    {
-        // We found a match, but we also have to check that it matched
-        // everything between commas or start or end of string.
-
-        const char* after_match = match + match_length;
-        if (*after_match != '\0' && *after_match != ',')
-        {
-            match = strstr(match + 1, s);
-            continue; // There was something more, not a complete match.
-        }
-        const size_t offset = match - CF_BOOL;
-        if (offset == 0)
-        {
-            return true; // We matched the beginning, so a complete match.
-        }
-        if (CF_BOOL[offset - 1] == ',')
-        {
-            return true; // Previous character was comma, so a complete match.
-        }
-        match = strstr(match + 1, s);
-    }
-    return false;
+    return (StringEqual(s, "true")
+            || StringEqual(s, "false")
+            || StringEqual(s, "yes")
+            || StringEqual(s, "no")
+            || StringEqual(s, "on")
+            || StringEqual(s, "off"));
 }
 
 /****************************************************************************/

--- a/libpromises/conversion.h
+++ b/libpromises/conversion.h
@@ -58,6 +58,7 @@ int Month2Int(const char *string);
 
 // Evalaution conversion
 bool BooleanFromString(const char *val);
+bool StringIsBoolean(const char *val);
 long IntFromString(const char *s);
 bool DoubleFromString(const char *s, double *value_out);
 bool IntegerRangeFromString(const char *intrange, long *min_out, long *max_out);

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -132,8 +132,7 @@ static ClassRef IDRefQualify(const EvalContext *ctx, const char *id);
  */
 struct EvalContext_
 {
-    /* TODO: a pointer to read-only version of config is often needed. */
-    /* const GenericAgentConfig *config; */
+    const GenericAgentConfig *config;
 
     int eval_options;
     bool bundle_aborted;
@@ -194,6 +193,18 @@ struct EvalContext_
 
     bool dump_reports;
 };
+
+void EvalContextSetConfig(EvalContext *ctx, const GenericAgentConfig *config)
+{
+    assert(ctx != NULL);
+    ctx->config = config;
+}
+
+const GenericAgentConfig *EvalContextGetConfig(EvalContext *ctx)
+{
+    assert(ctx != NULL);
+    return ctx->config;
+}
 
 bool EvalContextGetSelectEndMatchEof(const EvalContext *ctx)
 {

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -38,6 +38,7 @@
 #include <iteration.h>
 #include <rb-tree.h>
 #include <ring_buffer.h>
+#include <generic_agent.h>
 
 typedef enum
 {
@@ -113,6 +114,9 @@ typedef enum
 
 EvalContext *EvalContextNew(void);
 void EvalContextDestroy(EvalContext *ctx);
+
+void EvalContextSetConfig(EvalContext *ctx, const GenericAgentConfig *config);
+const GenericAgentConfig *EvalContextGetConfig(EvalContext *ctx);
 
 Rlist *EvalContextGetRestrictKeys(const EvalContext *ctx);
 void EvalContextSetRestrictKeys(EvalContext *ctx, const Rlist *restrict_keys);

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -962,16 +962,22 @@ static void ResolveControlBody(EvalContext *ctx, GenericAgentConfig *config,
         {
             Log(LOG_LEVEL_VERBOSE, "SET ignore_missing_inputs %s",
                 RvalScalarValue(evaluated_rval));
-            config->ignore_missing_inputs = BooleanFromString(
-                RvalScalarValue(evaluated_rval));
+            if (StringIsBoolean(RvalScalarValue(evaluated_rval)))
+            {
+                config->ignore_missing_inputs = BooleanFromString(
+                    RvalScalarValue(evaluated_rval));
+            }
         }
 
         if (strcmp(lval, CFG_CONTROLBODY[COMMON_CONTROL_IGNORE_MISSING_BUNDLES].lval) == 0)
         {
             Log(LOG_LEVEL_VERBOSE, "SET ignore_missing_bundles %s",
                 RvalScalarValue(evaluated_rval));
-            config->ignore_missing_bundles = BooleanFromString(
-                RvalScalarValue(evaluated_rval));
+            if (StringIsBoolean(RvalScalarValue(evaluated_rval)))
+            {
+                config->ignore_missing_bundles = BooleanFromString(
+                    RvalScalarValue(evaluated_rval));
+            }
         }
 
         if (strcmp(lval, CFG_CONTROLBODY[COMMON_CONTROL_CACHE_SYSTEM_FUNCTIONS].lval) == 0)

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -2565,6 +2565,8 @@ void GenericAgentConfigApply(EvalContext *ctx, const GenericAgentConfig *config)
 {
     assert(config != NULL);
 
+    EvalContextSetConfig(ctx, config);
+
     if (config->heap_soft)
     {
         StringSetIterator it = StringSetIteratorInit(config->heap_soft);

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -531,8 +531,7 @@ Policy *LoadPolicy(EvalContext *ctx, GenericAgentConfig *config)
             {
                 Log(LOG_LEVEL_VERBOSE,
                     "Running full policy integrity checks");
-                PolicyCheckRunnable(ctx, policy, errors,
-                                    config->ignore_missing_bundles);
+                PolicyCheckRunnable(ctx, policy, errors);
             }
         }
 

--- a/libpromises/policy.h
+++ b/libpromises/policy.h
@@ -163,7 +163,7 @@ void PolicyErrorDestroy(PolicyError *error);
 void PolicyErrorWrite(Writer *writer, const PolicyError *error);
 
 bool PolicyCheckPartial(const Policy *policy, Seq *errors);
-bool PolicyCheckRunnable(const EvalContext *ctx, const Policy *policy, Seq *errors, bool ignore_missing_bundles);
+bool PolicyCheckRunnable(const EvalContext *ctx, const Policy *policy, Seq *errors);
 
 Bundle *PolicyAppendBundle(Policy *policy, const char *ns, const char *name, const char *type, const Rlist *args, const char *source_path);
 Body *PolicyAppendBody(Policy *policy, const char *ns, const char *name,

--- a/tests/acceptance/01_vars/02_functions/mustach_doesnt_render_null.cf
+++ b/tests/acceptance/01_vars/02_functions/mustach_doesnt_render_null.cf
@@ -31,6 +31,7 @@ bundle agent check
 
       "check" usebundle => dcs_check_regcmp("one two three ", $(test.mustache_string), $(this.promise_filename), "no");
 
+  reports:
     DEBUG|EXTRA::
       "Diff string: $(test.diff_string)";
       "Mustache string: $(test.mustache_string)";

--- a/tests/acceptance/21_methods/reachable/bundle_promiser_call_by_arg_defined.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_promiser_call_by_arg_defined.cf
@@ -1,0 +1,27 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent baz
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}
+
+bundle agent bar(x)
+{
+  methods:
+    "$(x)"; # Tries to call baz, exists, works
+}
+
+bundle agent main
+{
+  methods:
+    "foo"
+      usebundle => bar("baz");
+}

--- a/tests/acceptance/21_methods/reachable/bundle_promiser_call_by_arg_undefined.x.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_promiser_call_by_arg_undefined.x.cf
@@ -1,0 +1,27 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent baz
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}
+
+bundle agent bar(x)
+{
+  methods:
+    "$(x)"; # Tries to call bazz, doesn't exist, shouldn't work
+}
+
+bundle agent main
+{
+  methods:
+    "foo"
+      usebundle => bar("bazz");
+}

--- a/tests/acceptance/21_methods/reachable/bundle_promiser_defined.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_promiser_defined.cf
@@ -1,0 +1,20 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent foo
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}
+
+bundle agent main
+{
+  methods:
+    "foo";
+}

--- a/tests/acceptance/21_methods/reachable/bundle_promiser_undefined.x.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_promiser_undefined.x.cf
@@ -1,0 +1,14 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent main
+{
+  methods:
+    "foo"; # Should error because foo does not exist
+}

--- a/tests/acceptance/21_methods/reachable/bundle_promiser_unreachable.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_promiser_unreachable.cf
@@ -1,0 +1,23 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent bar
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}
+
+bundle agent main
+{
+  methods:
+    out_of_context::
+      "foo"; # Should not error because it's unreachable
+    any::
+      "bar";
+}

--- a/tests/acceptance/21_methods/reachable/bundle_reversed_usebundle_parameters_defined.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_reversed_usebundle_parameters_defined.cf
@@ -1,0 +1,26 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+# reversed tests are just to show it should behave the same
+# if the called bundle comes after instead of before
+
+bundle agent main
+{
+  methods:
+    "foo"
+      usebundle => bar("baz");
+}
+
+bundle agent bar(x)
+{
+  # bar exists and it's the bundle we want, so this will pass:
+  reports:
+    "$(x)";
+    "$(this.promise_filename) Pass";
+}

--- a/tests/acceptance/21_methods/reachable/bundle_reversed_usebundle_parameters_undefined.x.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_reversed_usebundle_parameters_undefined.x.cf
@@ -1,0 +1,26 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+# reversed tests are just to show it should behave the same
+# if the called bundle comes after instead of before
+
+bundle agent main
+{
+  methods:
+    "foo"
+      usebundle => bar("baz"); # Should error because bar does not exist
+}
+
+bundle agent foo(x)
+{
+  # foo exists, but it's not the bundle we are looking for
+  reports:
+    "$(x)";
+    "$(this.promise_filename) Pass";
+}

--- a/tests/acceptance/21_methods/reachable/bundle_usebundle_call_by_arg_defined.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_usebundle_call_by_arg_defined.cf
@@ -1,0 +1,28 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent baz
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}
+
+bundle agent bar(x)
+{
+  methods:
+    "foo"
+      usebundle => "$(x)"; # Will call baz, which exists, should work
+}
+
+bundle agent main
+{
+  methods:
+    "foo"
+      usebundle => bar("baz");
+}

--- a/tests/acceptance/21_methods/reachable/bundle_usebundle_call_by_arg_undefined.x.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_usebundle_call_by_arg_undefined.x.cf
@@ -1,0 +1,28 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent baz
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}
+
+bundle agent bar(x)
+{
+  methods:
+    "foo"
+      usebundle => "$(x)"; # Tries to call bazz, doesn't exist, shouldn't work
+}
+
+bundle agent main
+{
+  methods:
+    "foo"
+      usebundle => bar("bazz");
+}

--- a/tests/acceptance/21_methods/reachable/bundle_usebundle_defined.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_usebundle_defined.cf
@@ -1,0 +1,21 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent bar
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}
+
+bundle agent main
+{
+  methods:
+    "foo"
+      usebundle => bar;
+}

--- a/tests/acceptance/21_methods/reachable/bundle_usebundle_parameters_defined.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_usebundle_parameters_defined.cf
@@ -1,0 +1,23 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent bar(x)
+{
+  # bar exists and it's the bundle we want, so this will pass:
+  reports:
+    "$(x)";
+    "$(this.promise_filename) Pass";
+}
+
+bundle agent main
+{
+  methods:
+    "foo"
+      usebundle => bar("baz");
+}

--- a/tests/acceptance/21_methods/reachable/bundle_usebundle_parameters_undefined.x.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_usebundle_parameters_undefined.x.cf
@@ -1,0 +1,23 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent foo(x)
+{
+  # foo exists, but it's not the bundle we are looking for
+  reports:
+    "$(x)";
+    "$(this.promise_filename) Pass";
+}
+
+bundle agent main
+{
+  methods:
+    "foo"
+      usebundle => bar("baz"); # Should error because bar does not exist
+}

--- a/tests/acceptance/21_methods/reachable/bundle_usebundle_undefined.x.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_usebundle_undefined.x.cf
@@ -1,0 +1,20 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent foo
+{
+  # foo exists but it's not the bundle we are looking for
+}
+
+bundle agent main
+{
+  methods:
+    "foo"
+      usebundle => bar; # Should error because bar does not exist
+}

--- a/tests/acceptance/21_methods/reachable/bundle_usebundle_unreachable.cf
+++ b/tests/acceptance/21_methods/reachable/bundle_usebundle_unreachable.cf
@@ -1,0 +1,23 @@
+# Reachable bundle tests verify that you are allowed have references
+# to undefined bundles, as long as they are not actually called.
+
+# These tests are left very simple on purpose,
+# they are not using the test framework.
+# They should be seen together, note that defined vs undefined variants are
+# almost identical, just replacing one detail to show what should work
+# and what should error.
+
+bundle agent baz
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}
+
+bundle agent main
+{
+  methods:
+    "foo"
+      if => "out_of_context",
+      usebundle => "bar"; # Should not error because it's unreachable
+    "baz";
+}

--- a/tests/unit/conversion_test.c
+++ b/tests/unit/conversion_test.c
@@ -3,6 +3,40 @@
 #include <cmockery.h>
 #include <conversion.h>
 
+static void test_string_is_boolean(void)
+{
+    // This test should be updated if someone changes CF_BOOL:
+    assert_string_equal(CF_BOOL, "true,false,yes,no,on,off");
+
+    // Accepted boolean values:
+    assert_true(StringIsBoolean("true"));
+    assert_true(StringIsBoolean("false"));
+    assert_true(StringIsBoolean("yes"));
+    assert_true(StringIsBoolean("no"));
+    assert_true(StringIsBoolean("on"));
+    assert_true(StringIsBoolean("off"));
+
+    // Anything else is not boolean:
+    assert_false(StringIsBoolean("boolean"));
+    assert_false(StringIsBoolean("bool"));
+    assert_false(StringIsBoolean(""));
+    assert_false(StringIsBoolean(" "));
+    assert_false(StringIsBoolean(","));
+    assert_false(StringIsBoolean(",,"));
+    assert_false(StringIsBoolean("()"));
+    assert_false(StringIsBoolean("$(foo)"));
+    assert_false(StringIsBoolean("$(true)"));
+    assert_false(StringIsBoolean("y"));
+    assert_false(StringIsBoolean("n"));
+    assert_false(StringIsBoolean("tru"));
+    assert_false(StringIsBoolean("fals"));
+    assert_false(StringIsBoolean("true,"));
+    assert_false(StringIsBoolean(",false"));
+    assert_false(StringIsBoolean("o,n"));
+    assert_false(StringIsBoolean(" on "));
+    assert_false(StringIsBoolean("onoff"));
+    assert_false(StringIsBoolean("onon"));
+}
 
 static void test_int_from_string(void)
 {
@@ -208,6 +242,7 @@ int main()
     PRINT_TEST_BANNER();
     const UnitTest tests[] =
     {
+        unit_test(test_string_is_boolean),
         unit_test(test_int_from_string),
         unit_test(test_double_from_string),
         unit_test(test_CommandArg0_bound),

--- a/tests/unit/conversion_test.c
+++ b/tests/unit/conversion_test.c
@@ -38,6 +38,43 @@ static void test_string_is_boolean(void)
     assert_false(StringIsBoolean("onon"));
 }
 
+static void test_boolean_from_string(void)
+{
+    // This test should be updated if someone changes CF_BOOL:
+    assert_string_equal(CF_BOOL, "true,false,yes,no,on,off");
+
+    // Expected true values:
+    assert_true(BooleanFromString("true"));
+    assert_true(BooleanFromString("yes"));
+    assert_true(BooleanFromString("on"));
+
+    // Expected false values:
+    assert_false(BooleanFromString("false"));
+    assert_false(BooleanFromString("no"));
+    assert_false(BooleanFromString("off"));
+
+    // Edge cases, default to true:
+    assert_true(BooleanFromString("boolean"));
+    assert_true(BooleanFromString("bool"));
+    assert_true(BooleanFromString(""));
+    assert_true(BooleanFromString(" "));
+    assert_true(BooleanFromString(","));
+    assert_true(BooleanFromString(",,"));
+    assert_true(BooleanFromString("()"));
+    assert_true(BooleanFromString("$(foo)"));
+    assert_true(BooleanFromString("$(true)"));
+    assert_true(BooleanFromString("y"));
+    assert_true(BooleanFromString("n"));
+    assert_true(BooleanFromString("tru"));
+    assert_true(BooleanFromString("fals"));
+    assert_true(BooleanFromString("true,"));
+    assert_true(BooleanFromString(",false"));
+    assert_true(BooleanFromString("o,n"));
+    assert_true(BooleanFromString(" on "));
+    assert_true(BooleanFromString("onoff"));
+    assert_true(BooleanFromString("onon"));
+}
+
 static void test_int_from_string(void)
 {
     assert_int_equal(IntFromString("0"), 0);
@@ -243,6 +280,7 @@ int main()
     const UnitTest tests[] =
     {
         unit_test(test_string_is_boolean),
+        unit_test(test_boolean_from_string),
         unit_test(test_int_from_string),
         unit_test(test_double_from_string),
         unit_test(test_CommandArg0_bound),

--- a/tests/unit/policy_test.c
+++ b/tests/unit/policy_test.c
@@ -89,7 +89,7 @@ static void test_failsafe(void)
     {
         EvalContext *ctx = EvalContextNew();
 
-        PolicyCheckRunnable(ctx, failsafe, errs, false);
+        PolicyCheckRunnable(ctx, failsafe, errs);
 
         DumpErrors(errs);
         assert_int_equal(0, SeqLength(errs));


### PR DESCRIPTION
I fixed this issue, but refrained from starting to fix more than necessary.

Merge together:
https://github.com/cfengine/core/pull/4929
https://github.com/cfengine/masterfiles/pull/2268