### PR TITLE
ENT-10696: Added selinux policy to allow cf-hub to initiate scheduled reports

### DIFF
--- a/misc/selinux/cfengine-enterprise.te
+++ b/misc/selinux/cfengine-enterprise.te
@@ -356,6 +356,8 @@ type cfengine_hub_t;
 typeattribute cfengine_hub_t domain;
 role system_r types cfengine_hub_t;
 
+# cf-hub uses setuid/setgid to initiate scheduled reports as cfapache:cfpostgres
+allow cfengine_hub_t self:capability { setgid setuid };
 # /var/cfengine/bin/cf-hub has the 'cfengine_hub_exec_t' context which is an
 # entrypoint for the 'cfengine_hub_t' domain
 type cfengine_hub_exec_t;


### PR DESCRIPTION
https://github.com/cfengine/nova/commit/8b8726e7b2896d601f05d1b4392abef705d1489a
changed cf-hub behavior for ENT-9825

This change fixes an issue with hubs that have SELinux set to enforce.
Hubs which do not have SELinux set to enforce are unaffected by this issue.

Ticket: ENT-10696
Changelog: title
