### PR TITLE
Acceptance test for expireafter with commands

### DIFF
--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/expireafter.cf
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/expireafter.cf
@@ -1,0 +1,67 @@
+##############################################################################
+#
+#  Test that expireafter works with commands promise type
+#
+##############################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+##############################################################################
+
+bundle agent init
+{
+  files:
+      "$(G.testfile)"
+        delete => tidy;
+}
+
+##############################################################################
+
+body action background {
+  background => "true";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-1188" }
+        string => "Test that expireafter works with commands promise type";
+
+  commands:
+      "$(sys.cf_agent) --inform --file $(this.promise_filename).sub --"
+        action => background,
+        comment => "I will get killed by the second agent";
+      "/bin/sleep 90"
+        comment => "I will wait for the first agent to expire";
+      "$(sys.cf_agent) --inform --file $(this.promise_filename).sub"
+        comment => "I will kill the first agent";
+}
+
+##############################################################################
+
+bundle agent check
+{
+  vars:
+      "expected"
+        string => "Hello CFEngine";
+      "actual"
+        string => readfile("$(G.testfile)"),
+        if => fileexists("$(G.testfile)");
+
+  classes:
+      "ok"
+        expression => strcmp("$(expected)", "$(actual)");
+
+  reports:
+    DEBUG::
+      "Expected '$(expected)', found '$(actual)'";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/00_basics/ifelapsed_and_expireafter/expireafter.cf.sub
+++ b/tests/acceptance/00_basics/ifelapsed_and_expireafter/expireafter.cf.sub
@@ -1,0 +1,28 @@
+##############################################################################
+#
+#  Test that expireafter works with commands promise type
+#
+##############################################################################
+
+body common control
+{
+  inputs => { "../../default.cf.sub" };
+  bundlesequence  => { "hang" };
+  version => "1.0";
+}
+
+##############################################################################
+
+body action timeout
+{
+  expireafter => "1";
+  ifelapsed => "0";
+}
+
+bundle agent hang
+{
+  commands:
+      "/bin/sleep 120; printf 'Hello CFEngine' >> $(G.testfile)"
+        contain => in_shell,
+        action => timeout;
+}


### PR DESCRIPTION
Acceptance test for expireafter with commands promise.

Depends on https://github.com/cfengine/enterprise/pull/699 and https://github.com/cfengine/core/pull/5080

Ticket: CFE-1188
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>