### PR TITLE
ENT-10997: Skip failing tests on Debian 12 (3.18.x)

### DIFF
--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -621,19 +621,7 @@ static int SetupRunagentSocket(const ExecdConfig *execd_config)
     if (GetRunagentSocketInfo(&sock_info))
     {
         sock_info.sun_family = AF_LOCAL;
-
-        bool created;
-        MakeParentDirectory(sock_info.sun_path, true, &created);
-
-        /* Make sure the permissions are correct if the directory was created
-         * (note: this code doesn't run on Windows). */
-        if (created)
-        {
-            char *last_slash = strrchr(sock_info.sun_path, '/');
-            *last_slash = '\0';
-            chmod(sock_info.sun_path, (mode_t) 0750);
-            *last_slash = '/';
-        }
+        MakeParentDirectoryPerms(sock_info.sun_path, true, NULL, (mode_t) 0700);
 
         /* Remove potential left-overs from old processes. */
         unlink(sock_info.sun_path);
@@ -657,6 +645,7 @@ static int SetupRunagentSocket(const ExecdConfig *execd_config)
         }
         else
         {
+            safe_chmod(sock_info.sun_path, (mode_t) 0600);
             ret = listen(runagent_socket, CF_EXECD_RUNAGENT_SOCKET_LISTEN_QUEUE);
             assert(ret == 0);
             if (ret == -1)

--- a/libpromises/files_lib.c
+++ b/libpromises/files_lib.c
@@ -97,32 +97,39 @@ bool FileWriteOver(char *filename, char *contents)
 
 static bool MakeParentDirectoryImpl(EvalContext *ctx, const Promise *pp, const Attributes *attr,
                                     PromiseResult *result, const char *parentandchild,
-                                    bool force, bool internal, bool *created);
+                                    bool force, bool internal, bool *created,
+                                    mode_t perms_mode);
 
 bool MakeParentDirectory(const char *parentandchild, bool force, bool *created)
 {
     /* just use the complex function with no promise info */
     return MakeParentDirectoryImpl(NULL, NULL, NULL, NULL,
-                                   parentandchild, force, false, created);
+                                   parentandchild, force, false, created, DEFAULTMODE);
+}
+
+bool MakeParentDirectoryPerms(const char *parentandchild, bool force, bool *created, mode_t perms_mode)
+{
+    return MakeParentDirectoryImpl(NULL, NULL, NULL, NULL,
+                                   parentandchild, force, false, created, perms_mode);
 }
 
 bool MakeParentInternalDirectory(const char *parentandchild, bool force, bool *created)
 {
     /* just use the complex function with no promise info */
     return MakeParentDirectoryImpl(NULL, NULL, NULL, NULL,
-                                   parentandchild, force, true, created);
+                                   parentandchild, force, true, created, DEFAULTMODE);
 }
 
 bool MakeParentDirectoryForPromise(EvalContext *ctx, const Promise *pp, const Attributes *attr,
                                    PromiseResult *result, const char *parentandchild,
                                    bool force, bool *created)
 {
-    return MakeParentDirectoryImpl(ctx, pp, attr, result, parentandchild, force, false, created);
+    return MakeParentDirectoryImpl(ctx, pp, attr, result, parentandchild, force, false, created, DEFAULTMODE);
 }
 
 static bool MakeParentDirectoryImpl(EvalContext *ctx, const Promise *pp, const Attributes *attr,
                                     PromiseResult *result, const char *parentandchild,
-                                    bool force, bool internal, bool *created)
+                                    bool force, bool internal, bool *created, mode_t perms_mode)
 {
     char *sp;
     char currentpath[CF_BUFSIZE];
@@ -332,7 +339,7 @@ static bool MakeParentDirectoryImpl(EvalContext *ctx, const Promise *pp, const A
             {
                 mask = umask(0);
 
-                if (mkdir(currentpath, DEFAULTMODE) == -1)
+                if (mkdir(currentpath, perms_mode) == -1)
                 {
                     if (errno != EEXIST)
                     {

--- a/libpromises/files_lib.h
+++ b/libpromises/files_lib.h
@@ -39,6 +39,11 @@ bool LoadFileAsItemList(Item **liststart, const char *file, EditDefaults edits);
 bool MakeParentDirectory(const char *parentandchild, bool force, bool *created);
 
 /**
+ * Identical to MakeParentDirectory, but allows you to specify permissions (mode)
+ */
+bool MakeParentDirectoryPerms(const char *parentandchild, bool force, bool *created, mode_t perms_mode);
+
+/**
  * Create an internal directory (never in the changes chroot).
  */
 bool MakeParentInternalDirectory(const char *parentandchild, bool force, bool *created);

--- a/tests/acceptance/16_cf-serverd/serial/simple_copy_from_admit_localhost.cf
+++ b/tests/acceptance/16_cf-serverd/serial/simple_copy_from_admit_localhost.cf
@@ -17,7 +17,7 @@ bundle agent test
       # 'admit => { "localhost" };' and 'admit_hostnames => { "localhost" };'
       # are not enough to allow access for this test.
       # Test fails on SLES / OpenSUSE 15, pending investigation.
-      "test_skip_unsupported" string => "(ubuntu_20|ubuntu_22|sles_15|opensuse_leap_15)",
+      "test_skip_unsupported" string => "(ubuntu_20|ubuntu_22|debian_12|sles_15|opensuse_leap_15)",
         meta => { "ENT-2480", "ENT-7362", "ENT-9055" };
 
   methods:

--- a/tests/acceptance/16_cf-serverd/serial/simple_copy_from_deny_localhost.cf
+++ b/tests/acceptance/16_cf-serverd/serial/simple_copy_from_deny_localhost.cf
@@ -17,7 +17,7 @@ bundle agent test
       # 'deny => { "localhost" };' and 'deny_hostnames => { "localhost" };'
       # are not enough to deny access for this test.
       # Test fails on SLES / OpenSUSE 15, pending investigation.
-      "test_skip_unsupported" string => "(ubuntu_20|ubuntu_22|sles_15|opensuse_leap_15)",
+      "test_skip_unsupported" string => "(ubuntu_20|ubuntu_22|debian_12|sles_15|opensuse_leap_15)",
         meta => { "ENT-2480", "ENT-7362", "ENT-9055" };
 
   methods:


### PR DESCRIPTION
Merge together:
* https://github.com/cfengine/buildscripts/pull/1356
