### PR TITLE
ENT-8824: Adjust selinux policy for RHEL 9 (3.18)

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -112,9 +112,17 @@ Here we have examples of command lines for various systems to install dependenci
 needed to build. The version and date checked are noted in parenthesis. Please
 submit PRs with updates to this information.
 
-* Debian (Raspbian 9 2020-04-24)
+* CentOS (centos7 2021-07-02)
 
-# apt-get install build-essential autoconf automake libssl-dev libpcre3 libpcre3-dev bison libbison-dev libacl1 libacl1-dev libpq-dev lmdb-utils liblmdb-dev libpam0g-dev flex libtool
+Note that first you will need to install epel-release (https://fedoraproject.org/wiki/EPEL) for lmdb-devel to be available.
+
+$ sudo yum install -y gcc gdb make git libtool autoconf automake byacc flex openssl-devel pcre-devel lmdb-devel pam-devel flex-devel yaml-devel
+
+For SELinux support you will need selinux-policy-devel package and specify `--with-selinux-policy` to `autogen.sh` or `configure`
+
+* Debian (Raspbian 10 2021-07-02)
+
+$ sudo apt-get install -y build-essential git libtool autoconf automake bison flex libssl-dev libpcre3-dev libbison-dev libacl1 libacl1-dev lmdb-utils liblmdb-dev libpam0g-dev libtool libyaml-dev
 
 * FreeBSD (12.1 2020-04-07)
 

--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -149,14 +149,15 @@ require {
 	class ib_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
 	class mpls_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
 	class process { setrlimit transition dyntransition execstack execheap execmem signull siginh getattr };
-	class file { execute execute_no_trans getattr ioctl map open read unlink write entrypoint lock link rename append setattr create relabelfrom relabelto };
+	class file { execute execute_no_trans getattr ioctl map open read unlink write entrypoint lock link rename append setattr create relabelfrom relabelto watch watch_reads };
 	class fifo_file { create open getattr setattr read write append rename link unlink ioctl lock relabelfrom relabelto };
 	class dir { getattr read search open write add_name remove_name lock ioctl create };
 	class filesystem getattr;
 	class lnk_file { create getattr read unlink };
 	class unix_stream_socket connectto;
 	class capability { dac_read_search sys_module chown dac_read_search dac_override fowner fsetid sys_admin mknod net_raw net_admin sys_nice sys_rawio sys_resource setuid setgid sys_nice sys_ptrace kill net_bind_service };
-	class capability2 { mac_admin mac_override block_suspend syslog compromise_kernel wake_alarm };
+	class cap_userns sys_ptrace;
+	class capability2 { mac_admin mac_override block_suspend syslog wake_alarm };
 	class association { sendto recvfrom setcontext polmatch };
 	class security setsecparam;
 	class service { start stop status reload enable disable };
@@ -210,6 +211,7 @@ allow cfengine_execd_t proc_xen_t:dir search;
 
 allow cfengine_execd_t cfengine_log_t:file { read unlink write };
 allow cfengine_execd_t cfengine_log_t:lnk_file { create getattr read unlink };
+allow cfengine_execd_t cfengine_log_t:dir add_name;
 allow cfengine_execd_t cfengine_monitord_exec_t:file getattr;
 allow cfengine_execd_t cfengine_serverd_exec_t:file getattr;
 allow cfengine_execd_t cfengine_hub_exec_t:file getattr;


### PR DESCRIPTION
RHEL 9 required a few adjustments to cfengine-enterprise selinux policy which do not break RHEL 8.

Ticket: ENT-8824
Changelog: title
(cherry picked from commit abf36bbe4d4a4107f3666dde606d1bad4525fab8)

 Conflicts:
	INSTALL
	misc/selinux/cfengine-enterprise.te