### PR TITLE
CFE-3916: content files promises now creates files by default

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -546,6 +546,22 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
             result = PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
             goto exit;
         }
+
+        /* Files promises that promise full file content shall create files by
+         * default, unless `create => "false"` is specified. */
+        if (!exists && !CreateFalseWasSpecified(pp))
+        {
+            exists = CfCreateFile(ctx, path, pp, &a, &result);
+        }
+
+        if (!exists)
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Cannot render file '%s' with content '%s': file does not exist",
+                path, a.content);
+            goto exit;
+        }
+
         Log(LOG_LEVEL_VERBOSE, "Replacing '%s' with content '%s'",
             path, a.content);
 

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -662,6 +662,7 @@ static PromiseResult WriteContentFromString(EvalContext *ctx, const char *path, 
 {
     assert(path != NULL);
     assert(attr != NULL);
+    assert(attr->content != NULL);
 
     const char *changes_path = path;
     if (ChrootChanges())
@@ -670,12 +671,6 @@ static PromiseResult WriteContentFromString(EvalContext *ctx, const char *path, 
     }
 
     PromiseResult result = PROMISE_RESULT_NOOP;
-
-    if (attr->content == NULL)
-    {
-        RecordFailure(ctx, pp, attr, "'content' not set for promiser: '%s'", path);
-        return PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
-    }
 
     unsigned char existing_content_digest[EVP_MAX_MD_SIZE + 1] = { 0 };
     if (access(changes_path, R_OK) == 0)

--- a/tests/acceptance/10_files/01_create/content_create_by_default.cf
+++ b/tests/acceptance/10_files/01_create/content_create_by_default.cf
@@ -1,0 +1,110 @@
+##############################################################################
+#
+# content files promises shall create files by default unless `create =>
+# "false"` is specified.
+#
+##############################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+##############################################################################
+
+bundle agent init
+{
+  vars:
+      "delete_range"
+        slist => { expandrange("[1-3]", 1) };
+      "create_range"
+        slist => { expandrange("[4-6]", 1) };
+
+  files:
+      "$(G.testfile)_$(delete_range)"
+        delete => tidy;
+      "$(G.testfile)_$(create_range)"
+        create => "true";
+}
+
+##############################################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-3916" }
+        string => "files with content attribute shall create promiser by default";
+
+  files:
+    # File should be created by default
+      "$(G.testfile)_1"
+        content => "Hello World!";
+
+      "$(G.testfile)_2"
+        create => "true",
+        content => "Hello World!";
+
+      "$(G.testfile)_3"
+        create => "false",
+        content => "Hello World!";
+
+      "$(G.testfile)_4"
+        content => "Hello World!";
+
+      "$(G.testfile)_5"
+        create => "true",
+        content => "Hello World!";
+
+      "$(G.testfile)_6"
+        create => "false",
+        content => "Hello World!";
+}
+
+##############################################################################
+
+bundle agent check
+{
+  vars:
+    # Get lists of successful / failed checks so we can report them
+      "checks"
+        slist => { expandrange("check_[1-6]", 1) };
+      "successful_checks"
+        slist => sort(classesmatching("check_[1-6]"), "lex");
+      "failed_checks"
+        slist => sort(difference("checks", "successful_checks"), "lex");
+
+  classes:
+      "check_1"
+        expression => strcmp(readfile("$(G.testfile)_1"), "Hello World!"),
+        if => fileexists("$(G.testfile)_1");
+      "check_2"
+        expression => strcmp(readfile("$(G.testfile)_2"), "Hello World!"),
+        if => fileexists("$(G.testfile)_2");
+      "check_3"
+        expression => not(fileexists("$(G.testfile)_3"));
+      "check_4"
+        expression => strcmp(readfile("$(G.testfile)_4"), "Hello World!"),
+        if => fileexists("$(G.testfile)_4");
+      "check_5"
+        expression => strcmp(readfile("$(G.testfile)_5"), "Hello World!"),
+        if => fileexists("$(G.testfile)_5");
+      "check_6"
+        expression => strcmp(readfile("$(G.testfile)_6"), "Hello World!"),
+        if => fileexists("$(G.testfile)_6");
+      "ok"
+        expression => and("check_1", "check_2", "check_3", "check_4",
+                          "check_5", "check_6");
+
+  methods:
+    "Pass/Fail"
+      usebundle => dcs_passif("ok", $(this.promise_filename)),
+      inherit => "true"; # We want dcs_passif to inhert bundle scoped classes from our check bundle
+    
+  reports:
+    DEBUG::
+      "'$(successful_checks)' succeded!";
+      "'$(failed_checks)' failed!";
+
+}


### PR DESCRIPTION
```
root@hub:~# cat ~/content.cf 
bundle agent __main__
{
  files:
      "/tmp/test_1"
        content => "Hello one!$(const.n)";

      "/tmp/test_2"
        create => "true",
        content => "Hello two!$(const.n)";

      "/tmp/test_3"
        create => "false",
        content => "Hello three!$(const.n)";
}
root@hub:~# cf-agent -KIf ~/content.cf 
    info: Created file '/tmp/test_1', mode 0600
    info: Updated content of '/tmp/test_1' with content 'Hello one!
'
    info: Created file '/tmp/test_2', mode 0600
    info: Updated content of '/tmp/test_2' with content 'Hello two!
'
root@hub:~# cat /tmp/test_1
Hello one!
root@hub:~# cat /tmp/test_2
Hello two!
root@hub:~# cat /tmp/test_3
cat: /tmp/test_3: No such file or directory
```