### PR TITLE
CFE-4300: Fixed cf-support call to cf-promises to collect all classes and vars (3.18)

### DIFF
--- a/misc/cf-support
+++ b/misc/cf-support
@@ -342,7 +342,7 @@ log_cmd "$BINDIR/cf-key -p $WORKDIR/ppkeys/localhost.pub"
 log_cmd "grep 'version =' $WORKDIR/inputs/promises.cf"
 log_cmd "$BINDIR/cf-key -s -n"
 log_cmd "$BINDIR/cf-check diagnose"
-$BINDIR/cf-promises --no-lock --show-classes --show-vars > "$tmpdir/classes-and-vars.txt" 2>&1
+$BINDIR/cf-promises --show-classes --show-vars > "$tmpdir/classes-and-vars.txt" 2>&1
 $BINDIR/cf-agent --no-lock --file update.cf --show-evaluated-classes --show-evaluated-vars > "$tmpdir/update-evaluated-classes-and-vars.txt" 2>&1
 $BINDIR/cf-agent --no-lock --file promises.cf --show-evaluated-classes --show-evaluated-vars > "$tmpdir/promises-evaluated-classes-and-vars.txt" 2>&1
 


### PR DESCRIPTION
Had a --no-lock argument which is not supported so nothing was collected.

Ticket: CFE-4300
Changelog: title
(cherry picked from commit bc8a0de71e63a26fb689dab4f0011935e9c3def9)