### PR TITLE
ENT-9162: Refined testall check for rpmcmpver binary

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -929,7 +929,8 @@ do
     esac
 done
 
-if [ -n "$AGENT" -o -n "$CF_PROMISES" -o -n "$CF_SERVERD" -o -n "$CF_EXECD" -o -n "$CF_KEY" -o -n "$CF_SECRET" -o -n "$CF_NET" -o -n "$CF_CHECK" -o -n "$CF_RUNAGENT" -o -n "$RPMVERCMP" -o -n "$DIFF" ]
+# check specified binaries, but only check RPMVERCMP on systems with rpm command
+if [ -n "$AGENT" -o -n "$CF_PROMISES" -o -n "$CF_SERVERD" -o -n "$CF_EXECD" -o -n "$CF_KEY" -o -n "$CF_SECRET" -o -n "$CF_NET" -o -n "$CF_CHECK" -o -n "$CF_RUNAGENT" -o \( -n "$(command -v rpm)" -a -n "$RPMVERCMP" \) -o -n "$DIFF" ]
 then
     if [ -n "$BINDIR" ]
     then


### PR DESCRIPTION
On systems without rpm don't bother checking.

Ticket: ENT-9162
Changelog: none

Wish github actions knew about related PRs, TODO
merge together:
https://github.com/cfengine/core/pull/5061
https://github.com/cfengine/masterfiles/pull/2493