### PR TITLE
ENT-9711: Added condition to runalerts service to require stamp directory

### DIFF
--- a/misc/systemd/cf-runalerts.service.in
+++ b/misc/systemd/cf-runalerts.service.in
@@ -3,6 +3,7 @@ Description=CFEngine Enterprise SQL Alerts
 After=syslog.target
 ConditionPathExists=@bindir@/runalerts.php
 ConditionFileIsExecutable=@workdir@/httpd/php/bin/php
+ConditionPathIsDirectory=@workdir@/httpd/php/runalerts-stamp
 
 PartOf=cfengine3.service
 After=cf-postgres.service


### PR DESCRIPTION
The directory really needs to exist in order for the service to update time-stamps.
There is policy managing it's existence, so if we wait for it, it will appear.

Ticket: ENT-9711
Changelog: Title

together:
https://github.com/cfengine/masterfiles/pull/2564
https://github.com/cfengine/core/pull/5136