### PR TITLE
ENT-9615: Added support for submodules in masterfiles-stage

### DIFF
--- a/contrib/masterfiles-stage/README.org
+++ b/contrib/masterfiles-stage/README.org
@@ -43,6 +43,18 @@ simple environments this will be =$(sys.masterdir)= (typically
   - =VCS_TYPE="GIT_POLICY_CHANNELS"=
   - =VCS_TYPE="SVN"=
 
+- Git submodules supported
+  Note however that submodules can be "tricky".
+  Because of the way this script currently handles the repo, changes in url or branch of a submodule are handled well.
+  When changing url/branch in your working directory you may notice that the submodule is not updated properly. The following procedure will fix the situation:
+
+```
+  git submodule deinit <name_of_submodule>
+  git rm -rf <name_of_submodule>
+  rm -rf .git/modules/<name_of_submodule>
+  git submodule add --force [-b <branch>] <submodule_url> <name_of_submodule>
+```
+
 * Dependencies
 :PROPERTIES:
 :ID:       b04a05f5-f84f-4c38-aed0-837e2ca6c10c

--- a/contrib/masterfiles-stage/common.sh
+++ b/contrib/masterfiles-stage/common.sh
@@ -108,6 +108,10 @@ git_deploy_refspec() {
   # and https://github.com/cfengine/core/pull/2465#issuecomment-173656475
   git --git-dir="${local_mirrored_repo}" --work-tree="${temp_stage}" checkout -q -f "${2}^0" ||
     error_exit "Failed to checkout '$2' from '${local_mirrored_repo}'"
+  cd "${temp_stage}"
+  git --git-dir="${local_mirrored_repo}" --work-tree="${temp_stage}" submodule sync
+  git --git-dir="${local_mirrored_repo}" --work-tree="${temp_stage}" submodule update --init --recursive
+  cd -
   # Grab HEAD so it can be used to populate cf_promises_release_id
   mkdir -p "${temp_stage}/.git"
   cp "${local_mirrored_repo}/HEAD" "${temp_stage}/.git/"
@@ -212,6 +216,10 @@ git_cfbs_deploy_refspec() {
   # and https://github.com/cfengine/core/pull/2465#issuecomment-173656475
   git --git-dir="${local_mirrored_repo}" --work-tree="${temp_stage}" checkout -q -f "${2}^0" ||
     error_exit "Failed to checkout '$2' from '${local_mirrored_repo}'"
+  cd "${temp_stage}"
+  git --git-dir="${local_mirrored_repo}" --work-tree="${temp_stage}" submodule sync
+  git --git-dir="${local_mirrored_repo}" --work-tree="${temp_stage}" submodule update --init --recursive
+  cd -
 
   ########################## 3. cfbs build
   # Remember what directory we were in when we started.


### PR DESCRIPTION
Also added to README.org how to handle changing url/branch of submodules in a local working directory, which is rather tricky and non-obvious.

Ticket: ENT-9615
Changelog: title