### PR TITLE
ENT-10432: Added new platform-agnostic constant `linesep`

### DIFF
--- a/examples/const.cf
+++ b/examples/const.cf
@@ -13,6 +13,7 @@ bundle agent __main__
                           "before const.at $(const.at) after const.at$(const.n)",
                           "before const.dollar $(const.dollar) after const.dollar$(const.n)",
                           "before const.dirsep $(const.dirsep) after const.dirsep$(const.n)",
+                          "before const.linesep $(const.linesep) after const.linesep$(const.n)",
                           "before const.endl$(const.endl) after const.endl$(const.n)",
                           "before const.n$(const.n) after const.n$(const.n)",
                           "before const.r $(const.r) after const.r$(const.n)",
@@ -41,6 +42,7 @@ body printfile cat(file)
 #@       "default:const.dirsep": "/",
 #@       "default:const.dollar": "$",
 #@       "default:const.endl": "\n",
+#@       "default:const.linesep": "\n",
 #@       "default:const.n": "\n",
 #@       "default:const.r": "\r",
 #@       "default:const.t": "\t"
@@ -50,6 +52,8 @@ body printfile cat(file)
 #@ R: before const.at @ after const.at
 #@ R: before const.dollar $ after const.dollar
 #@ R: before const.dirsep / after const.dirsep
+#@ R: before const.linesep 
+#@ R:  after const.linesep
 #@ R: before const.endl
 #@ R:  after const.endl
 #@ R: before const.n

--- a/libenv/constants.c
+++ b/libenv/constants.c
@@ -27,6 +27,12 @@
 #include <eval_context.h>
 #include <file_lib.h>
 
+#ifdef _WIN32
+#define LINESEP "\r\n"
+#else
+#define LINESEP "\n"
+#endif
+
 void LoadSystemConstants(EvalContext *ctx)
 {
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_CONST, "at", "@", CF_DATA_TYPE_STRING, "source=agent");
@@ -36,5 +42,6 @@ void LoadSystemConstants(EvalContext *ctx)
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_CONST, "t", "\t", CF_DATA_TYPE_STRING, "source=agent");
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_CONST, "endl", "\n", CF_DATA_TYPE_STRING, "source=agent");
     EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_CONST, "dirsep", FILE_SEPARATOR_STR, CF_DATA_TYPE_STRING, "source=agent");
+    EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_CONST, "linesep", LINESEP, CF_DATA_TYPE_STRING, "source=agent");
     /* NewScalar("const","0","\0",cf_str);  - this cannot work */
 }

--- a/tests/acceptance/00_basics/linesep.cf
+++ b/tests/acceptance/00_basics/linesep.cf
@@ -1,0 +1,29 @@
+body common control
+{
+  bundlesequence => { "test", "check" };
+  version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+    "description" -> { "ENT-10432" }
+      string => "Test platform-agnostic linesep constant";
+}
+
+bundle agent check
+{
+  classes:
+    windows::
+      "ok"
+        expression => strcmp("$(const.linesep)", "$(const.r)$(const.n)");
+    !windows::
+      "ok"
+        expression => strcmp("$(const.linesep)", "$(const.n)");
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
- Added new platform-agnostic constant `linesep`
- Added `linesep` to constants example
- Added acceptance test for `linesep` constant

Merge together with https://github.com/cfengine/documentation/pull/3106

- [x] Tested manually on Windows Server 2019