### PR TITLE
ENT-9340: Fixed cf-support shellcheck check target (3.18)

### DIFF
--- a/misc/Makefile.am
+++ b/misc/Makefile.am
@@ -38,5 +38,9 @@ endif
 dist_bin_SCRIPTS = cf-support
 
 check-local:
-	command -v shellcheck 2>/dev/null && shellcheck --version
-	command -v shellcheck 2>/dev/null && shellcheck cf-support
+	@if command -v shellcheck 2>/dev/null; then \
+	  shellcheck --version; \
+	  shellcheck cf-support; \
+	else \
+	  echo "Install shellcheck to check cf-support script."; \
+	fi


### PR DESCRIPTION
Needed to check shellcheck command differently.

Ticket: ENT-9340
Changelog: none
(cherry picked from commit 999b930e6ba97f17a272d769a08730f05d9c4717)