### PR TITLE
More SELinux fixes for sending reports via email

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -94,7 +94,7 @@ require {
 	class rawip_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
 	class netlink_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
 	class packet_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
-	class unix_stream_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
+	class unix_stream_socket { create ioctl read getattr lock write setattr append bind connect connectto getopt setopt shutdown };
 	class unix_dgram_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown sendto };
 	class appletalk_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };
 	class netlink_route_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown nlmsg_read getopt };
@@ -156,7 +156,6 @@ require {
 	class dir { getattr read search open write add_name remove_name lock ioctl create setattr rmdir };
 	class filesystem getattr;
 	class lnk_file { create getattr read unlink };
-	class unix_stream_socket connectto;
 	class capability { dac_read_search sys_module chown dac_read_search dac_override fowner fsetid sys_admin mknod net_raw net_admin sys_nice sys_rawio sys_resource setuid setgid sys_nice sys_ptrace kill net_bind_service };
 	class cap_userns sys_ptrace;
 	class capability2 { mac_admin mac_override block_suspend syslog wake_alarm };
@@ -453,6 +452,7 @@ allow cfengine_hub_t user_cron_spool_t:dir getattr;
 allow cfengine_hub_t useradd_exec_t:file getattr;
 allow cfengine_hub_t var_t:dir read;
 allow cfengine_hub_t ssh_exec_t:file getattr;
+allow cfengine_hub_t tmp_t:dir read;
 
 # TODO: these should not be needed
 allow cfengine_hub_t ifconfig_exec_t:file { execute execute_no_trans open read getattr map };
@@ -573,6 +573,7 @@ allow cfengine_httpd_t cfengine_action_script_exec_t:file { create write setattr
 # sending reports via email
 allow cfengine_httpd_t postfix_etc_t:dir { getattr open read search };
 allow cfengine_httpd_t postfix_etc_t:file { getattr open read };
+allow cfengine_httpd_t postfix_master_t:unix_stream_socket connectto;
 allow cfengine_httpd_t postfix_postdrop_exec_t:file { execute execute_no_trans map open read };
 allow cfengine_httpd_t postfix_public_t:dir search;
 allow cfengine_httpd_t postfix_public_t:sock_file { getattr write };


### PR DESCRIPTION
PHP (cfengine_httpd_t) needs to be able to talk to Postfix Master process via a unix socket when sending emails directly and cf-hub needs to be able to read /tmp when processing scheduled reports.