### PR TITLE
ENT-8824: Adjust selinux policy for RHEL 9 (3.15)

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -102,3 +102,45 @@ RUNNING TESTSUITE
 -----------------
 
 Please refer to the instructions in tests/README file.
+
+INSTALL DEPENDENCIES
+--------------------
+
+Here we have examples of command lines for various systems to install dependencies
+needed to build. The version and date checked are noted in parenthesis. Please
+submit PRs with updates to this information.
+
+* CentOS (centos7 2021-07-02)
+
+Note that first you will need to install epel-release (https://fedoraproject.org/wiki/EPEL) for lmdb-devel to be available.
+
+$ sudo yum install -y gcc gdb make git libtool autoconf automake byacc flex openssl-devel pcre-devel lmdb-devel pam-devel flex-devel yaml-devel
+
+For SELinux support you will need selinux-policy-devel package and specify `--with-selinux-policy` to `autogen.sh` or `configure`
+
+* Debian (Raspbian 10 2021-07-02)
+
+$ sudo apt-get install -y build-essential git libtool autoconf automake bison flex libssl-dev libpcre3-dev libbison-dev libacl1 libacl1-dev lmdb-utils liblmdb-dev libpam0g-dev libtool libyaml-dev
+
+* FreeBSD (12.1 2020-04-07)
+
+See docs/BSD.md
+
+* SUSE (Tumbleweed 2020-02-02)
+
+$ sudo zypper install gdb gcc make lmdb autoconf automake libtool git python3 pcre-devel libopenssl-devel pam-devel
+
+* AlpineOS (3.11.3 x86_64 2020-04-13)
+
+$ sudo apk add alpine-sdk lmdb-dev openssl-dev bison flex-dev acl-dev pcre-dev autoconf automake libtool git python3 gdb
+$ ./autogen.sh --without-pam
+
+* Termux (2020-04-24)
+
+$ pkg install build-essential git autoconf automake bison flex liblmdb openssl pcre libacl libyaml
+$ ./autogen.sh --without-pam
+
+* OSX (2021-10-20)
+
+$ brew install openssl@1.1 lmdb autoconf automake libtool bison flex pcre m4 gcc make
+$ ./autogen.sh --enable-debug --with-openssl="$(brew --prefix openssl@1.1)"

--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -156,7 +156,8 @@ require {
 	class lnk_file { create getattr read unlink };
 	class unix_stream_socket connectto;
 	class capability { dac_read_search sys_module chown dac_read_search dac_override fowner fsetid sys_admin mknod net_raw net_admin sys_nice sys_rawio sys_resource setuid setgid sys_nice sys_ptrace kill net_bind_service };
-	class capability2 { mac_admin mac_override block_suspend syslog compromise_kernel wake_alarm };
+	class cap_userns sys_ptrace;
+	class capability2 { mac_admin mac_override block_suspend syslog wake_alarm };
 	class association { sendto recvfrom setcontext polmatch };
 	class security setsecparam;
 	class service { start stop status reload enable disable };
@@ -211,6 +212,7 @@ allow cfengine_execd_t ssh_port_t:tcp_socket name_connect;
 
 allow cfengine_execd_t cfengine_log_t:file { read unlink write };
 allow cfengine_execd_t cfengine_log_t:lnk_file { create getattr read unlink };
+allow cfengine_execd_t cfengine_log_t:dir add_name;
 allow cfengine_execd_t cfengine_monitord_exec_t:file getattr;
 allow cfengine_execd_t cfengine_serverd_exec_t:file getattr;
 allow cfengine_execd_t cfengine_hub_exec_t:file getattr;


### PR DESCRIPTION
RHEL 9 required a few adjustments to cfengine-enterprise selinux policy which do not break RHEL 8.

Ticket: ENT-8824
Changelog: title
(cherry picked from commit abf36bbe4d4a4107f3666dde606d1bad4525fab8)

 Conflicts:
	INSTALL
	misc/selinux/cfengine-enterprise.te