### PR TITLE
ENT-10347: Fixed changing perms noise in no-noise sequential test

### DIFF
--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -631,19 +631,7 @@ static int SetupRunagentSocket(const ExecdConfig *execd_config)
     if (GetRunagentSocketInfo(&sock_info))
     {
         sock_info.sun_family = AF_LOCAL;
-
-        bool created;
-        MakeParentDirectory(sock_info.sun_path, true, &created);
-
-        /* Make sure the permissions are correct if the directory was created
-         * (note: this code doesn't run on Windows). */
-        if (created)
-        {
-            char *last_slash = strrchr(sock_info.sun_path, '/');
-            *last_slash = '\0';
-            chmod(sock_info.sun_path, (mode_t) 0750);
-            *last_slash = '/';
-        }
+        MakeParentDirectoryPerms(sock_info.sun_path, true, NULL, (mode_t) 0700);
 
         /* Remove potential left-overs from old processes. */
         unlink(sock_info.sun_path);
@@ -667,6 +655,7 @@ static int SetupRunagentSocket(const ExecdConfig *execd_config)
         }
         else
         {
+            safe_chmod(sock_info.sun_path, (mode_t) 0600);
             ret = listen(runagent_socket, CF_EXECD_RUNAGENT_SOCKET_LISTEN_QUEUE);
             assert(ret == 0);
             if (ret == -1)


### PR DESCRIPTION
Happens on Debian 12:
```
info: Socket "/var/cfengine/state/./cf-execd.sockets/runagent.socket" had permissions 0700, changed it to 0600
info: Directory "/var/cfengine/state/./cf-execd.sockets" had permissions 0750, changed it to 0700
```

Merge together with:
 - https://github.com/NorthernTechHQ/infra/pull/416
 - https://github.com/cfengine/system-testing/pull/510
 - https://github.com/cfengine/buildscripts/pull/1337
