### PR TITLE
ENT-9605: Added setopt for cf-hub connecting to cf-serverd

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -377,7 +377,7 @@ allow cfengine_hub_t cfengine_var_lib_t:file { getattr open read };
 
 # allow cf-hub to read/write from/to a socket owned by cf-serverd (passed in
 # case of call-collect)
-allow cfengine_hub_t cfengine_serverd_t:tcp_socket { read write };
+allow cfengine_hub_t cfengine_serverd_t:tcp_socket { read write setopt };
 
 allow cfengine_hub_t cfengine_agent_exec_t:file getattr;
 allow cfengine_hub_t cfengine_execd_exec_t:file getattr;


### PR DESCRIPTION
cf-hub needs access to set socket options when connecting to cf-serverd (port 5308)

Ticket: ENT-9605
Changelog: none