### PR TITLE
[3.18.x] More SELinux policy changes for httpd/php to run ps

### DIFF
--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -661,6 +661,9 @@ allow init_t cfengine_httpd_t:dbus send_msg;
 # this is a macro invocation, the file has to be processed with
 # make -f /usr/share/selinux/devel/Makefile
 ps_process_pattern(cfengine_httpd_t, domain)
+allow cfengine_httpd_t bin_t:file { map execute execute_no_trans };
+allow cfengine_httpd_t proc_t:dir read;
+allow cfengine_httpd_t proc_t:file { open read };
 
 # TODO: these should not be needed
 allow cfengine_httpd_t passwd_file_t:file { getattr open read };


### PR DESCRIPTION
It needs to be able to actually execute `/bin/ps` (and `/bin/bash`, but that's already allowed) and read `/proc`.

Ticket: ENT-11154
Changelog: None
(cherry picked from commit d34bdf5a52a309354a7d28274637653706ae4823)