### PR TITLE
ENT-10347: Skip failing tests on Debian 12

### DIFF
--- a/tests/acceptance/16_cf-serverd/serial/simple_copy_from_admit_localhost.cf
+++ b/tests/acceptance/16_cf-serverd/serial/simple_copy_from_admit_localhost.cf
@@ -17,7 +17,7 @@ bundle agent test
       # 'admit => { "localhost" };' and 'admit_hostnames => { "localhost" };'
       # are not enough to allow access for this test.
       # Test fails on SLES / OpenSUSE 15, pending investigation.
-      "test_skip_unsupported" string => "(ubuntu_20|ubuntu_22|sles_15|opensuse_leap_15)",
+      "test_skip_unsupported" string => "(ubuntu_20|ubuntu_22|debian_12|sles_15|opensuse_leap_15)",
         meta => { "ENT-2480", "ENT-7362", "ENT-9055" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/serial/simple_copy_from_deny_localhost.cf
+++ b/tests/acceptance/16_cf-serverd/serial/simple_copy_from_deny_localhost.cf
@@ -17,7 +17,7 @@ bundle agent test
       # 'deny => { "localhost" };' and 'deny_hostnames => { "localhost" };'
       # are not enough to deny access for this test.
       # Test fails on SLES / OpenSUSE 15, pending investigation.
-      "test_skip_unsupported" string => "(ubuntu_20|ubuntu_22|sles_15|opensuse_leap_15)",
+      "test_skip_unsupported" string => "(ubuntu_20|ubuntu_22|debian_12|sles_15|opensuse_leap_15)",
         meta => { "ENT-2480", "ENT-7362", "ENT-9055" };
 
   methods:


### PR DESCRIPTION
We should to investigate this, but first we should to get Debian 12 into the next release. See ticket ENT-9055.

Merge together:
 - https://github.com/cfengine/system-testing/pull/506
 - https://github.com/mendersoftware/infra/pull/382
 - https://github.com/cfengine/buildscripts/pull/1313
