### PR TITLE
CFE-3987 Added tests related to inserting text based on a location within select_region

### DIFF
--- a/tests/acceptance/31_tickets/CFE-3987/1/before_test.xml.txt
+++ b/tests/acceptance/31_tickets/CFE-3987/1/before_test.xml.txt
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+      <web-app xmlns="http://java.sun.com/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+      version="3.0"
+      metadata-complete="true">
+      <!-- General -->
+      <display-name>Atlassian JIRA Web Application</display-name>
+      <description>The Atlassian JIRA web application - see http://www.atlassian.com/software/jira for more information
+      </description>
+
+      <absolute-ordering />
+
+      <!-- Filters -->
+
+      <!-- Special filters that must come at the beginning of the chain because they prevent
+      all other filters from running.  This is to prevent those later filters from doing
+      lookups in Pico, which could alter the order in which it instantiates components
+      and thereby trigger a deadlock. -->
+
+      <filter>
+      <filter-name>JiraImportProgressFilter</filter-name>
+      <filter-class>com.atlassian.jira.web.filters.JiraImportProgressFilter</filter-class>
+      </filter>
+
+      <!-- ========================================================
+           THIS MUST BE THE FIRST FILTER IN THE NORMAL FILTER CHAIN
+           ======================================================== -->
+
+      <filter>
+      <filter-name>JiraFirstFilter</filter-name>
+      <filter-class>com.atlassian.jira.web.filters.JiraFirstFilter</filter-class>
+      </filter>
+
+      <!-- =====================================================
+           THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN
+           ===================================================== -->
+
+      <filter>
+      <filter-name>JiraLastFilter</filter-name>
+      <filter-class>com.atlassian.jira.web.filters.JiraLastFilter</filter-class>
+      </filter>
+
+      <!-- =====================================================
+           FILTER MAPPINGS FOLLOW :
+           ===================================================== -->
+
+</web-app>

--- a/tests/acceptance/31_tickets/CFE-3987/1/test.cf
+++ b/tests/acceptance/31_tickets/CFE-3987/1/test.cf
@@ -1,0 +1,72 @@
+body file control
+{
+        inputs => {
+                    "../../../default.cf.sub",
+        };
+}
+bundle agent __main__
+# If this is the policy entry (cf-agent --file) then this bundle will be run by default.
+{
+  methods:
+        "bundlesequence"  usebundle => default("$(this.promise_filename)");
+}
+
+bundle agent init
+{
+  files:
+      # Seed the file we will exercise the test on
+      "$(G.testfile)"
+        copy_from => local_dcp( "$(this.promise_dirname)/before_test.xml.txt" );
+}
+bundle agent test
+{
+  meta:
+      "description"
+        string => "edit_line doesn't insert text immediately before a selected region if a location body only explicitly sets before_after => 'before'",
+        meta => { "CFE-3987" };
+
+      "test_soft_fail"
+        string => "any",
+        meta => { "CFE-3987" };
+
+  vars:
+      "seed_file" string => "$(this.promise_dirname)/before_test.xml.txt";
+      "test_file" string => "$(G.testfile)";
+
+  files:
+    "$(test_file)"
+        edit_line => CFE_3987;
+}
+
+bundle agent check
+{
+  methods:
+      "Pass/FAIL"
+        usebundle => dcs_check_regcmp(
+                                       ".*INSERT\sME\R\s+<!--\s=+\R\s+THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN.*",
+                                       readfile( "$(test.test_file)" ),
+                                       $(this.promise_filename),
+                                       "no"
+        );
+}
+
+bundle edit_line CFE_3987
+{
+  insert_lines:
+      "INSERT ME"
+        select_region => my_comment_last_filter,
+        location => my_location_before;
+}
+body location my_location_before
+# @brief Editing occurs before the matched line (but here select_line_matching is not defined explicitly)
+{
+        before_after => "before";
+}
+
+body select_region my_comment_last_filter
+{
+        select_start => "\s+<!--.*";
+        select_end => "\s+THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN";
+        include_start_delimiter => "true";
+        select_end_match_eof => "false";
+}

--- a/tests/acceptance/31_tickets/CFE-3987/2/before_test.xml.txt
+++ b/tests/acceptance/31_tickets/CFE-3987/2/before_test.xml.txt
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+      <web-app xmlns="http://java.sun.com/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+      version="3.0"
+      metadata-complete="true">
+      <!-- General -->
+      <display-name>Atlassian JIRA Web Application</display-name>
+      <description>The Atlassian JIRA web application - see http://www.atlassian.com/software/jira for more information
+      </description>
+
+      <absolute-ordering />
+
+      <!-- Filters -->
+
+      <!-- Special filters that must come at the beginning of the chain because they prevent
+      all other filters from running.  This is to prevent those later filters from doing
+      lookups in Pico, which could alter the order in which it instantiates components
+      and thereby trigger a deadlock. -->
+
+      <filter>
+      <filter-name>JiraImportProgressFilter</filter-name>
+      <filter-class>com.atlassian.jira.web.filters.JiraImportProgressFilter</filter-class>
+      </filter>
+
+      <!-- ========================================================
+           THIS MUST BE THE FIRST FILTER IN THE NORMAL FILTER CHAIN
+           ======================================================== -->
+
+      <filter>
+      <filter-name>JiraFirstFilter</filter-name>
+      <filter-class>com.atlassian.jira.web.filters.JiraFirstFilter</filter-class>
+      </filter>
+
+      <!-- =====================================================
+           THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN
+           ===================================================== -->
+
+      <filter>
+      <filter-name>JiraLastFilter</filter-name>
+      <filter-class>com.atlassian.jira.web.filters.JiraLastFilter</filter-class>
+      </filter>
+
+      <!-- =====================================================
+           FILTER MAPPINGS FOLLOW :
+           ===================================================== -->
+
+</web-app>

--- a/tests/acceptance/31_tickets/CFE-3987/2/test.cf
+++ b/tests/acceptance/31_tickets/CFE-3987/2/test.cf
@@ -1,0 +1,69 @@
+body file control
+{
+        inputs => {
+                    "../../../default.cf.sub",
+        };
+}
+bundle agent __main__
+# If this is the policy entry (cf-agent --file) then this bundle will be run by default.
+{
+  methods:
+        "bundlesequence"  usebundle => default("$(this.promise_filename)");
+}
+
+bundle agent init
+{
+  files:
+      # Seed the file we will exercise the test on
+      "$(G.testfile)"
+        copy_from => local_dcp( "$(this.promise_dirname)/before_test.xml.txt" );
+}
+bundle agent test
+{
+  meta:
+      "description"
+        string => "Workaround for bug where edit_line doesn't insert text immediately before a selected region if a location body only explicitly sets before_after => 'before'",
+        meta => { "CFE-3987" };
+
+  vars:
+      "seed_file" string => "$(this.promise_dirname)/before_test.xml.txt";
+      "test_file" string => "$(G.testfile)";
+
+  files:
+    "$(test_file)"
+        edit_line => CFE_3987;
+}
+
+bundle agent check
+{
+  methods:
+      "Pass/FAIL"
+        usebundle => dcs_check_regcmp(
+                                       ".*INSERT\sME\R\s+<!--\s=+\R\s+THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN.*",
+                                       readfile( "$(test.test_file)" ),
+                                       $(this.promise_filename),
+                                       "no"
+        );
+}
+
+bundle edit_line CFE_3987
+{
+  insert_lines:
+      "INSERT ME"
+        select_region => my_comment_last_filter,
+        location => my_location_before;
+}
+body location my_location_before
+# @brief Editing occurs before the matched line (here select_line_matching is defined explicitly to match any line, and the default is to insert based on the first matching line (first_last defaults to first))
+{
+        before_after => "before";
+        select_line_matching => ".*";
+}
+
+body select_region my_comment_last_filter
+{
+        select_start => "\s+<!--.*";
+        select_end => "\s+THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN";
+        include_start_delimiter => "true";
+        select_end_match_eof => "false";
+}


### PR DESCRIPTION
This change adds two tests, the first (acceptance/31_tickets/CFE-3987/1/test.cf)
tests the behavior described by the related issue, inserting text before a
selected region should insert immediately before the selected region even if
select_line_matching is not explicitly specified. This test is currently set to soft fail.

The second (acceptance/31_tickets/CFE-3987/2/test.cf) tests the workaround where
after select_line_matching is explicitly defined, the text is inserted
immediately before the selected region. This test passes (as expected).