### PR TITLE
Git ignored emacs flycheck temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,9 @@ cscope.*
 /contrib/*.elc
 /contrib/vagrant-ci/centos-7-x64/.vagrant
 
+## Flycheck
+flycheck_*
+
 # eclipse
 .cproject
 .project


### PR DESCRIPTION
This change prevents temporary files created by emacs flycheck from being
considered by git, mucking up git status output.

Changelog: None