### PR TITLE
Change suppress fail to soft fail on known failing tests

### DIFF
--- a/tests/acceptance/08_commands/01_modules/long-module-lines.cf
+++ b/tests/acceptance/08_commands/01_modules/long-module-lines.cf
@@ -26,8 +26,8 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
-        meta => { "redmine1884" };
+      "test_soft_fail" string => "windows",
+        meta => { "ENT-1623" };
 
   commands:
       "$(init.script_name)" module => "true";

--- a/tests/acceptance/09_services/custom.cf
+++ b/tests/acceptance/09_services/custom.cf
@@ -24,7 +24,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_soft_fail" string => "windows",
         meta => { "CFE-2402" };
 
   services:

--- a/tests/acceptance/09_services/disable.cf
+++ b/tests/acceptance/09_services/disable.cf
@@ -24,7 +24,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_soft_fail" string => "windows",
         meta => { "CFE-2402" };
 
   services:

--- a/tests/acceptance/09_services/enable.cf
+++ b/tests/acceptance/09_services/enable.cf
@@ -24,7 +24,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_soft_fail" string => "windows",
         meta => { "CFE-2402" };
 
   services:

--- a/tests/acceptance/09_services/reload.cf
+++ b/tests/acceptance/09_services/reload.cf
@@ -24,7 +24,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_soft_fail" string => "windows",
         meta => { "redmine4772,ENT-2161" };
 
   services:

--- a/tests/acceptance/09_services/restart.cf
+++ b/tests/acceptance/09_services/restart.cf
@@ -24,7 +24,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_soft_fail" string => "windows",
         meta => { "redmine4772,ENT-2161" };
 
   services:

--- a/tests/acceptance/09_services/service_cannot_be_resolved.cf
+++ b/tests/acceptance/09_services/service_cannot_be_resolved.cf
@@ -20,7 +20,7 @@ bundle agent init
 bundle common test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_soft_fail" string => "windows",
         meta => { "redmine4772,ENT-2161" };
 
   classes:

--- a/tests/acceptance/09_services/start.cf
+++ b/tests/acceptance/09_services/start.cf
@@ -24,7 +24,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_soft_fail" string => "windows",
         meta => { "redmine4772,ENT-2161" };
 
   services:

--- a/tests/acceptance/09_services/stop.cf
+++ b/tests/acceptance/09_services/stop.cf
@@ -24,7 +24,7 @@ bundle agent init
 bundle agent test
 {
   meta:
-      "test_suppress_fail" string => "windows",
+      "test_soft_fail" string => "windows",
         meta => { "redmine4772,ENT-2161" };
 
   services:


### PR DESCRIPTION
Ticket: ENT-10470

Issue was that these failures were visible in Jenkins, turning build "unstable".