### PR TITLE
ENT-7725: Variables & Classes Modules automatically tagged

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -8817,6 +8817,9 @@ void ModuleProtocol(EvalContext *ctx, const char *command, const char *line, int
 {
     assert(tags);
 
+    StringSetAdd(tags, xstrdup("source=module"));
+    StringSetAddF(tags, "derived_from=%s", command);
+
     // see the sscanf() limit below
     if(context_size < 51)
     {
@@ -8879,6 +8882,7 @@ void ModuleProtocol(EvalContext *ctx, const char *command, const char *line, int
 
             StringSetAddSplit(tags, content, ',');
             StringSetAdd(tags, xstrdup("source=module"));
+            StringSetAddF(tags, "derived_from=%s", command);
         }
         else if (sscanf(line + 1, "persistence=%ld", persistence) == 1)
         {

--- a/tests/acceptance/08_commands/01_modules/set-tags.cf
+++ b/tests/acceptance/08_commands/01_modules/set-tags.cf
@@ -62,10 +62,10 @@ bundle agent check
       "jtags2" string => join(",", "tags2");
       "jtags3" string => join(",", "tags3");
 
-      "etags0" string => "xyz,abc=def,,??what is this??,source=module";
-      "etags1" string => "xyz,abc=def,,??what is this??,source=module";
-      "etags2" string => "1,2,3,source=module";
-      "etags3" string => "a,b,c,source=module";
+      "etags0" string => "xyz,abc=def,,\?\?what is this\?\?,source=module,derived_from=.*";
+      "etags1" string => "xyz,abc=def,,\?\?what is this\?\?,source=module,derived_from=.*";
+      "etags2" string => "1,2,3,source=module,derived_from=.*";
+      "etags3" string => "a,b,c,source=module,derived_from=.*";
 
   classes:
 
@@ -76,10 +76,10 @@ bundle agent check
       "var3ok" expression => strcmp("${this.joined3}" , "${this.actual3}");
       "var4ok" expression => strcmp("hello there" , "${xyz.myvar}");
 
-      "tags0ok" expression => strcmp($(jtags0), $(etags0));
-      "tags1ok" expression => strcmp($(jtags1), $(etags1));
-      "tags2ok" expression => strcmp($(jtags2), $(etags2));
-      "tags3ok" expression => strcmp($(jtags3), $(etags3));
+      "tags0ok" expression => regcmp($(etags0), $(jtags0));
+      "tags1ok" expression => regcmp($(etags1), $(jtags1));
+      "tags2ok" expression => regcmp($(etags2), $(jtags2));
+      "tags3ok" expression => regcmp($(etags3), $(jtags3));
 
       "ok" and => { "myclass", "var0ok", "var1ok", "var2ok", "var3ok", "var4ok",
                     "tags0ok", "tags1ok", "tags2ok", "tags3ok", };
@@ -88,15 +88,15 @@ bundle agent check
     DEBUG::
       "xyzvars = $(xyzvars)";
 
-      "tags0ok => strcmp('$(jtags0)', '$(etags0)')" if => "tags0ok";
-      "tags1ok => strcmp('$(jtags1)', '$(etags1)')" if => "tags1ok";
-      "tags2ok => strcmp('$(jtags2)', '$(etags2)')" if => "tags2ok";
-      "tags3ok => strcmp('$(jtags3)', '$(etags3)')" if => "tags3ok";
+      "tags0ok => regcmp('$(etags0)', '$(jtags0)')" if => "tags0ok";
+      "tags1ok => regcmp('$(etags1)', '$(jtags1)')" if => "tags1ok";
+      "tags2ok => regcmp('$(etags2)', '$(jtags2)')" if => "tags2ok";
+      "tags3ok => regcmp('$(etags3)', '$(jtags3)')" if => "tags3ok";
 
-      "tags0 NOT ok => strcmp('$(jtags0)', '$(etags0)')" if => "!tags0ok";
-      "tags1 NOT ok => strcmp('$(jtags1)', '$(etags1)')" if => "!tags1ok";
-      "tags2 NOT ok => strcmp('$(jtags2)', '$(etags2)')" if => "!tags2ok";
-      "tags3 NOT ok => strcmp('$(jtags3)', '$(etags3)')" if => "!tags3ok";
+      "tags0 NOT ok => regcmp('$(etags0)', '$(jtags0)')" if => "!tags0ok";
+      "tags1 NOT ok => regcmp('$(etags1)', '$(jtags1)')" if => "!tags1ok";
+      "tags2 NOT ok => regcmp('$(etags2)', '$(jtags2)')" if => "!tags2ok";
+      "tags3 NOT ok => regcmp('$(etags3)', '$(jtags3)')" if => "!tags3ok";
 
     ok::
       "$(this.promise_filename) Pass";

--- a/tests/acceptance/08_commands/01_modules/vars-from-module-have-source-and-derived_from-tags.cf
+++ b/tests/acceptance/08_commands/01_modules/vars-from-module-have-source-and-derived_from-tags.cf
@@ -15,10 +15,6 @@ bundle agent test
         string => "windows",
         comment => "The subtest policy uses /bin/echo";
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "ENT-7725" };
-
   commands:
       "/bin/echo"
         args => "=my_var_from_module= my val from module",
@@ -34,12 +30,12 @@ bundle agent check
   reports:
 
       # Every variable should have a source=SOMETHING tag
-      "Pass $(this.promise_filename)"
+      "$(this.promise_filename) Pass"
         if => and(
                    reglist( @(my_var_from_module_tags), "source=.*" ),
                    reglist( @(my_var_from_module_tags), "derived_from=.*" )
                    );
-      "FAIL $(this.promise_filename)"
+      "$(this.promise_filename) FAIL"
         unless => and(
                    reglist( @(my_var_from_module_tags), "source=.*" ),
                    reglist( @(my_var_from_module_tags), "derived_from=.*" )


### PR DESCRIPTION
According to the docs; all variables and classes will be tagged with `source=module`. This was apparently only the case when specifying tags using `^meta=Tag1,Tag2`. Now this tag is added all the time, even when you don't specify tags.

Furthermore, we added an additional meta tag `derived_from=<SOME_COMMAND>` which holds the path to the module script when using the `usemodule()` policy function or the command when using a commands promise with `module => "true"`.

Example output when using both `usemodule()` and commands promise without specifying meta tags:
```
$ sudo cf-agent -KIf ~/test.cf 
    info: Executing 'no timeout' ... '/bin/echo "=bogus=Hello CFEngine!"'
    info: Completed execution of '/bin/echo "=bogus=Hello CFEngine!"'
R: getvariablemetatags(doofus.doofus) => '{ "source=module", "derived_from=\"/var/cfengine/modules/doofus\" " }'
R: getvariablemetatags(echo.bogus) => '{ "source=module", "derived_from=/bin/echo \"=bogus=Hello CFEngine!\"" }'
```
