### PR TITLE
[3.15.x] Fixes for the cfengine_action_script_t domain

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -674,7 +674,7 @@ typeattribute cfengine_action_script_exec_t exec_type;
 typeattribute cfengine_action_script_exec_t file_type, non_security_file_type, non_auth_file_type;
 role object_r types cfengine_action_script_exec_t;
 
-type_transition init_t cfengine_action_script_exec_t:process cfengine_action_script_t;
+type_transition cfengine_httpd_t cfengine_action_script_exec_t:process cfengine_action_script_t;
 allow cfengine_httpd_t cfengine_action_script_t:process transition;
 allow cfengine_httpd_t cfengine_action_script_exec_t:file { execute execute_no_trans getattr open read };
 allow cfengine_httpd_t cfengine_action_script_t:process siginh;


### PR DESCRIPTION
It should be entered by a transition from the cfengine_httpd_t
domain not from init_t.

(cherry picked from commit 2646f98e1948dede617e2f15e51e9fdd1f194dc9)