### PR TITLE
Fixed infinite loop on error bug while reading interface exception file (3.21.x)

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -849,7 +849,15 @@ static void InitIgnoreInterfaces()
     while (!feof(fin))
     {
         regex[0] = '\0';
-        int scanCount = fscanf(fin,"%255s",regex);
+        int scanCount = fscanf(fin, "%255s", regex);
+        if (ferror(fin) != 0)
+        {
+            Log(LOG_LEVEL_ERR,
+                "Failed to read interface exception file %s: %s",
+                filename,
+                GetErrorStr());
+            break;
+        }
 
         if (scanCount != 0 && *regex != '\0')
         {


### PR DESCRIPTION
Fixed bug where the agent may enter an infinite loop while trying to read the interface exception file. The problem comes from the fact that the while loop for reading each line in the file checks for end-of-file, but not error. If an error occurs, end-of-file will never be reached, hence the loop will never break.

Back-ported from https://github.com/cfengine/core/pull/5357