### PR TITLE
ENT-9402: Moved ignore_interfaces.rx to $(sys.workdir)

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -836,24 +836,30 @@ static void FindV6InterfacesInfo(EvalContext *ctx, Rlist **interfaces, Rlist **h
 static void InitIgnoreInterfaces()
 {
     FILE *fin;
-    char filename[CF_BUFSIZE],regex[256];
+    char filename[CF_BUFSIZE], regex[256];
 
-    snprintf(filename, sizeof(filename), "%s%c%s", GetInputDir(), FILE_SEPARATOR, CF_IGNORE_INTERFACES);
+    snprintf(
+        filename,
+        sizeof(filename),
+        "%s%c%s",
+        GetInputDir(),
+        FILE_SEPARATOR,
+        CF_IGNORE_INTERFACES);
 
-    if ((fin = fopen(filename,"r")) == NULL)
+    if ((fin = fopen(filename, "r")) == NULL)
     {
-        Log(LOG_LEVEL_VERBOSE, "No interface exception file %s",filename);
+        Log(LOG_LEVEL_VERBOSE, "No interface exception file %s", filename);
         return;
     }
 
     while (!feof(fin))
     {
         regex[0] = '\0';
-        int scanCount = fscanf(fin,"%255s",regex);
+        int scanCount = fscanf(fin, "%255s", regex);
 
         if (scanCount != 0 && *regex != '\0')
         {
-           RlistPrependScalarIdemp(&IGNORE_INTERFACES, regex);
+            RlistPrependScalarIdemp(&IGNORE_INTERFACES, regex);
         }
     }
 

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -849,6 +849,11 @@ static void InitIgnoreInterfaces()
 
     if ((fin = fopen(filename, "r")) == NULL)
     {
+        Log((errno == ENOENT) ? LOG_LEVEL_VERBOSE : LOG_LEVEL_ERR,
+            "Failed to open interface exception file %s: %s",
+            filename,
+            GetErrorStr());
+
         /* LEGACY: The 'ignore_interfaces.rx' file was previously located in
          * $(sys.inputdir). Consequently, if the file is found in this
          * directory but not in $(sys.workdir), we will still process it, but
@@ -864,7 +869,10 @@ static void InitIgnoreInterfaces()
 
         if ((fin = fopen(filename, "r")) == NULL)
         {
-            Log(LOG_LEVEL_VERBOSE, "No interface exception file %s", filename);
+            Log((errno == ENOENT) ? LOG_LEVEL_VERBOSE : LOG_LEVEL_ERR,
+                "Failed to open interface exception file %s: %s",
+                filename,
+                GetErrorStr());
             return;
         }
 

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -888,6 +888,14 @@ static void InitIgnoreInterfaces()
     {
         regex[0] = '\0';
         int scanCount = fscanf(fin, "%255s", regex);
+        if (ferror(fin) != 0)
+        {
+            Log(LOG_LEVEL_ERR,
+                "Failed to read interface exception file %s: %s",
+                filename,
+                GetErrorStr());
+            break;
+        }
 
         if (scanCount != 0 && *regex != '\0')
         {


### PR DESCRIPTION
Merge together:
- https://github.com/cfengine/masterfiles/pull/2750
- https://github.com/cfengine/documentation/pull/3102

PR includes:
- Formatted InitIgnoreInterfaces() with clang-format
- Moved ignore_interfaces.rx to $(sys.workdir)
- Added error message based on errno to InitIgnoreInterfaces()
- Fixed infinite loop on error bug while reading interface exception file

Demo:
```
root@hub:/var/cfengine/inputs# /var/cfengine/bin/cf-agent -KI
 warning: Found interface exception file ignore_interfaces.rx in /var/cfengine/inputs but it should be in /var/cfengine. Please consider moving it to the appropriate location.
 warning: Found interface exception file ignore_interfaces.rx in /var/cfengine/inputs but it should be in /var/cfengine. Please consider moving it to the appropriate location.
root@hub:/var/cfengine/inputs# mv /var/cfengine/inputs/ignore_interfaces.rx /var/cfengine/
root@hub:/var/cfengine/inputs# /var/cfengine/bin/cf-agent -KI
root@hub:/var/cfengine/inputs# 
```