### PR TITLE
ENT-9759: Improved syntax description for validjson() (3.18)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -9482,7 +9482,7 @@ static const FnCallArg READFILE_ARGS[] =
 
 static const FnCallArg VALIDDATATYPE_ARGS[] =
 {
-    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Data to validate"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "String to validate as JSON"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 


### PR DESCRIPTION
This function takes a string, and not a data container, it has confused people.

Ticket: ENT-9759
Changelog: Title
(cherry picked from commit c4ffbdb1e1c4b2186107f1647c4c0ae2aedf48c6)