### PR TITLE
[3.18.x] ENT-5899: Support adding sleeps between signals in processes promises

### DIFF
--- a/cf-agent/verify_processes.c
+++ b/cf-agent/verify_processes.c
@@ -182,15 +182,11 @@ static PromiseResult VerifyProcessOp(EvalContext *ctx, const Attributes *a, cons
 {
     assert(a != NULL);
     assert(pp != NULL);
-    bool do_signals = true;
-    int out_of_range;
-    int killed = 0;
-    bool need_to_restart = true;
-    Item *killlist = NULL;
 
-    int matches = FindPidMatches(&killlist, a, pp->promiser);
+    Item *matched_procs = NULL;
+    int matches = FindPidMatches(&matched_procs, a, pp->promiser);
 
-/* promise based on number of matches */
+    /* promise based on number of matches */
 
     PromiseResult result = PROMISE_RESULT_NOOP;
     if (a->process_count.min_range != CF_NOINT)  /* if a range is specified */
@@ -203,7 +199,6 @@ static PromiseResult VerifyProcessOp(EvalContext *ctx, const Attributes *a, cons
             {
                 ProcessCountMaybeDefineClass(ctx, rp, pp, "out_of_range_define");
             }
-            out_of_range = true;
         }
         else
         {
@@ -212,32 +207,20 @@ static PromiseResult VerifyProcessOp(EvalContext *ctx, const Attributes *a, cons
                 ProcessCountMaybeDefineClass(ctx, rp, pp, "in_range_define");
             }
             cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a, "Process promise for '%s' is kept", pp->promiser);
-            out_of_range = false;
+            DeleteItemList(matched_procs);
+            return result;
         }
     }
-    else
-    {
-        out_of_range = true;
-    }
 
-    if (!out_of_range)
+    bool do_signals = (a->transaction.action != cfa_warn);
+    if (!do_signals)
     {
-        DeleteItemList(killlist);
-        return result;
-    }
-
-    if (a->transaction.action == cfa_warn)
-    {
-        do_signals = false;
         result = PromiseResultUpdate(result, PROMISE_RESULT_WARN);
     }
-    else
-    {
-        do_signals = true;
-    }
 
-/* signal/kill promises for existing matches */
+    /* signal/kill promises for existing matches */
 
+    bool killed = false;
     if (do_signals && (matches > 0))
     {
         if (a->process_stop != NULL)
@@ -275,21 +258,19 @@ static PromiseResult VerifyProcessOp(EvalContext *ctx, const Attributes *a, cons
                          "Process promise to stop '%s' could not be kept because '%s' is not executable",
                          pp->promiser, a->process_stop);
                     result = PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
-                    DeleteItemList(killlist);
+                    DeleteItemList(matched_procs);
                     return result;
                 }
             }
         }
 
-        killed = DoAllSignals(ctx, killlist, a, pp, &result);
+        killed = DoAllSignals(ctx, matched_procs, a, pp, &result);
     }
+    DeleteItemList(matched_procs);
 
-/* delegated promise to restart killed or non-existent entries */
+    /* delegated promise to restart killed or non-existent entries */
 
-    need_to_restart = (a->restart_class != NULL) && (killed || (matches == 0));
-
-    DeleteItemList(killlist);
-
+    bool need_to_restart = (a->restart_class != NULL) && (killed || (matches == 0));
     if (!need_to_restart)
     {
         cfPS(ctx, LOG_LEVEL_VERBOSE, PROMISE_RESULT_NOOP, pp, a, "No restart promised for %s", pp->promiser);
@@ -317,26 +298,26 @@ static PromiseResult VerifyProcessOp(EvalContext *ctx, const Attributes *a, cons
 }
 
 #ifndef __MINGW32__
-int DoAllSignals(EvalContext *ctx, Item *siglist, const Attributes *a, const Promise *pp, PromiseResult *result)
+bool DoAllSignals(EvalContext *ctx, Item *procs_to_signal, const Attributes *a, const Promise *pp, PromiseResult *result)
 {
     Item *ip;
     Rlist *rp;
     pid_t pid;
-    int killed = false;
+    bool killed = false;
     bool failure = false;
 
-    if (siglist == NULL)
+    if (procs_to_signal == NULL)
     {
-        return 0;
+        return false;
     }
 
     if (a->signals == NULL)
     {
         Log(LOG_LEVEL_VERBOSE, "No signals to send for '%s'", pp->promiser);
-        return 0;
+        return false;
     }
 
-    for (ip = siglist; ip != NULL; ip = ip->next)
+    for (ip = procs_to_signal; ip != NULL; ip = ip->next)
     {
         pid = ip->counter;
 

--- a/cf-agent/verify_processes.h
+++ b/cf-agent/verify_processes.h
@@ -28,9 +28,6 @@
 #include <cf3.defs.h>
 
 PromiseResult VerifyProcessesPromise(EvalContext *ctx, const Promise *pp);
-
-/* To be implemented in Nova for Win32 */
-
-int DoAllSignals(EvalContext *ctx, Item *siglist, const Attributes *a, const Promise *pp, PromiseResult *result);
+bool DoAllSignals(EvalContext *ctx, Item *siglist, const Attributes *a, const Promise *pp, PromiseResult *result);
 
 #endif

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -553,7 +553,6 @@ typedef enum
 #define CF_HIGHINIT 999999L
 #define CF_LOWINIT -999999L
 
-#define CF_SIGNALRANGE "hup,int,trap,kill,pipe,cont,abrt,stop,quit,term,child,usr1,usr2,bus,segv"
 #define CF_BOOL      "true,false,yes,no,on,off"
 #define CF_LINKRANGE "symlink,hardlink,relative,absolute"
 #define CF_TIMERANGE "0,2147483647" /* i.e. "0,0x7fffffff" */
@@ -750,25 +749,6 @@ typedef enum
     FILE_CHANGE_REPORT_STATS_CHANGE,
     FILE_CHANGE_REPORT_ALL
 } FileChangeReport;
-
-enum signalnames
-{
-    cfa_hup,
-    cfa_int,
-    cfa_trap,
-    cfa_kill,
-    cfa_pipe,
-    cfa_cont,
-    cfa_abrt,
-    cfa_stop,
-    cfa_quit,
-    cfa_term,
-    cfa_child,
-    cfa_usr1,
-    cfa_usr2,
-    cfa_bus,
-    cfa_segv
-};
 
 typedef enum
 {

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -221,56 +221,24 @@ char *Rlist2String(Rlist *list, char *sep)
 
 int SignalFromString(const char *s)
 {
-    int i = 0;
-    Item *ip, *names = SplitString(CF_SIGNALRANGE, ',');
+    char *signal_names[15] = {
+        "hup", "int", "trap", "kill", "pipe", "cont", "abrt", "stop",
+        "quit", "term", "child", "usr1", "usr2", "bus", "segv"
+    };
+    int signals[15] = {
+       SIGHUP, SIGINT, SIGTRAP, SIGKILL, SIGPIPE, SIGCONT, SIGABRT, SIGSTOP,
+       SIGQUIT, SIGTERM, SIGCHLD, SIGUSR1, SIGUSR2, SIGBUS, SIGSEGV
+    };
 
-    for (ip = names; ip != NULL; ip = ip->next)
+    for (size_t i = 0; i < 15; i++)
     {
-        if (strcmp(s, ip->name) == 0)
+        if (StringEqual(s, signal_names[i]))
         {
-            break;
+            return signals[i];
         }
-        i++;
     }
 
-    DeleteItemList(names);
-
-    switch (i)
-    {
-    case cfa_hup:
-        return SIGHUP;
-    case cfa_int:
-        return SIGINT;
-    case cfa_trap:
-        return SIGTRAP;
-    case cfa_kill:
-        return SIGKILL;
-    case cfa_pipe:
-        return SIGPIPE;
-    case cfa_cont:
-        return SIGCONT;
-    case cfa_abrt:
-        return SIGABRT;
-    case cfa_stop:
-        return SIGSTOP;
-    case cfa_quit:
-        return SIGQUIT;
-    case cfa_term:
-        return SIGTERM;
-    case cfa_child:
-        return SIGCHLD;
-    case cfa_usr1:
-        return SIGUSR1;
-    case cfa_usr2:
-        return SIGUSR2;
-    case cfa_bus:
-        return SIGBUS;
-    case cfa_segv:
-        return SIGSEGV;
-    default:
-        return -1;
-    }
-
+    return -1;
 }
 
 ContextScope ContextScopeFromString(const char *scope_str)

--- a/libpromises/mod_process.c
+++ b/libpromises/mod_process.c
@@ -72,7 +72,8 @@ static const ConstraintSyntax processes_constraints[] =
     ConstraintSyntaxNewString("process_stop", CF_ABSPATHRANGE, "A command used to stop a running process", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewString("restart_class", CF_IDRANGE,
      "A class to be defined globally if the process is not running, so that a command: rule can be referred to restart the process", SYNTAX_STATUS_NORMAL),
-    ConstraintSyntaxNewOptionList("signals", CF_SIGNALRANGE, "A list of menu options representing signals to be sent to a process", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewStringList("signals", "(hup|int|trap|kill|pipe|cont|abrt|stop|quit|term|child|usr1|usr2|bus|segv|[0-9]+s?)",
+                                  "A list of strings representing signals to be sent to a process or sleep periods", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewNull()
 };
 


### PR DESCRIPTION
3.18.x version of https://github.com/cfengine/core/pull/4936