### PR TITLE
ENT-7362 Skip tests that require reverse lookup of localhost on Ubuntu 22 (3.18)

### DIFF
--- a/tests/acceptance/16_cf-serverd/serial/simple_copy_from_admit_localhost.cf
+++ b/tests/acceptance/16_cf-serverd/serial/simple_copy_from_admit_localhost.cf
@@ -10,13 +10,14 @@ bundle agent test
 {
   meta:
       "test_suppress_fail" string => "windows",
-        meta => { "redmine6405" };
+        meta => { "redmine6405", "ENT-2480"};
 
       # Ubuntu 20 (at least our build machines) doesn't know how to resolve
       # 127.0.0.1/::1 to localhost, the reverse lookup fails and so
       # 'admit => { "localhost" };' and 'admit_hostnames => { "localhost" };'
       # are not enough to allow access for this test.
-      "test_skip_unsupported" string => "ubuntu_20";
+      "test_skip_unsupported" string => "(ubuntu_20|ubuntu_22)",
+        meta => { "ENT-2480", "ENT-7362" };
 
   methods:
       # source file

--- a/tests/acceptance/16_cf-serverd/serial/simple_copy_from_deny_localhost.cf
+++ b/tests/acceptance/16_cf-serverd/serial/simple_copy_from_deny_localhost.cf
@@ -10,13 +10,14 @@ bundle agent test
 {
   meta:
       "test_suppress_fail" string => "windows",
-        meta => { "redmine6405" };
+        meta => { "redmine6405", "ENT-2480"};
 
       # Ubuntu 20 (at least our build machines) doesn't know how to resolve
       # 127.0.0.1/::1 to localhost, the reverse lookup fails and so
       # 'deny => { "localhost" };' and 'deny_hostnames => { "localhost" };'
       # are not enough to deny access for this test.
-      "test_skip_unsupported" string => "ubuntu_20";
+      "test_skip_unsupported" string => "(ubuntu_20|ubuntu_22)",
+        meta => { "ENT-2480", "ENT-7362" };
 
   methods:
       # source file


### PR DESCRIPTION
See https://github.com/cfengine/core/commit/b1797df53cb1f95e5af2bdf83f5e174901f06393

Ubuntu 20 and 22 fail to resolve 127.0.0.1/::1 to localhost
and so we must skip these two tests.

Ticket: ENT-7362
Changelog: none
(cherry picked from commit be7b592b51b8ac44c72109a3274efa8d38f7344e)


https://github.com/cfengine/buildscripts/pull/1098
https://github.com/cfengine/core/pull/4991