### PR TITLE
CFE-4295: Adjusted static-check/run.sh to expose errors in create_image() (3.18)

### DIFF
--- a/tests/static-check/run.sh
+++ b/tests/static-check/run.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+# Note that this container build requires about 700MB minimum RAM for dnf to operate
+# use debian-12+ or rhel-8+, debian-11 buildah seems to fail setting up networking/dns for the container so dnf doesn't work (CFE-4295)
 
-set -e
+set -eE # include E so that create_image() failures bubble up to the surface
 trap "echo FAILURE" ERR
 
 if [ -z "$STATIC_CHECKS_FEDORA_VERSION" ]; then


### PR DESCRIPTION
Was trying to run on debian-11 which had dns issues and couldn't see the error easily.

Ticket: CFE-4295
Changelog: none
(cherry picked from commit c54801546100be7dc160aaf417f4f80206ed2a53)
