### PR TITLE
Fix non-root builds

### DIFF
--- a/cf-agent/Makefile.am
+++ b/cf-agent/Makefile.am
@@ -129,7 +129,7 @@ TESTS =
 if !NT
 noinst_PROGRAMS = manifest_file
 manifest_file_SOURCES = manifest_file.c
-manifest_file_LDADD = ${top_srcdir}/libntech/libutils/libutils.la \
+manifest_file_LDADD = ../libntech/libutils/libutils.la \
 					  ../libpromises/libpromises.la \
                       libcf-agent.la
 TESTS += manifest_file

--- a/cf-monitord/Makefile.am
+++ b/cf-monitord/Makefile.am
@@ -77,7 +77,7 @@ if LINUX
 TESTS += get_socket_info
 noinst_PROGRAMS = get_socket_info
 get_socket_info_SOURCES = get_socket_info.c
-get_socket_info_LDADD = ${top_srcdir}/libntech/libutils/libutils.la \
+get_socket_info_LDADD = ../libntech/libutils/libutils.la \
 	$(PCRE_LIBS) \
 	$(LIBYAML_LIBS) \
     libcf-monitord.la


### PR DESCRIPTION
Out of tree builds not working:

$ cd core
$ make distclean
$ cd ..
$ mkdir build
$ cd build
$ ../core/autogen.sh --enable-debug
$ make -j8

Eventually gives me:

Making all in cf-agent
make[2]: *** No rule to make target '../../core/libntech/libutils/libutils.la', needed by 'manifest_file'.  Stop.

Signed-off-by: Stefan Weil <sw@weilnetz.de>