### PR TITLE
ENT-8819 Do not unshallow git repo in Travis script - 3.15.x

### DIFF
--- a/travis-scripts/script.sh
+++ b/travis-scripts/script.sh
@@ -18,11 +18,10 @@ INSTDIR=$HOME/cf_install
 #     exit 0
 # fi
 
-# Unshallow the clone. Fetch the tags from upstream even if we are on a
+# Fetch the tags from upstream even if we are on a
 # foreign clone. Needed for determine-version.sh to work.
-git fetch --unshallow
 git remote add upstream https://github.com/cfengine/core.git  \
-    && git fetch upstream 'refs/tags/*:refs/tags/*'
+    && git fetch --no-recurse-submodules upstream 'refs/tags/*:refs/tags/*'
 
 if [ "$TRAVIS_OS_NAME" = osx ]
 then


### PR DESCRIPTION
New version of determitne-version.sh doesn't need it

Also, stop fetching submodules recursevely

IDK how it worked before, but recently Travis started failing with an error like this:

	Fetching submodule libntech
	fatal: remote error: upload-pack: not our ref 54e12b54a0be037b8fab70433c29194debcb1c91
	Errors during submodule fetch:
		libntech

(cherry picked from commit 29567b8ecb8e6014fd1a80c9304ac551a86c0327)