### PR TITLE
Do not finalize things before printing digest in cf-key

### DIFF
--- a/cf-key/cf-key.c
+++ b/cf-key/cf-key.c
@@ -172,10 +172,10 @@ int main(int argc, char *argv[])
 
     if (print_digest_arg)
     {
-        GenericAgentFinalize(ctx, config);
-        CallCleanupFunctions();
         int rc = PrintDigest(print_digest_arg);
         free(print_digest_arg);
+        GenericAgentFinalize(ctx, config);
+        CallCleanupFunctions();
         return rc;
     }
 


### PR DESCRIPTION
Getting the digest needs crypto functions and finalization also
unloads crypto providers. Also, it just doesn't make sense.