### PR TITLE
CFE-4122: Fixed debug module expand logging for scalars (3.18)

### DIFF
--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -607,8 +607,10 @@ char *ExpandScalar(const EvalContext *ctx, const char *ns, const char *scope,
 
     BufferDestroy(current_item);
 
-    LogDebug(LOG_MOD_EXPAND, "ExpandScalar( %s : %s . %s )  =>  %s",
-             SAFENULL(ns), SAFENULL(scope), string, BufferData(out));
+    LogDebug(LOG_MOD_EXPAND,
+             "Expanded scalar '%s' to '%s' using %s namespace and %s scope.",
+             string, BufferData(out), (ns == NULL) ? "current" : ns,
+             (scope == NULL) ? "current" : scope);
 
     return out_belongs_to_us ? BufferClose(out) : BufferGet(out);
 }


### PR DESCRIPTION
This change makes the log message less confusing as it used to look like
a variable expansion.

Ticket: CFE-4122
Changelog: Title
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
Co-authored-by: Nick Anderson <nick.anderson@northern.tech>
(cherry picked from commit fa903e9b03d05aa863df89be8ab5f56781b344fa)