### PR TITLE
CFE-4244: Added the function name to the result cache key (3.21.x)

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -2832,6 +2832,10 @@ bool EvalContextFunctionCacheGet(const EvalContext *ctx,
                                  const FnCall *fp ARG_UNUSED,
                                  const Rlist *args, Rval *rval_out)
 {
+    assert(fp != NULL);
+    assert(fp->name != NULL);
+    assert(ctx != NULL);
+
     if (!(ctx->eval_options & EVAL_OPTION_CACHE_SYSTEM_FUNCTIONS))
     {
         return false;
@@ -2839,9 +2843,6 @@ bool EvalContextFunctionCacheGet(const EvalContext *ctx,
 
     // The cache key is made of the function name and all args values
     Rlist *args_copy = RlistCopy(args);
-    assert(fp != NULL);
-    assert(fp->name != NULL);
-    assert(ctx != NULL);
     Rlist *key = RlistPrepend(&args_copy, fp->name, RVAL_TYPE_SCALAR);
     Rval *rval = FuncCacheMapGet(ctx->function_cache, key);
     RlistDestroy(key);
@@ -2863,6 +2864,10 @@ void EvalContextFunctionCachePut(EvalContext *ctx,
                                  const FnCall *fp ARG_UNUSED,
                                  const Rlist *args, const Rval *rval)
 {
+    assert(fp != NULL);
+    assert(fp->name != NULL);
+    assert(ctx != NULL);
+
     if (!(ctx->eval_options & EVAL_OPTION_CACHE_SYSTEM_FUNCTIONS))
     {
         return;
@@ -2872,9 +2877,6 @@ void EvalContextFunctionCachePut(EvalContext *ctx,
     *rval_copy = RvalCopy(*rval);
 
     Rlist *args_copy = RlistCopy(args);
-    assert(fp != NULL);
-    assert(fp->name != NULL);
-    assert(ctx != NULL);
     Rlist *key = RlistPrepend(&args_copy, fp->name, RVAL_TYPE_SCALAR);
     
     FuncCacheMapInsert(ctx->function_cache, key, rval_copy);

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -2837,7 +2837,14 @@ bool EvalContextFunctionCacheGet(const EvalContext *ctx,
         return false;
     }
 
-    Rval *rval = FuncCacheMapGet(ctx->function_cache, args);
+    // The cache key is made of the function name and all args values
+    Rlist *args_copy = RlistCopy(args);
+    assert(fp != NULL);
+    assert(fp->name != NULL);
+    assert(ctx != NULL);
+    Rlist *key = RlistPrepend(&args_copy, fp->name, RVAL_TYPE_SCALAR);
+    Rval *rval = FuncCacheMapGet(ctx->function_cache, key);
+    RlistDestroy(key);
     if (rval)
     {
         if (rval_out)
@@ -2863,7 +2870,14 @@ void EvalContextFunctionCachePut(EvalContext *ctx,
 
     Rval *rval_copy = xmalloc(sizeof(Rval));
     *rval_copy = RvalCopy(*rval);
-    FuncCacheMapInsert(ctx->function_cache, RlistCopy(args), rval_copy);
+
+    Rlist *args_copy = RlistCopy(args);
+    assert(fp != NULL);
+    assert(fp->name != NULL);
+    assert(ctx != NULL);
+    Rlist *key = RlistPrepend(&args_copy, fp->name, RVAL_TYPE_SCALAR);
+    
+    FuncCacheMapInsert(ctx->function_cache, key, rval_copy);
 }
 
 /* cfPS and associated machinery */

--- a/tests/acceptance/01_vars/02_functions/cache_name.cf
+++ b/tests/acceptance/01_vars/02_functions/cache_name.cf
@@ -1,0 +1,51 @@
+#######################################################
+#
+# Test that the function result cache checks function name
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+
+bundle agent init
+{
+  vars:
+      "agent_regex" string => ".*cf-agent.*";
+}
+
+#######################################################
+
+bundle common test
+{
+  meta:
+    "description" -> { "CFE-4244" }
+      string => "Test that the function result cache checks function name";
+
+  vars:
+      "res1" data => findprocesses("${init.agent_regex}");
+
+  classes:
+      # must not reuse result from previous line
+      # is reused, produces a type error
+      "_pass" expression => processexists("${init.agent_regex}");
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  methods:
+    _pass:: 
+      "pass" usebundle => dcs_pass("$(this.promise_filename)");
+
+    !_pass::
+      "pass" usebundle => dcs_fail("$(this.promise_filename)");
+}


### PR DESCRIPTION
The function cache only used the args values, which in some cases could
lead to mixing results from different functions with the same arguments.

Ticket: CFE-4244
Changelog: Cashed policy function results now take into account number of arguments and function name.
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
Co-authored-by: Alexis Mousset <alexis.mousset@rudder.io>
(cherry picked from commit 29e60a9ba05016847c3b601f469bcb5e19147960)
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Backported from https://github.com/cfengine/core/pull/5317
