### PR TITLE
ENT-10442: Switch together-javascript-action to main to avoid dependency update …

### DIFF
--- a/.github/workflows/job-static-check.yml
+++ b/.github/workflows/job-static-check.yml
@@ -14,7 +14,7 @@ jobs:
         path: core
 
     - name: Get Togethers
-      uses: cfengine/together-javascript-action@v1.7
+      uses: cfengine/together-javascript-action@main
       id: together
       with:
         myToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/job-valgrind-check.yml
+++ b/.github/workflows/job-valgrind-check.yml
@@ -14,7 +14,7 @@ jobs:
         path: core
 
     - name: Get Togethers
-      uses: cfengine/together-javascript-action@v1.7
+      uses: cfengine/together-javascript-action@main
       id: together
       with:
         myToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -15,7 +15,7 @@ jobs:
         path: core
         submodules: recursive
     - name: Get Togethers
-      uses: cfengine/together-javascript-action@v1.7
+      uses: cfengine/together-javascript-action@main
       id: together
       with:
         myToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…work

We control the code, so no need to be "careful" here.

Ticket: ENT-10442
Changelog: none