### PR TITLE
CFE-4274: Have `protocol_test` depend explicitly on libsystemd

### DIFF
--- a/cf-serverd/Makefile.am
+++ b/cf-serverd/Makefile.am
@@ -36,6 +36,8 @@ AM_CFLAGS = \
 	$(PTHREAD_CFLAGS) \
 	$(ENTERPRISE_CFLAGS)
 
+LIBS += $(SYSTEMD_SOCKET_LIBS)
+
 libcf_serverd_la_LIBADD = ../libpromises/libpromises.la
 
 libcf_serverd_la_SOURCES = \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -46,6 +46,8 @@ LDADD = ../../libpromises/libpromises.la libtest.la
 # implementation, then we are pretty sure that they will be overriden by
 # our local implementation. So we include *everything*...
 LIBS = $(CORE_LIBS)
+# protocol_test relies on cf-serverd-functions which can rely on libsystemd so need SYSTEMD_SOCKET_LIBS here
+LIBS += $(SYSTEMD_SOCKET_LIBS)
 AM_LDFLAGS = $(CORE_LDFLAGS)
 
 AM_CFLAGS = $(PTHREAD_CFLAGS)
@@ -240,6 +242,7 @@ protocol_test_SOURCES = protocol_test.c \
 	../../cf-serverd/server_access.c \
 	../../cf-serverd/strlist.c
 protocol_test_LDADD = ../../libpromises/libpromises.la libtest.la
+protocol_test_LDFLAGS = -lsystemd
 
 if HAVE_AVAHI_CLIENT
 if HAVE_AVAHI_COMMON


### PR DESCRIPTION
On Debian, when I configure with argument `--with-systemd-service=no`, the unit test `protocol_test` fails to build with a link-time error:

    /usr/bin/ld: cf-serverd-functions.o: undefined reference to symbol 'sd_notifyf@@LIBSYSTEMD_209'
    /usr/bin/ld: /lib/x86_64-linux-gnu/libsystemd.so.0: error adding symbols: DSO missing from command line
    collect2: error: ld returned 1 exit status

This change makes `protocol_test` depend unconditionally on `libsystemd`.  TBH I'm not sure this is the proper way to fix this; submitting my local fix for posterity's sake as much as anything else.