### PR TITLE
[3.18.x] ENT-9018: Make sure cipher list strings don't have trailing colons

### DIFF
--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -1021,8 +1021,22 @@ bool TLSSetCipherList(SSL_CTX *ssl_ctx, const char *cipher_list)
         }
     }
 
+    /* The above code can leave a trailing colon in the lists because it copies
+     * the items over *with* the colons splitting them. */
+    if ((ciphers_len > 0) && (ciphers[ciphers_len - 1] == ':'))
+    {
+        ciphers[ciphers_len - 1] = '\0';
+        ciphers_len--;
+    }
+    if ((cipher_suites_len > 0) && (cipher_suites[cipher_suites_len - 1] == ':'))
+    {
+        cipher_suites[cipher_suites_len - 1] = '\0';
+        cipher_suites_len--;
+    }
+
     if (ciphers_len != 0)       /* TLS <= 1.2 ciphers */
     {
+        Log(LOG_LEVEL_VERBOSE, "Enabling ciphers '%s' for TLS 1.2 and older", ciphers);
         int ret = SSL_CTX_set_cipher_list(ssl_ctx, ciphers);
         if (ret != 1)
         {
@@ -1034,6 +1048,7 @@ bool TLSSetCipherList(SSL_CTX *ssl_ctx, const char *cipher_list)
 #ifdef HAVE_TLS_1_3
     if (cipher_suites_len != 0) /* TLS >= 1.3 ciphers */
     {
+        Log(LOG_LEVEL_VERBOSE, "Enabling cipher suites '%s' for TLS 1.3 and newer", cipher_suites);
         int ret = SSL_CTX_set_ciphersuites(ssl_ctx, cipher_suites);
         if (ret != 1)
         {

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_reordered_ciphers_success.cf
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_reordered_ciphers_success.cf
@@ -1,0 +1,23 @@
+body common control
+{
+      inputs => { "../../default.cf.sub", "../../run_with_server.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  methods:
+      # source file
+      "any" usebundle => file_make("$(G.testdir)/source_file",
+                                   "Source file to copy, always fresh, $(sys.date)");
+
+      # ensure destination files are not there
+      "any" usebundle => dcs_fini("$(G.testdir)/destfile1");
+
+      "any" usebundle => generate_key;
+
+      "any" usebundle => start_server("$(this.promise_dirname)/reordered_default_ciphers_tlsversion.srv");
+      "any" usebundle => run_test("$(this.promise_filename).sub");
+      "any" usebundle => stop_server("$(this.promise_dirname)/reordered_default_ciphers_tlsversion.srv");
+}

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_reordered_ciphers_success.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_reordered_ciphers_success.cf.sub
@@ -1,0 +1,47 @@
+#######################################################
+#
+# Tries to copy using TLS (which is default now), from two servers: one
+# with the default TLS ciphers list and another with a non-default very
+# restricted one.
+#
+# It should succeed in both cases since default client-side cipherlist
+# is OpenSSL's default, which is very broad.
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+
+      # Do not set this, just use the very broad OpenSSL default.
+      #
+      # tls_ciphers => "";
+}
+
+bundle agent init
+{
+}
+
+bundle agent test
+{
+  files:
+      # Server with reordered default "allowciphers"
+      "$(G.testdir)/destfile1"
+          copy_from => dcs_remote_cp("simple_source", "127.0.0.1", "9893"),
+          classes => classes_generic("copy1");
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "dummy"   expression => regextract("(.*)\.sub", $(this.promise_filename), "fn");
+      "exists1" expression => fileexists("$(G.testdir)/destfile1");
+
+  reports:
+
+    copy1_repaired.exists1::
+      "$(fn[1]) Pass";
+}

--- a/tests/acceptance/16_cf-serverd/serial/default_ciphers_tlsversion.srv
+++ b/tests/acceptance/16_cf-serverd/serial/default_ciphers_tlsversion.srv
@@ -16,8 +16,8 @@ body server control
 
 # Use the defaults, i.e. the following:
 #
-#      allowciphers    => "AES256-GCM-SHA384:AES256-SHA";
-#      allowtlsversion => "1.0";
+#      allowciphers    => "AES256-GCM-SHA384:AES256-SHA:TLS_AES_256_GCM_SHA384";
+#      allowtlsversion => "1.1";
 
       allowconnects         => { "127.0.0.1" , "::1" };
       allowallconnects      => { "127.0.0.1" , "::1" };

--- a/tests/acceptance/16_cf-serverd/serial/reordered_default_ciphers_tlsversion.srv
+++ b/tests/acceptance/16_cf-serverd/serial/reordered_default_ciphers_tlsversion.srv
@@ -1,0 +1,34 @@
+body common control
+{
+      bundlesequence => { "access_rules" };
+      inputs => { "../../default.cf.sub" };
+
+}
+
+#########################################################
+# Server config
+#########################################################
+
+body server control
+
+{
+      port => "9893";
+
+      # Use the defaults, but reordered:
+      allowciphers    => "TLS_AES_256_GCM_SHA384:AES256-GCM-SHA384:AES256-SHA";
+
+      allowconnects         => { "127.0.0.1" , "::1" };
+      allowallconnects      => { "127.0.0.1" , "::1" };
+      trustkeysfrom         => { "127.0.0.1" , "::1" };
+}
+
+#########################################################
+
+bundle server access_rules()
+
+{
+  access:
+      "$(G.testdir)/source_file"
+        admit    => { "127.0.0.1", "::1" },
+        shortcut => "simple_source";
+}


### PR DESCRIPTION
3.18.x backport of #5025.