### PR TITLE
Check if $with_libxml2/bin/xml2-config exists and is executable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -637,7 +637,9 @@ if test "x$with_libxml2" != "xno"; then
     fi
 
     if test "x$have_libxml2" = "xno"; then
-        if test "x$with_libxml2" != "xyes" && test "x$with_libxml2" != "xcheck"
+        if test "x$with_libxml2" != "xyes" &&
+           test "x$with_libxml2" != "xcheck" &&
+           test -x "$with_libxml2/bin/xml2-config"
         then
             XML2_CONFIG=$with_libxml2/bin/xml2-config
         else


### PR DESCRIPTION
Otherwise we rely on it and fail to get data from it. Not all our
builds provide xml2-config even when they use
'--with-libxml2=/var/cfengine'.

Ticket: ENT-9070
Changelog: None