### PR TITLE
ENT-9621: Added support for redhat 9 agent (3.18)

### DIFF
--- a/cf-key/cf-key-functions.c
+++ b/cf-key/cf-key-functions.c
@@ -315,7 +315,6 @@ bool KeepKeyPromises(const char *public_key_file, const char *private_key_file, 
 
     Log(LOG_LEVEL_INFO, "Making a key pair for CFEngine, please wait, this could take a minute...");
 
-#ifdef OPENSSL_NO_DEPRECATED
     RSA *pair = RSA_new();
     BIGNUM *rsa_bignum = BN_new();
     if (pair != NULL && rsa_bignum != NULL)
@@ -334,10 +333,6 @@ bool KeepKeyPromises(const char *public_key_file, const char *private_key_file, 
 
     BN_clear_free(rsa_bignum);
 
-#else
-    RSA *pair = RSA_generate_key(key_size, 65537, NULL, NULL);
-
-#endif
     if (pair == NULL)
     {
         Log(LOG_LEVEL_ERR, "Unable to generate cryptographic key (RSA_generate_key: %s)",

--- a/configure.ac
+++ b/configure.ac
@@ -475,6 +475,8 @@ CF3_WITH_LIBRARY(openssl, [
       AC_MSG_ERROR(Cannot find OpenSSL)
    fi
 
+   AC_DEFINE([OPENSSL_SUPPRESS_DEPRECATED], [1], [Suppress deprecation warnings from OpenSSL 3])
+
    AC_CHECK_DECL([SSL_OP_NO_TLSv1_1],
     [AC_DEFINE([HAVE_TLS_1_1], [1], [Define if TLS 1.1 is supported by OpenSSL])],
     [], [[#include <openssl/ssl.h>]]

--- a/configure.ac
+++ b/configure.ac
@@ -466,17 +466,12 @@ CF3_WITH_LIBRARY(openssl, [
    AC_PREPROC_IFELSE([AC_LANG_SOURCE([[
    #include <openssl/opensslv.h>
 
-   #if OPENSSL_VERSION_NUMBER < 0x0090602fL
+   #if OPENSSL_VERSION_NUMBER < 0x1000000fL
    #This OpenSSL is too old
    #endif
-   ]])],[AC_MSG_RESULT(OK)],[AC_MSG_ERROR(This release of CFEngine requires OpenSSL >= 0.9.7)])
+   ]])],[AC_MSG_RESULT(OK)],[AC_MSG_ERROR(This release of CFEngine requires OpenSSL >= 1.0.0)])
 
-   if test "x$ac_cv_lib_crypto_RSA_generate_key_ex" = "xyes" ; then
-      AC_DEFINE(OPENSSL_NO_DEPRECATED, 1, [Define if non deprecated API is available.])
-   fi
-
-   if test "x$ac_cv_lib_crypto_RSA_generate_key_ex" = "xno" && \
-      test "x$ac_cv_lib_crypto_RSA_generate_key" = "xno" ; then
+   if test "x$ac_cv_lib_crypto_RSA_generate_key_ex" = "xno" ; then
       AC_MSG_ERROR(Cannot find OpenSSL)
    fi
 

--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -29,6 +29,10 @@
 #include <openssl/bn.h>                                         /* BN_* */
 #include <libcrypto-compat.h>
 
+#if OPENSSL_VERSION_NUMBER > 0x30000000
+#include <openssl/provider.h>                                   /* OSSL_PROVIDER_* */
+#endif
+
 #include <cf3.defs.h>
 #include <lastseen.h>
 #include <files_interfaces.h>
@@ -74,6 +78,13 @@ void CryptoInitialize()
         OpenSSL_add_all_digests();
         ERR_load_crypto_strings();
 
+#if OPENSSL_VERSION_NUMBER > 0x30000000
+        /* We need Blowfish for legacy encrypted network stuff and in OpenSSL
+         * 3+, it's only available when the legacy provider is loaded. And we
+         * also need the default provider. */
+        OSSL_PROVIDER_load(NULL, "legacy");
+        OSSL_PROVIDER_load(NULL, "default");
+#endif
         RandomSeed();
 
         crypto_initialized = true;

--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -47,10 +47,7 @@
 #endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000
-/* The deprecated is the easy way to setup threads for OpenSSL. */
-#ifdef OPENSSL_NO_DEPRECATED
 void CRYPTO_set_id_callback(unsigned long (*func)(void));
-#endif
 #endif
 
 static void RandomSeed(void);

--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -87,7 +87,7 @@ require {
 	type sshd_t;
 	type rpm_script_t;
 	class tcp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown name_connect accept listen name_bind node_bind };
-	class udp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown node_bind name_connect };
+	class udp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown node_bind };
 	class sock_file { create write getattr setattr unlink };
 	class rawip_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
 	class netlink_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
@@ -587,7 +587,7 @@ allow cfengine_httpd_t self:netlink_route_socket { bind create getattr nlmsg_rea
 allow cfengine_httpd_t self:process execmem;
 allow cfengine_httpd_t unconfined_t:process signull;
 allow cfengine_httpd_t self:tcp_socket { accept bind connect create getattr getopt listen setopt shutdown read write ioctl setattr append name_connect };
-allow cfengine_httpd_t self:udp_socket { create ioctl read getattr write setattr append connect getopt setopt shutdown name_connect setattr };
+allow cfengine_httpd_t self:udp_socket { create ioctl read getattr write setattr append connect getopt setopt shutdown setattr };
 allow cfengine_httpd_t self:unix_dgram_socket { connect create };
 allow cfengine_httpd_t sssd_public_t:dir search;
 allow cfengine_httpd_t sssd_public_t:file map;


### PR DESCRIPTION
Backported changes from master for redhat 9 to 3.18.x branch.

Includes selinux policy changes as well as adjustments to work with OpenSSL 3+.

merge together:
https://github.com/cfengine/buildscripts/pull/1159
https://github.com/cfengine/core/pull/5114
https://github.com/cfengine/masterfiles/pull/2544