### PR TITLE
ENT-9402: Moved ignore_interfaces.rx to $(sys.workdir) (3.21.x)

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -836,13 +836,19 @@ static void FindV6InterfacesInfo(EvalContext *ctx, Rlist **interfaces, Rlist **h
 static void InitIgnoreInterfaces()
 {
     FILE *fin;
-    char filename[CF_BUFSIZE],regex[256];
+    char filename[CF_BUFSIZE], regex[256];
 
-    snprintf(filename, sizeof(filename), "%s%c%s", GetInputDir(), FILE_SEPARATOR, CF_IGNORE_INTERFACES);
+    snprintf(
+        filename,
+        sizeof(filename),
+        "%s%c%s",
+        GetInputDir(),
+        FILE_SEPARATOR,
+        CF_IGNORE_INTERFACES);
 
-    if ((fin = fopen(filename,"r")) == NULL)
+    if ((fin = fopen(filename, "r")) == NULL)
     {
-        Log(LOG_LEVEL_VERBOSE, "No interface exception file %s",filename);
+        Log(LOG_LEVEL_VERBOSE, "No interface exception file %s", filename);
         return;
     }
 
@@ -861,7 +867,7 @@ static void InitIgnoreInterfaces()
 
         if (scanCount != 0 && *regex != '\0')
         {
-           RlistPrependScalarIdemp(&IGNORE_INTERFACES, regex);
+            RlistPrependScalarIdemp(&IGNORE_INTERFACES, regex);
         }
     }
 

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -849,6 +849,11 @@ static void InitIgnoreInterfaces()
 
     if ((fin = fopen(filename, "r")) == NULL)
     {
+        Log((errno == ENOENT) ? LOG_LEVEL_VERBOSE : LOG_LEVEL_ERR,
+            "Failed to open interface exception file %s: %s",
+            filename,
+            GetErrorStr());
+
         /* LEGACY: The 'ignore_interfaces.rx' file was previously located in
          * $(sys.inputdir). Consequently, if the file is found in this
          * directory but not in $(sys.workdir), we will still process it, but
@@ -864,7 +869,10 @@ static void InitIgnoreInterfaces()
 
         if ((fin = fopen(filename, "r")) == NULL)
         {
-            Log(LOG_LEVEL_VERBOSE, "No interface exception file %s", filename);
+            Log((errno == ENOENT) ? LOG_LEVEL_VERBOSE : LOG_LEVEL_ERR,
+                "Failed to open interface exception file %s: %s",
+                filename,
+                GetErrorStr());
             return;
         }
 


### PR DESCRIPTION
Back-ported from https://github.com/cfengine/core/pull/5357