### PR TITLE
CFE-4109: Log msg now mentions filetype when changing perms

### DIFF
--- a/tests/acceptance/28_inform_testing/01_files/copy_from01.cf.expected
+++ b/tests/acceptance/28_inform_testing/01_files/copy_from01.cf.expected
@@ -1,9 +1,9 @@
     info: Created directory '/tmp/TEST.destination/subdir/.'
     info: Copied file '/tmp/TEST.source/file-perms-644' to '/tmp/TEST.destination/file-perms-644.cfnew' (permissions preserved)
     info: Moved '/tmp/TEST.destination/file-perms-644.cfnew' to '/tmp/TEST.destination/file-perms-644'
-    info: Object '/tmp/TEST.destination/file-perms-644' had permissions 0600, changed it to 0644
+    info: Regular file '/tmp/TEST.destination/file-perms-644' had permissions 0600, changed it to 0644
     info: Updated file '/tmp/TEST.destination/file-perms-644' from 'localhost:/tmp/TEST.source/file-perms-644'
     info: Copied file '/tmp/TEST.source/subdir/subdir-file' to '/tmp/TEST.destination/subdir/subfile.cfnew' (permissions preserved)
     info: Moved '/tmp/TEST.destination/subdir/subfile.cfnew' to '/tmp/TEST.destination/subdir/subfile'
-    info: Object '/tmp/TEST.destination/subdir/subfile' had permissions 0600, changed it to 0644
+    info: Regular file '/tmp/TEST.destination/subdir/subfile' had permissions 0600, changed it to 0644
     info: Updated file '/tmp/TEST.destination/subdir/subfile' from 'localhost:/tmp/TEST.source/subdir/subdir-file'

--- a/tests/acceptance/28_inform_testing/01_files/copy_from03.cf.expected
+++ b/tests/acceptance/28_inform_testing/01_files/copy_from03.cf.expected
@@ -2,7 +2,7 @@
     info: Created file '/tmp/TEST.destination/subdir/purgeme', mode 0600
     info: Copied file '/tmp/TEST.source/file-perms-644' to '/tmp/TEST.destination/file-perms-644.cfnew' (permissions preserved)
     info: Moved '/tmp/TEST.destination/file-perms-644.cfnew' to '/tmp/TEST.destination/file-perms-644'
-    info: Object '/tmp/TEST.destination/file-perms-644' had permissions 0600, changed it to 0644
+    info: Regular file '/tmp/TEST.destination/file-perms-644' had permissions 0600, changed it to 0644
     info: Updated file '/tmp/TEST.destination/file-perms-644' from 'localhost:/tmp/TEST.source/file-perms-644'
     info: Copied file '/tmp/TEST.source/subdir/./subdir-file' to '/tmp/TEST.destination/subdir/./subdir-file.cfnew' (mode '600')
     info: Moved '/tmp/TEST.destination/subdir/./subdir-file.cfnew' to '/tmp/TEST.destination/subdir/./subdir-file'

--- a/tests/acceptance/28_inform_testing/01_files/perms.cf
+++ b/tests/acceptance/28_inform_testing/01_files/perms.cf
@@ -9,16 +9,56 @@ bundle common testcase
     "filename" string => "$(this.promise_filename)";
 }
 
+body link_from link_info(source)
+{
+  source => "$(source)";
+  link_type => "symlink";
+}
+
 bundle agent setup
 {
   files:
-    "$(G.testfile)"
-      create => "true";
+    "$(G.testdir)/foo"
+      create => "true",
+      comment => "A regular file";
+
+    "$(G.testdir)/bar"
+      create => "true",
+      comment => "A regular file symlink target";
+
+    "$(G.testdir)/baz"
+      link_from => link_info("$(G.testdir)/bar"),
+      comment => "A symbolic link to a regular file";
+
+    "$(G.testdir)/foobar/."
+      create => "true",
+      comment => "A directory";
+
+# See ticket CFE-4148:
+#
+#   "$(G.testdir)/foobaz/."
+#     create => "true",
+#     comment => "A directory symlink taget";
+#
+#   "$(G.testdir)/barbaz/."
+#     link_from => link_info("$(G.testdir)/foobaz"),
+#     comment => "A symbolic link to a directory";
 }
 
 bundle agent main
 {
   files:
-    "$(G.testfile)"
-    perms => m(000);
+      "$(G.testdir)/foo"
+        perms => m(777);
+
+      "$(G.testdir)/baz"
+        perms => m(777);
+
+      "$(G.testdir)/foobar"
+        perms => m(777);
+
+# See ticket CFE-4148:
+#
+#     "$(G.testdir)/barbaz/."
+#       perms => m(777);
 }

--- a/tests/acceptance/28_inform_testing/01_files/perms.cf.expected
+++ b/tests/acceptance/28_inform_testing/01_files/perms.cf.expected
@@ -1,1 +1,3 @@
-    info: Object '/tmp/TEST.cfengine' had permissions 0600, changed it to 0000
+    info: Regular file '/tmp/TESTDIR.cfengine/foo' had permissions 0600, changed it to 0777
+    info: Symbolic link to regular file '/tmp/TESTDIR.cfengine/baz' had permissions 0600, changed it to 0777
+    info: Directory '/tmp/TESTDIR.cfengine/foobar' had permissions 0700, changed it to 0777


### PR DESCRIPTION
Log message now says:
```
info: [Regular file|Directory|etc...] '/tmp/foo' had permissions 0600, changed it to 0700
```

instead of:
```
info: Object '/tmp/foo' had permissions 0600, changed it to 0700
```

Ticket: CFE-4109
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>