### PR TITLE
SELinux fixes for call-collect

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -308,8 +308,11 @@ allow cfengine_serverd_t cfengine_var_lib_t:file execute;
 # allow cf-serverd to execute cf-promises
 allow cfengine_serverd_t cfengine_var_lib_t:file execute_no_trans;
 
-# allow cf-serverd to connect in case of call-collect
+# allow cf-serverd to connect to the CFEngine port and to write into a local socket (in case of
+# call-collect on hosts and the hub itself, respectively)
 allow cfengine_serverd_t unreserved_port_t:tcp_socket name_connect;
+allow cfengine_serverd_t cfengine_var_lib_t:sock_file write;
+allow cfengine_serverd_t cfengine_hub_t:unix_stream_socket connectto;
 
 # TODO: this should not be needed
 allow cfengine_serverd_t ssh_port_t:tcp_socket name_connect;


### PR DESCRIPTION
Extra two rules for call-collect when RHEL 8 is running on the hub not just on the hosts.