### PR TITLE
ENT-8788: Respect 'file_preserve_block' and 'preserve_all_lines' in InsertLineAtLocation()

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -2009,7 +2009,14 @@ static bool InsertLineAtLocation(EvalContext *ctx, char *newline, Item **start, 
 
 /* Check line neighbourhood in whole file to avoid edge effects, iff we are not preseving block structure */
 
-{   int preserve_block = StringEqual(a->sourcetype, "preserve_block");
+{
+    assert(start != NULL);
+    assert(a != NULL);
+    assert(edcontext != NULL);
+
+    bool preserve_block = (StringEqual(a->sourcetype, "preserve_block") ||
+                           StringEqual(a->sourcetype, "file_preserve_block") ||
+                           StringEqual(a->sourcetype, "preserve_all_lines"));
 
     if (!prev)      /* Insert at first line */
     {

--- a/tests/acceptance/31_tickets/ENT-8788/1/main.cf
+++ b/tests/acceptance/31_tickets/ENT-8788/1/main.cf
@@ -18,10 +18,6 @@ bundle agent test
         string => "Inserting content that contains blank lines with file_preserve_block before select_line_matching does not split inserted content before and after select_line_matching",
         meta => { "ENT-8788" };
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "ENT-8788" };
-
   vars:
       "test_file" string => "$(this.promise_dirname)/start.xml.txt";
       "new_content_file" string => "$(this.promise_dirname)/newcontent.xml.txt";


### PR DESCRIPTION
Ticket: ENT-8788
Changelog: Insertion of contents of a file with blank lines into
           another file with blank lines no longer results in
           mixed content