### PR TITLE
ENT-11137: Warn if no action requested when parsing

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -617,8 +617,9 @@ exit:
     free(chrooted_path);
     if (AttrHasNoAction(&a))
     {
-        Log(LOG_LEVEL_WARNING,
-            "No action was requested for file '%s'. Maybe a typo in the policy?", path);
+        Log(LOG_LEVEL_VERBOSE, "No action was requested for file '%s'. "
+            "Maybe all attributes are skipped due to unresolved arguments in policy functions? "
+            "Maybe a typo in the policy?", path);
     }
 
     switch(result)

--- a/libpromises/cf3parse.y
+++ b/libpromises/cf3parse.y
@@ -297,6 +297,9 @@ classpromises:         classpromise
 
 classpromise:          class
                      | promise_decl
+                       {
+                          ParserCheckPromiseLine();
+                       }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/libpromises/parser.c
+++ b/libpromises/parser.c
@@ -164,6 +164,10 @@ int ParserWarningFromString(const char *warning_str)
     {
         return PARSER_WARNING_REMOVED;
     }
+    else if (strcmp("sanity-check", warning_str) == 0)
+    {
+        return PARSER_WARNING_SANITY_CHECK;
+    }
     else if (strcmp("all", warning_str) == 0)
     {
         return PARSER_WARNING_ALL;
@@ -182,6 +186,8 @@ const char *ParserWarningToString(unsigned int warning)
         return "deprecated";
     case PARSER_WARNING_REMOVED:
         return "removed";
+    case PARSER_WARNING_SANITY_CHECK:
+        return "sanity-check";
 
     default:
         ProgrammingError("Invalid parser warning: %u", warning);

--- a/libpromises/parser.h
+++ b/libpromises/parser.h
@@ -29,6 +29,7 @@
 
 #define PARSER_WARNING_DEPRECATED       (1 << 0)
 #define PARSER_WARNING_REMOVED          (1 << 1)
+#define PARSER_WARNING_SANITY_CHECK     (1 << 2)
 
 #define PARSER_WARNING_ALL              0xfffffff
 

--- a/libpromises/policy.c
+++ b/libpromises/policy.c
@@ -2328,7 +2328,7 @@ static Body *PolicyAppendBodyJson(Policy *policy, JsonElement *json_body)
     }
 
     Body *body = PolicyAppendBody(policy, ns, name, type, args, source_path, false);
-
+    RlistDestroy(args); // It's copied by PolicyAppendBody()
     {
         JsonElement *json_contexts = JsonObjectGetAsArray(json_body, "contexts");
         for (size_t i = 0; i < JsonLength(json_contexts); i++)

--- a/tests/unit/data/benchmark.cf
+++ b/tests/unit/data/benchmark.cf
@@ -22,7 +22,14 @@ bundle agent main
       perms => myperms;
 
   processes:
-      "/bin/stuff" -> { "stakeholder" };
+      "/bin/stuff" -> { "stakeholder" }
+      process_count => any_count("stuff_running");
+}
+
+body process_count any_count(cl)
+{
+      match_range => "0,0";
+      out_of_range_define => { "$(cl)" };
 }
 
 body perms myperms

--- a/tests/unit/policy_test.c
+++ b/tests/unit/policy_test.c
@@ -174,7 +174,7 @@ static void test_policy_json_to_from(void)
     assert_true(policy);
 
     assert_int_equal(1, SeqLength(policy->bundles));
-    assert_int_equal(2, SeqLength(policy->bodies));
+    assert_int_equal(3, SeqLength(policy->bodies));
 
     {
         Bundle *main_bundle = PolicyGetBundle(policy, NULL, "agent", "main");
@@ -320,7 +320,7 @@ static void test_policy_json_offsets(void)
 
         JsonElement *myperms_body = JsonArrayGetAsObject(json_bodies, 1);
         line = JsonPrimitiveGetAsInteger(JsonObjectGet(myperms_body, "line"));
-        assert_int_equal(28, line);
+        assert_int_equal(29, line);
 
         JsonElement *myperms_contexts = JsonObjectGetAsArray(myperms_body, "contexts");
         JsonElement *any_context = JsonArrayGetAsObject(myperms_contexts, 0);
@@ -328,7 +328,7 @@ static void test_policy_json_offsets(void)
         {
             JsonElement *mode_attrib = JsonArrayGetAsObject(any_attribs, 0);
             line = JsonPrimitiveGetAsInteger(JsonObjectGet(mode_attrib, "line"));
-            assert_int_equal(30, line);
+            assert_int_equal(31, line);
         }
     }
 


### PR DESCRIPTION
- Agent now warns on unresolved function arguments
- Agent no longer warns if there are no action in files promise
- Added warning to parser in case of promises with no action requested

```
$ cat ~/foo.cf 
bundle agent main
{
  files:
      "/tmp/testfile"
        comment => "No action";
}
$ sudo /var/cfengine/bin/cf-agent -KIf ~/foo.cf 
/home/vagrant/foo.cf:5:32: warning: No action requested for files promise with promiser '/tmp/testfile' in /home/vagrant/foo.cf:main close to line 4 [-Wsanity-check]
        comment => "No action";
                               ^
```

```
$ cat bar.cf 
bundle agent main
{
  files:
    "/tmp/testfile"
      content => concat("$(bogus)", "doofus");
}
$ sudo /var/cfengine/bin/cf-agent -KIf ~/bar.cf 
 warning: Function 'concat' in promise '/home/vagrant/bar.cf' near line 4 contains unresolved arguments on last pass
$ sudo /var/cfengine/bin/cf-agent -KIf ~/bar.cf --verbose | grep "No action was requested"
 verbose: No action was requested for file '/tmp/testfile'. Maybe all attributes are skipped due to unresolved arguments in policy functions? Maybe a typo in the policy?
```

```
$ cat baz.cf 
bundle agent main
{
  vars:
    bogus::
      "lastname"
        string => "Smith";

  users:
      "jsmith"
        policy => "present",
        description => concat("John", "$(lastname)");
}
$ sudo /var/cfengine/bin/cf-agent -KIf ~/baz.cf
    info: Created user 'jsmith'
 warning: Function 'concat' in promise '/home/vagrant/baz.cf' near line 9 contains unresolved arguments on last pass
$ sudo /var/cfengine/bin/cf-agent -KIf ~/baz.cf -D bogus
    info: Modified user 'jsmith'

```