### PR TITLE
[3.18.x] Allow httpd to run `ps` and get info about processes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@
 	- cf_lock.lmdb is no longer restored from backup on every boot (CFE-3982)
 	- Fixed cf-support call to cf-promises to collect all classes and vars
 	  (CFE-4300)
+	- SELinux no longer breaks exporting large reports as PDF (ENT-11154)
 
 3.18.6:
 	- Fixed and improved postgresql server state handling in package installer

--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -657,6 +657,11 @@ allow cfengine_httpd_t system_dbusd_var_run_t:dir search;
 allow cfengine_httpd_t system_dbusd_var_run_t:sock_file write;
 allow init_t cfengine_httpd_t:dbus send_msg;
 
+# allow httpd to run 'ps' and thus gather information about all running processes on the system
+# this is a macro invocation, the file has to be processed with
+# make -f /usr/share/selinux/devel/Makefile
+ps_process_pattern(cfengine_httpd_t, domain)
+
 # TODO: these should not be needed
 allow cfengine_httpd_t passwd_file_t:file { getattr open read };
 allow cfengine_httpd_t shell_exec_t:file map;


### PR DESCRIPTION
Needed for httpd/php to monitor exporting large PDF reports.

Ticket: ENT-11154
Changelog: SELinux no longer breaks exporting large reports as PDF (cherry picked from commit 0229b4006c243a6dd0d7c0bdab74a637310a804f)