### PR TITLE
[3.18.x] ENT-9496: Allow PostgreSQL to create directories under /var/cfengine

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,8 @@
 	  the related files promise (ENT-5866)
 	- Use of an external SMTP server for reports from Mission Portal is no
 	  longer blocked by SELinux (ENT-9473)
+	- SELinux no longer breaks SQL queries with large result sets on RHEL 8
+	  hubs (ENT-9496)
 
 3.18.2:
 	- 'N' or 'Ns' signal specs can now be used to sleep

--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -477,7 +477,7 @@ allow cfengine_postgres_t cfengine_postgres_exec_t:file { ioctl read getattr loc
 allow cfengine_postgres_t cfengine_var_lib_t:file map;
 allow cfengine_postgres_t cfengine_var_lib_t:file { create execute execute_no_trans getattr link open read rename unlink write };
 
-allow cfengine_postgres_t cfengine_var_lib_t:dir { add_name getattr open read remove_name search write };
+allow cfengine_postgres_t cfengine_var_lib_t:dir { add_name getattr open create read remove_name search write };
 
 allow cfengine_postgres_t postgresql_port_t:tcp_socket name_bind;
 


### PR DESCRIPTION
It needs some space for temporary files when returning large data sets as query results.

Ticket: ENT-9496
Changelog: SELinux no longer breaks SQL queries with large result
           sets on RHEL 8 hubs
(cherry picked from commit 0177e6c3f0d03d19b1cf3f0c6977e9f68e0a8d9d)