### PR TITLE
CFE-4249: Revert "Re-enabled passopenfile_test after migrating to github actions"

### DIFF
--- a/tests/unit/passopenfile_test.c
+++ b/tests/unit/passopenfile_test.c
@@ -1286,6 +1286,10 @@ static void test_send_connect_silent(void)
 
 static void test_connect_outlive(void)
 {
+#ifdef __APPLE__
+    // FIXME: This test has spurios errors on OS X in travis
+    return;
+#endif
     clear_previous_test();
     pid_t new_pid = fork();
     if (new_pid == 0)
@@ -1320,6 +1324,10 @@ static void test_connect_outlive(void)
 
 static void test_listen_outlive(void)
 {
+#ifdef __APPLE__
+    // FIXME: This test has spurios errors on OS X in travis
+    return;
+#endif
     clear_previous_test();
     pid_t new_pid = fork();
     if (new_pid == 0)


### PR DESCRIPTION
This reverts commit dbda08aec9e1590a7b841740bb22bccec11fbb84.

Ticket: CFE-4249
Changelog: none
Turns out it is still failing even in github. Already reverted in 3.18.x and 3.21.x.
