### PR TITLE
ENT-10206: Added mctp_socket class to selinux policy (3.18)

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -89,6 +89,7 @@ require {
 	type rpm_script_t;
 	class lockdown { confidentiality integrity };
 	class tcp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown name_connect accept listen name_bind node_bind };
+	class mctp_socket { ioctl read write create getattr setattr lock relabelfrom relabelto append map bind connect listen accept getopt setopt shutdown recvfrom sendto recv_msg send_msg name_bind };
 	class udp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown node_bind };
 	class sock_file { create write getattr setattr unlink };
 	class rawip_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown };


### PR DESCRIPTION
Needed by rhel-9.2 linux kernel

Ticket: ENT-10206
Changelog: title
(cherry picked from commit f3ef17c3ec2d8afb35a73ced6938750aefb84a5f)