### PR TITLE
CFE-4146: Defined feature class built_with_enable_fhs when compiled with --enable-fhs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -189,7 +189,8 @@ dnl ######################################################################
 AC_ARG_ENABLE([fhs],
         [AS_HELP_STRING([--enable-fhs], [Enable FHS compliance. Defaults to custom CFEngine files layout])])
 
-#
+AM_CONDITIONAL(HAVE_FHS, [test x"$enable_fhs" = xyes])
+
 # pkglibdir/pkgdatadir are not overridable, so use our own invention instead.
 #
 

--- a/libpromises/feature.c
+++ b/libpromises/feature.c
@@ -5,6 +5,9 @@
 #include <buffer.h>
 
 static const char* features[] = {
+#ifdef HAVE_FHS
+    "built_with_enable_fhs",
+#endif
 #ifdef HAVE_LIBYAML
     "yaml",
 #endif


### PR DESCRIPTION
Naive attempt at having a class defined when a binary is built with FHS is useful for dealing
with different expectations.

Ticket: CFE-4146
Changelog: Title