### PR TITLE
Removed LGTM banner that no longer works (3.18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Gitter chat](https://badges.gitter.im/cfengine/core.png)](https://gitter.im/cfengine/core)
-[![Language grade: C](https://img.shields.io/lgtm/grade/cpp/g/cfengine/core.svg?logo=lgtm&logoWidth=18&label=code%20quality)](https://lgtm.com/projects/g/cfengine/core/)
 
 # CFEngine 3
 


### PR DESCRIPTION
(cherry picked from commit 66490d6c29fb6145e6933c46fc27f4acd95624ef)