### PR TITLE
Fixed static-check job by forcing inclusion of config.h (3.18)

### DIFF
--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -26,9 +26,11 @@ function check_with_cppcheck() {
   # cppcheck options:
   #   -I -- include paths
   #   -i -- ignored files/folders
+  #   --include=<file> -- force including a file, e.g. config.h
   # Identified issues are printed to stderr
   cppcheck --quiet -j${n_procs} --error-exitcode=1 ./ \
            --suppressions-list=tests/static-check/cppcheck_suppressions.txt \
+           --include=config.h \
            -I cf-serverd/ -I libpromises/ -I libcfnet/ -I libntech/libutils/ \
            -i 3rdparty -i .lgtm -i libntech/.lgtm -i tests -i libpromises/cf3lex.c \
            2>&1 1>/dev/null


### PR DESCRIPTION
Apparently config.h is not included from platform.h because HAVE_CONFIG_H is not defined or not checked as a possibility soon enough by cppcheck.

Ticket: CFE-4310
Changelog: none
(cherry picked from commit d8f2a75db2ab826c80051b035f569142a663d8b9)
