### PR TITLE
CFE-2724: The `arglist` attribute now preserves spaces in arguments

### DIFF
--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -336,7 +336,7 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
         else
         {
             pfp =
-                cf_popensetuid(cmdline, open_mode, a->contain.owner, a->contain.group, a->contain.chdir, a->contain.chroot,
+                cf_popensetuid(cmdline, NULL, open_mode, a->contain.owner, a->contain.group, a->contain.chdir, a->contain.chroot,
                                a->transaction.background);
         }
 

--- a/cf-monitord/history.c
+++ b/cf-monitord/history.c
@@ -179,6 +179,8 @@ static void Nova_HistoryUpdate(time_t time, const Averages *newvals)
 static Item *NovaReSample(EvalContext *ctx, int slot, const Attributes *attr, const Promise *pp, PromiseResult *result)
 {
     assert(attr != NULL);
+    assert(pp != NULL);
+
     Attributes a = *attr; // TODO: try to remove this local copy
     CfLock thislock;
     char eventname[CF_BUFSIZE];
@@ -311,7 +313,7 @@ static Item *NovaReSample(EvalContext *ctx, int slot, const Attributes *attr, co
             else
             {
                 fin =
-                    cf_popensetuid(pp->promiser, "r", a.contain.owner, a.contain.group, a.contain.chdir,
+                    cf_popensetuid(pp->promiser, NULL, "r", a.contain.owner, a.contain.group, a.contain.chdir,
                                    a.contain.chroot, false);
             }
         }

--- a/libpromises/exec_tools.c
+++ b/libpromises/exec_tools.c
@@ -261,7 +261,7 @@ void ArgGetExecutableAndArgs(const char *comm, char **exec, char **args)
 
 #define INITIAL_ARGS 8
 
-char **ArgSplitCommand(const char *comm)
+char **ArgSplitCommand(const char *comm, const Seq *arglist)
 {
     const char *s = comm;
 
@@ -320,14 +320,16 @@ char **ArgSplitCommand(const char *comm)
         args[argc++] = arg;
     }
 
-/* Trailing NULL */
-
-    if (argc == argslen)
+    size_t extra = (arglist == NULL) ? 0 : SeqLength(arglist);
+    if (argc + extra + 1 /* NULL */ > argslen)
     {
-        argslen += 1;
-        args = xrealloc(args, argslen * sizeof(char *));
+        args = xrealloc(args, (argc + extra + 1) * sizeof(char *));
     }
-    args[argc++] = NULL;
+
+    for (size_t i = 0; i < extra; i++) {
+        args[argc++] = xstrdup(SeqAt(arglist, i));
+    }
+    args[argc] = NULL;
 
     return args;
 }

--- a/libpromises/exec_tools.h
+++ b/libpromises/exec_tools.h
@@ -34,7 +34,15 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell);
 bool GetExecOutput(const char *command, char **buffer, size_t *buffer_size, ShellType shell, OutputSelect output_select, int *ret_out);
 void ActAsDaemon();
 void ArgGetExecutableAndArgs(const char *comm, char **exec, char **args);
-char **ArgSplitCommand(const char *comm);
+
+/**
+ * Create a argument list as expected by execv(3)
+ * @param command is split on spaces, unless quoted
+ * @param arglist is not split (can have embedded spaces)
+ * @return null-terminated argument list
+ */
+char **ArgSplitCommand(const char *command, const Seq *arglist);
+
 void ArgFree(char **args);
 
 #endif

--- a/libpromises/pipes.h
+++ b/libpromises/pipes.h
@@ -49,7 +49,7 @@ int cf_pclose_full_duplex_side(int fd);
 
 FILE *cf_popen(const char *command, const char *type, bool capture_stderr);
 FILE *cf_popen_select(const char *command, const char *type, OutputSelect output_select);
-FILE *cf_popensetuid(const char *command, const char *type, uid_t uid, gid_t gid, char *chdirv, char *chrootv, int background);
+FILE *cf_popensetuid(const char *command, const Seq *arglist, const char *type, uid_t uid, gid_t gid, char *chdirv, char *chrootv, int background);
 FILE *cf_popen_sh(const char *command, const char *type);
 FILE *cf_popen_sh_select(const char *command, const char *type, OutputSelect output_select);
 FILE *cf_popen_shsetuid(const char *command, const char *type, uid_t uid, gid_t gid, char *chdirv, char *chrootv, int background);

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -467,15 +467,15 @@ FILE *cf_popen(const char *command, const char *type, bool capture_stderr)
  * WARNING: this is only allowed to be called from single-threaded code,
  *          because of the safe_chdir() call in the forked child.
  */
-FILE *cf_popensetuid(const char *command, const char *type,
-                     uid_t uid, gid_t gid, char *chdirv, char *chrootv,
-                     ARG_UNUSED int background)
+FILE *cf_popensetuid(const char *command, const Seq *arglist,
+                     const char *type, uid_t uid, gid_t gid, char *chdirv,
+                     char *chrootv, ARG_UNUSED int background)
 {
     int pd[2];
     pid_t pid;
     FILE *pp = NULL;
 
-    char **argv = ArgSplitCommand(command, NULL);
+    char **argv = ArgSplitCommand(command, arglist);
 
     pid = CreatePipeAndFork(type, pd);
     if (pid == (pid_t) -1)

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -287,7 +287,7 @@ IOData cf_popen_full_duplex(const char *command, bool capture_stderr, bool requi
     int parent_pipe[2]; /* From parent to child */
     pid_t pid;
 
-    char **argv = ArgSplitCommand(command);
+    char **argv = ArgSplitCommand(command, NULL);
 
     fflush(NULL); /* Empty file buffers */
     pid = CreatePipesAndFork("r+t", child_pipe, parent_pipe);
@@ -377,7 +377,7 @@ FILE *cf_popen_select(const char *command, const char *type, OutputSelect output
     pid_t pid;
     FILE *pp = NULL;
 
-    char **argv = ArgSplitCommand(command);
+    char **argv = ArgSplitCommand(command, NULL);
 
     pid = CreatePipeAndFork(type, pd);
     if (pid == (pid_t) -1)
@@ -475,7 +475,7 @@ FILE *cf_popensetuid(const char *command, const char *type,
     pid_t pid;
     FILE *pp = NULL;
 
-    char **argv = ArgSplitCommand(command);
+    char **argv = ArgSplitCommand(command, NULL);
 
     pid = CreatePipeAndFork(type, pd);
     if (pid == (pid_t) -1)

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -195,7 +195,7 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
         }
         else
         {
-            char **argv = ArgSplitCommand(command);
+            char **argv = ArgSplitCommand(command, NULL);
             int devnull;
 
             if (LogGetGlobalLevel() < LOG_LEVEL_INFO)

--- a/tests/acceptance/08_commands/arglist.cf
+++ b/tests/acceptance/08_commands/arglist.cf
@@ -1,0 +1,67 @@
+##############################################################################
+#
+# CFE-2724: Test that arglist attribute preserves white-spaces
+#
+##############################################################################
+
+body common control
+{
+  inputs => { "../default.cf.sub" };
+  bundlesequence  => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+##############################################################################
+
+bundle agent init
+{
+  files:
+    "$(G.testfile).actual"
+      delete => tidy;
+    "$(G.testfile).sh"
+      perms => mog("700", "root", "root"),
+      content => '#!/bin/sh
+for arg in "$(const.dollar)$(const.at)"
+do
+    echo "$(const.dollar)arg" >> $(G.testfile).actual
+done';
+}
+
+##############################################################################
+
+bundle agent test
+{
+  meta:
+    "description" -> { "CFE-2724" }
+      string => "Test that arglist attribute preserves white-spaces";
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "See ticket CFE-4294";
+
+  commands:
+    "$(G.testfile).sh"
+      args => "one two three",
+      arglist => { "four", "five six", " seven$(const.t)" };
+}
+
+##############################################################################
+
+bundle agent check
+{
+  vars:
+    "actual"
+      string => readfile("$(G.testfile).actual");
+    "expected"
+      string => "one
+two
+three
+four
+five six
+ seven$(const.t)
+";
+
+  methods:
+    "any"
+      usebundle => dcs_check_strcmp("$(actual)", "$(expected)",
+                                    "$(this.promise_filename)", "no");
+}


### PR DESCRIPTION
Merge together with:
- https://github.com/cfengine/enterprise/pull/775
- https://github.com/cfengine/masterfiles/pull/2804