### PR TITLE
ENT-9162: Refined check of rpmvercmp in testall script

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -929,8 +929,15 @@ do
     esac
 done
 
-# check specified binaries, but only check RPMVERCMP on systems with rpm command
-if [ -n "$AGENT" -o -n "$CF_PROMISES" -o -n "$CF_SERVERD" -o -n "$CF_EXECD" -o -n "$CF_KEY" -o -n "$CF_SECRET" -o -n "$CF_NET" -o -n "$CF_CHECK" -o -n "$CF_RUNAGENT" -o \( -n "$(command -v rpm)" -a -n "$RPMVERCMP" \) -o -n "$DIFF" ]
+# check if rpm is used on this host, sometimes it can be installed but not used say on Ubuntu
+if [ -n "$(command -v rpm)" -a "0" != "$(rpm -qa | wc -l)" ]
+then
+  NEED_RPMVERCMP="yes"
+else
+  NEED_RPMVERCMP="no"
+fi
+
+if [ -n "$AGENT" -o -n "$CF_PROMISES" -o -n "$CF_SERVERD" -o -n "$CF_EXECD" -o -n "$CF_KEY" -o -n "$CF_SECRET" -o -n "$CF_NET" -o -n "$CF_CHECK" -o -n "$CF_RUNAGENT" -o \( "$NEED_RPMVERCMP" = "yes" -a -n "$RPMVERCMP" \) -o -n "$DIFF" ]
 then
     if [ -n "$BINDIR" ]
     then
@@ -964,7 +971,10 @@ find_default_binary DEFCF_SECRET cf-secret
 find_default_binary DEFCF_NET cf-net
 find_default_binary DEFCF_CHECK cf-check
 find_default_binary DEFCF_RUNAGENT cf-runagent
-find_default_binary DEFRPMVERCMP rpmvercmp
+if [ "$NEED_RPMVERCMP" = "yes" ]
+then
+  find_default_binary DEFRPMVERCMP rpmvercmp
+fi
 find_default_binary DIFF diff
 
 [ -x "`pwd`/libtool" ] && DEFLIBTOOL="`pwd`/libtool"
@@ -982,7 +992,7 @@ CF_RUNAGENT=${CF_RUNAGENT:-${DEFCF_RUNAGENT}}
 RPMVERCMP=${RPMVERCMP:-${DEFRPMVERCMP}}
 LIBTOOL=${LIBTOOL:-${DEFLIBTOOL}}
 
-if [ ! -x "$AGENT" -o ! -x "$CF_PROMISES" -o ! -x "$CF_SERVERD" -o ! -x "$CF_EXECD" -o ! -x "$CF_KEY" -o ! -x "$CF_SECRET" -o ! -x "$CF_NET" -o ! -x "$CF_CHECK" -o ! -x "$CF_RUNAGENT" -o \( -n "$(command -v rpm)" -a ! -x "$RPMVERCMP" \) ]
+if [ ! -x "$AGENT" -o ! -x "$CF_PROMISES" -o ! -x "$CF_SERVERD" -o ! -x "$CF_EXECD" -o ! -x "$CF_KEY" -o ! -x "$CF_SECRET" -o ! -x "$CF_NET" -o ! -x "$CF_CHECK" -o ! -x "$CF_RUNAGENT" -o \( "$NEED_RPMVERCMP" = "yes" -a ! -x "$RPMVERCMP" \) ]
 then
     echo "ERROR: can't find cf-agent or other binary;"     \
          " Are you sure you're running this from OBJDIR"   \


### PR DESCRIPTION
On a test system running Ubuntu, the rpm binary was installed but almost certainly will have no packages installed that way. So make that test instead: rpm -qa | wc -l != 0 means we need rpmvercmp.

Ticket: ENT-9162
Changelog: none