### PR TITLE
ENT-9685: Enabled install-time selinux policy compiling

### DIFF
--- a/misc/selinux/Makefile.am
+++ b/misc/selinux/Makefile.am
@@ -4,6 +4,8 @@ cfengine-enterprise.pp: cfengine-enterprise.te cfengine-enterprise.fc
 
 selinuxdir = $(prefix)/selinux
 selinux_DATA = cfengine-enterprise.pp
+selinux_DATA += cfengine-enterprise.te
+selinux_DATA += cfengine-enterprise.fc
 
 clean-local:
 	rm -rf tmp

--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -89,6 +89,7 @@ require {
 	type ssh_exec_t;
 	type ssh_home_t;
 	type rpm_script_t;
+	class lockdown { confidentiality integrity };
 	class tcp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown name_connect accept listen name_bind node_bind };
 	class udp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown node_bind };
 	class sock_file { create write getattr setattr unlink };


### PR DESCRIPTION
by installing the .te and .fc files as well as the build .pp file

buildscripts repo will need install scripts changes to take advantage of this change.

Ticket: ENT-9685
Changelog: title

https://github.com/cfengine/core/pull/5146
https://github.com/cfengine/buildscripts/pull/1187
