### PR TITLE
Updated copyright notices to 2023

### DIFF
--- a/cf-agent/abstract_dir.c
+++ b/cf-agent/abstract_dir.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/abstract_dir.h
+++ b/cf-agent/abstract_dir.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/acl_posix.c
+++ b/cf-agent/acl_posix.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/acl_posix.h
+++ b/cf-agent/acl_posix.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/agent-diagnostics.c
+++ b/cf-agent/agent-diagnostics.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/agent-diagnostics.h
+++ b/cf-agent/agent-diagnostics.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/cf-agent-enterprise-stubs.c
+++ b/cf-agent/cf-agent-enterprise-stubs.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/cf-agent-enterprise-stubs.h
+++ b/cf-agent/cf-agent-enterprise-stubs.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/cf-agent-windows-functions.h
+++ b/cf-agent/cf-agent-windows-functions.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/cf_sql.c
+++ b/cf-agent/cf_sql.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/cf_sql.h
+++ b/cf-agent/cf_sql.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/comparray.c
+++ b/cf-agent/comparray.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/comparray.h
+++ b/cf-agent/comparray.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_changes.c
+++ b/cf-agent/files_changes.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_changes.h
+++ b/cf-agent/files_changes.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_edit.c
+++ b/cf-agent/files_edit.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_edit.h
+++ b/cf-agent/files_edit.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_editline.h
+++ b/cf-agent/files_editline.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_editxml.c
+++ b/cf-agent/files_editxml.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_editxml.h
+++ b/cf-agent/files_editxml.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_properties.c
+++ b/cf-agent/files_properties.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_properties.h
+++ b/cf-agent/files_properties.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_select.c
+++ b/cf-agent/files_select.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/files_select.h
+++ b/cf-agent/files_select.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/findhub.c
+++ b/cf-agent/findhub.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/findhub.h
+++ b/cf-agent/findhub.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/findhub_priv.h
+++ b/cf-agent/findhub_priv.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/load_avahi.c
+++ b/cf-agent/load_avahi.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/load_avahi.h
+++ b/cf-agent/load_avahi.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/manifest_file.c
+++ b/cf-agent/manifest_file.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/nfs.c
+++ b/cf-agent/nfs.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/nfs.h
+++ b/cf-agent/nfs.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/package_module.c
+++ b/cf-agent/package_module.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/package_module.h
+++ b/cf-agent/package_module.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/promiser_regex_resolver.c
+++ b/cf-agent/promiser_regex_resolver.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/promiser_regex_resolver.h
+++ b/cf-agent/promiser_regex_resolver.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/retcode.c
+++ b/cf-agent/retcode.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/retcode.h
+++ b/cf-agent/retcode.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/simulate_mode.c
+++ b/cf-agent/simulate_mode.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/simulate_mode.h
+++ b/cf-agent/simulate_mode.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/tokyo_check.c
+++ b/cf-agent/tokyo_check.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/tokyo_check.h
+++ b/cf-agent/tokyo_check.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/vercmp.c
+++ b/cf-agent/vercmp.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/vercmp.h
+++ b/cf-agent/vercmp.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/vercmp_internal.c
+++ b/cf-agent/vercmp_internal.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/vercmp_internal.h
+++ b/cf-agent/vercmp_internal.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_acl.c
+++ b/cf-agent/verify_acl.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_acl.h
+++ b/cf-agent/verify_acl.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_databases.c
+++ b/cf-agent/verify_databases.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_databases.h
+++ b/cf-agent/verify_databases.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_environments.c
+++ b/cf-agent/verify_environments.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_environments.h
+++ b/cf-agent/verify_environments.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_exec.h
+++ b/cf-agent/verify_exec.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_files.h
+++ b/cf-agent/verify_files.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_files_hashes.c
+++ b/cf-agent/verify_files_hashes.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_files_hashes.h
+++ b/cf-agent/verify_files_hashes.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_files_utils.h
+++ b/cf-agent/verify_files_utils.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_methods.c
+++ b/cf-agent/verify_methods.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_methods.h
+++ b/cf-agent/verify_methods.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_new_packages.c
+++ b/cf-agent/verify_new_packages.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_new_packages.h
+++ b/cf-agent/verify_new_packages.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_packages.h
+++ b/cf-agent/verify_packages.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_processes.c
+++ b/cf-agent/verify_processes.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_processes.h
+++ b/cf-agent/verify_processes.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_services.c
+++ b/cf-agent/verify_services.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_services.h
+++ b/cf-agent/verify_services.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_storage.c
+++ b/cf-agent/verify_storage.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_storage.h
+++ b/cf-agent/verify_storage.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_users.c
+++ b/cf-agent/verify_users.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_users.h
+++ b/cf-agent/verify_users.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-agent/verify_users_stub.c
+++ b/cf-agent/verify_users_stub.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-execd/cf-execd-runagent.c
+++ b/cf-execd/cf-execd-runagent.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-execd/cf-execd-runagent.h
+++ b/cf-execd/cf-execd-runagent.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-execd/cf-execd-runner.c
+++ b/cf-execd/cf-execd-runner.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-execd/cf-execd-runner.h
+++ b/cf-execd/cf-execd-runner.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-execd/cf-execd.h
+++ b/cf-execd/cf-execd.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-execd/exec-config.c
+++ b/cf-execd/exec-config.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-execd/exec-config.h
+++ b/cf-execd/exec-config.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-execd/execd-config.c
+++ b/cf-execd/execd-config.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-execd/execd-config.h
+++ b/cf-execd/execd-config.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-key/cf-key-functions.c
+++ b/cf-key/cf-key-functions.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-key/cf-key-functions.h
+++ b/cf-key/cf-key-functions.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/env_monitor.c
+++ b/cf-monitord/env_monitor.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/env_monitor.h
+++ b/cf-monitord/env_monitor.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/get_socket_info.c
+++ b/cf-monitord/get_socket_info.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/history.c
+++ b/cf-monitord/history.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/history.h
+++ b/cf-monitord/history.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon.h
+++ b/cf-monitord/mon.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_cpu.c
+++ b/cf-monitord/mon_cpu.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_cumulative.c
+++ b/cf-monitord/mon_cumulative.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_cumulative.h
+++ b/cf-monitord/mon_cumulative.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_disk.c
+++ b/cf-monitord/mon_disk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_entropy.c
+++ b/cf-monitord/mon_entropy.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_io_linux.c
+++ b/cf-monitord/mon_io_linux.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_io_stub.c
+++ b/cf-monitord/mon_io_stub.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_load.c
+++ b/cf-monitord/mon_load.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_mem_linux.c
+++ b/cf-monitord/mon_mem_linux.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_mem_solaris.c
+++ b/cf-monitord/mon_mem_solaris.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_mem_stub.c
+++ b/cf-monitord/mon_mem_stub.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_network.c
+++ b/cf-monitord/mon_network.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_network_sniffer.c
+++ b/cf-monitord/mon_network_sniffer.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_processes.c
+++ b/cf-monitord/mon_processes.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/mon_temp.c
+++ b/cf-monitord/mon_temp.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/monitoring.c
+++ b/cf-monitord/monitoring.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/monitoring.h
+++ b/cf-monitord/monitoring.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/probes.c
+++ b/cf-monitord/probes.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/probes.h
+++ b/cf-monitord/probes.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/proc_net_parsing.c
+++ b/cf-monitord/proc_net_parsing.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/proc_net_parsing.h
+++ b/cf-monitord/proc_net_parsing.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/shared_kstat.c
+++ b/cf-monitord/shared_kstat.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/shared_kstat.h
+++ b/cf-monitord/shared_kstat.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/verify_measurements.c
+++ b/cf-monitord/verify_measurements.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-monitord/verify_measurements.h
+++ b/cf-monitord/verify_measurements.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-net/cf-net.c
+++ b/cf-net/cf-net.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-promises/cf-promises.c
+++ b/cf-promises/cf-promises.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-secret/cf-secret.c
+++ b/cf-secret/cf-secret.c
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 Northern.tech AS
+   Copyright 2023 Northern.tech AS
 
    This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/cf-serverd-enterprise-stubs.c
+++ b/cf-serverd/cf-serverd-enterprise-stubs.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/cf-serverd-enterprise-stubs.h
+++ b/cf-serverd/cf-serverd-enterprise-stubs.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/cf-serverd-functions.c
+++ b/cf-serverd/cf-serverd-functions.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/cf-serverd-functions.h
+++ b/cf-serverd/cf-serverd-functions.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/cf-serverd.c
+++ b/cf-serverd/cf-serverd.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server.c
+++ b/cf-serverd/server.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server.h
+++ b/cf-serverd/server.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server_access.c
+++ b/cf-serverd/server_access.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server_access.h
+++ b/cf-serverd/server_access.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server_classic.c
+++ b/cf-serverd/server_classic.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server_classic.h
+++ b/cf-serverd/server_classic.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server_common.c
+++ b/cf-serverd/server_common.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server_common.h
+++ b/cf-serverd/server_common.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server_tls.h
+++ b/cf-serverd/server_tls.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/server_transform.h
+++ b/cf-serverd/server_transform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/strlist.c
+++ b/cf-serverd/strlist.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-serverd/strlist.h
+++ b/cf-serverd/strlist.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-testd/cf-testd.c
+++ b/cf-testd/cf-testd.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/alloc-mini.c
+++ b/cf-upgrade/alloc-mini.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/alloc-mini.h
+++ b/cf-upgrade/alloc-mini.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/cf-upgrade.c
+++ b/cf-upgrade/cf-upgrade.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/command_line.c
+++ b/cf-upgrade/command_line.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/command_line.h
+++ b/cf-upgrade/command_line.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/configuration.c
+++ b/cf-upgrade/configuration.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/configuration.h
+++ b/cf-upgrade/configuration.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/log.c
+++ b/cf-upgrade/log.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/log.h
+++ b/cf-upgrade/log.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/process.c
+++ b/cf-upgrade/process.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/process.h
+++ b/cf-upgrade/process.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/update.c
+++ b/cf-upgrade/update.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/cf-upgrade/update.h
+++ b/cf-upgrade/update.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/addr_lib.c
+++ b/libcfnet/addr_lib.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/addr_lib.h
+++ b/libcfnet/addr_lib.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/cfnet.h
+++ b/libcfnet/cfnet.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/classic.c
+++ b/libcfnet/classic.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/classic.h
+++ b/libcfnet/classic.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/client_code.h
+++ b/libcfnet/client_code.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/client_protocol.c
+++ b/libcfnet/client_protocol.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/client_protocol.h
+++ b/libcfnet/client_protocol.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/communication.c
+++ b/libcfnet/communication.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/communication.h
+++ b/libcfnet/communication.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/conn_cache.c
+++ b/libcfnet/conn_cache.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/conn_cache.h
+++ b/libcfnet/conn_cache.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/connection_info.c
+++ b/libcfnet/connection_info.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/connection_info.h
+++ b/libcfnet/connection_info.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/key.c
+++ b/libcfnet/key.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/key.h
+++ b/libcfnet/key.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/misc.c
+++ b/libcfnet/misc.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/net.c
+++ b/libcfnet/net.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/net.h
+++ b/libcfnet/net.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/policy_server.c
+++ b/libcfnet/policy_server.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/policy_server.h
+++ b/libcfnet/policy_server.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/protocol.c
+++ b/libcfnet/protocol.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/protocol.h
+++ b/libcfnet/protocol.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/protocol_version.h
+++ b/libcfnet/protocol_version.h
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 Northern.tech AS
+   Copyright 2023 Northern.tech AS
 
    This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/stat_cache.c
+++ b/libcfnet/stat_cache.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/stat_cache.h
+++ b/libcfnet/stat_cache.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/tls_client.c
+++ b/libcfnet/tls_client.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/tls_client.h
+++ b/libcfnet/tls_client.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/tls_generic.c
+++ b/libcfnet/tls_generic.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcfnet/tls_generic.h
+++ b/libcfnet/tls_generic.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libenv/constants.c
+++ b/libenv/constants.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libenv/constants.h
+++ b/libenv/constants.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libenv/sysinfo.h
+++ b/libenv/sysinfo.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libenv/sysinfo_priv.h
+++ b/libenv/sysinfo_priv.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libenv/time_classes.c
+++ b/libenv/time_classes.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libenv/time_classes.h
+++ b/libenv/time_classes.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libenv/zones.c
+++ b/libenv/zones.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libenv/zones.h
+++ b/libenv/zones.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/acl_tools.h
+++ b/libpromises/acl_tools.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/acl_tools_posix.c
+++ b/libpromises/acl_tools_posix.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/actuator.c
+++ b/libpromises/actuator.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/actuator.h
+++ b/libpromises/actuator.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/assoc.c
+++ b/libpromises/assoc.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/assoc.h
+++ b/libpromises/assoc.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/attributes.h
+++ b/libpromises/attributes.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/audit.c
+++ b/libpromises/audit.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/audit.h
+++ b/libpromises/audit.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/bootstrap.c
+++ b/libpromises/bootstrap.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/bootstrap.h
+++ b/libpromises/bootstrap.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/cf-windows-functions.h
+++ b/libpromises/cf-windows-functions.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/cf3.extern.h
+++ b/libpromises/cf3.extern.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/cf3globals.c
+++ b/libpromises/cf3globals.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/cf3parse_logic.h
+++ b/libpromises/cf3parse_logic.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/changes_chroot.c
+++ b/libpromises/changes_chroot.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/changes_chroot.h
+++ b/libpromises/changes_chroot.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/chflags.c
+++ b/libpromises/chflags.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/chflags.h
+++ b/libpromises/chflags.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/class.c
+++ b/libpromises/class.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/class.h
+++ b/libpromises/class.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/cmdb.c
+++ b/libpromises/cmdb.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/cmdb.h
+++ b/libpromises/cmdb.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/constants.c
+++ b/libpromises/constants.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/conversion.c
+++ b/libpromises/conversion.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/conversion.h
+++ b/libpromises/conversion.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/crypto.h
+++ b/libpromises/crypto.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/dbm_api.h
+++ b/libpromises/dbm_api.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/dbm_api_types.h
+++ b/libpromises/dbm_api_types.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/dbm_migration.c
+++ b/libpromises/dbm_migration.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/dbm_migration.h
+++ b/libpromises/dbm_migration.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/dbm_migration_lastseen.c
+++ b/libpromises/dbm_migration_lastseen.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/dbm_priv.h
+++ b/libpromises/dbm_priv.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/dbm_quick.c
+++ b/libpromises/dbm_quick.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/dbm_tokyocab.c
+++ b/libpromises/dbm_tokyocab.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/enterprise_stubs.c
+++ b/libpromises/enterprise_stubs.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/evalfunction.h
+++ b/libpromises/evalfunction.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/exec_tools.c
+++ b/libpromises/exec_tools.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/exec_tools.h
+++ b/libpromises/exec_tools.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/expand.h
+++ b/libpromises/expand.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/extensions.c
+++ b/libpromises/extensions.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/extensions.h
+++ b/libpromises/extensions.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_copy.c
+++ b/libpromises/files_copy.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_copy.h
+++ b/libpromises/files_copy.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_interfaces.c
+++ b/libpromises/files_interfaces.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_interfaces.h
+++ b/libpromises/files_interfaces.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_lib.h
+++ b/libpromises/files_lib.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_links.c
+++ b/libpromises/files_links.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_links.h
+++ b/libpromises/files_links.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_names.c
+++ b/libpromises/files_names.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_names.h
+++ b/libpromises/files_names.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_operators.c
+++ b/libpromises/files_operators.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_operators.h
+++ b/libpromises/files_operators.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_repository.c
+++ b/libpromises/files_repository.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/files_repository.h
+++ b/libpromises/files_repository.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/fncall.c
+++ b/libpromises/fncall.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/fncall.h
+++ b/libpromises/fncall.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/global_mutex.c
+++ b/libpromises/global_mutex.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/global_mutex.h
+++ b/libpromises/global_mutex.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/granules.c
+++ b/libpromises/granules.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/granules.h
+++ b/libpromises/granules.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/instrumentation.c
+++ b/libpromises/instrumentation.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/instrumentation.h
+++ b/libpromises/instrumentation.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/item_lib.c
+++ b/libpromises/item_lib.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/item_lib.h
+++ b/libpromises/item_lib.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/iteration.h
+++ b/libpromises/iteration.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/keyring.c
+++ b/libpromises/keyring.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/keyring.h
+++ b/libpromises/keyring.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/loading.c
+++ b/libpromises/loading.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/loading.h
+++ b/libpromises/loading.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/locks.h
+++ b/libpromises/locks.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/logic_expressions.c
+++ b/libpromises/logic_expressions.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/logic_expressions.h
+++ b/libpromises/logic_expressions.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/match_scope.c
+++ b/libpromises/match_scope.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/match_scope.h
+++ b/libpromises/match_scope.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/matching.c
+++ b/libpromises/matching.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/matching.h
+++ b/libpromises/matching.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/math_eval.c
+++ b/libpromises/math_eval.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/math_eval.h
+++ b/libpromises/math_eval.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_access.c
+++ b/libpromises/mod_access.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_access.h
+++ b/libpromises/mod_access.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_common.h
+++ b/libpromises/mod_common.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_custom.h
+++ b/libpromises/mod_custom.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_databases.c
+++ b/libpromises/mod_databases.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_databases.h
+++ b/libpromises/mod_databases.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_environ.c
+++ b/libpromises/mod_environ.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_environ.h
+++ b/libpromises/mod_environ.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_exec.c
+++ b/libpromises/mod_exec.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_exec.h
+++ b/libpromises/mod_exec.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_files.c
+++ b/libpromises/mod_files.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_files.h
+++ b/libpromises/mod_files.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_knowledge.c
+++ b/libpromises/mod_knowledge.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_knowledge.h
+++ b/libpromises/mod_knowledge.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_measurement.c
+++ b/libpromises/mod_measurement.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_measurement.h
+++ b/libpromises/mod_measurement.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_methods.c
+++ b/libpromises/mod_methods.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_methods.h
+++ b/libpromises/mod_methods.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_outputs.c
+++ b/libpromises/mod_outputs.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_outputs.h
+++ b/libpromises/mod_outputs.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_packages.c
+++ b/libpromises/mod_packages.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_packages.h
+++ b/libpromises/mod_packages.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_process.c
+++ b/libpromises/mod_process.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_process.h
+++ b/libpromises/mod_process.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_report.c
+++ b/libpromises/mod_report.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_report.h
+++ b/libpromises/mod_report.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_services.c
+++ b/libpromises/mod_services.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_services.h
+++ b/libpromises/mod_services.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_storage.c
+++ b/libpromises/mod_storage.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_storage.h
+++ b/libpromises/mod_storage.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_users.c
+++ b/libpromises/mod_users.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/mod_users.h
+++ b/libpromises/mod_users.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/modes.c
+++ b/libpromises/modes.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/monitoring_read.c
+++ b/libpromises/monitoring_read.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/monitoring_read.h
+++ b/libpromises/monitoring_read.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/ornaments.c
+++ b/libpromises/ornaments.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/ornaments.h
+++ b/libpromises/ornaments.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/parser.c
+++ b/libpromises/parser.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/parser.h
+++ b/libpromises/parser.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/parser_helpers.h
+++ b/libpromises/parser_helpers.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/parser_state.h
+++ b/libpromises/parser_state.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/patches.c
+++ b/libpromises/patches.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/pipes.c
+++ b/libpromises/pipes.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/pipes.h
+++ b/libpromises/pipes.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/policy.h
+++ b/libpromises/policy.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/process_aix.c
+++ b/libpromises/process_aix.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/process_freebsd.c
+++ b/libpromises/process_freebsd.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/process_hpux.c
+++ b/libpromises/process_hpux.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/process_lib.h
+++ b/libpromises/process_lib.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/process_linux.c
+++ b/libpromises/process_linux.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/process_solaris.c
+++ b/libpromises/process_solaris.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/process_unix.c
+++ b/libpromises/process_unix.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/process_unix_priv.h
+++ b/libpromises/process_unix_priv.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/process_unix_stub.c
+++ b/libpromises/process_unix_stub.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/processes_select.c
+++ b/libpromises/processes_select.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/processes_select.h
+++ b/libpromises/processes_select.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/promises.h
+++ b/libpromises/promises.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/prototypes3.h
+++ b/libpromises/prototypes3.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/rlist.h
+++ b/libpromises/rlist.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/scope.c
+++ b/libpromises/scope.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/scope.h
+++ b/libpromises/scope.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/shared_lib.c
+++ b/libpromises/shared_lib.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/shared_lib.h
+++ b/libpromises/shared_lib.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/signals.c
+++ b/libpromises/signals.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/signals.h
+++ b/libpromises/signals.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/sort.h
+++ b/libpromises/sort.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/storage_tools.c
+++ b/libpromises/storage_tools.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/string_expressions.c
+++ b/libpromises/string_expressions.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/string_expressions.h
+++ b/libpromises/string_expressions.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/syntax.h
+++ b/libpromises/syntax.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/syslog_client.c
+++ b/libpromises/syslog_client.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/syslog_client.h
+++ b/libpromises/syslog_client.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/systype.c
+++ b/libpromises/systype.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/systype.h
+++ b/libpromises/systype.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/timeout.h
+++ b/libpromises/timeout.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/unix.h
+++ b/libpromises/unix.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/var_expressions.c
+++ b/libpromises/var_expressions.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/var_expressions.h
+++ b/libpromises/var_expressions.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/variable.c
+++ b/libpromises/variable.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/variable.h
+++ b/libpromises/variable.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/vars.c
+++ b/libpromises/vars.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/vars.h
+++ b/libpromises/vars.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/verify_classes.c
+++ b/libpromises/verify_classes.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/verify_classes.h
+++ b/libpromises/verify_classes.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/verify_reports.c
+++ b/libpromises/verify_reports.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libpromises/verify_vars.h
+++ b/libpromises/verify_vars.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/tests/acceptance/25_cf-execd/cf-execd-rpl-functions.c
+++ b/tests/acceptance/25_cf-execd/cf-execd-rpl-functions.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/tests/acceptance/fakesyslog.c
+++ b/tests/acceptance/fakesyslog.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/tests/acceptance/no_fds.c
+++ b/tests/acceptance/no_fds.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/tests/unit/changes_migration_test.c
+++ b/tests/unit/changes_migration_test.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/tests/unit/db_stubs.c
+++ b/tests/unit/db_stubs.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/tests/unit/files_copy_test.c
+++ b/tests/unit/files_copy_test.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/tests/unit/init_script_test_helper.c
+++ b/tests/unit/init_script_test_helper.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/tests/unit/process_test.c
+++ b/tests/unit/process_test.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Northern.tech AS
+  Copyright 2023 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 


### PR DESCRIPTION
Ran command:

```
find . -name '*.[hc]' -exec replacer.py 'Copyright 2022 Northern.tech' 'Copyright 2023 Northern.tech' '{}' \;
```

Using replacer.py script:
https://github.com/olehermanse/dotfiles/blob/d3a155320b4ec5c297f9364ebcfbc39dc7dbaa01/bin/replacer.py
