### PR TITLE
[3.18.x] Add more details to the warning in PromiseGetConstraintAsBooleanWithDefault()

### DIFF
--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2544,8 +2544,9 @@ int PromiseGetConstraintAsBooleanWithDefault(const EvalContext *ctx, const char 
         if (with_warning)
         {
             Log(LOG_LEVEL_WARNING,
-                "Using the default value '%s' for attribute %s (promiser: %s), please set it explicitly",
-                default_val ? "true" : "false", lval, pp->promiser);
+                "Using the default value '%s' for attribute %s (promiser: %s, file: %s:%zd), please set it explicitly",
+                default_val ? "true" : "false", lval,
+                pp->promiser, PromiseGetBundle(pp)->source_path, pp->offset.line);
         }
         retval = default_val;
     }


### PR DESCRIPTION
When a default value for an attribute that should be set
explicitly is used, a warning is emitted. It should be easier for
the user to identify which promise exactly it is coming from.

Ticket: CFE-951
Changelog: None
(cherry picked from commit 4025aa1ae1fbeada324c67e95ae929c928a5a6a1)