### PR TITLE
ENT-10832: Fixed inventoried policy release id when masterfiles-stage.sh deploys with cfbs

### DIFF
--- a/contrib/masterfiles-stage/common.sh
+++ b/contrib/masterfiles-stage/common.sh
@@ -222,8 +222,8 @@ git_cfbs_deploy_refspec() {
   # Switch back to the original working dir
   cd "${_start_wrkdir}"
   # Grab HEAD so it can be used to populate cf_promises_release_id
-  mkdir -p "${temp_stage}/.git"
-  cp "${local_mirrored_repo}/HEAD" "${temp_stage}/.git/"
+  mkdir -p "${temp_stage}/out/masterfiles/.git"
+  cp "${local_mirrored_repo}/HEAD" "${temp_stage}/out/masterfiles/.git/"
 
   ########################## 3. SET PERMISSIONS ON POLICY SET
   chown -R root:root "${temp_stage}" || error_exit "Unable to chown '${temp_stage}'"


### PR DESCRIPTION
When policy is tagged (with cf-promises -T) cf-promises looks for .git/HEAD and
uses it's content as the policy release id in the generated
cf_promises_release_id file. If .git/HEAD does not exist the policy tree is
hashed and that value is used instead.

For traditional deployments straight from version control, this works. When
deploying from cfbs .git/HEAD needs to be copied to out/masterfiles or it won't
be part of the tagged policy. This change adjusts the target appropriately when
deploying with cfbs.

Ticket: ENT-10832
Changelog: Title