### PR TITLE
Load the legacy provider on OpenSSL 3+

### DIFF
--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -29,6 +29,10 @@
 #include <openssl/bn.h>                                         /* BN_* */
 #include <libcrypto-compat.h>
 
+#if OPENSSL_VERSION_NUMBER > 0x30000000
+#include <openssl/provider.h>                                   /* OSSL_PROVIDER_* */
+#endif
+
 #include <cf3.defs.h>
 #include <lastseen.h>
 #include <files_interfaces.h>
@@ -74,6 +78,13 @@ void CryptoInitialize()
         OpenSSL_add_all_digests();
         ERR_load_crypto_strings();
 
+#if OPENSSL_VERSION_NUMBER > 0x30000000
+        /* We need Blowfish for legacy encrypted network stuff and in OpenSSL
+         * 3+, it's only available when the legacy provider is loaded. And we
+         * also need the default provider. */
+        OSSL_PROVIDER_load(NULL, "legacy");
+        OSSL_PROVIDER_load(NULL, "default");
+#endif
         RandomSeed();
 
         crypto_initialized = true;


### PR DESCRIPTION
The legacy encrypted network stuff on community uses Blowfish
which is only provided by the legacy provider in OpenSSL 3+.