### PR TITLE
ENT-9083: package[update]smatching now looks for software inventory databases (3.18.x)

### DIFF
--- a/libpromises/dbm_api.h
+++ b/libpromises/dbm_api.h
@@ -29,6 +29,7 @@
 #define EC_CORRUPTION_REPAIR_FAILED 121
 
 #include <map.h>
+#include <sequence.h>
 #include <dbm_api_types.h>
 
 // Only append to the end, keep in sync with DB_PATHS_STATEDIR array
@@ -106,6 +107,7 @@ bool DeleteDBCursor(CF_DBC *dbcp);
 
 char *DBIdToPath(dbid id);
 char *DBIdToSubPath(dbid id, const char *subdb_name);
+Seq *SearchExistingSubDBNames(dbid id);
 
 StringMap *LoadDatabaseToStringMap(dbid database_id);
 


### PR DESCRIPTION
If the default software inventory from context is not specified, the package[update]smatching policy functions now looks for the software inventory databases in the state directory and uses them if found. This change enables the usage of these functions in standalone policy files without the demand for specifying the default package inventory attribute in body common control. However, you still need the default package inventory attribute specified in the policy framework for the software inventory databases to exist in the first place and to be maintained.

https://github.com/cfengine/core/pull/5274