### PR TITLE
CFE-4145: Fixed segfault caused by empty array in CMDB class specification (3.21.x)

### DIFF
--- a/libpromises/cmdb.c
+++ b/libpromises/cmdb.c
@@ -414,12 +414,25 @@ static bool ReadCMDBClasses(EvalContext *ctx, JsonElement *classes)
         else if (JsonGetContainerType(data) == JSON_CONTAINER_TYPE_ARRAY &&
                  JsonArrayContainsOnlyPrimitives(data))
         {
-            if ((JsonLength(data) != 1) ||
-                (!StringEqual(JsonPrimitiveGetAsString(JsonArrayGet(data, 0)), "any::")))
+            switch (JsonLength(data))
             {
+            case 0:
                 Log(LOG_LEVEL_ERR,
-                    "Invalid class specification '%s' in CMDB data, only '[\"any::\"]' allowed",
-                    JsonPrimitiveGetAsString(JsonArrayGet(data, 0)));
+                    "Empty class specification '[]' in CMDB data not allowed, only '[\"any::\"]'");
+                continue;;
+            case 1:
+                if (!StringEqual(JsonPrimitiveGetAsString(JsonArrayGet(data, 0)), "any::"))
+                {
+                    Log(LOG_LEVEL_ERR,
+                        "Invalid class specification '[\"%s\"]' in CMDB data, only '[\"any::\"]' allowed",
+                        JsonPrimitiveGetAsString(JsonArrayGet(data, 0)));
+                    continue;
+                }
+                // All good :)
+                break;
+            default:
+                Log(LOG_LEVEL_ERR,
+                    "Too many elements in class specification in CMDB data, only '[\"any::\"]' allowed");
                 continue;
             }
             StringSet *default_tags = StringSetNew();


### PR DESCRIPTION
Now an error message is emitted instead, when array is empty:

```
   error: Empty class specification '[]' in CMDB data not allowed, only '["any::"]'
```

Also added an error message when array contains more than one element:

```
   error: Too many elements in class specification in CMDB data, only '["any::"]' allowed
```

And the old error message is now only emitted when array contains one element that is not "any::":

```
   error: Invalid class specification '["linux::"]' in CMDB data, only '["any::"]' allowed
```

Cherry picked from https://github.com/cfengine/core/pull/5181