### PR TITLE
CFE-4310: Fixed static-check job by forcing inclusion of config.h

### DIFF
--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -593,7 +593,9 @@ static bool ChangePasswordHashUsingLckpwdf(const char *puser, const char *passwo
     }
 
     fclose(edit_fd);
+    edit_fd = NULL; // mark as NULL so we don't close it later
     fclose(passwd_fd);
+    passwd_fd = NULL; // mark as NULL so we don't close it later
 
     if (!CopyFilePermissionsDisk(passwd_file, edit_file))
     {
@@ -613,10 +615,16 @@ static bool ChangePasswordHashUsingLckpwdf(const char *puser, const char *passwo
     goto unlock_passwd;
 
 close_both:
-    fclose(edit_fd);
+    if (edit_fd != NULL)
+    {
+        fclose(edit_fd);
+    }
     unlink(edit_file);
 close_passwd_fd:
-    fclose(passwd_fd);
+    if (passwd_fd != NULL)
+    {
+        fclose(passwd_fd);
+    }
 unlock_passwd:
     ulckpwdf();
 

--- a/cf-check/diagnose.c
+++ b/cf-check/diagnose.c
@@ -281,6 +281,7 @@ static int diagnose(const char *path, bool temporary_redirect, bool validate)
             return errno;
         }
         assert(f_result == stdout);
+        fclose(f_result);
         ret = lmdump(LMDUMP_VALUES_ASCII, path);
     }
     return lmdb_errno_to_cf_check_code(ret);

--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -26,9 +26,11 @@ function check_with_cppcheck() {
   # cppcheck options:
   #   -I -- include paths
   #   -i -- ignored files/folders
+  #   --include=<file> -- force including a file, e.g. config.h
   # Identified issues are printed to stderr
   cppcheck --quiet -j${n_procs} --error-exitcode=1 ./ \
            --suppressions-list=tests/static-check/cppcheck_suppressions.txt \
+           --include=config.h \
            -I cf-serverd/ -I libpromises/ -I libcfnet/ -I libntech/libutils/ \
            -i 3rdparty -i .github/codeql -i libntech/.lgtm -i tests -i libpromises/cf3lex.c \
            2>&1 1>/dev/null


### PR DESCRIPTION
Apparently config.h is not included from platform.h because HAVE_CONFIG_H is not defined or not checked as a possibility soon enough by cppcheck.

Ticket: CFE-4310
Changelog: none
