### PR TITLE
Fix building on solaris and hpux

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,4 @@
 3.18.5:
-	- The CF3_WITH_LIBRARY and AC_CHECK_HEADERS were moved to outside of the check for with-libxml2=no (CFE-4023)
-	- configure.ac: Enabled use of pkg-config to find libxml2 (CFE-4014)
 	- Added --help option to cf-support and aligned output with other
 	  components (ENT-9740)
 	- Added classes and vars to cf-support (CFE-4160)

--- a/configure.ac
+++ b/configure.ac
@@ -136,14 +136,6 @@ AC_CONFIG_LIBOBJ_DIR(libntech/libcompat)
 AC_PATH_PROG(GETCONF, getconf, false, $PATH:$prefix/bin:/usr/bin:/usr/local/bin:/sw/bin)
 AM_CONDITIONAL(CROSS_COMPILING, test "x$cross_compiling" = "xyes")
 
-# Check whether `pkg-config' is available
-AC_ARG_VAR([PKG_CONFIG], [path to pkg-config])
-AC_ARG_VAR([PKG_CONFIG_PATH], [directories to add to the pkg-config search path])
-AC_ARG_VAR([PKG_CONFIG_LIBDIR], [path overriding pkg-config's search path])
-
-if test "x$ac_cv_env_PKG_CONFIG_set" != "xset"; then
-    AC_PATH_TOOL([PKG_CONFIG], [pkg-config])
-fi
 
 dnl ######################################################################
 dnl Use pthreads if available
@@ -619,57 +611,43 @@ AC_ARG_WITH([libxml2],
     [],
     [with_libxml2=check])
 
-have_libxml2="no"
-
-if test "x$with_libxml2" != "xno"; then
-    if test -n "$PKG_CONFIG"; then
-        AC_MSG_CHECKING([for libxml2 via pkg-config])
-        if `$PKG_CONFIG --exists libxml-2.0`; then
-            LIBXML2_CFLAGS=`$PKG_CONFIG --cflags libxml-2.0`
-            LIBXML2_CPPFLAGS="$LIBXML2_CFLAGS"
-            LIBXML2_LIBS=`$PKG_CONFIG --libs libxml-2.0`
-            LIBXML2_VERSION=`$PKG_CONFIG --modversion libxml-2.0`
-            AC_MSG_RESULT([found version $LIBXML2_VERSION])
-            have_libxml2="yes"
-        else
-            AC_MSG_RESULT([not found])
-        fi
+if test "x$with_libxml2" != xno
+then
+    if test "x$with_libxml2" != xyes &&
+       test "x$with_libxml2" != xcheck
+    then
+        XML2_CONFIG=$with_libxml2/bin/xml2-config
+    else
+        XML2_CONFIG=xml2-config
     fi
 
-    if test "x$have_libxml2" = "xno"; then
-        if test "x$with_libxml2" != "xyes" && test "x$with_libxml2" != "xcheck"
+    # xml2-config is only for native builds
+    if test "x$cross_compiling" = "xno" && test x`which $XML2_CONFIG` != x
+    then
+        xml2_include_dir=`$XML2_CONFIG --cflags`
+        if test -n "$xml2_include_dir"
         then
-            XML2_CONFIG=$with_libxml2/bin/xml2-config
-        else
-            AC_PATH_PROG([XML2_CONFIG], [xml2-config])
+            LIBXML2_CPPFLAGS="$xml2_include_dir"
         fi
-
-        # xml2-config is only for native builds
-        if test "x$cross_compiling" = "xno" && test -n "$XML2_CONFIG"; then
-            xml2_include_dir=`$XML2_CONFIG --cflags`
-            if test -n "$xml2_include_dir"; then
-                LIBXML2_CPPFLAGS="$xml2_include_dir"
-            fi
-        else # xml2-config not found
-            # if a path, e.g. /var/cfengine was given, then we
-            # must take into account that libxml2 includes are in
-            # /var/cfengine/include/libxml2
-            LIBXML2_CPPFLAGS=-I$with_libxml2/include/libxml2
-        fi
+    else                # xml2-config not found
+        # if a path, e.g. /var/cfengine was given, then we
+        # must take into account that libxml2 includes are in
+        # /var/cfengine/include/libxml2
+        LIBXML2_CPPFLAGS=-I$with_libxml2/include/libxml2
     fi
-fi
 
-CF3_WITH_LIBRARY(libxml2,
-    [AC_CHECK_LIB(xml2, xmlFirstElementChild,
-    [],
-    [if test "x$with_libxml2" != xcheck; then
-        AC_MSG_ERROR(Cannot find libxml2); fi]
+    CF3_WITH_LIBRARY(libxml2,
+        [AC_CHECK_LIB(xml2, xmlFirstElementChild,
+            [],
+            [if test "x$with_libxml2" != xcheck; then
+                AC_MSG_ERROR(Cannotfind libxml2); fi]
+        )
+        AC_CHECK_HEADERS([libxml/xmlwriter.h], [break],
+            [if test "x$with_libxml2" != xcheck; then
+                AC_MSG_ERROR(Cannot find libxml2); fi]
+        )]
     )
-    AC_CHECK_HEADERS([libxml/xmlwriter.h], [break],
-        [if test "x$with_libxml2" != xcheck; then
-            AC_MSG_ERROR(Cannot find libxml2); fi]
-    )]
-)
+fi
 
 AM_CONDITIONAL([HAVE_LIBXML2],
     [test "x$with_libxml2" != xno &&

--- a/configure.ac
+++ b/configure.ac
@@ -657,20 +657,19 @@ if test "x$with_libxml2" != "xno"; then
             LIBXML2_CPPFLAGS=-I$with_libxml2/include/libxml2
         fi
     fi
+fi
 
-    CF3_WITH_LIBRARY(libxml2,
-        [AC_CHECK_LIB(xml2, xmlFirstElementChild,
-        [],
+CF3_WITH_LIBRARY(libxml2,
+    [AC_CHECK_LIB(xml2, xmlFirstElementChild,
+    [],
+    [if test "x$with_libxml2" != xcheck; then
+        AC_MSG_ERROR(Cannot find libxml2); fi]
+    )
+    AC_CHECK_HEADERS([libxml/xmlwriter.h], [break],
         [if test "x$with_libxml2" != xcheck; then
             AC_MSG_ERROR(Cannot find libxml2); fi]
-        )
-        AC_CHECK_HEADERS([libxml/xmlwriter.h], [break],
-            [if test "x$with_libxml2" != xcheck; then
-                AC_MSG_ERROR(Cannot find libxml2); fi]
-        )]
-    )
-    
-fi
+    )]
+)
 
 AM_CONDITIONAL([HAVE_LIBXML2],
     [test "x$with_libxml2" != xno &&


### PR DESCRIPTION
I had to revert these three commits to make 3.18.x build on Solaris 10 and HP-UX. I believe they're not really necessary?

Failures were:

On Solaris 10 (both SPARC and x86):
```
00:16:20.675 xml-c14nize.c: In function ‘xmlC14nizeFile’:
00:16:21.104 xml-c14nize.c:25:37: error: ‘XML_C14N_1_0’ undeclared (first use in this function)
00:16:21.129      if (xmlC14NDocSaveTo(doc, NULL, XML_C14N_1_0, 0, true, out) < 0)
00:16:21.129                                      ^
```

on HP-UX:
```
00:10:41.199 checking for xmlFirstElementChild in -lxml2... ./configure[15954]: /var/cfengine/bin/xml2-config:  not found.
00:10:41.570 yes
00:10:41.596 checking libxml/xmlwriter.h usability... no
00:10:41.912 checking libxml/xmlwriter.h presence... no
00:10:42.147 checking for libxml/xmlwriter.h... no
00:10:42.147 configure: error: Cannot find libxml2
00:10:42.357 + [ xyes = xyes ]
```

followed by:

```
00:11:11.262 + cd core
00:11:11.287 + /usr/local/bin/gmake V=1 dist
00:11:11.287 gmake: *** No rule to make target 'dist'.  Stop.
```
