### PR TITLE
ENT-9759: Improved syntax description for validjson()

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -9740,7 +9740,7 @@ static const FnCallArg READFILE_ARGS[] =
 
 static const FnCallArg VALIDDATATYPE_ARGS[] =
 {
-    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Data to validate"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "String to validate as JSON"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 


### PR DESCRIPTION
This function takes a string, and not a data container, it has confused people.

Ticket: ENT-9759
Changelog: Title