### PR TITLE
ENT-9557: Allow selinux hub context to send email (3.18)

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -429,6 +429,7 @@ allow cfengine_hub_t self:netlink_route_socket { create getopt setopt bind getat
 allow cfengine_hub_t self:unix_dgram_socket { create connect read write };
 allow cfengine_hub_t semanage_exec_t:file getattr;
 allow cfengine_hub_t shadow_t:file getattr;
+allow cfengine_hub_t smtp_port_t:tcp_socket name_connect;
 allow cfengine_hub_t sssd_public_t:dir search;
 allow cfengine_hub_t sssd_public_t:file map;
 allow cfengine_hub_t sssd_public_t:file { getattr open read };


### PR DESCRIPTION
Found when testing scheduled reports emailing.

Ticket: ENT-9557
Changelog: title
(cherry picked from commit a304cf100825886af8c929456128194be64b7680)