### PR TITLE
Symlink rpmvercmp only when needed (3.18)

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -431,7 +431,10 @@ runtest() {
                 $LN_CMD "$CF_NET" "$WORKDIR/bin"
                 $LN_CMD "$CF_CHECK" "$WORKDIR/bin"
                 $LN_CMD "$CF_RUNAGENT" "$WORKDIR/bin"
-                $LN_CMD "$RPMVERCMP" "$WORKDIR/bin"
+                if [ "$NEED_RPMVERCMP" = "yes" ]
+                then
+                    $LN_CMD "$RPMVERCMP" "$WORKDIR/bin"
+                fi
                 $LN_CMD "$DIFF" "$WORKDIR/bin"
             fi
             for inc in $INCLUDE_IN_WORKDIR


### PR DESCRIPTION
Ticket: ENT-9891

Issue was that when "$RPMVERCMP" variable is not set, this command:

	ln "$RPMVERCMP" "$WORKDIR/bin"

was printing an unhelpful error message that it can't overwrite a directory, thus polluting logs.

So the solution is to not run this command when this variable is not set, a.k.a. when we don't need rpmvercmp.

(cherry picked from commit 3cec91067a300bf721610a08eb3909b41439a434)