### PR TITLE
[3.18.x] ENT-8456: Move cf-serverd.service to the network-online.target

### DIFF
--- a/misc/systemd/cf-serverd.service.in
+++ b/misc/systemd/cf-serverd.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=CFEngine Enterprise file server
 After=syslog.target
-After=network.target
+After=network-online.target
 ConditionPathExists=@bindir@/cf-serverd
 ConditionPathExists=@workdir@/policy_server.dat
 ConditionPathExists=@workdir@/inputs/promises.cf
@@ -14,5 +14,5 @@ Restart=always
 RestartSec=10
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=network-online.target
 WantedBy=cfengine3.service


### PR DESCRIPTION
cf-serverd needs working network so it should only start when working network is ready.

Ticket: ENT-8456
Changelog: cf-serverd now starts in the network-online.target on
           systemd-based systems

(cherry picked from commit https://github.com/vpodzime/cfengine-core/commit/962bac57c2afb1d70f33b9f463b763bc9395a296)

Merge together:
https://github.com/cfengine/core/pull/5070
https://github.com/cfengine/masterfiles/pull/2508