### PR TITLE
ENT-9083: package[update]smatching now looks for software inventory databases (3.21.x)

### DIFF
--- a/libpromises/dbm_api.h
+++ b/libpromises/dbm_api.h
@@ -29,6 +29,7 @@
 #define EC_CORRUPTION_REPAIR_FAILED 121
 
 #include <map.h>
+#include <sequence.h>
 #include <dbm_api_types.h>
 
 // Only append to the end, keep in sync with DB_PATHS_STATEDIR array
@@ -106,6 +107,7 @@ bool DeleteDBCursor(CF_DBC *dbcp);
 
 char *DBIdToPath(dbid id);
 char *DBIdToSubPath(dbid id, const char *subdb_name);
+Seq *SearchExistingSubDBNames(dbid id);
 
 StringMap *LoadDatabaseToStringMap(dbid database_id);
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1956,6 +1956,24 @@ static FnCallResult FnCallPackagesMatching(ARG_UNUSED EvalContext *ctx, ARG_UNUS
 
     Rlist *default_inventory = GetDefaultInventoryFromContext(ctx);
 
+    bool inventory_allocated = false;
+    if (default_inventory == NULL)
+    {
+        // Did not find default inventory from context, try looking for
+        // existing LMDB databases in the state directory
+        dbid database = (installed_mode ? dbid_packages_installed
+                                        : dbid_packages_updates);
+        Seq *const seq = SearchExistingSubDBNames(database);
+        const size_t length = SeqLength(seq);
+        for (size_t i = 0; i < length; i++)
+        {
+            const char *const db_name = SeqAt(seq, i);
+            RlistAppendString(&default_inventory, db_name);
+            inventory_allocated = true;
+        }
+        SeqDestroy(seq);
+    }
+
     if (!default_inventory)
     {
         // Legacy package promise
@@ -1983,10 +2001,18 @@ static FnCallResult FnCallPackagesMatching(ARG_UNUSED EvalContext *ctx, ARG_UNUS
             Log(LOG_LEVEL_DEBUG, "No valid package module inventory found");
             pcre_free(matcher);
             JsonDestroy(json);
+            if (inventory_allocated)
+            {
+                RlistDestroy(default_inventory);
+            }
             return FnFailure();
         }
     }
 
+    if (inventory_allocated)
+    {
+        RlistDestroy(default_inventory);
+    }
     pcre_free(matcher);
 
     if (ret == false)


### PR DESCRIPTION
If the default software inventory from context is not specified, the package[update]smatching policy functions now looks for the software inventory databases in the state directory and uses them if found. This change enables the usage of these functions in standalone policy files without the demand for specifying the default package inventory attribute in body common control. However, you still need the default package inventory attribute specified in the policy framework for the software inventory databases to exist in the first place and to be maintained.

Cherry picked from https://github.com/cfengine/core/pull/5274