### PR TITLE
Enable use of the 'meta' attribute with custom promises

### DIFF
--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -666,7 +666,8 @@ static void PromiseModule_AppendAllAttributes(
             || StringEqual(name, "ifvarclass")
             || StringEqual(name, "unless")
             || StringEqual(name, "depends_on")
-            || StringEqual(name, "with"))
+            || StringEqual(name, "with")
+            || StringEqual(name, "meta"))
         {
             // Evaluated by agent and not sent to module, skip
             continue;
@@ -746,7 +747,8 @@ static inline bool CustomPromise_IsFullyResolved(const EvalContext *ctx, const P
     for (size_t i = 0; i < attributes; i++)
     {
         const Constraint *attribute = SeqAt(pp->conlist, i);
-        if (IsClassesBodyConstraint(attribute->lval))
+        if (IsClassesBodyConstraint(attribute->lval) ||
+            StringEqual(attribute->lval, "meta"))
         {
             /* Not passed to the modules, handled on the agent side. */
             continue;

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2688,8 +2688,7 @@ static bool ValidateCustomPromise(const Promise *pp, Seq *errors)
                     promise_type));
             valid = false;
         } else if (StringEqual(name, "action_policy")
-            || StringEqual(name, "expireafter")
-            || StringEqual(name, "meta"))
+                   || StringEqual(name, "expireafter"))
         {
             // TODO: Remove 1 attribute at a time, test and fix.
             //       https://tracker.mender.io/browse/CFE-3392

--- a/tests/acceptance/30_custom_promise_types/05_meta_attr.cf
+++ b/tests/acceptance/30_custom_promise_types/05_meta_attr.cf
@@ -1,0 +1,99 @@
+######################################################
+#
+#  Basic test of custom promise types / promise modules checking that using a
+#  'meta' attribute in combination with a custom promise works (i.e. doesn't
+#  crash).
+#
+#####################################################
+body common control
+{
+    inputs => { "../default.cf.sub" };
+    bundlesequence  => { default("$(this.promise_filename)") };
+    version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  files:
+    "$(G.testfile)"
+      delete => init_delete;
+}
+
+body delete init_delete
+{
+      dirlinks => "delete";
+      rmdirs   => "true";
+}
+
+#######################################################
+
+promise agent example
+{
+    interpreter => "/bin/bash";
+    path => "$(this.promise_dirname)/example_module.sh";
+}
+
+body classes example
+{
+        promise_repaired => { "example_promise_repaired" };
+}
+
+bundle agent test
+{
+  meta:
+    "description" -> { "CFE-3440" }
+      string => "Test that you can use a meta attribute with a custom promise";
+
+  vars:
+    "test_string"
+      string => "hello, modules";
+
+  example:
+    cfengine::
+      "$(G.testfile)"
+        message => "$(test_string)",
+        classes => example,
+        meta => { "tag1", "tag2" };
+
+  classes:
+      "file_created"
+        expression => canonify("$(G.testfile)_created"),
+        scope => "namespace";
+      "file_updated"
+        expression => canonify("$(G.testfile)_content_updated"),
+        scope => "namespace";
+      "file_update_failed"
+        expression => canonify("$(G.testfile)_content_update_failed"),
+        scope => "namespace";
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "file_ok"
+        expression => strcmp("$(test.test_string)", readfile("$(G.testfile)")),
+        if => fileexists("$(G.testfile)");
+
+      "ok" expression => "file_ok.file_created.file_updated.(!file_update_failed).example_promise_repaired";
+
+  reports:
+    DEBUG.file_ok::
+      "file_ok";
+    DEBUG.file_created::
+      "file_created";
+    DEBUG.file_updated::
+      "file_updated";
+    DEBUG.file_update_failed::
+      "file_update_failed";
+    DEBUG.example_promise_repaired::
+      "example_promise_repaired";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Resulting in no special behavior or handling, just like for all
the other promise types except 'vars' and 'classes'.

Ticket: CFE-3440
Changelog: 'meta' attribute can now be used in custom promises