### PR TITLE
CFE-4080: validjson() no longer accepts trailing bogus data (3.18.x)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -7035,7 +7035,7 @@ static FnCallResult ValidateDataGeneric(const char *const fname,
     }
 
     JsonElement *json = NULL;
-    JsonParseError err = JsonParse(&data, &json);
+    JsonParseError err = JsonParseAll(&data, &json);
     if (err != JSON_PARSE_OK)
     {
         Log(LOG_LEVEL_VERBOSE, "%s: %s", fname, JsonParseErrorToString(err));

--- a/tests/acceptance/01_vars/02_functions/validjson_trailing_bogus_data.cf
+++ b/tests/acceptance/01_vars/02_functions/validjson_trailing_bogus_data.cf
@@ -1,0 +1,54 @@
+##############################################################################
+#
+# Test validjson() evaluates to !any:: when there is trailing bogus data after
+# termination for JSON object.
+#
+##############################################################################
+
+body common control
+{
+  bundlesequence => { "test", "check" };
+  version => "1.0";
+}
+
+##############################################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-4080" }
+        string => "Test validjson() with trailing bogus data";
+}
+
+##############################################################################
+
+bundle agent check
+{
+  classes:
+      "ok"
+        and => {
+          not(validjson('""a')),
+          validjson('""'),
+          not(validjson('{}b')),
+          validjson('{}'),
+          not(validjson('[]c')),
+          not(validjson('{}}')),
+          not(validjson('{"d": "e"}}')),
+          not(validjson('[]]')),
+          not(validjson('[[]]]')),
+          not(validjson('[[[]]]]')),
+          not(validjson('  []]')),
+          not(validjson('"some": [ "json" ] }')),
+          not(validjson('{ "some": [ "json" ] } [')),
+          not(validjson('["some", "json"]!')),
+          not(validjson('    ["some", "json"]a')),
+          not(validjson('["some", "json"] {"foo": "var"}   ')),
+          validjson('{"test": [1, 2, 3]}'),
+        };
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Policy function validjson() no longer accepts trailing bogus data. I.e.
non-whitespace characters after json element termination.

Cherry picked from https://github.com/cfengine/core/pull/5191