### PR TITLE
CFE-3955 & CFE-3954: cfengine template method now creates files by default

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -574,8 +574,9 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
         }
         else
         {
-            RecordFailure(ctx, pp, &a, "Promised to edit '%s', but file does not exist", path);
-            result = PromiseResultUpdate(result, PROMISE_RESULT_FAIL);
+            Log(LOG_LEVEL_VERBOSE,
+                "Cannot render file '%s': file does not exist", path);
+            goto exit;
         }
     }
 

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -559,16 +559,8 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
 
     if (a.haveedit)
     {
-        /* Files promises that promise full file content - like the template
-         * methods 'mustache' and 'inline_mustache' - are exeptions to the
-         * normal behaviour related to the 'create' attribute. Instead we have
-         * the following behaviour:
-         *  - If `create => "true"` is specified; the file is created even
-         *    though rendering fails.
-         *  - If `create => "false"` is specified; the file is never created.
-         *  - If not specified; the file is created by default, but only upon
-         *    successful rendering.
-         */
+        /* Files promises that promise full file content shall create files by
+         * default, unless `create => "false"` is specified. */
         if (exists ||
             ((StringEqual(a.template_method, "mustache") ||
               StringEqual(a.template_method, "inline_mustache")) &&

--- a/tests/acceptance/10_files/01_create/cfengine_create_by_default.cf
+++ b/tests/acceptance/10_files/01_create/cfengine_create_by_default.cf
@@ -1,0 +1,126 @@
+##############################################################################
+#
+# template_method cfengine should create files by default, unless
+# `create => "false"` is specified.
+#
+##############################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+##############################################################################
+
+bundle agent init
+{
+  vars:
+      "range"
+        slist => { expandrange("[1-4]", 1) };
+
+  files:
+      "$(G.testfile).test_$(range)"
+        delete => tidy;
+
+      "$(G.testfile).test_5"
+        create => "true";
+
+      "$(G.testfile).valid_template"
+        content => "[%CFEngine BEGIN %]
+I have $(const.dollar)(sys.cpus) CPU's!
+[%CFEngine END %]
+";
+
+      "$(G.testfile).invalid_template"
+        content => "[%CFEngine BEGIN %]
+I have $(const.dollar)(sys.cpus) CPU's!
+[%CFEngine END %)
+";
+}
+
+##############################################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-3955" }
+        string => "template_method cfengine creates promiser by default";
+
+  files:
+    # File should be created by default and rendered with content
+      "$(G.testfile).test_1"
+        template_method => "cfengine",
+        edit_template => "$(G.testfile).valid_template",
+        if => fileexists("$(G.testfile).valid_template");
+
+    # File should not be created due to invalid template
+      "$(G.testfile).test_2"
+        template_method => "cfengine",
+        edit_template => "$(G.testfile).invalid_template",
+        if => fileexists("$(G.testfile).invalid_template");
+
+    # File should be created even though template is invalid
+      "$(G.testfile).test_3"
+        create => "true",
+        template_method => "cfengine",
+        edit_template => "$(G.testfile).invalid_template",
+        if => fileexists("$(G.testfile).invalid_template");
+
+    # File should not be created even though template is valid
+      "$(G.testfile).test_4"
+        create => "false",
+        template_method => "cfengine",
+        edit_template => "$(G.testfile).valid_template",
+        if => fileexists("$(G.testfile).valid_template");
+
+    # File should be rendered with content, since it already exists
+      "$(G.testfile).test_5"
+        create => "false",
+        template_method => "cfengine",
+        edit_template => "$(G.testfile).valid_template",
+        if => fileexists("$(G.testfile).valid_template");
+}
+
+##############################################################################
+
+bundle agent check
+{
+  vars:
+    # Get lists of successful / failed checks so we can report them
+      "checks"
+        slist => { expandrange("check_[1-5]", 1) };
+      "successful_checks"
+        slist => sort(classesmatching("check_[1-5]"), "lex");
+      "failed_checks"
+        slist => sort(difference("checks", "successful_checks"), "lex");
+
+  classes:
+      "check_1"
+        expression => regcmp("I have [0-9]+ CPU's!",
+                             readfile("$(G.testfile).test_1")),
+        if => fileexists("$(G.testfile).test_1");
+      "check_2"
+        expression => not(fileexists("$(G.testfile).test_2"));
+      "check_3"
+        expression => fileexists("$(G.testfile).test_3");
+      "check_4"
+        expression => not(fileexists("$(G.testfile).test_4"));
+      "check_5"
+        expression => regcmp("I have [0-9]+ CPU's!",
+                             readfile("$(G.testfile).test_5")),
+        if => fileexists("$(G.testfile).test_5");
+      "ok"
+        expression => and("check_1", "check_2", "check_3", "check_4",
+                          "check_5");
+
+  reports:
+    DEBUG::
+      "'$(successful_checks)' succeded!";
+      "'$(failed_checks)' failed!";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/10_files/templating/missing_file.cf
+++ b/tests/acceptance/10_files/templating/missing_file.cf
@@ -27,7 +27,7 @@ bundle agent test
       # Run subtests.  Need to be in verbose mode to see the output.
       # The full verbose output is too big for variable assignment here.
       # So extract (grep) only potentially interesting lines.
-      "subout" string => execresult("$(sys.cf_agent) -KI -b run -f $(this.promise_filename).sub 2>&1 | $(G.grep) '/no/such/file'", "useshell");
+      "subout" string => execresult("$(sys.cf_agent) -KIv -b run -f $(this.promise_filename).sub 2>&1 | $(G.grep) '/no/such/file'", "useshell");
 }
 
 
@@ -36,7 +36,7 @@ bundle agent test
 bundle agent check
 {
   vars:
-      "must_have" string => ".*Promised to edit.*but file does not exist.*";
+      "must_have" string => ".*Cannot render file '/no/such/file': file does not exist.*";
       "cant_have" string => ".*no longer access file.*";
 
   classes:


### PR DESCRIPTION
cfengine template method files promises now create files by default, unless `create => "false"` is specified. Files are not created if the rendering failes, unless `create => "true"` is specified.