### PR TITLE
Do not #include libcrypto-compat

### DIFF
--- a/cf-key/cf-key-functions.c
+++ b/cf-key/cf-key-functions.c
@@ -27,7 +27,6 @@
 
 #include <openssl/bn.h>                                     /* BN_*, BIGNUM */
 #include <openssl/rand.h>                                   /* RAND_* */
-#include <libcrypto-compat.h>
 
 #include <lastseen.h>
 #include <dir.h>

--- a/cf-serverd/server_classic.c
+++ b/cf-serverd/server_classic.c
@@ -25,7 +25,6 @@
 
 #include <openssl/bn.h>                                    /* BN_* */
 #include <openssl/err.h>                                   /* ERR_get_error */
-#include <libcrypto-compat.h>
 
 #include <cf3.defs.h>
 #include <item_lib.h>                 /* IsMatchItemIn */

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -30,7 +30,6 @@
 #include <net.h>                      /* SendTransaction,ReceiveTransaction */
 #include <openssl/err.h>                                   /* ERR_get_error */
 #include <protocol.h>                              /* ProtocolIsUndefined() */
-#include <libcrypto-compat.h>
 #include <tls_client.h>               /* TLSTry */
 #include <tls_generic.h>              /* TLSVerifyPeer */
 #include <dir.h>

--- a/libcfnet/client_protocol.c
+++ b/libcfnet/client_protocol.c
@@ -26,7 +26,7 @@
 
 #include <openssl/bn.h>                                    /* BN_* */
 #include <openssl/err.h>                                   /* ERR_get_error */
-#include <libcrypto-compat.h>
+#include <openssl/rsa.h>
 
 #include <communication.h>
 #include <net.h>

--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -27,7 +27,6 @@
 #include <openssl/err.h>                                        /* ERR_* */
 #include <openssl/rand.h>                                       /* RAND_* */
 #include <openssl/bn.h>                                         /* BN_* */
-#include <libcrypto-compat.h>
 
 #if OPENSSL_VERSION_NUMBER > 0x30000000
 #include <openssl/provider.h>                                   /* OSSL_PROVIDER_* */

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -69,7 +69,6 @@
 #include <signals.h>
 #include <addr_lib.h>
 #include <openssl/evp.h>
-#include <libcrypto-compat.h>
 #include <libgen.h>
 #include <cleanup.h>
 #include <cmdb.h>               /* LoadCMDBData() */

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -41,7 +41,6 @@
 #include <known_dirs.h>
 #include <sysinfo.h>
 #include <openssl/evp.h>
-#include <libcrypto-compat.h>
 
 #ifdef LMDB
 // Be careful if you want to change this,


### PR DESCRIPTION
We require OpenSSL 1.0.0 or newer so we don't need this compatibility code for older versions.

Merge together:
https://github.com/cfengine/core/pull/5332
https://github.com/cfengine/nova/pull/2124