### PR TITLE
Use Fedora 36 for static checks by default

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -1167,9 +1167,6 @@ static bool DeletePromisedLinesMatching(EvalContext *ctx, Item **start, Item *be
                     }
 
                     np = ip->next;
-                    free((char *) ip);
-
-                    lp = ip;
 
                     if (ip == *start)
                     {
@@ -1192,6 +1189,7 @@ static bool DeletePromisedLinesMatching(EvalContext *ctx, Item **start, Item *be
 
                         lp->next = np;
                     }
+                    free((char *) ip);
 
                     (edcontext->num_edits)++;
 

--- a/cf-agent/simulate_mode.c
+++ b/cf-agent/simulate_mode.c
@@ -750,13 +750,14 @@ bool DiffPkgOperations()
     while ((line = GetCsvLineNext(csv_file)) != NULL)
     {
         Seq *fields = SeqParseCsvString(line);
-        free(line);
         if ((fields == NULL) || (SeqLength(fields) != 4))
         {
             Log(LOG_LEVEL_ERR, "Invalid package operation record: '%s'", line);
+            free(line);
             SeqDestroy(fields);
             continue;
         }
+        free(line);
 
         /* See RecordPkgOperationInChroot() */
         const char *op       = SeqAt(fields, 0);
@@ -941,13 +942,14 @@ bool ManifestPkgOperations()
     while ((line = GetCsvLineNext(csv_file)) != NULL)
     {
         Seq *fields = SeqParseCsvString(line);
-        free(line);
         if ((fields == NULL) || (SeqLength(fields) != 4))
         {
             Log(LOG_LEVEL_ERR, "Invalid package operation record: '%s'", line);
+            free(line);
             SeqDestroy(fields);
             continue;
         }
+        free(line);
 
         /* See RecordPkgOperationInChroot() */
         const char *op       = SeqAt(fields, 0);

--- a/libpromises/syslog_client.c
+++ b/libpromises/syslog_client.c
@@ -120,7 +120,7 @@ void RemoteSysLog(int log_priority, const char *log_string)
             snprintf(
                 message,
                 sizeof(message),
-                "<%i>%.15s %s %s[%ld]: %s",
+                "<%i>%.15s %.256s %.256s[%ld]: %s",
                 (log_priority | SYSLOG_FACILITY),
                 (cf_strtimestamp_local(now, timebuffer) + 4), // Skips day str
                 VFQNAME,

--- a/tests/static-check/run.sh
+++ b/tests/static-check/run.sh
@@ -4,7 +4,7 @@ set -e
 trap "echo FAILURE" ERR
 
 if [ -z "$STATIC_CHECKS_FEDORA_VERSION" ]; then
-  default_f_ver="35"
+  default_f_ver="36"
   echo "No Fedora version for static checks specified, using the default (Fedora $default_f_ver)"
   BASE_IMG="fedora:$default_f_ver"
   STATIC_CHECKS_FEDORA_VERSION="$default_f_ver"


### PR DESCRIPTION
And fix the newly-discovered issues...

(the first 2 commits are from #4958)

Merge together:
https://github.com/cfengine/libntech/pull/160