### PR TITLE
ENT-8818: Added test variables referencing non-existing namespaces do not crash

### DIFF
--- a/tests/acceptance/31_tickets/ENT-8818/1/README.org
+++ b/tests/acceptance/31_tickets/ENT-8818/1/README.org
@@ -1,0 +1,5 @@
+#+title: ENT-8818
+
+This test reproduces a crash (assert). Our test system does not support suppression of crashing tests, instead they must live in staging directories and be moved back out when they are fixed. This is unfortunate as it gives us little ability to run crahsing tests contunually and spot cases when they stop crashing un-expectedly.
+
+So, when a fix for this is ready, move staging/main.cf up to the level of this readme and delete this readme.

--- a/tests/acceptance/31_tickets/ENT-8818/1/staging/main.cf
+++ b/tests/acceptance/31_tickets/ENT-8818/1/staging/main.cf
@@ -1,0 +1,33 @@
+# NOTE: This test file must have it's be renamed from .x.cf to .cf when the bug is fixed.
+body file control
+{
+        inputs => {
+                    "../../../default.cf.sub",
+        };
+}
+bundle agent __main__
+# If this is the policy entry (cf-agent --file) then this bundle will be run by default.
+{
+  methods:
+        "bundlesequence"  usebundle => default("$(this.promise_filename)");
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "ENT-8818" }
+        string => "Referencing variables in a namespace that does not exist should not cause the agent to crash";
+
+  reports:
+      # NOTE: Here in the last variable I misspelled default as defult which is how I originally found this bug.
+
+      "In $(this.namespace):$(this.bundle) $(const.dollar)(default:sys.cf_version_major) == $(defult:sys.cf_version_major)";
+}
+
+bundle agent check
+{
+  methods:
+
+      # If we make ti this far we pass.
+      "Pass" usebundle => dcs_pass( $(this.promise_filename) );
+}


### PR DESCRIPTION
This test exercises a bug that causes the agent to crash with an error like:

cf-agent: eval_context.c:2233: GetVariableTableForScope: Assertion `!ns || strcmp("default", ns) == 0' failed.