### PR TITLE
CFE-3292: Removed soft fail related to the use of globs

### DIFF
--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -35,6 +35,7 @@
 #include <known_dirs.h>
 #include <string_lib.h>
 #include <time.h>          /* time() */
+#include <glob_lib.h>
 
 
 static bool DBPathLock(FileLock *lock, const char *filename);

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -75,6 +75,7 @@
 #include <string_lib.h>
 #include <version_comparison.h>
 #include <mutex.h>          /* ThreadWait */
+#include <glob_lib.h>
 
 #include <math_eval.h>
 

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -8756,6 +8756,7 @@ static FnCallResult FnCallFindfilesUp(ARG_UNUSED EvalContext *ctx, ARG_UNUSED co
         return FnFailure();
     }
 
+    MapName(path); // Makes sure we get host native path separators
     DeleteRedundantSlashes(path);
 
     size_t len = strlen(path);

--- a/tests/acceptance/01_vars/02_functions/findfiles-GLOB_BRACE.cf
+++ b/tests/acceptance/01_vars/02_functions/findfiles-GLOB_BRACE.cf
@@ -14,11 +14,7 @@ body common control
 bundle common findfiles
 {
   vars:
-    # * in filenames not allowed on win
-    windows::
       "names" slist => { "a", "bc", "d/e/f", "g/h/i/j", "klm/nop/qrs" };
-    !windows::
-      "names" slist => { "a", "bc", "d/e/f", "g/h/i/j", "klm/nop/qrs", "tu/*" };
 }
 
 #######################################################
@@ -43,13 +39,6 @@ bundle agent test
       "description" -> { "CFE-3292" }
         string => "Test that findfiles() works as expected.";
 
-      #"test_suppress_fail" string => "windows",
-      #  meta => { "redmine4730" };
-      # This test should be merged with findfiles.cf when it's fixed.
-      # In order to soft-fail it as requested, I had to strip it to a separate-test
-      "test_soft_fail" string => "any",
-        meta => { "CFE-3292" };
-
   vars:
       "patterns[GLOB_BRACE]" string => "$(G.testdir)/{a,bc}";
 
@@ -70,7 +59,7 @@ bundle agent test
 bundle agent check
 {
   vars:
-      "expected[GLOB_BRACE]" string => "$(G.testdir)/a,$(G.testdir)/bc";
+      "expected[GLOB_BRACE]" string => "$(G.testdir)$(const.dirsep)a,$(G.testdir)$(const.dirsep)bc";
 
       "expects" slist => getindices("expected");
 

--- a/tests/acceptance/01_vars/02_functions/findfiles.cf
+++ b/tests/acceptance/01_vars/02_functions/findfiles.cf
@@ -53,7 +53,7 @@ bundle agent test
       # escape wildcards with backslash when it is a file separator.
       "patterns[f]" string => "$(G.testdir)/tu/\\*";
   any::
-      "patterns[g]" string => "$(G.testdir)/**";
+      "patterns[g]" string => "$(G.testdir)/*/**";
       "patterns[h]" string => "$(G.testdir)/**/j";
 
       "pnames" slist => getindices("patterns");

--- a/tests/acceptance/01_vars/02_functions/findfiles.cf
+++ b/tests/acceptance/01_vars/02_functions/findfiles.cf
@@ -17,7 +17,7 @@ bundle common findfiles
     # * in filenames not allowed on win
     windows::
       "names" slist => { "a", "bc", "d/e/f", "g/h/i/j", "klm/nop/qrs" };
-    !windows::
+   !windows::
       "names" slist => { "a", "bc", "d/e/f", "g/h/i/j", "klm/nop/qrs", "tu/*" };
 }
 
@@ -39,10 +39,6 @@ bundle agent init
 
 bundle agent test
 {
-  meta:
-      "test_suppress_fail" string => "windows",
-        meta => { "redmine4730,ENT-2145" };
-
   vars:
       "patterns[a]" string => "$(G.testdir)/?";
       "patterns[b]" string => "$(G.testdir)/*";
@@ -52,13 +48,14 @@ bundle agent test
       "patterns[relative_path_1]" string => "./*";
       "patterns[relative_path_2]" string => "**";
       "patterns[relative_path_3]" string => "../**";
-
-    !windows::
+  !windows::
+      # First of all '*' is an illegal filename on Windows. Also you cannot
+      # escape wildcards with backslash when it is a file separator.
       "patterns[f]" string => "$(G.testdir)/tu/\\*";
+  any::
       "patterns[g]" string => "$(G.testdir)/**";
       "patterns[h]" string => "$(G.testdir)/**/j";
 
-    any::
       "pnames" slist => getindices("patterns");
 
       "found[$(pnames)]" slist => findfiles("$(patterns[$(pnames)])");
@@ -76,27 +73,33 @@ bundle agent test
 bundle agent check
 {
   vars:
-      "expected[a]" string => "$(G.testdir)/a,$(G.testdir)/d,$(G.testdir)/g";
-    windows::
-      "expected[b]" string => "$(G.testdir)/a,$(G.testdir)/bc,$(G.testdir)/d,$(G.testdir)/g,$(G.testdir)/klm";
     !windows::
+      "expected[a]" string => "$(G.testdir)/a,$(G.testdir)/d,$(G.testdir)/g";
       "expected[b]" string => "$(G.testdir)/a,$(G.testdir)/bc,$(G.testdir)/d,$(G.testdir)/g,$(G.testdir)/klm,$(G.testdir)/tu";
 
-    any::
       "expected[c]" string => "$(G.testdir)/d/e,$(G.testdir)/g/h";
       "expected[d]" string => "$(G.testdir)/a,$(G.testdir)/bc";
       "expected[e]" string => "";
 
-    !windows::
       "expected[f]" string => "$(G.testdir)/tu/*";
       "expected[g]" string => "$(G.testdir)/a,$(G.testdir)/bc,$(G.testdir)/d,$(G.testdir)/g,$(G.testdir)/klm,$(G.testdir)/tu,$(G.testdir)/d/e,$(G.testdir)/g/h,$(G.testdir)/klm/nop,$(G.testdir)/tu/*,$(G.testdir)/d/e/f,$(G.testdir)/g/h/i,$(G.testdir)/klm/nop/qrs,$(G.testdir)/g/h/i/j";
       "expected[h]" string => "$(G.testdir)/g/h/i/j";
+    windows::
+      "expected[a]" string => "$(G.testdir)\\a,$(G.testdir)\\d,$(G.testdir)\\g";
+      "expected[b]" string => "$(G.testdir)\\a,$(G.testdir)\\bc,$(G.testdir)\\d,$(G.testdir)\\g,$(G.testdir)\\klm";
+
+      "expected[c]" string => "$(G.testdir)\\d\\e,$(G.testdir)\\g\\h";
+      "expected[d]" string => "$(G.testdir)\\a,$(G.testdir)\\bc";
+      "expected[e]" string => "";
+
+      "expected[g]" string => "$(G.testdir)\\a,$(G.testdir)\\bc,$(G.testdir)\\d,$(G.testdir)\\g,$(G.testdir)\\klm,$(G.testdir)\\d\\e,$(G.testdir)\\g\\h,$(G.testdir)\\klm\\nop,$(G.testdir)\\d\\e\\f,$(G.testdir)\\g\\h\\i,$(G.testdir)\\klm\\nop\\qrs,$(G.testdir)\\g\\h\\i\\j";
+      "expected[h]" string => "$(G.testdir)\\g\\h\\i\\j";
+    any::
       # relative paths are skipped, thus return empty list
       "expected[relative_path_1]" string => "";
       "expected[relative_path_2]" string => "";
       "expected[relative_path_3]" string => "";
 
-    any::
       "expects" slist => getindices("expected");
 
       "fstring" slist => getindices("test.found_string");

--- a/tests/acceptance/01_vars/02_functions/findfiles_glob_bracket.cf
+++ b/tests/acceptance/01_vars/02_functions/findfiles_glob_bracket.cf
@@ -1,0 +1,114 @@
+#######################################################
+#
+# Test that square bracket works in glob patterns
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { "init", "test", "check" };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "filenames"
+        slist => { "foo", "bar", "baz" };
+
+  files:
+      "$(G.testdir)/$(filenames)"
+        create => "true";
+
+  reports:
+    DEBUG::
+      "Created $(G.testdir)/$(filenames)";
+}
+
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      "description"
+        string => "Test that square bracket works in glob patterns.";
+
+  vars:
+      "patterns[a]"
+        string => "$(G.testdir)/[f]oo";
+      "patterns[b]"
+        string => "$(G.testdir)/b[a]r";
+      "patterns[c]"
+        string => "$(G.testdir)/ba[z]";
+      "patterns[d]"
+        string => "$(G.testdir)/[a-z][a-z][a-z]";
+      "patterns[e]"
+        string => "$(G.testdir)/ba[rz]";
+      "patterns[f]"
+        string => "$(G.testdir)/[fb][oa][orz]";
+
+      "pnames"
+        slist => getindices("patterns");
+      "found[$(pnames)]"
+        slist => findfiles("$(patterns[$(pnames)])");
+      "found_string[$(pnames)]"
+        string => join(",", "found[$(pnames)]");
+
+  reports:
+    DEBUG::
+      "findfiles pattern $(pnames) '$(patterns[$(pnames)])' => '$(found_string[$(pnames)])'";
+}
+
+
+#######################################################
+
+bundle agent check
+{
+  meta:
+      "test_skip_needs_work" string => "windows",
+        meta => { "ENT-11176" };
+
+  vars:
+      "expected[a]"
+        string => "$(G.testdir)$(const.dirsep)foo";
+      "expected[b]"
+        string => "$(G.testdir)$(const.dirsep)bar";
+      "expected[c]"
+        string => "$(G.testdir)$(const.dirsep)baz";
+      "expected[d]"
+        string => "$(G.testdir)$(const.dirsep)bar,$(G.testdir)$(const.dirsep)baz,$(G.testdir)$(const.dirsep)foo";
+      "expected[e]"
+        string => "$(G.testdir)$(const.dirsep)bar,$(G.testdir)$(const.dirsep)baz";
+      "expected[f]"
+        string => "$(G.testdir)$(const.dirsep)bar,$(G.testdir)$(const.dirsep)baz,$(G.testdir)$(const.dirsep)foo";
+
+      "expects"
+        slist => getindices("expected");
+      "fstring"
+        slist => getindices("test.found_string");
+      "joint_condition"
+        string => join(".", "expects");
+
+  classes:
+      "$(expects)"
+        expression => strcmp("$(test.found_string[$(expects)])", "$(expected[$(expects)])");
+      "ok"
+        expression => "$(joint_condition)";
+
+  reports:
+    DEBUG::
+      "pattern $(expects) matches as expected: '$(expected[$(expects)])'"
+        if => "$(expects)";
+
+      "pattern $(expects) does NOT match expected: '$(test.found_string[$(expects)])' != '$(expected[$(expects)])'"
+        if => "!$(expects)";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/01_vars/02_functions/findfiles_up.cf
+++ b/tests/acceptance/01_vars/02_functions/findfiles_up.cf
@@ -1,132 +1,177 @@
 body common control
 {
-  inputs => { "../../default.cf.sub" };
-  bundlesequence => { default("$(this.promise_filename)") };
+  bundlesequence => { "init", "test", "check" };
   version => "1.0";
 }
 
-bundle common my_vars
-{
+bundle common G {
   vars:
-      "files" slist => {
-        "file_1.txt",
-        "file_1.png",
-        "a/file_2.txt",
-        "a/file_22.txt",
-        "a/b/file_3.txt",
-        "a/b/c/d/file_3.txt",
-        "a/b/c/d/e/f/file_3.txt"
-      };
+      "testdir"
+        string => concat(
+          getenv("TEMP", "65535"),
+          "$(const.dirsep)TESTDIR.cfengine"
+        );
 }
 
 bundle agent init
 {
+  vars:
+      "files"
+        slist => {
+          "core/.gitignore",
+          "core/.git/config",
+          "core/libpromises/cf3parse.y",
+          "core/libpromises/cf3lex.l",
+          "core/libntech/.gitignore",
+          "core/libntech/.git/config",
+          "core/libntech/libutils/string.h",
+          "core/libntech/libutils/string.c"
+        };
+
   files:
-      "$(G.testdir)/$(my_vars.files)"
+      "$(G.testdir)/$(files)"
         create => "true";
 
   reports:
     DEBUG::
-      "Created $(G.testdir)/$(my_vars.files)";
-}
-
-# Test findfiles_up with optional third argument specified
-bundle agent test_wapper_1(index, path, glob, level)
-{
-  vars:
-      "test"
-        data => findfiles_up("$(G.testdir)$(path)", "$(glob)", "$(level)"),
-        if => isdir("$(G.testdir)$(path)");
-
-      "test"
-        slist => filter("^$(G.testdir)/.*", test, true, false, inf);
-
-      "test"
-        slist => maplist(regex_replace("$(this)", "$(G.testdir)", "", "g"), test);
-
-      "test"
-        string => join(", ", getvalues(test));
-  reports:
-      "$(test)"
-        bundle_return_value_index => "$(index)";
-}
-
-# Test findfiles_up with optional third argument not specified
-bundle agent test_wapper_2(index, path, glob)
-{
-  vars:
-      "test"
-        data => findfiles_up("$(G.testdir)$(path)", "$(glob)"),
-        if => isdir("$(G.testdir)$(path)");
-
-      "test"
-        slist => filter("^$(G.testdir)/.*", test, true, false, inf);
-
-      "test"
-        slist => maplist(regex_replace("$(this)", "$(G.testdir)", "", "g"), test);
-
-      "test"
-        string => join(", ", getvalues(test));
-
-  reports:
-      "$(test)"
-        bundle_return_value_index => "$(index)";
+      "Created $(G.testdir)/$(files)";
 }
 
 bundle agent test
 {
   meta:
       "description" -> { "CFE-3577" }
-        string => "Test for expected results from policy function search_up";
-      "test_skip_needs_work" string => "windows",
-        meta => { "ENT-10250" };
+        string => "Test for expected results from policy function findfiles_up";
 
-  methods:
-       "Test 0"
-        usebundle => test_wapper_1("0", "/", "*", 123),
-        useresult => "test";
-
-      "Test 1"
-        usebundle => test_wapper_1("1", "/a/b/c/d/e/f", ".", inf),
-        useresult => "test";
-
-      "Test 2"
-        usebundle => test_wapper_1("2", "/a/b/c/d/e/f", "file_1.txt", inf),
-        useresult => "test";
-
-      "Test 3"
-        usebundle => test_wapper_2("3", "/a/b/c/d/e/f", "file_2.txt"),
-        useresult => "test";
-
-      "Test 4"
-        usebundle => test_wapper_1("4", "/a/b/c/d/e/f", "file_3.txt", 0),
-        useresult => "test";
-
-      "Test 5"
-        usebundle => test_wapper_1("5", "/a/b/c/d/e/f", "file_3.txt", 2),
-        useresult => "test";
-
-      "Test 6"
-        usebundle => test_wapper_2("6", "/a/b//c/d/e/f", "file_1.*"),
-        useresult => "test";
-
-      "Test 7"
-        usebundle => test_wapper_2("7", "/a/b/c/d/e/f", "file_?.txt"),
-        useresult => "test";
-
-      "Test 8"
-        usebundle => test_wapper_2("8", "/a/b/c/d/e/f", "c//d/file_?.txt"),
-        useresult => "test";
-
-      "Test 9"
-        usebundle => test_wapper_1("9", "/a//b//c//d/e/f", "c/d/file_?.txt", 4),
-        useresult => "test";
+  vars:
+      "t1"
+        data => findfiles_up("$(G.testdir)/core/libntech/libutils/", ".gitignore", "inf");
+      "t2"
+        data => findfiles_up("$(G.testdir)/core/libntech/libutils/", "string.?");
+      "t3"
+        data => findfiles_up("$(G.testdir)/core/libntech/libutils/", ".git/");
+      "t4"
+        data => findfiles_up("$(G.testdir)/core/libntech/libutils/", ".git/", "1");
+      "t5"
+        data => findfiles_up("$(G.testdir)/core/libntech/libutils/", ".git/config");
+      "t6"
+        data => findfiles_up("$(G.testdir)/core/libntech/libutils/", "*/cf?{lex,parse}.[ly]");
 }
 
 bundle agent check
 {
-  methods:
-      "check"  usebundle => dcs_check_state(test,
-                                           "$(this.promise_filename).expected.json",
-                                           "$(this.promise_filename)");
+  classes:
+    windows::
+      "c1"
+        expression => and(
+          strcmp("$(G.testdir)\\core\\libntech\\.gitignore", "$(test.t1[0])"),
+          strcmp("$(G.testdir)\\core\\.gitignore", "$(test.t1[1])")
+        );
+      "c2"
+        expression => and(
+          strcmp("$(G.testdir)\\core\\libntech\\libutils\\string.c", "$(test.t2[0])"),
+          strcmp("$(G.testdir)\\core\\libntech\\libutils\\string.h", "$(test.t2[1])")
+        );
+      "c3"
+        expression => and(
+          strcmp("$(G.testdir)\\core\\libntech\\.git", "$(test.t3[0])"),
+          strcmp("$(G.testdir)\\core\\.git", "$(test.t3[1])")
+        );
+      "c4"
+        expression => and(
+          strcmp("$(G.testdir)\\core\\libntech\\.git", "$(test.t4[0])"),
+          not(isvariable("test.t4[1]"))
+        );
+      "c5"
+        expression => and(
+          strcmp("$(G.testdir)\\core\\libntech\\.git\\config", "$(test.t5[0])"),
+          strcmp("$(G.testdir)\\core\\.git\\config", "$(test.t5[1])")
+        );
+      "c6"
+        expression => and(
+          strcmp("$(G.testdir)\\core\\libpromises\\cf3lex.l", "$(test.t6[0])"),
+          strcmp("$(G.testdir)\\core\\libpromises\\cf3parse.y", "$(test.t6[1])")
+        );
+
+    !windows::
+      "c1"
+        expression => and(
+          strcmp("$(G.testdir)/core/libntech/.gitignore", "$(test.t1[0])"),
+          strcmp("$(G.testdir)/core/.gitignore", "$(test.t1[1])")
+        );
+      "c2"
+        expression => and(
+          strcmp("$(G.testdir)/core/libntech/libutils/string.c", "$(test.t2[0])"),
+          strcmp("$(G.testdir)/core/libntech/libutils/string.h", "$(test.t2[1])")
+        );
+      "c3"
+        expression => and(
+          strcmp("$(G.testdir)/core/libntech/.git", "$(test.t3[0])"),
+          strcmp("$(G.testdir)/core/.git", "$(test.t3[1])")
+        );
+      "c4"
+        expression => and(
+          strcmp("$(G.testdir)/core/libntech/.git", "$(test.t4[0])"),
+          not(isvariable("test.t4[1]"))
+        );
+      "c5"
+        expression => and(
+          strcmp("$(G.testdir)/core/libntech/.git/config", "$(test.t5[0])"),
+          strcmp("$(G.testdir)/core/.git/config", "$(test.t5[1])")
+        );
+      "c6"
+        expression => and(
+          strcmp("$(G.testdir)/core/libpromises/cf3lex.l", "$(test.t6[0])"),
+          strcmp("$(G.testdir)/core/libpromises/cf3parse.y", "$(test.t6[1])")
+        );
+
+    any::
+      "ok"
+        expression => and("c1", "c2", "c3", "c4", "c5", "c6");
+
+  reports:
+    DEBUG.windows.!c1::
+      "$(const.dollar)(test.t1[0]): Expected '$(G.testdir)\\core\\libntech\\.gitignore', found '$(test.t1[0])'";
+      "$(const.dollar)(test.t1[1]): Expected '$(G.testdir)\\core\\.gitignore', found '$(test.t1[1])'";
+    DEBUG.windows.!c2::
+      "$(const.dollar)(test.t2[0]): Expected '$(G.testdir)\\core\\libntech\\libutils\\string.c', found '$(test.t2[0])'";
+      "$(const.dollar)(test.t2[1]): Expected '$(G.testdir)\\core\\libntech\\libutils\\string.h', found '$(test.t2[1])'";
+    DEBUG.windows.!c3::
+      "$(const.dollar)(test.t3[0]): Expected '$(G.testdir)\\core\\libntech\\.git', found '$(test.t3[0])'";
+      "$(const.dollar)(test.t3[1]): Expected '$(G.testdir)\\core\\.git', found '$(test.t3[1])'";
+    DEBUG.windows.!c4::
+      "$(const.dollar)(test.t4[0]): Expected '$(G.testdir)\\core\\libntech\\.git', found '$(test.t4[0])'";
+      "$(const.dollar)(test.t4[1]): Should not exist, $(with). Expanded value: '$(test.t4[1])'"
+        with => ifelse(isvariable("test.t4[1]"), "but does exist", "and does not exist");
+    DEBUG.windows.!c5::
+      "$(const.dollar)(test.t5[0]): Expected '$(G.testdir)\\core\\libntech\\.git\\config', found '$(test.t5[0])'";
+      "$(const.dollar)(test.t5[1]): Expected '$(G.testdir)\\core\\.git\\config', found '$(test.t5[1])'";
+    DEBUG.windows.!c6::
+      "$(const.dollar)(test.t6[0]): Expected '$(G.testdir)\\core\\libpromises\\cf3lex.l', found '$(test.t6[0])'";
+      "$(const.dollar)(test.t6[1]): Expected '$(G.testdir)\\core\\libpromises\\cf3parse.y', found '$(test.t6[1])'";
+
+    DEBUG.!windows.!c1::
+      "$(const.dollar)(test.t1[0]): Expected '$(G.testdir)/core/libntech/.gitignore', found '$(test.t1[0])'";
+      "$(const.dollar)(test.t1[1]): Expected '$(G.testdir)/core/.gitignore', found '$(test.t1[1])'";
+    DEBUG.!windows.!c2::
+      "$(const.dollar)(test.t2[0]): Expected '$(G.testdir)/core/libntech/libutils/string.c', found '$(test.t2[0])'";
+      "$(const.dollar)(test.t2[1]): Expected '$(G.testdir)/core/libntech/libutils/string.h', found '$(test.t2[1])'";
+    DEBUG.!windows.!c3::
+      "$(const.dollar)(test.t3[0]): Expected '$(G.testdir)/core/libntech/.git', found '$(test.t3[0])'";
+      "$(const.dollar)(test.t3[1]): Expected '$(G.testdir)/core/.git', found '$(test.t3[1])'";
+    DEBUG.!windows.!c4::
+      "$(const.dollar)(test.t4[0]): Expected '$(G.testdir)/core/libntech/.git', found '$(test.t4[0])'";
+      "$(const.dollar)(test.t4[1]): Should not exist, $(with). Expanded value: '$(test.t4[1])'"
+        with => ifelse(isvariable("test.t4[1]"), "but does exist", "and does not exist");
+    DEBUG.!windows.!c5::
+      "$(const.dollar)(test.t5[0]): Expected '$(G.testdir)/core/libntech/.git/config', found '$(test.t5[0])'";
+      "$(const.dollar)(test.t5[1]): Expected '$(G.testdir)/core/.git/config', found '$(test.t5[1])'";
+    DEBUG.!windows.!c6::
+      "$(const.dollar)(test.t6[0]): Expected '$(G.testdir)/core/libpromises/cf3lex.l', found '$(test.t6[0])'";
+      "$(const.dollar)(test.t6[1]): Expected '$(G.testdir)/core/libpromises/cf3parse.y', found '$(test.t6[1])'";
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
 }

--- a/tests/unit/getopt_test.c
+++ b/tests/unit/getopt_test.c
@@ -4,6 +4,7 @@
 #include <alloc.h>
 #include <string_lib.h>
 #include <getopt.h>
+#include <sequence.h>
 
 /* Test that we have a working version of getopt functionality, either
  * system-provided or our own in libcfecompat. */


### PR DESCRIPTION
Merge together:
* https://github.com/cfengine/enterprise/pull/786

TODO:
- [x] Manually test on Windows
- [x] Fix `findfiles_up.cf` acceptance test on windows