### PR TITLE
ENT-10190: Upgraded together javascript action (3.21)

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -15,7 +15,7 @@ jobs:
         path: core
         submodules: recursive
     - name: Get Togethers
-      uses: cfengine/together-javascript-action@v1.6
+      uses: cfengine/together-javascript-action@v1.7
       id: together
       with:
         myToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ticket: ENT-10190
Changelog: none
(cherry picked from commit ed867c06259bd3ed1d00dcd6d673316c05d9e03f)

 Conflicts:
	.github/workflows/job-static-check.yml
	.github/workflows/job-valgrind-check.yml
	.github/workflows/valgrind.yml

valgrind.yml needed and upgrade, the other two are not present in 3.21.x and so were removed