### PR TITLE
[3.18.x] ENT-7008: Define '$(this.promiser)' for checking if/unless in 'files' promises

### DIFF
--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -586,8 +586,7 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
     pcopy->promiser = RvalScalarValue(returnval);
 
     /* TODO remove the conditions here for fixing redmine#7880. */
-    if ((strcmp("files", PromiseGetPromiseType(pp)) != 0) &&
-        (strcmp("storage", PromiseGetPromiseType(pp)) != 0))
+    if (!StringEqual("storage", PromiseGetPromiseType(pp)))
     {
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_THIS, "promiser", pcopy->promiser,
                                       CF_DATA_TYPE_STRING, "source=promise");
@@ -724,6 +723,17 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
                 }
             }
         }
+    }
+
+    /* NOTE: We have to undefine the '$(this.promiser)' variable for a 'files'
+     *       promise now because it is later defined for the individual
+     *       expansions of the promise and so it has to be left unexpanded in
+     *       the constraints/attributes. It is, however, defined above just like
+     *       for any other promise so that it can be used in the common
+     *       if/ifvarclass/unless checking. */
+    if (StringEqual(PromiseGetPromiseType(pp), "files"))
+    {
+        EvalContextVariableRemoveSpecial(ctx, SPECIAL_SCOPE_THIS, "promiser");
     }
 
     /* Evaluate all constraints. */

--- a/tests/acceptance/01_vars/01_basic/this_promiser_ifvarclass.cf
+++ b/tests/acceptance/01_vars/01_basic/this_promiser_ifvarclass.cf
@@ -22,10 +22,6 @@ bundle agent test
         string => "Test that it is possible to use this.promiser in ifvarclass.",
         meta => { "redmine#7880", "CFE-2262" };
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "CFE-2262" };
-
   files:
     # I should be able to use this.promiser to check if the file is a plain
     # file


### PR DESCRIPTION
Just like for other promise types, use the real promiser from the
policy file (with variables expanded) for if/ifvarclass/unless
checking and then undefine it again to let the special behavior
of '$(this.promiser)' in 'files' promises take part.

Ticket: ENT-7008
Ticket: CFE-2262
Changelog: '$(this.promiser)' can now be used in 'files' promise
           attributes 'if', 'ifvarclass' and 'unless'
(cherry picked from commit 433c193b7d4b4fefc623a505251848b344d6af58)