### PR TITLE
ENT-10172: Fixed workflow refs for push events

### DIFF
--- a/.github/workflows/job-static-check.yml
+++ b/.github/workflows/job-static-check.yml
@@ -25,7 +25,7 @@ jobs:
         repository: cfengine/buildscripts
         submodules: recursive
         path: buildscripts
-        ref: ${{steps.together.outputs.buildscripts}}
+        ref: ${{steps.together.outputs.buildscripts || github.base_ref || github.ref}}
 
     - name: Checkout Masterfiles
       uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
         repository: cfengine/masterfiles
         submodules: recursive
         path: masterfiles
-        ref: ${{steps.together.outputs.masterfiles}}
+        ref: ${{steps.together.outputs.masterfiles || github.base_ref || github.ref}}
 
     - name: Prepare Environment
       run: |

--- a/.github/workflows/job-valgrind-check.yml
+++ b/.github/workflows/job-valgrind-check.yml
@@ -25,7 +25,7 @@ jobs:
         repository: cfengine/masterfiles
         submodules: recursive
         path: masterfiles
-        ref: ${{steps.together.outputs.masterfiles}}
+        ref: ${{steps.together.outputs.masterfiles || github.base_ref || github.ref}}
 
     - name: Run The Test
       working-directory: ./core/tests/valgrind-check

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: cfengine/masterfiles
-        ref: ${{steps.together.outputs.masterfiles}}
+        ref: ${{steps.together.outputs.masterfiles || github.base_ref || github.ref}}
         path: masterfiles
         submodules: recursive
     - name: Install dependencies


### PR DESCRIPTION
When a PR is merged a push event occurs and workflows are triggered.

At this time an empty ref: will default to master instead of the appropriate branch.

So include github.base_ref and github.ref as fallbacks.

Ticket: ENT-10172
Changelog: none