### PR TITLE
ENT-10753: Improved locale override in masterfiles stage scripts

### DIFF
--- a/contrib/masterfiles-stage/common.sh
+++ b/contrib/masterfiles-stage/common.sh
@@ -190,7 +190,7 @@ git_cfbs_deploy_refspec() {
   #    (See long comment at end of function def.)
 
   # The chipmunk in cfbs output breaks things without this or similar
-  export LANG=en_US.utf-8
+  export LC_ALL=en_US.utf-8
 
   # Ensure absolute pathname is given
   [ "${1:0:1}" = / ] ||


### PR DESCRIPTION
LANG is not sufficient to guard against odd environment vars, LC_ALL is a master override so prefer that.

Ticket: ENT-10753
Changelog: title

together
https://github.com/cfengine/nova/pull/2129
https://github.com/cfengine/core/pull/5344