### PR TITLE
ENT-9363: Improved MacOS Support

### DIFF
--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -11,9 +11,9 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: brew install lmdb automake openssl@1.1 pcre
+      run: brew install lmdb automake openssl pcre
     - name: Run autotools / configure
-      run: ./autogen.sh --enable-debug --with-openssl="$(brew --prefix openssl@1.1)"
+      run: ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests

--- a/INSTALL
+++ b/INSTALL
@@ -144,5 +144,5 @@ $ ./autogen.sh --without-pam
 
 * OSX (2021-10-20)
 
-brew install openssl@1.1 lmdb autoconf automake libtool bison flex pcre m4 gcc make
+brew install openssl lmdb autoconf automake libtool bison flex pcre m4 gcc make
 ./autogen.sh --enable-debug --with-openssl="$(brew --prefix openssl@1.1)"

--- a/configure.ac
+++ b/configure.ac
@@ -455,10 +455,10 @@ if test x"$with_openssl" = xno ; then
     AC_MSG_ERROR([This release of CFEngine requires OpenSSL >= 0.9.7])
 fi
 
-if  test -d /usr/local/Cellar/openssl/ && \
+if  test -d /usr/local/Cellar/ && \
     test -d /usr/local/opt/openssl/ && \
     test "x$with_openssl" = "xyes" ; then
-    with_openssl="/usr/local/opt/openssl"
+    with_openssl=$(brew --prefix openssl)
     echo "OS X Homebrew detected"
     echo "Defaulting to: --with-openssl=$with_openssl"
 fi

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -713,7 +713,7 @@ static void FindV6InterfacesInfo(EvalContext *ctx, Rlist **interfaces, Rlist **h
 
                 // We know there was more data, at least a colon:
                 assert(src_length == bytes_to_copy);
-                const size_t dst_length = src_length - 1;
+                NDEBUG_UNUSED const size_t dst_length = src_length - 1;
 
                 // We copied everything up to, but not including, the colon:
                 assert(ifconfig_line[dst_length] == ':');


### PR DESCRIPTION
- Find openssl libraries in a more dynamic way.
- Fixup unix_iface.c compiler warnings.
