### PR TITLE
CFE-4122: Fixed debug module expand logging for scalars

### DIFF
--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -607,8 +607,10 @@ char *ExpandScalar(const EvalContext *ctx, const char *ns, const char *scope,
 
     BufferDestroy(current_item);
 
-    LogDebug(LOG_MOD_EXPAND, "ExpandScalar( %s : %s . %s )  =>  %s",
-             SAFENULL(ns), SAFENULL(scope), string, BufferData(out));
+    LogDebug(LOG_MOD_EXPAND,
+             "Expanded scalar '%s' to '%s' using %s namespace and %s scope.",
+             string, BufferData(out), (ns == NULL) ? "current" : ns,
+             (scope == NULL) ? "current" : scope);
 
     return out_belongs_to_us ? BufferClose(out) : BufferGet(out);
 }


### PR DESCRIPTION
This naive change both removes un-necessary whitespace to align with the format
(namespace:bundle.varname) and fixes the output to include the variable name
instead of it's value.

Ticket: CFE-4122
Changelog: Title