### PR TITLE
ENT-9878: Fixed compiler warnings for clang 14.0.3 (3.21)

### DIFF
--- a/cf-agent/verify_methods.c
+++ b/cf-agent/verify_methods.c
@@ -95,10 +95,8 @@ PromiseResult VerifyMethod(EvalContext *ctx, const Rval call, const Attributes *
         const FnCall *fp = RvalFnCallValue(call);
         ExpandScalar(ctx, PromiseGetBundle(pp)->ns, PromiseGetBundle(pp)->name, fp->name, method_name);
         args = fp->args;
-        int arg_index = 0;
         while (args)
         {
-           ++arg_index;
            args = args->next;
         }
         args = fp->args;

--- a/cf-net/cf-net.c
+++ b/cf-net/cf-net.c
@@ -156,7 +156,7 @@ static const char *command_strings[] =
 
 // INIT:
 static void CFNetSetDefault(CFNetOptions *opts);
-static void CFNetInit();
+static void CFNetInit(const char *min_tls_version, const char *allow_ciphers);
 static void CFNetOptionsClear(CFNetOptions *opts);
 
 // MAIN LOGIC:

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -572,7 +572,7 @@ bool CompareHashNet(const char *file1, const char *file2, bool encrypt, AgentCon
 
 static bool EncryptCopyRegularFileNet(const char *source, const char *dest, off_t size, AgentConnection *conn)
 {
-    int blocksize = 2048, n_read = 0, plainlen, more = true, finlen, cnt = 0;
+    int blocksize = 2048, n_read = 0, plainlen, more = true, finlen;
     int tosend, cipherlen = 0;
     char *buf, in[CF_BUFSIZE], out[CF_BUFSIZE], workbuf[CF_BUFSIZE], cfchangedstr[265];
     unsigned char iv[32] =
@@ -658,7 +658,6 @@ static bool EncryptCopyRegularFileNet(const char *source, const char *dest, off_
             return false;
         }
 
-        cnt++;
 
         /* If the first thing we get is an error message, break. */
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -3644,7 +3644,6 @@ static FnCallResult FnCallMapData(EvalContext *ctx, ARG_UNUSED const Policy *pol
         {
             const JsonElement *e2;
             JsonIterator iter2 = JsonIteratorInit(e);
-            int position = 0;
             while ((e2 = JsonIteratorNextValueByType(&iter2, JSON_ELEMENT_TYPE_PRIMITIVE, true)) != NULL)
             {
                 char *key = (char*) JsonGetPropertyAsString(e2);
@@ -3697,7 +3696,6 @@ static FnCallResult FnCallMapData(EvalContext *ctx, ARG_UNUSED const Policy *pol
                     EvalContextVariableRemoveSpecial(ctx, SPECIAL_SCOPE_THIS, "k[1]");
                 }
                 EvalContextVariableRemoveSpecial(ctx, SPECIAL_SCOPE_THIS, "v");
-                position++;
             }
         }
         break;

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -100,9 +100,6 @@ typedef struct {
      * field never changes after Wheel initialisation. */
     char *varname_unexp;
 
-    /* Number of dependencies of varname_unexp */
-    //    const size_t deps;
-
     /* On each iteration of the wheels, the unexpanded string is
      * re-expanded, so the following is refilled, again and again. */
     char *varname_exp;
@@ -527,7 +524,6 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
         s_end = s + s_max;
     }
     char *next_var = s + FindDollarParen(s, s_max);
-    size_t deps    = 0;
 
     while (next_var < s_end)              /* does it have nested variables? */
     {
@@ -552,7 +548,6 @@ static char *ProcessVar(PromiseIterator *iterctx, const EvalContext *evalctx,
         else                          /* inner variable processed correctly */
         {
             /* This variable depends on inner expansions. */
-            deps++;
             /* We are sure (subvar_end+1) is not out of bounds. */
             char *s_next = subvar_end + 1;
             const size_t s_next_len = strlen(s_next);

--- a/libpromises/sort.c
+++ b/libpromises/sort.c
@@ -203,7 +203,7 @@ static bool RlistCustomItemLess(void *lhs_, void *rhs_, void *ctx)
 {
     Rlist *lhs = lhs_;
     Rlist *rhs = rhs_;
-    bool (*cmp)() = ctx;
+    bool (*cmp)(void *a, void *b) = ctx;
 
     return (*cmp)(lhs->val.item, rhs->val.item);
 }


### PR DESCRIPTION
Really fixing compiler warnings from clang 14.

Ticket: ENT-9878