### PR TITLE
CFE-4114: Directories are now created with correct perms (3.21.x)

### DIFF
--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -120,11 +120,15 @@ bool MakeParentInternalDirectory(const char *parentandchild, bool force, bool *c
                                    parentandchild, force, true, created, DEFAULTMODE);
 }
 
-bool MakeParentDirectoryForPromise(EvalContext *ctx, const Promise *pp, const Attributes *attr,
-                                   PromiseResult *result, const char *parentandchild,
-                                   bool force, bool *created)
+bool MakeParentDirectoryForPromise(EvalContext *ctx, const Promise *pp,
+                                   const Attributes *attr,
+                                   PromiseResult *result,
+                                   const char *parentandchild,
+                                   bool force, bool *created,
+                                   const mode_t perms_mode)
 {
-    return MakeParentDirectoryImpl(ctx, pp, attr, result, parentandchild, force, false, created, DEFAULTMODE);
+    return MakeParentDirectoryImpl(ctx, pp, attr, result, parentandchild,
+                                   force, false, created, perms_mode);
 }
 
 static bool MakeParentDirectoryImpl(EvalContext *ctx, const Promise *pp, const Attributes *attr,

--- a/libpromises/files_lib.h
+++ b/libpromises/files_lib.h
@@ -52,9 +52,12 @@ bool MakeParentInternalDirectory(const char *parentandchild, bool force, bool *c
  * @warning This function will not behave right on Windows if the path
  *          contains double (back)slashes!
  **/
-bool MakeParentDirectoryForPromise(EvalContext *ctx, const Promise *pp, const Attributes *attr,
-                                   PromiseResult *result, const char *parentandchild,
-                                   bool force, bool *created);
+bool MakeParentDirectoryForPromise(EvalContext *ctx, const Promise *pp,
+                                   const Attributes *attr,
+                                   PromiseResult *result,
+                                   const char *parentandchild,
+                                   bool force, bool *created,
+                                   mode_t perms_mode);
 
 void RotateFiles(const char *name, int number);
 void CreateEmptyFile(char *name);

--- a/libpromises/files_links.c
+++ b/libpromises/files_links.c
@@ -137,9 +137,9 @@ PromiseResult VerifyLink(EvalContext *ctx, char *destination, const char *source
         }
 
         bool dir_created = false;
-        if (MakeParentDirectoryForPromise(ctx, pp, attr, &result,
-                                          destination, attr->move_obstructions,
-                                          &dir_created))
+        if (MakeParentDirectoryForPromise(ctx, pp, attr, &result, destination,
+                                          attr->move_obstructions,
+                                          &dir_created, DEFAULTMODE))
         {
             if (dir_created)
             {

--- a/tests/acceptance/28_inform_testing/01_files/copy_from01.cf.expected
+++ b/tests/acceptance/28_inform_testing/01_files/copy_from01.cf.expected
@@ -1,4 +1,4 @@
-    info: Created directory '/tmp/TEST.destination/subdir/.'
+    info: Created directory '/tmp/TEST.destination/subdir/.', mode 0700
     info: Copied file '/tmp/TEST.source/file-perms-644' to '/tmp/TEST.destination/file-perms-644.cfnew' (permissions preserved)
     info: Moved '/tmp/TEST.destination/file-perms-644.cfnew' to '/tmp/TEST.destination/file-perms-644'
     info: Object '/tmp/TEST.destination/file-perms-644' had permissions 0600, changed it to 0644

--- a/tests/acceptance/28_inform_testing/01_files/copy_from02.cf.expected
+++ b/tests/acceptance/28_inform_testing/01_files/copy_from02.cf.expected
@@ -1,4 +1,4 @@
-    info: Created directory '/tmp/TEST.destination/subdir/.'
+    info: Created directory '/tmp/TEST.destination/subdir/.', mode 0700
     info: Copied file '/tmp/TEST.source/file-perms-644' to '/tmp/TEST.destination/file-perms-644.cfnew' (mode '600')
     info: Moved '/tmp/TEST.destination/file-perms-644.cfnew' to '/tmp/TEST.destination/file-perms-644'
     info: Updated file '/tmp/TEST.destination/file-perms-644' from 'localhost:/tmp/TEST.source/file-perms-644'


### PR DESCRIPTION
Instead of creating the directories with the default file permissions, then change them to the desired state; directories are now created with the desired set of permissions.

```
    info: Created file '/tmp/testfile', mode 0655
    info: Created directory '/tmp/testdir/.', mode 0655
```

Cherry picked from https://github.com/cfengine/core/pull/5193