### PR TITLE
ENT-8447: Changed the default mode for directories from 755 to 700

### DIFF
--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -339,7 +339,7 @@ struct GidList_
 #define CF_NOINT    -678L
 #define CF_UNDEFINED_ITEM (void *)0x1234
 
-#define DEFAULTMODE ((mode_t)0755)
+#define DEFAULTMODE ((mode_t)0700)
 
 #define CF_DONEPASSES  4
 

--- a/tests/acceptance/29_simulate_mode/diff_mode.cf.expected
+++ b/tests/acceptance/29_simulate_mode/diff_mode.cf.expected
@@ -34,7 +34,7 @@ foobar
 ===========================================================================
 'WORKDIR/tmp/SUBDIR' is a directory
 Size: SIZE
-Access: (0755/rwxr-xr-x)  Uid: (0/root)   Gid: (0/root)
+Access: (0700/rwx------)  Uid: (0/root)   Gid: (0/root)
 Access: TIMESTAMP
 Modify: TIMESTAMP
 Change: TIMESTAMP

--- a/tests/acceptance/29_simulate_mode/manifest_full_mode.cf.expected
+++ b/tests/acceptance/29_simulate_mode/manifest_full_mode.cf.expected
@@ -34,7 +34,7 @@ foobar
 ===========================================================================
 'WORKDIR/tmp/SUBDIR' is a directory
 Size: SIZE
-Access: (0755/rwxr-xr-x)  Uid: (0/root)   Gid: (0/root)
+Access: (0700/rwx------)  Uid: (0/root)   Gid: (0/root)
 Access: TIMESTAMP
 Modify: TIMESTAMP
 Change: TIMESTAMP
@@ -58,7 +58,7 @@ These are my source file contents.
 ===========================================================================
 'WORKDIR/tmp/sub-dir/.' is a directory
 Size: SIZE
-Access: (0755/rwxr-xr-x)  Uid: (0/root)   Gid: (0/root)
+Access: (0700/rwx------)  Uid: (0/root)   Gid: (0/root)
 Access: TIMESTAMP
 Modify: TIMESTAMP
 Change: TIMESTAMP

--- a/tests/acceptance/29_simulate_mode/manifest_mode.cf.expected
+++ b/tests/acceptance/29_simulate_mode/manifest_mode.cf.expected
@@ -34,7 +34,7 @@ foobar
 ===========================================================================
 'WORKDIR/tmp/SUBDIR' is a directory
 Size: SIZE
-Access: (0755/rwxr-xr-x)  Uid: (0/root)   Gid: (0/root)
+Access: (0700/rwx------)  Uid: (0/root)   Gid: (0/root)
 Access: TIMESTAMP
 Modify: TIMESTAMP
 Change: TIMESTAMP
@@ -58,7 +58,7 @@ These are my source file contents.
 ===========================================================================
 'WORKDIR/tmp/sub-dir/.' is a directory
 Size: SIZE
-Access: (0755/rwxr-xr-x)  Uid: (0/root)   Gid: (0/root)
+Access: (0700/rwx------)  Uid: (0/root)   Gid: (0/root)
 Access: TIMESTAMP
 Modify: TIMESTAMP
 Change: TIMESTAMP


### PR DESCRIPTION
This more restrictive default directory permission better aligns with our more
secure defaults for files.

Ticket: ENT-8447
Changelog: Title