### PR TITLE
ENT-9162: Refined testall check for rpmcmpver binary (follow up)

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -982,7 +982,7 @@ CF_RUNAGENT=${CF_RUNAGENT:-${DEFCF_RUNAGENT}}
 RPMVERCMP=${RPMVERCMP:-${DEFRPMVERCMP}}
 LIBTOOL=${LIBTOOL:-${DEFLIBTOOL}}
 
-if [ ! -x "$AGENT" -o ! -x "$CF_PROMISES" -o ! -x "$CF_SERVERD" -o ! -x "$CF_EXECD" -o ! -x "$CF_KEY" -o ! -x "$CF_SECRET" -o ! -x "$CF_NET" -o ! -x "$CF_CHECK" -o ! -x "$CF_RUNAGENT" -o ! -x "$RPMVERCMP" ]
+if [ ! -x "$AGENT" -o ! -x "$CF_PROMISES" -o ! -x "$CF_SERVERD" -o ! -x "$CF_EXECD" -o ! -x "$CF_KEY" -o ! -x "$CF_SECRET" -o ! -x "$CF_NET" -o ! -x "$CF_CHECK" -o ! -x "$CF_RUNAGENT" -o \( -n "$(command -v rpm)" -a ! -x "$RPMVERCMP" \) ]
 then
     echo "ERROR: can't find cf-agent or other binary;"     \
          " Are you sure you're running this from OBJDIR"   \


### PR DESCRIPTION
Needed to add the check for `rpm` to another section where we check that all set binaries exist and are executable.

Ticket: ENT-9162
Changelog: none