### PR TITLE
CFE-3020: ps output line ... is shorter than its associated header

### DIFF
--- a/tests/unit/split_process_line_test.c
+++ b/tests/unit/split_process_line_test.c
@@ -126,7 +126,7 @@ static void test_split_line_nocmd(void)
 
         "USER       PID STAT    VSZ  NI   RSS NLWP STIME     ELAPSED     TIME COMMAND",
         "spacecmd   4 S         0   0     0    1 10:30       54:29 00:00:01  ",
-        "nullcmd    4 S         0   0     0    1 10:30       54:29 00:00:01 ",
+        "nullcmd    4 S         0   0     0    1 10:30       54:29 00:00:01 "
     };
     char *name[CF_PROCCOLS] = { 0 }; /* Headers */
     char *field[CF_PROCCOLS] = { 0 }; /* Content */


### PR DESCRIPTION
A program can overwrite its incoming arguments.  This can include blanking them out, and subsequent "ps" output can be empty.

Add an additional test.

While this test itself does not expose or address the CFE-3020 bug, nevertheless it seems worth having such a test in place.