### PR TITLE
ENT-9050: Adjust cf-check and package module code for empty updates list (3.15)

### DIFF
--- a/cf-agent/package_module.c
+++ b/cf-agent/package_module.c
@@ -741,9 +741,9 @@ int UpdatePackagesDB(Rlist *data, const char *pm_name, UpdateType type)
         char *inventory_list = BufferClose(inventory_data);
 
         /* We can have empty list of installed software or available updates. */
-        if (!inventory_list)
+        if (inventory_list == NULL)
         {
-            WriteDB(db_cached, inventory_key, "\n", 1);
+            WriteDB(db_cached, inventory_key, "", 0);
         }
         else
         {

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -47,7 +47,6 @@ static void print_json_string(
     const char *const data, size_t size, const bool strip_strings)
 {
     assert(data != NULL);
-    assert(size != 0); // Don't know of anything we store which can be size 0
 
     printf("\"");
     if (size == 0)


### PR DESCRIPTION
In some cases the response from the module results in empty
data and sometimes no data at all. Not sure why.

Regardless it makes sense to refactor the package module handling
code to save the updates <inventory> key with a zero length value
in this case instead of sometimes a zero length and sometimes a
`\n` (newline) character.

Adjusted cf-check to allow zero length values in both dump and
validate portions of the code.

Ticket: ENT-9050
Changelog: title
(cherry picked from commit aebabc46e7adc63d000fa1b0eb4f673fe9273235)