### PR TITLE
ENT-9567: Included openssl/applink.c to avoid runtime error

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -102,6 +102,11 @@
 
 #include <ornaments.h>
 
+// OPENSSL_Applink - glue between OpenSSL BIO and Win32 compiler run-time
+#ifdef _WIN32
+#include <openssl/applink.c>
+#endif // _WIN32
+
 
 extern int PR_KEPT;
 extern int PR_REPAIRED;

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -43,6 +43,11 @@
 
 #include <cf-key-functions.h>
 
+// OPENSSL_Applink - glue between OpenSSL BIO and Win32 compiler run-time
+#ifdef _WIN32
+#include <openssl/applink.c>
+#endif // _WIN32
+
 bool SHOWHOSTS = false;                                         /* GLOBAL_A */
 bool NO_TRUNCATE = false;                                       /* GLOBAL_A */
 bool FORCEREMOVAL = false;                                      /* GLOBAL_A */


### PR DESCRIPTION
OPENSSL_Applink - glue between OpenSSL BIO and Win32 compiler run-time

Ticket: ENT-9567
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>