### PR TITLE
ENT-9050: Removed assert in cf-check dump.c

### DIFF
--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -47,7 +47,6 @@ static void print_json_string(
     const char *const data, size_t size, const bool strip_strings)
 {
     assert(data != NULL);
-    assert(size != 0); // Don't know of anything we store which can be size 0
 
     printf("\"");
     if (size == 0)


### PR DESCRIPTION
in print_json_string() we had

assert(size != 0); // Don't know of anything we store which can be size 0

in cf-agent/package_module.c:744-754 we have had for 7 years that we can
write an empty value if no software updates are available:

https://github.com/cfengine/core/commit/ef097b847aa236811bbbaa48569a38499a621268

        /* We can have empty list of installed software or available updates. */
        if (!inventory_list)
        {
            WriteDB(db_cached, inventory_key, "\n", 1);
        }

So here we adjust cf-check's asserts since print_json_string() already handles
zero size by printing an empty.

Ticket: ENT-9050
Changelog: title