### PR TITLE
ENT-9039: Fixed git_cfbs_deploy_refspec in masterfiles_stage leaving temp dir (3.18)

### DIFF
--- a/contrib/masterfiles-stage/common.sh
+++ b/contrib/masterfiles-stage/common.sh
@@ -254,6 +254,7 @@ git_cfbs_deploy_refspec() {
       # If the above command fails we will have an extra temp dir left.  Otherwise not.
     mv "${temp_stage}/out/masterfiles" "${1}"          || error_exit "Can't mv ${temp_stage}/out/masterfiles to ${1}"
     cp "${temp_stage}/cfbs.json" "${1}"          || error_exit "Can't cp ${temp_stage}/cfbs.json to ${1}"
+    rm -rf "${temp_stage}"
     rm -rf "${third_dir}"
     trap -- EXIT
   fi


### PR DESCRIPTION
in git_deploy_refspec ${temp_stage} is moved entirely to ${1} (the target aka /var/cfengine/masterfiles)

But in git_cfbs_deploy_refspec only out/masterfiles is moved so the directory is left.

Ticket: ENT-9039
Changelog: title
(cherry picked from commit 64f6f919c1b463ba4fe5de0fa9b107360ca3126c)