### PR TITLE
ENT-9759: Fixed syntax description of validjson() (3.21)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -9589,7 +9589,7 @@ static const FnCallArg READDATA_ARGS[] =
 
 static const FnCallArg VALIDDATA_ARGS[] =
 {
-    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Data to validate"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "String to validate as JSON"},
     {"JSON", CF_DATA_TYPE_OPTION, "Type of data to validate"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };


### PR DESCRIPTION
This change simply clarifies that the input to the function is a string and not
a data container.