### PR TITLE
CFE-2367: Added tests that fileexists does not error fatally when given an undefined var parameter

### DIFF
--- a/tests/acceptance/31_tickets/CFE-2367/1/test.cf
+++ b/tests/acceptance/31_tickets/CFE-2367/1/test.cf
@@ -1,0 +1,34 @@
+body file control
+{
+        inputs => {
+                    "../../../default.cf.sub",
+        };
+}
+bundle agent __main__
+# If this is the policy entry (cf-agent --file) then this bundle will be run by default.
+{
+  methods:
+        "bundlesequence"  usebundle => default("$(this.promise_filename)");
+}
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2367" }
+        string => "cf-agent should not fatally error when fileexists() is given an undefined variable as a parameter";
+
+  files:
+    "$(G.testfile)"
+        content => "CFE-2367",
+        unless => fileexists( $(testfile) ); # testfile is not defined, in the
+                                             # original ticket filed this caused
+                                             # a fatal error
+}
+
+bundle agent check
+{
+  methods:
+      # Since this was testing for the absence of a fatal error, if we get to
+      # this point, we pass.
+      "Pass"
+        usebundle => dcs_pass("$(this.promise_filename)" );
+}

--- a/tests/acceptance/31_tickets/CFE-2367/2/test.cf
+++ b/tests/acceptance/31_tickets/CFE-2367/2/test.cf
@@ -1,0 +1,40 @@
+body file control
+{
+        inputs => {
+                    "../../../default.cf.sub",
+        };
+}
+bundle agent __main__
+# If this is the policy entry (cf-agent --file) then this bundle will be run by default.
+{
+  methods:
+        "bundlesequence"  usebundle => default("$(this.promise_filename)");
+}
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2367" }
+        string => "cf-agent should not fatally error when fileexists() is given an undefined variable as a parameter";
+
+  files:
+    "$(G.testfile)"
+        content => "CFE-2367",
+        unless => and( fileexists( $(testfile) ) ); # testfile is not defined,
+                                                    # in the original ticket
+                                                    # filed this caused a fatal
+                                                    # error and the workaround
+                                                    # was to wrap the function
+                                                    # call with and(), so we
+                                                    # simply test that as in the
+                                                    # original case, there is no
+                                                    # fatal error.
+}
+
+bundle agent check
+{
+  methods:
+      # Since this was testing for the absence of a fatal error, if we get to
+      # this point, we pass.
+      "Pass"
+        usebundle => dcs_pass("$(this.promise_filename)" );
+}


### PR DESCRIPTION
Adding tests for CFE-2367 posthumously since I found this is no longer happening but the ticket was never closed.
