### PR TITLE
Core examples for simple small examples to files promise type docs

### DIFF
--- a/examples/files-content-if-fileexists.cf
+++ b/examples/files-content-if-fileexists.cf
@@ -1,0 +1,23 @@
+#+begin_src prep
+#@ ```
+#@ rm -f /tmp/hello && touch /tmp/hello
+#@ ```
+#+end_src
+#+begin_src cfengine3
+body agent control
+{
+        inform => "true";
+}
+bundle agent __main__
+{
+  files:
+    "/tmp/hello"
+      content => "Hello, CFEngine",
+      if => fileexists("/tmp/hello");
+}
+#+end_src
+#+begin_src example_output
+#@ ```
+#@    info: Updated file '/tmp/hello' with content 'Hello, CFEngine'
+#@ ```
+#+end_src

--- a/examples/files-content-with.cf
+++ b/examples/files-content-with.cf
@@ -1,0 +1,24 @@
+#+begin_src prep
+#@ ```
+#@ test -e /tmp/hello && rm /tmp/hello
+#@ ```
+#+end_src
+#+begin_src cfengine3
+body agent control
+{
+        inform => "true";
+}
+bundle agent __main__
+{
+  files:
+      "/tmp/hello"
+        content => "Output from stat: $(with)",
+        with => execresult( 'stat -c "%U" /', "useshell" );
+}
+#+end_src
+#+begin_src example_output
+#@ ```
+#@    info: Created file '/tmp/hello', mode 0600
+#@    info: Updated file '/tmp/hello' with content 'Output from stat: root'
+#@ ```
+#+end_src

--- a/examples/files-content.cf
+++ b/examples/files-content.cf
@@ -1,0 +1,23 @@
+#+begin_src prep
+#@ ```
+#@ test -e /tmp/hello && rm -f /tmp/hello
+#@ ```
+#+end_src
+#+begin_src cfengine3
+body agent control
+{
+        inform => "true";
+}
+bundle agent __main__
+{
+  files:
+    "/tmp/hello"
+      content => "Hello, CFEngine";
+}
+#+end_src
+#+begin_src example_output
+#@ ```
+#@    info: Created file '/tmp/hello', mode 0600
+#@    info: Updated file '/tmp/hello' with content 'Hello, CFEngine'
+#@ ```
+#+end_src

--- a/examples/files-create-class-expression.cf
+++ b/examples/files-create-class-expression.cf
@@ -1,0 +1,23 @@
+#+begin_src prep
+#@ ```
+#@ test -e /tmp/linux && rm /tmp/linux
+#@ ```
+#+end_src
+#+begin_src cfengine3
+body agent control
+{
+      inform => "true";
+}
+bundle agent __main__
+{
+  files:
+    linux::
+      "/tmp/linux"
+        create => "true";
+}
+#+end_src
+#+begin_src example_output
+#@ ```
+#@    info: Created file '/tmp/linux', mode 0600
+#@ ```
+#+end_src


### PR DESCRIPTION
Intended to replace the inline examples introduced to docs here: https://github.com/cfengine/documentation/pull/2877, see comment: https://github.com/cfengine/documentation/pull/2877#pullrequestreview-1101189833