### PR TITLE
Allow PostgreSQL to getattr in tmpfs

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -512,7 +512,7 @@ allow cfengine_postgres_t tmp_t:dir { add_name write remove_name };
 allow cfengine_postgres_t tmp_t:file { create write unlink };
 allow cfengine_postgres_t tmp_t:sock_file { create setattr unlink write };
 allow cfengine_postgres_t tmpfs_t:dir { add_name write remove_name };
-allow cfengine_postgres_t tmpfs_t:file { create open read write map unlink };
+allow cfengine_postgres_t tmpfs_t:file { create open read write map unlink getattr };
 allow cfengine_postgres_t tmpfs_t:filesystem getattr;
 allow cfengine_postgres_t var_log_t:file { append open };
 


### PR DESCRIPTION
PostgreSQL 15 needs this because it does stat() on its shared memory blocks (on /dev/shm which is a tmpfs).