### PR TITLE
[3.18.x] ENT-4617: Add tests for connections requiring TLS 1.3

### DIFF
--- a/tests/acceptance/16_cf-serverd/serial/copy_from_tls_1_3_fail.cf
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_tls_1_3_fail.cf
@@ -1,0 +1,32 @@
+body common control
+{
+      inputs => { "../../default.cf.sub", "../../run_with_server.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "test_skip_unsupported" string => "!feature_tls_1_3";
+
+      "description" -> {"ENT-4617"}
+        string => "Test that requiring TLS 1.3 works fine";
+
+  methods:
+      # source file
+      "any" usebundle => file_make("$(G.testdir)/source_file",
+                                   "Source file to copy, always fresh, $(sys.date)");
+
+      # ensure destination files are not there
+      "any" usebundle => dcs_fini("$(G.testdir)/destfile1");
+      "any" usebundle => dcs_fini("$(G.testdir)/destfile2");
+
+      "any" usebundle => generate_key;
+
+      "any" usebundle => start_server("$(this.promise_dirname)/no_tls_1_3.srv");
+      "any" usebundle => start_server("$(this.promise_dirname)/default_ciphers_tlsversion.srv");
+      "any" usebundle => run_test("$(this.promise_filename).sub");
+      "any" usebundle => stop_server("$(this.promise_dirname)/no_tls_1_3.srv");
+      "any" usebundle => stop_server("$(this.promise_dirname)/default_ciphers_tlsversion.srv");
+}

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_tls_1_3_fail.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_tls_1_3_fail.cf.sub
@@ -1,0 +1,48 @@
+#######################################################
+#
+# Tries to copy using TLS 1.3, from two servers:
+# - one not supporting TLS 1.3
+# - one with the defaults
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+
+      # Require TLS 1.3
+      tls_min_version => "1.3";
+}
+
+bundle agent init
+{
+}
+
+bundle agent test
+{
+  files:
+      # Server not supporting TLS 1.3
+      "$(G.testdir)/destfile1"
+          copy_from => dcs_remote_cp("simple_source", "127.0.0.1", "9895"),
+          classes => classes_generic("copy1");
+      # Server with default "allowciphers" and "allowtlsversion"
+      "$(G.testdir)/destfile2"
+          copy_from => dcs_remote_cp("simple_source", "127.0.0.1", "9889"),
+          classes => classes_generic("copy2");
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "dummy"   expression => regextract("(.*)\.sub", $(this.promise_filename), "fn");
+      "exists1" expression => fileexists("$(G.testdir)/destfile1");
+      "exists2" expression => fileexists("$(G.testdir)/destfile2");
+
+  reports:
+
+    (copy1_failed.copy2_repaired).(!exists1.exists2)::
+      "$(fn[1]) Pass";
+}

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_tls_1_3_success.cf
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_tls_1_3_success.cf
@@ -1,0 +1,32 @@
+body common control
+{
+      inputs => { "../../default.cf.sub", "../../run_with_server.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "test_skip_unsupported" string => "!feature_tls_1_3";
+
+      "description" -> {"ENT-4617"}
+        string => "Test that CFEngine connections over TLS 1.3 work fine";
+
+  methods:
+      # source file
+      "any" usebundle => file_make("$(G.testdir)/source_file",
+                                   "Source file to copy, always fresh, $(sys.date)");
+
+      # ensure destination files are not there
+      "any" usebundle => dcs_fini("$(G.testdir)/destfile1");
+      "any" usebundle => dcs_fini("$(G.testdir)/destfile2");
+
+      "any" usebundle => generate_key;
+
+      "any" usebundle => start_server("$(this.promise_dirname)/tls_1_3_only.srv");
+      "any" usebundle => start_server("$(this.promise_dirname)/default_ciphers_tlsversion.srv");
+      "any" usebundle => run_test("$(this.promise_filename).sub");
+      "any" usebundle => stop_server("$(this.promise_dirname)/tls_1_3_only.srv");
+      "any" usebundle => stop_server("$(this.promise_dirname)/default_ciphers_tlsversion.srv");
+}

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_tls_1_3_success.cf.sub
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_tls_1_3_success.cf.sub
@@ -1,0 +1,48 @@
+#######################################################
+#
+# Tries to copy using TLS 1.3, from two servers:
+# - one with only TLS 1.3 enabled
+# - one with the defaults
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+
+      # Require TLS 1.3
+      tls_min_version => "1.3";
+}
+
+bundle agent init
+{
+}
+
+bundle agent test
+{
+  files:
+      # Server only allowing TLS 1.3
+      "$(G.testdir)/destfile1"
+          copy_from => dcs_remote_cp("simple_source", "127.0.0.1", "9894"),
+          classes => classes_generic("copy1");
+      # Server with default "allowciphers" and "allowtlsversion"
+      "$(G.testdir)/destfile2"
+          copy_from => dcs_remote_cp("simple_source", "127.0.0.1", "9889"),
+          classes => classes_generic("copy2");
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "dummy"   expression => regextract("(.*)\.sub", $(this.promise_filename), "fn");
+      "exists1" expression => fileexists("$(G.testdir)/destfile1");
+      "exists2" expression => fileexists("$(G.testdir)/destfile2");
+
+  reports:
+
+    (copy1_repaired.copy2_repaired).(exists1.exists2)::
+      "$(fn[1]) Pass";
+}

--- a/tests/acceptance/16_cf-serverd/serial/no_tls_1_3.srv
+++ b/tests/acceptance/16_cf-serverd/serial/no_tls_1_3.srv
@@ -1,0 +1,35 @@
+body common control
+{
+      bundlesequence => { "access_rules" };
+      inputs => { "../../default.cf.sub" };
+
+}
+
+#########################################################
+# Server config
+#########################################################
+
+body server control
+
+{
+      port => "9895";
+
+      # Do not allow TLS 1.3 (no TLS 1.3 cipher suites listed below)
+      allowciphers    => "AES256-GCM-SHA384:AES256-SHA";
+      allowtlsversion => "1.1";
+
+      allowconnects         => { "127.0.0.1" , "::1" };
+      allowallconnects      => { "127.0.0.1" , "::1" };
+      trustkeysfrom         => { "127.0.0.1" , "::1" };
+}
+
+#########################################################
+
+bundle server access_rules()
+
+{
+  access:
+      "$(G.testdir)/source_file"
+        admit    => { "127.0.0.1", "::1" },
+        shortcut => "simple_source";
+}

--- a/tests/acceptance/16_cf-serverd/serial/tls_1_3_only.srv
+++ b/tests/acceptance/16_cf-serverd/serial/tls_1_3_only.srv
@@ -1,0 +1,35 @@
+body common control
+{
+      bundlesequence => { "access_rules" };
+      inputs => { "../../default.cf.sub" };
+
+}
+
+#########################################################
+# Server config
+#########################################################
+
+body server control
+
+{
+      port => "9894";
+
+      # Allow TLS 1.3 only
+      allowciphers    => "TLS_AES_256_GCM_SHA384";
+      allowtlsversion => "1.3";
+
+      allowconnects         => { "127.0.0.1" , "::1" };
+      allowallconnects      => { "127.0.0.1" , "::1" };
+      trustkeysfrom         => { "127.0.0.1" , "::1" };
+}
+
+#########################################################
+
+bundle server access_rules()
+
+{
+  access:
+      "$(G.testdir)/source_file"
+        admit    => { "127.0.0.1", "::1" },
+        shortcut => "simple_source";
+}


### PR DESCRIPTION
To make sure it actually works as expected.

Ticket: ENT-4617
Changelog: None
(cherry picked from commit 37f412596f4449e511de43367b811f873df550ad)