### PR TITLE
Sleep after stopping Apache via apachectl

### DIFF
--- a/misc/systemd/cf-apache.service.in
+++ b/misc/systemd/cf-apache.service.in
@@ -9,7 +9,7 @@ PartOf=cfengine3.service
 [Service]
 Type=forking
 ExecStart=@workdir@/httpd/bin/apachectl start
-ExecStop=@workdir@/httpd/bin/apachectl stop
+ExecStop=@workdir@/httpd/bin/apachectl stop; sleep 2
 PIDFile=@workdir@/httpd/httpd.pid
 Restart=always
 RestartSec=10


### PR DESCRIPTION
This change works around the fact that apachectl stop returns before it
has actually completed stopping all httpd processes. A subsequent
promise can fail to re-start apache since there are still active
processes. Limited testing showed that the processes hung around for
less than one second, so hopefully a 2 second sleep after issuing stop
will be sufficient.

Ticket: ENT-8209

merge together: https://github.com/cfengine/masterfiles/pull/2279