### PR TITLE
ENT-9496: Allow PostgreSQL to create directories under /var/cfengine

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -484,7 +484,7 @@ allow cfengine_postgres_t cfengine_postgres_exec_t:file { ioctl read getattr loc
 allow cfengine_postgres_t cfengine_var_lib_t:file map;
 allow cfengine_postgres_t cfengine_var_lib_t:file { create execute execute_no_trans getattr link open read rename unlink write };
 
-allow cfengine_postgres_t cfengine_var_lib_t:dir { add_name getattr open read remove_name search write };
+allow cfengine_postgres_t cfengine_var_lib_t:dir { add_name getattr open create read remove_name search write };
 
 allow cfengine_postgres_t postgresql_port_t:tcp_socket name_bind;
 


### PR DESCRIPTION
It needs some space for temporary files when returning large data sets as query results.

Ticket: ENT-9496
Changelog: SELinux no longer breaks SQL queries with large result
           sets on RHEL 8 hubs