### PR TITLE
CFE-4114: Directories are now created with correct perms

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -341,8 +341,8 @@ static PromiseResult CfCopyFile(EvalContext *ctx, char *sourcefile,
     else
     {
         bool dir_created = false;
-        if (!MakeParentDirectoryForPromise(ctx, pp, &attr, &result,
-                                           destfile, true, &dir_created))
+        if (!MakeParentDirectoryForPromise(ctx, pp, &attr, &result, destfile,
+                                           true, &dir_created, DEFAULTMODE))
         {
             return result;
         }
@@ -757,8 +757,9 @@ static PromiseResult SourceSearchAndCopy(EvalContext *ctx, const char *from, cha
     struct stat tostat;
 
     bool dir_created = false;
-    if (!MakeParentDirectoryForPromise(ctx, pp, attr, &result,
-                                       newto, attr->move_obstructions, &dir_created))
+    if (!MakeParentDirectoryForPromise(ctx, pp, attr, &result, newto,
+                                       attr->move_obstructions, &dir_created,
+                                       DEFAULTMODE))
     {
         return result;
     }
@@ -3191,8 +3192,9 @@ static PromiseResult CopyFileSources(EvalContext *ctx, char *destination, const 
 
     PromiseResult result = PROMISE_RESULT_NOOP;
     bool dir_created = false;
-    if (!MakeParentDirectoryForPromise(ctx, pp, attr, &result,
-                                       vbuff, attr->move_obstructions, &dir_created))
+    if (!MakeParentDirectoryForPromise(ctx, pp, attr, &result, vbuff,
+                                       attr->move_obstructions, &dir_created,
+                                       DEFAULTMODE))
     {
         BufferDestroy(source_buf);
         return result;
@@ -4376,15 +4378,30 @@ bool CfCreateFile(EvalContext *ctx, char *file, const Promise *pp, const Attribu
 
         if (MakingChanges(ctx, pp, attr, result, "create directory '%s'", file))
         {
+            mode_t filemode = DEFAULTMODE;
+            if (PromiseGetConstraintAsRval(pp, "mode", RVAL_TYPE_SCALAR) == NULL)
+            {
+                Log(LOG_LEVEL_VERBOSE,
+                    "No mode was set, choosing directory default %04jo",
+                    (uintmax_t) filemode);
+            }
+            else
+            {
+                filemode = attr->perms.plus & ~(attr->perms.minus);
+            }
+
             bool dir_created = false;
-            if (!MakeParentDirectoryForPromise(ctx, pp, attr, result,
-                                               file, attr->move_obstructions, &dir_created))
+            if (!MakeParentDirectoryForPromise(ctx, pp, attr, result, file,
+                                               attr->move_obstructions,
+                                               &dir_created, filemode))
             {
                 return false;
             }
             if (dir_created)
             {
-                RecordChange(ctx, pp, attr, "Created directory '%s'", file);
+                RecordChange(ctx, pp, attr,
+                             "Created directory '%s', mode %04jo", file,
+                             (uintmax_t) filemode);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_CHANGE);
             }
         }
@@ -4407,8 +4424,9 @@ bool CfCreateFile(EvalContext *ctx, char *file, const Promise *pp, const Attribu
         }
 
         bool dir_created = false;
-        if (!MakeParentDirectoryForPromise(ctx, pp, attr, result,
-                                           file, attr->move_obstructions, &dir_created))
+        if (!MakeParentDirectoryForPromise(ctx, pp, attr, result, file,
+                                           attr->move_obstructions,
+                                           &dir_created, DEFAULTMODE))
         {
             return false;
         }
@@ -4460,8 +4478,9 @@ bool CfCreateFile(EvalContext *ctx, char *file, const Promise *pp, const Attribu
         }
 
         bool dir_created = false;
-        if (!MakeParentDirectoryForPromise(ctx, pp, attr, result,
-                                           file, attr->move_obstructions, &dir_created))
+        if (!MakeParentDirectoryForPromise(ctx, pp, attr, result, file,
+                                           attr->move_obstructions,
+                                           &dir_created, DEFAULTMODE))
         {
             return false;
         }

--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -120,11 +120,15 @@ bool MakeParentInternalDirectory(const char *parentandchild, bool force, bool *c
                                    parentandchild, force, true, created, DEFAULTMODE);
 }
 
-bool MakeParentDirectoryForPromise(EvalContext *ctx, const Promise *pp, const Attributes *attr,
-                                   PromiseResult *result, const char *parentandchild,
-                                   bool force, bool *created)
+bool MakeParentDirectoryForPromise(EvalContext *ctx, const Promise *pp,
+                                   const Attributes *attr,
+                                   PromiseResult *result,
+                                   const char *parentandchild,
+                                   bool force, bool *created,
+                                   const mode_t perms_mode)
 {
-    return MakeParentDirectoryImpl(ctx, pp, attr, result, parentandchild, force, false, created, DEFAULTMODE);
+    return MakeParentDirectoryImpl(ctx, pp, attr, result, parentandchild,
+                                   force, false, created, perms_mode);
 }
 
 static bool MakeParentDirectoryImpl(EvalContext *ctx, const Promise *pp, const Attributes *attr,

--- a/libpromises/files_lib.h
+++ b/libpromises/files_lib.h
@@ -52,9 +52,12 @@ bool MakeParentInternalDirectory(const char *parentandchild, bool force, bool *c
  * @warning This function will not behave right on Windows if the path
  *          contains double (back)slashes!
  **/
-bool MakeParentDirectoryForPromise(EvalContext *ctx, const Promise *pp, const Attributes *attr,
-                                   PromiseResult *result, const char *parentandchild,
-                                   bool force, bool *created);
+bool MakeParentDirectoryForPromise(EvalContext *ctx, const Promise *pp,
+                                   const Attributes *attr,
+                                   PromiseResult *result,
+                                   const char *parentandchild,
+                                   bool force, bool *created,
+                                   mode_t perms_mode);
 
 void RotateFiles(const char *name, int number);
 void CreateEmptyFile(char *name);

--- a/libpromises/files_links.c
+++ b/libpromises/files_links.c
@@ -137,9 +137,9 @@ PromiseResult VerifyLink(EvalContext *ctx, char *destination, const char *source
         }
 
         bool dir_created = false;
-        if (MakeParentDirectoryForPromise(ctx, pp, attr, &result,
-                                          destination, attr->move_obstructions,
-                                          &dir_created))
+        if (MakeParentDirectoryForPromise(ctx, pp, attr, &result, destination,
+                                          attr->move_obstructions,
+                                          &dir_created, DEFAULTMODE))
         {
             if (dir_created)
             {

--- a/tests/acceptance/28_inform_testing/01_files/copy_from01.cf.expected
+++ b/tests/acceptance/28_inform_testing/01_files/copy_from01.cf.expected
@@ -1,4 +1,4 @@
-    info: Created directory '/tmp/TEST.destination/subdir/.'
+    info: Created directory '/tmp/TEST.destination/subdir/.', mode 0700
     info: Copied file '/tmp/TEST.source/file-perms-644' to '/tmp/TEST.destination/file-perms-644.cfnew' (permissions preserved)
     info: Moved '/tmp/TEST.destination/file-perms-644.cfnew' to '/tmp/TEST.destination/file-perms-644'
     info: Regular file '/tmp/TEST.destination/file-perms-644' had permissions 0600, changed it to 0644

--- a/tests/acceptance/28_inform_testing/01_files/copy_from02.cf.expected
+++ b/tests/acceptance/28_inform_testing/01_files/copy_from02.cf.expected
@@ -1,4 +1,4 @@
-    info: Created directory '/tmp/TEST.destination/subdir/.'
+    info: Created directory '/tmp/TEST.destination/subdir/.', mode 0700
     info: Copied file '/tmp/TEST.source/file-perms-644' to '/tmp/TEST.destination/file-perms-644.cfnew' (mode '600')
     info: Moved '/tmp/TEST.destination/file-perms-644.cfnew' to '/tmp/TEST.destination/file-perms-644'
     info: Updated file '/tmp/TEST.destination/file-perms-644' from 'localhost:/tmp/TEST.source/file-perms-644'


### PR DESCRIPTION
Instead of creating the directories with the default file permissions,
then change them to the desired state; directories are now created with
the desired set of permissions.

```
    info: Created file '/tmp/testfile', mode 0655
    info: Created directory '/tmp/testdir/.', mode 0655
```
