### PR TITLE
[3.21.x] Add options to skip loading augments and host-specific data to cf-agent

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -203,6 +203,8 @@ static const struct option OPTIONS[] =
     /* Only long option for the rest */
     {"ignore-preferred-augments", no_argument, 0, 0},
     {"log-modules", required_argument, 0, 0},
+    {"no-augments", no_argument, 0, 0},
+    {"no-host-specific-data", no_argument, 0, 0},
     {"show-evaluated-classes", optional_argument, 0, 0 },
     {"show-evaluated-vars", optional_argument, 0, 0 },
     {"skip-bootstrap-policy-run", no_argument, 0, 0 },
@@ -235,6 +237,8 @@ static const char *const HINTS[] =
     "Log timestamps on each line of log output",
     "Ignore def_preferred.json file in favor of def.json",
     "Enable even more detailed debug logging for specific areas of the implementation. Use together with '-d'. Use --log-modules=help for a list of available modules",
+    "Do not load augments (def.json)",
+    "Do not load host-specific data (host_specific.json)",
     "Show *final* evaluated classes, including those defined in common bundles in policy. Optionally can take a regular expression.",
     "Show *final* evaluated variables, including those defined without dependency to user-defined classes in policy. Optionally can take a regular expression.",
     "Do not run policy as the last step of the bootstrap process",
@@ -679,6 +683,14 @@ static GenericAgentConfig *CheckOpts(int argc, char **argv)
                 {
                     DoCleanupAndExit(EXIT_FAILURE);
                 }
+            }
+            else if (StringEqual(option_name, "no-augments"))
+            {
+                config->agent_specific.common.no_augments = true;
+            }
+            else if (StringEqual(option_name, "no-host-specific-data"))
+            {
+                config->agent_specific.common.no_host_specific = true;
             }
             else if (StringEqual(option_name, "show-evaluated-classes"))
             {

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -942,6 +942,8 @@ static void AddPolicyEntryVariables (EvalContext *ctx, const GenericAgentConfig 
 void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config,
                                  const char *program_name)
 {
+    assert(config != NULL);
+
     strcpy(VPREFIX, "");
     if (program_name != NULL)
     {
@@ -1080,14 +1082,17 @@ void GenericAgentDiscoverContext(EvalContext *ctx, GenericAgentConfig *config,
     }
 
     /* Load CMDB data *before* augments. */
-    if (!LoadCMDBData(ctx))
+    if (!config->agent_specific.common.no_host_specific && !LoadCMDBData(ctx))
     {
         Log(LOG_LEVEL_ERR, "Failed to load CMDB data");
     }
 
-    /* load augments here so that they can make use of the classes added above
-     * (especially 'am_policy_hub' and 'policy_server') */
-    LoadAugments(ctx, config);
+    if (!config->agent_specific.common.no_augments)
+    {
+        /* load augments here so that they can make use of the classes added above
+         * (especially 'am_policy_hub' and 'policy_server') */
+        LoadAugments(ctx, config);
+    }
 }
 
 static bool IsPolicyPrecheckNeeded(GenericAgentConfig *config, bool force_validation)
@@ -2517,6 +2522,9 @@ GenericAgentConfig *GenericAgentConfigNewDefault(AgentType agent_type, bool tty_
 
     /* Log classes */
     config->agent_specific.agent.report_class_log = false;
+
+    config->agent_specific.common.no_augments = false;
+    config->agent_specific.common.no_host_specific = false;
 
     switch (agent_type)
     {

--- a/libpromises/generic_agent.h
+++ b/libpromises/generic_agent.h
@@ -80,6 +80,8 @@ typedef struct
             bool eval_functions;
             char *show_classes;
             char *show_variables;
+            bool no_augments;
+            bool no_host_specific;
         } common;
         struct
         {


### PR DESCRIPTION
Ticket: ENT-10792
Changelog: cf-agent has two new options --no-augments and
           --no-host-specific-data to skip loading augments
           (def.json or def_preferred.json) and host-specific
           data (host_specific.json), respectively
(cherry picked from commit 9aa4767eaa311b0558ea0f97a8420f475e877d21)