### PR TITLE
Mark two vars as NDEBUG_UNUSED

### DIFF
--- a/cf-agent/simulate_mode.c
+++ b/cf-agent/simulate_mode.c
@@ -105,8 +105,8 @@ static void ManifestStatInfo(const struct stat *st)
 #define MAX_TIMESTAMP_SIZE (sizeof("2020-10-05 12:56:18 +0200"))
     char buf[MAX_TIMESTAMP_SIZE] = {0};
 
-    size_t ret = strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %z",
-                          localtime((time_t*) &(st->st_atime)));
+    NDEBUG_UNUSED size_t ret = strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %z",
+                                        localtime((time_t*) &(st->st_atime)));
     assert((ret > 0) && (ret < MAX_TIMESTAMP_SIZE));
     printf("Access: %s\n", buf);
 

--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -370,7 +370,7 @@ static void PromiseModule_SendMessage(PromiseModule *module, Seq *message)
     for (size_t i = 0; i < length; ++i)
     {
         const char *line = SeqAt(message, i);
-        const size_t line_length = strlen(line);
+        NDEBUG_UNUSED const size_t line_length = strlen(line);
         assert(line_length > 0 && memchr(line, '\n', line_length) == NULL);
         fprintf(module->input, "%s\n", line);
     }


### PR DESCRIPTION
They are only used in assert()s. Found by GCC 4.8.5-44 on CentOS 7 which seems to be extra picky in some ways.