### PR TITLE
AUTHORS: minor fix to grammar.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,7 +32,7 @@ Bas van der Vlies
 Diego Zamboni
 Ted Zlatanov
 
-Contributors (people with less than 10 commits registered), sorted alphabetically:
+Contributors (people with fewer than 10 commits registered), sorted alphabetically:
 
 Trond Hasle Amundsen
 Cédric Cabessa


### PR DESCRIPTION
* "less than": something non-countable
* "fewer than": something countable

So change "people with less than 10 commits..." to "people with fewer than 10 commits...".

Example ref: https://www.grammarly.com/blog/fewer-vs-less/