### PR TITLE
ENT-7008: Define '$(this.promiser)' for checking if/unless in 'files' promises

### DIFF
--- a/tests/acceptance/01_vars/01_basic/this_promiser_ifvarclass.cf
+++ b/tests/acceptance/01_vars/01_basic/this_promiser_ifvarclass.cf
@@ -22,10 +22,6 @@ bundle agent test
         string => "Test that it is possible to use this.promiser in ifvarclass.",
         meta => { "redmine#7880", "CFE-2262" };
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "CFE-2262" };
-
   files:
     # I should be able to use this.promiser to check if the file is a plain
     # file


### PR DESCRIPTION
Just like for other promise types, use the real promiser from the
policy file (with variables expanded) for if/ifvarclass/unless
checking and then undefine it again to let the special behavior
of '$(this.promiser)' in 'files' promises take part.

Ticket: ENT-7008
Ticket: CFE-2262
Changelog: '$(this.promiser)' can now be used in 'files' promise
                   attributes 'if', 'ifvarclass' and 'unless'