### PR TITLE
[3.18.x] CFE-951: log a warning if 'mode' is set, but 'rxdirs' is not

### DIFF
--- a/examples/rxdirs.cf
+++ b/examples/rxdirs.cf
@@ -51,9 +51,17 @@ body perms m_rxdirs_off(mode)
 ###############################################################################
 #+begin_src example_output
 #@ ```
+#@  warning: Using the default value 'true' for attribute rxdirs (promiser: /tmp/rxdirs_example/rxdirs=default(true)-r), please set it explicitly
+#@  warning: Using the default value 'true' for attribute rxdirs (promiser: /tmp/rxdirs_example/rxdirs=default(true)-r), please set it explicitly
+#@  warning: Using the default value 'true' for attribute rxdirs (promiser: /tmp/rxdirs_example/rxdirs=default(true)-rx), please set it explicitly
+#@  warning: Using the default value 'true' for attribute rxdirs (promiser: /tmp/rxdirs_example/rxdirs=default(true)-rx), please set it explicitly
 #@ R: /tmp/rxdirs_example/rxdirs=default(true)-r modeoct='40700'
 #@ R: /tmp/rxdirs_example/rxdirs=default(true)-rx modeoct='40700'
 #@ R: /tmp/rxdirs_example/rxdirs=false-r modeoct='40600'
 #@ R: /tmp/rxdirs_example/rxdirs=false-rx modeoct='40700'
+#@  warning: Using the default value 'true' for attribute rxdirs (promiser: /tmp/rxdirs_example/rxdirs=default(true)-r), please set it explicitly
+#@  warning: Using the default value 'true' for attribute rxdirs (promiser: /tmp/rxdirs_example/rxdirs=default(true)-rx), please set it explicitly
+#@  warning: Using the default value 'true' for attribute rxdirs (promiser: /tmp/rxdirs_example/rxdirs=default(true)-r), please set it explicitly
+#@  warning: Using the default value 'true' for attribute rxdirs (promiser: /tmp/rxdirs_example/rxdirs=default(true)-rx), please set it explicitly
 #@ ```
 #+end_example

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -512,14 +512,7 @@ static FilePerms GetPermissionConstraints(const EvalContext *ctx, const Promise 
     p.groups = Rlist2GidList((Rlist *) PromiseGetConstraintAsRval(pp, "groups", RVAL_TYPE_LIST), pp);
 
     p.findertype = PromiseGetConstraintAsRval(pp, "findertype", RVAL_TYPE_SCALAR);
-    p.rxdirs = PromiseGetConstraintAsBoolean(ctx, "rxdirs", pp);
-
-// The default should be true
-
-    if (!PromiseGetConstraintAsRval(pp, "rxdirs", RVAL_TYPE_SCALAR))
-    {
-        p.rxdirs = true;
-    }
+    p.rxdirs = PromiseGetConstraintAsBooleanWithDefault(ctx, "rxdirs", pp, true, false);
 
     return p;
 }

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -483,15 +483,15 @@ Acl GetAclConstraints(const EvalContext *ctx, const Promise *pp)
 static FilePerms GetPermissionConstraints(const EvalContext *ctx, const Promise *pp)
 {
     FilePerms p;
-    char *value;
+    char *mode_value;
     Rlist *list;
 
-    value = PromiseGetConstraintAsRval(pp, "mode", RVAL_TYPE_SCALAR);
+    mode_value = PromiseGetConstraintAsRval(pp, "mode", RVAL_TYPE_SCALAR);
 
     p.plus = CF_SAMEMODE;
     p.minus = CF_SAMEMODE;
 
-    if (!ParseModeString(value, &p.plus, &p.minus))
+    if (!ParseModeString(mode_value, &p.plus, &p.minus))
     {
         Log(LOG_LEVEL_ERR, "Problem validating a mode string");
         PromiseRef(LOG_LEVEL_ERR, pp);
@@ -512,7 +512,8 @@ static FilePerms GetPermissionConstraints(const EvalContext *ctx, const Promise 
     p.groups = Rlist2GidList((Rlist *) PromiseGetConstraintAsRval(pp, "groups", RVAL_TYPE_LIST), pp);
 
     p.findertype = PromiseGetConstraintAsRval(pp, "findertype", RVAL_TYPE_SCALAR);
-    p.rxdirs = PromiseGetConstraintAsBooleanWithDefault(ctx, "rxdirs", pp, true, false);
+    p.rxdirs = PromiseGetConstraintAsBooleanWithDefault(ctx, "rxdirs", pp,
+                                                        true, (mode_value != NULL));
 
     return p;
 }

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2562,6 +2562,8 @@ int PromiseGetConstraintAsBoolean(const EvalContext *ctx, const char *lval, cons
 int PromiseGetConstraintAsBooleanWithDefault(const EvalContext *ctx, const char *lval, const Promise *pp,
                                              int default_val, bool with_warning)
 {
+    assert(pp != NULL);
+
     int retval = CF_UNDEFINED;
 
     for (size_t i = 0; i < SeqLength(pp->conlist); i++)

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2546,10 +2546,9 @@ void ConstraintDestroy(Constraint *cp)
 /*****************************************************************************/
 
 /**
- * @brief Get the trinary boolean value of the first effective constraint found matching, from a promise
- * @param lval
- * @param list
- * @return True/false, or CF_UNDEFINED if not found
+ * @brief Get the boolean value of the first effective constraint found matching, from a promise
+ * @return true/false
+ * @note Returns #false if no matching constraint is found
  */
 int PromiseGetConstraintAsBoolean(const EvalContext *ctx, const char *lval, const Promise *pp)
 {

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2552,6 +2552,16 @@ void ConstraintDestroy(Constraint *cp)
  */
 int PromiseGetConstraintAsBoolean(const EvalContext *ctx, const char *lval, const Promise *pp)
 {
+    return PromiseGetConstraintAsBooleanWithDefault(ctx, lval, pp, false, false);
+}
+
+/**
+ * @brief Get the boolean value of the first effective constraint found matching, from a promise
+ * @return true/false
+ */
+int PromiseGetConstraintAsBooleanWithDefault(const EvalContext *ctx, const char *lval, const Promise *pp,
+                                             int default_val, bool with_warning)
+{
     int retval = CF_UNDEFINED;
 
     for (size_t i = 0; i < SeqLength(pp->conlist); i++)
@@ -2596,7 +2606,13 @@ int PromiseGetConstraintAsBoolean(const EvalContext *ctx, const char *lval, cons
 
     if (retval == CF_UNDEFINED)
     {
-        retval = false;
+        if (with_warning)
+        {
+            Log(LOG_LEVEL_WARNING,
+                "Using the default value '%s' for attribute %s (promiser: %s), please set it explicitly",
+                default_val ? "true" : "false", lval, pp->promiser);
+        }
+        retval = default_val;
     }
 
     return retval;

--- a/libpromises/policy.h
+++ b/libpromises/policy.h
@@ -209,6 +209,8 @@ uid_t PromiseGetConstraintAsUid(const EvalContext *ctx, const char *lval, const 
 gid_t PromiseGetConstraintAsGid(const EvalContext *ctx, char *lval, const Promise *pp);
 Rlist *PromiseGetConstraintAsList(const EvalContext *ctx, const char *lval, const Promise *pp);
 int PromiseGetConstraintAsBoolean(const EvalContext *ctx, const char *lval, const Promise *list);
+int PromiseGetConstraintAsBooleanWithDefault(const EvalContext *ctx, const char *lval, const Promise *pp,
+                                             int default_val, bool with_warning);
 Constraint *PromiseGetConstraintWithType(const Promise *promise, const char *lval, RvalType type);
 Constraint *PromiseGetImmediateConstraint(const Promise *promise, const char *lval);
 void *PromiseGetConstraintAsRval(const Promise *promise, const char *lval, RvalType type);

--- a/tests/acceptance/plucked.cf.sub
+++ b/tests/acceptance/plucked.cf.sub
@@ -1580,6 +1580,7 @@ body perms m(mode)
 # @param mode The new mode
 {
       mode   => "$(mode)";
+      rxdirs => "true";
 }
 
 body perms mo(mode,user)
@@ -1589,6 +1590,7 @@ body perms mo(mode,user)
 {
       owners => { "$(user)" };
       mode   => "$(mode)";
+      rxdirs => "true";
 }
 
 body perms mog(mode,user,group)
@@ -1600,6 +1602,7 @@ body perms mog(mode,user,group)
       owners => { "$(user)" };
       groups => { "$(group)" };
       mode   => "$(mode)";
+      rxdirs => "true";
 }
 
 body perms og(u,g)
@@ -1632,6 +1635,7 @@ body perms system_owned(mode)
       mode   => "$(mode)";
       owners => { "root" };
       groups => { "$(sys.user_data[gid])" };
+      rxdirs => "true";
 }
 
 


### PR DESCRIPTION
Commits from #4927 cherry-picked to *3.18.x* **without changing the default for `rxdirs`**.
MPF changes: https://github.com/cfengine/masterfiles/pull/2270