### PR TITLE
ENT-9050: Address package cache lmdb validation issues in valgrind-check (3.18)

### DIFF
--- a/cf-agent/package_module.c
+++ b/cf-agent/package_module.c
@@ -742,7 +742,7 @@ int UpdatePackagesDB(Rlist *data, const char *pm_name, UpdateType type)
         char *inventory_list = BufferClose(inventory_data);
 
         /* We can have empty list of installed software or available updates. */
-        if (!inventory_list)
+        if (!inventory_list || inventory_list[0] == '\0')
         {
             WriteDB(db_cached, inventory_key, "\n", 1);
         }
@@ -750,6 +750,9 @@ int UpdatePackagesDB(Rlist *data, const char *pm_name, UpdateType type)
         {
             WriteDB(db_cached, inventory_key, inventory_list,
                     strlen(inventory_list));
+        }
+        if (inventory_list)
+        {
             free(inventory_list);
         }
 

--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -829,6 +829,7 @@ bool DBPrivWrite(
 {
     assert(db != NULL);
     assert(key_size >= 0);
+    assert(value_size > 0); // to match cf-check validate assumptions
 
     DBTxn *txn;
     int rc = GetWriteTransaction(db, &txn);


### PR DESCRIPTION
Ticket: ENT-9050
Changelog: none
(in each of two commits instead)