### PR TITLE
CFE-3435: Enable expireafter attribute

### DIFF
--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -708,7 +708,8 @@ static void PromiseModule_AppendAllAttributes(
             || StringEqual(name, "unless")
             || StringEqual(name, "depends_on")
             || StringEqual(name, "with")
-            || StringEqual(name, "meta"))
+            || StringEqual(name, "meta")
+            || StringEqual(name, "expireafter"))
         {
             // Evaluated by agent and not sent to module, skip
             continue;
@@ -1282,7 +1283,7 @@ PromiseResult EvaluateCustomPromise(EvalContext *ctx, const Promise *pp)
 
     CfLock promise_lock = AcquireLock(ctx, custom_promise_id, VUQNAME, CFSTARTTIME,
                                       a.transaction.ifelapsed, a.transaction.expireafter,
-                                      pp, true);
+                                      pp, false);
     if (promise_lock.lock == NULL)
     {
         return PROMISE_RESULT_SKIPPED;

--- a/libpromises/mod_custom.h
+++ b/libpromises/mod_custom.h
@@ -45,6 +45,8 @@ extern const BodySyntax CUSTOM_BODY_BLOCK_SYNTAX;
 
 typedef struct PromiseModule
 {
+    pid_t pid;
+    time_t process_start_time;
     IOData fds;
     FILE *input;
     FILE *output;
@@ -57,6 +59,7 @@ typedef struct PromiseModule
 
 bool InitializeCustomPromises();
 void FinalizeCustomPromises();
+void TerminateCustomPromises();
 
 Body *FindCustomPromiseType(const Promise *promise);
 PromiseResult EvaluateCustomPromise(ARG_UNUSED EvalContext *ctx, const Promise *pp);

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -61,8 +61,6 @@ static const char *const POLICY_ERROR_PROMISE_DUPLICATE_HANDLE =
     "Duplicate promise handle %s found";
 static const char *const POLICY_ERROR_LVAL_INVALID =
     "Promise type %s has unknown attribute %s";
-static const char *const POLICY_ERROR_PROMISE_ATTRIBUTE_NOT_IMPLEMENTED =
-    "Common attribute '%s' not implemented for custom promises (%s)";
 static const char *const POLICY_ERROR_PROMISE_ATTRIBUTE_NOT_SUPPORTED =
     "Common attribute '%s' not supported for custom promises, use '%s' instead (%s promises)";
 static const char *const POLICY_ERROR_PROMISE_TYPE_UNSUPPORTED =
@@ -2685,19 +2683,6 @@ static bool ValidateCustomPromise(const Promise *pp, Seq *errors)
                     POLICY_ERROR_PROMISE_ATTRIBUTE_NOT_SUPPORTED,
                     name,
                     "if",
-                    promise_type));
-            valid = false;
-        } else if (StringEqual(name, "expireafter"))
-        {
-            // TODO: Remove 1 attribute at a time, test and fix.
-            //       https://tracker.mender.io/browse/CFE-3392
-            SeqAppend(
-                errors,
-                PolicyErrorNew(
-                    POLICY_ELEMENT_TYPE_PROMISE,
-                    pp,
-                    POLICY_ERROR_PROMISE_ATTRIBUTE_NOT_IMPLEMENTED,
-                    name,
                     promise_type));
             valid = false;
         }

--- a/libpromises/signals.c
+++ b/libpromises/signals.c
@@ -26,6 +26,7 @@
 #include <cleanup.h>
 #include <known_dirs.h>         /* GetStateDir() */
 #include <file_lib.h>           /* FILE_SEPARATOR */
+#include <mod_custom.h>         /* TerminateCustomPromises */
 
 static bool PENDING_TERMINATION = false; /* GLOBAL_X */
 
@@ -155,6 +156,7 @@ void HandleSignalsForAgent(int signum)
     case SIGINT:
         /* TODO don't exit from the signal handler, just set a flag. Reason is
          * that all the cleanup() hooks we register are not reentrant. */
+        TerminateCustomPromises();
         DoCleanupAndExit(0);
     case SIGBUS:
         /* SIGBUS almost certainly means a violation of mmap() area boundaries

--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/expireafter.cf
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/expireafter.cf
@@ -1,0 +1,71 @@
+##############################################################################
+#
+#  Test that expireafter works with commands promise type
+#
+##############################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+##############################################################################
+
+bundle agent init
+{
+  meta:
+      # Solaris 9 & 10 don't seem to handle the backgrounding
+      "test_skip_needs_work"
+        string => "windows|sunos_5_9|sunos_5_10";
+  files:
+      "$(G.testfile)"
+        delete => tidy;
+}
+
+##############################################################################
+
+body action background {
+  background => "true";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-1188" }
+        string => "Test that expireafter works with commands promise type";
+
+  commands:
+      "$(sys.cf_agent) --inform --file $(this.promise_filename).sub --"
+        action => background,
+        comment => "I will get killed by the second agent";
+      "$(G.sleep) 90"
+        comment => "I will wait for the first agent to expire";
+      "$(sys.cf_agent) --inform --file $(this.promise_filename).sub"
+        comment => "I will kill the first agent";
+}
+
+##############################################################################
+
+bundle agent check
+{
+  vars:
+      "expected"
+        string => "Hello CFEngine";
+      "actual"
+        string => readfile("$(G.testfile)"),
+        if => fileexists("$(G.testfile)");
+
+  classes:
+      "ok"
+        expression => strcmp("$(expected)", "$(actual)");
+
+  reports:
+    DEBUG::
+      "Expected '$(expected)', found '$(actual)'";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/expireafter.cf.sub
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/expireafter.cf.sub
@@ -1,0 +1,39 @@
+##############################################################################
+#
+#  Test that expireafter works with commands promise type
+#
+##############################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { "hang" };
+  version => "1.0";
+}
+
+##############################################################################
+
+body action timeout
+{
+  expireafter => "1";
+  ifelapsed => "0";
+}
+
+bundle agent hang
+{
+  vars:
+      "content"
+        string => ifelse(fileexists("$(G.testfile)"),
+                         "Hello CFEngine",
+                         "Bye CFEngine");
+
+  commands:
+      "$(G.sleep) 120"
+        action => timeout,
+        handle => "done";
+
+  files:
+      "$(G.testfile)"
+        content => "$(content)",
+        depends_on => { "done" };
+}


### PR DESCRIPTION
Enable expireafter attribute for custom promise types.

Merge with:
 - https://github.com/cfengine/masterfiles/pull/2526