### PR TITLE
ENT-10428: Removed push event handling in github actions workflow (3.21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,6 @@ on:
   pull_request:
     branches: [ master, 3.21.x, 3.18.x ]
 
-  # run this workflow on push/merge activity
-  # pull_request activity won't detect changes
-  # in the upstream branch before we merge
-  push:
-    branches: [ master, 3.21.x, 3.18.x ]
-
-
 jobs:
   unit_tests:
     uses: ./.github/workflows/unit_tests.yml


### PR DESCRIPTION
We don't have easy visibility on the results of these events which only occur after we merge pull requests.
We use /merge refs in pull requests so running the actions again on push events (after the merge) don't really provide any additional information.

Pushes/commits to pull requests are handled by the pull_request event so no change there.

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push

Ticket: ENT-10428
Changelog: none
(cherry picked from commit 81b49e7b0edec53133d16b9dbe0ac8dfba17a7b5)