### PR TITLE
Added fifo_file write access for cf-reactor

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -813,7 +813,7 @@ allow cfengine_cfbs_t cfengine_var_lib_t:dir { add_name getattr create open read
 allow cfengine_cfbs_t cfengine_var_lib_t:file { create ioctl lock write unlink append setattr link rename execute execute_no_trans map getattr open read };
 allow cfengine_cfbs_t cfengine_var_lib_t:lnk_file { getattr read create unlink };
 
-allow cfengine_cfbs_t cfengine_reactor_t:fifo_file { getattr ioctl read };
+allow cfengine_cfbs_t cfengine_reactor_t:fifo_file { getattr ioctl read write };
 
 allow cfengine_cfbs_t bin_t:file { map execute };
 


### PR DESCRIPTION
This is needed in order for cf-reactor to write out to cfbs process to get module inputs.

Ticket: none
Changelog: none