### PR TITLE
Bump Travis to Ubuntu 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 os: linux
-dist: xenial
+dist: bionic
 
 # This is an addon for uploading artifacts to s3:
 # https://docs.travis-ci.com/user/uploading-artifacts/


### PR DESCRIPTION
Ubuntu 16.04 is no longer supported and it's using OpenSSL that
doesn't even support TLS 1.3.