### PR TITLE
CFE-4093: Fix storage promise for nfs on MacOS

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -144,5 +144,5 @@ $ ./autogen.sh --without-pam
 
 * OSX (2021-10-20)
 
-$ brew install openssl@1.1 lmdb autoconf automake libtool bison flex pcre m4 gcc make
-$ ./autogen.sh --enable-debug --with-openssl="$(brew --prefix openssl@1.1)"
+brew install openssl@1.1 lmdb autoconf automake libtool bison flex pcre m4 gcc make
+./autogen.sh --enable-debug --with-openssl="$(brew --prefix openssl@1.1)"

--- a/cf-agent/nfs.c
+++ b/cf-agent/nfs.c
@@ -485,12 +485,14 @@ int VerifyInFstab(EvalContext *ctx, char *name, const Attributes *a, const Promi
              mountpt, rmountpt, fstype, fstype, host, opts);
 #elif defined(__linux__)
     snprintf(fstab, CF_BUFSIZE, "%s:%s \t %s \t %s \t %s", host, rmountpt, mountpt, fstype, opts);
-#elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__FreeBSD__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__APPLE__)
     snprintf(fstab, CF_BUFSIZE, "%s:%s \t %s \t %s \t %s 0 0", host, rmountpt, mountpt, fstype, opts);
 #elif defined(__sun) || defined(sco) || defined(__SCO_DS)
     snprintf(fstab, CF_BUFSIZE, "%s:%s - %s %s - yes %s", host, rmountpt, mountpt, fstype, opts);
 #elif defined(__CYGWIN__)
     snprintf(fstab, CF_BUFSIZE, "/bin/mount %s:%s %s", host, rmountpt, mountpt);
+#else
+  #error "Could not determine format of fstab entry on this platform."
 #endif
 
     Log(LOG_LEVEL_VERBOSE, "Verifying '%s' in '%s'", mountpt, VFSTAB[VSYSTEMHARDCLASS]);


### PR DESCRIPTION
Previously the format of the line to check in
/etc/fstab would be empty, now it will conform
properly to the BSD style format as mentioned
in man fstab on MacOS.

Ticket: CFE-4093
Changelog: title