### PR TITLE
ENT-9203: Refactored github actions to add dependencies (3.15)

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -1,22 +1,13 @@
 name: Acceptance Tests
 
 on:
-  # run this workflow on pull_request activity
-  # this includes opening and pushing more commits
-  pull_request:
-    branches: [ master, 3.18.x, 3.15.x ]
-
-  # run this workflow on push/merge activity
-  # pull_request activity won't detect changes
-  # in the upstream branch before we merge
-  push:
-    branches: [ master, 3.18.x, 3.15.x ]
+  workflow_call
 
 jobs:
   acceptance_tests:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Continuous Integration
+
+on:
+  # run this workflow on pull_request activity
+  # this includes opening and pushing more commits
+  pull_request:
+    branches: [ master, 3.18.x, 3.15.x ]
+
+  # run this workflow on push/merge activity
+  # pull_request activity won't detect changes
+  # in the upstream branch before we merge
+  push:
+    branches: [ master, 3.18.x, 3.15.x ]
+
+
+jobs:
+  unit_tests:
+    uses: ./.github/workflows/unit_tests.yml
+  acceptance_tests:
+    needs: unit_tests
+    uses: ./.github/workflows/acceptance_tests.yml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,22 +1,12 @@
-name: Unit Tests
-
 on:
-  # run this workflow on pull_request activity
-  # this includes opening and pushing more commits
-  pull_request:
-    branches: [ master, 3.18.x, 3.15.x ]
-
-  # run this workflow on push/merge activity
-  # pull_request activity won't detect changes
-  # in the upstream branch before we merge
-  push:
-    branches: [ master, 3.18.x, 3.15.x ]
+  workflow_call
 
 jobs:
   unit_tests:
+    name: Run Unit Tests
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Install dependencies


### PR DESCRIPTION
No need to run acceptance tests which take a lot of minutes if unit tests don't pass.

Ticket: ENT-9203
Changelog: none
(cherry picked from commit bfbcfc4f0307c1efa4e0f00a8e0078ca98d29e3c)

 Conflicts:
	.github/workflows/cifuzz.yml
        .github/workflows/ci.yml

Removed cifuzz, asan_unit_tests and macos_unit_tests as not present in 3.15.x

(cherry picked from commit f02db53f2273098e5ad4690f45dc646849a33332)