### PR TITLE
In configure.ac, force with-systemd-socket=no when with-systemd-service=no (3.21)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -514,19 +514,6 @@ CF3_WITH_LIBRARY(pcre, [
                       AC_MSG_ERROR(Cannot find PCRE))])
 ])
 
-dnl systemd-socket activation
-
-AC_ARG_WITH([systemd-socket], [AS_HELP_STRING([--with-systemd-socket[[=PATH]]], [support systemd socket activation])], [], [with_systemd_socket=check])
-
-
-if test "x$with_systemd_socket" != xno
-then
-   CF3_WITH_LIBRARY(systemd_socket, [
-      AC_CHECK_LIB(systemd, sd_listen_fds, [], [if test "x$with_systemd_socket" != xcheck; then AC_MSG_ERROR(Cannot find systemd library); fi])
-      AC_CHECK_LIB(systemd, sd_notify_barrier, [AC_DEFINE([HAVE_SD_NOTIFY_BARRIER],[1],[sd_notify_barrier on recent systemd])])
-      AC_CHECK_HEADERS(systemd/sd-daemon.h, [], [if test "x$with_systemd_socket" != xcheck; then AC_MSG_ERROR(Cannot find systemd headers); fi])
-   ])
-fi
 
 dnl libvirt
 
@@ -1638,6 +1625,22 @@ else
     fi
 fi
 AC_SUBST([OS_ENVIRONMENT_PATH])
+
+dnl systemd-socket activation
+
+AC_ARG_WITH([systemd-socket], [AS_HELP_STRING([--with-systemd-socket[[=PATH]]], [support systemd socket activation])], [], [with_systemd_socket=check])
+
+dnl ########################################################################
+dnl systemd socket feature, only available if systemd init scripts requested
+dnl ########################################################################
+if test "x$with_systemd_service" != xno && test "x$with_systemd_socket" != xno
+then
+   CF3_WITH_LIBRARY(systemd_socket, [
+      AC_CHECK_LIB(systemd, sd_listen_fds, [], [if test "x$with_systemd_socket" != xcheck; then AC_MSG_ERROR(Cannot find systemd library); fi])
+      AC_CHECK_LIB(systemd, sd_notify_barrier, [AC_DEFINE([HAVE_SD_NOTIFY_BARRIER],[1],[sd_notify_barrier on recent systemd])])
+      AC_CHECK_HEADERS(systemd/sd-daemon.h, [], [if test "x$with_systemd_socket" != xcheck; then AC_MSG_ERROR(Cannot find systemd headers); fi])
+   ])
+fi
 
 dnl #####################################################################
 dnl SELinux policy build and installation


### PR DESCRIPTION
Previously --with-systemd-socket is defaulted to true always.

If a system has libsystemd-dev and configure is called with --with-systemd-service=no the build would fail.

Ticket: CFE-4274
Changelog: none
(cherry picked from commit a12d12a0089c012a9fa2f17c094f4555b8371be4)
