### PR TITLE
ENT-9711: Added condition to runalerts service to require stamp directory (3.18)

### DIFF
--- a/misc/systemd/cf-runalerts.service.in
+++ b/misc/systemd/cf-runalerts.service.in
@@ -3,6 +3,7 @@ Description=CFEngine Enterprise SQL Alerts
 After=syslog.target
 ConditionPathExists=@bindir@/runalerts.php
 ConditionFileIsExecutable=@workdir@/httpd/php/bin/php
+ConditionPathIsDirectory=@workdir@/httpd/php/runalerts-stamp
 
 PartOf=cfengine3.service
 After=cf-postgres.service


### PR DESCRIPTION
The directory really needs to exist in order for the service to update time-stamps. There is policy managing it's existence, so if we wait for it, it will appear.

Ticket: ENT-9711
Changelog: Title
(cherry picked from commit f9636ca357fdc9c4166c681675df91f623d30e10)

together:
https://github.com/cfengine/buildscripts/pull/1188
https://github.com/cfengine/masterfiles/pull/2569
https://github.com/cfengine/core/pull/5149