### PR TITLE
Pass the actual simulation threads to pthread_join functions

### DIFF
--- a/libpromises/dbm_test_api.c
+++ b/libpromises/dbm_test_api.c
@@ -593,7 +593,7 @@ void StopSimulation(DBLoadSimulation *simulation)
     if (simulation->read_th_started)
     {
         ret = pthread_timedjoin_np(simulation->read_th, NULL, &ts);
-        simulation->read_th_started = (ret == 0);
+        simulation->read_th_started = (ret != 0);
         if (ret != 0)
         {
             Log(LOG_LEVEL_ERR, "Failed to join read simulation thread: %s", GetErrorStrFromCode(ret));
@@ -602,7 +602,7 @@ void StopSimulation(DBLoadSimulation *simulation)
     if (simulation->write_th_started)
     {
         ret = pthread_timedjoin_np(simulation->write_th, NULL, &ts);
-        simulation->write_th_started = (ret == 0);
+        simulation->write_th_started = (ret != 0);
         if (ret != 0)
         {
             Log(LOG_LEVEL_ERR, "Failed to join write simulation thread: %s", GetErrorStrFromCode(ret));
@@ -611,7 +611,7 @@ void StopSimulation(DBLoadSimulation *simulation)
     if (simulation->iter_th_started)
     {
         ret = pthread_timedjoin_np(simulation->iter_th, NULL, &ts);
-        simulation->iter_th_started = (ret == 0);
+        simulation->iter_th_started = (ret != 0);
         if (ret != 0)
         {
             Log(LOG_LEVEL_ERR, "Failed to join iteration simulation thread: %s",

--- a/libpromises/dbm_test_api.c
+++ b/libpromises/dbm_test_api.c
@@ -558,7 +558,7 @@ void StopSimulation(DBLoadSimulation *simulation)
         Log(LOG_LEVEL_NOTICE, "Joining simulation threads with no timeout");
         if (simulation->read_th_started)
         {
-            ret = pthread_join(simulation->read_th_started, NULL);
+            ret = pthread_join(simulation->read_th, NULL);
             simulation->read_th_started = (ret == 0);
             if (ret != 0)
             {
@@ -568,7 +568,7 @@ void StopSimulation(DBLoadSimulation *simulation)
         }
         if (simulation->write_th_started)
         {
-            ret = pthread_join(simulation->write_th_started, NULL);
+            ret = pthread_join(simulation->write_th, NULL);
             simulation->write_th_started = (ret == 0);
             if (ret != 0)
             {
@@ -578,7 +578,7 @@ void StopSimulation(DBLoadSimulation *simulation)
         }
         if (simulation->iter_th_started)
         {
-            ret = pthread_join(simulation->iter_th_started, NULL);
+            ret = pthread_join(simulation->iter_th, NULL);
             simulation->iter_th_started = (ret == 0);
             if (ret != 0)
             {
@@ -592,7 +592,7 @@ void StopSimulation(DBLoadSimulation *simulation)
     ts.tv_sec += 5;
     if (simulation->read_th_started)
     {
-        ret = pthread_timedjoin_np(simulation->read_th_started, NULL, &ts);
+        ret = pthread_timedjoin_np(simulation->read_th, NULL, &ts);
         simulation->read_th_started = (ret == 0);
         if (ret != 0)
         {
@@ -601,7 +601,7 @@ void StopSimulation(DBLoadSimulation *simulation)
     }
     if (simulation->write_th_started)
     {
-        ret = pthread_timedjoin_np(simulation->write_th_started, NULL, &ts);
+        ret = pthread_timedjoin_np(simulation->write_th, NULL, &ts);
         simulation->write_th_started = (ret == 0);
         if (ret != 0)
         {
@@ -610,7 +610,7 @@ void StopSimulation(DBLoadSimulation *simulation)
     }
     if (simulation->iter_th_started)
     {
-        ret = pthread_timedjoin_np(simulation->iter_th_started, NULL, &ts);
+        ret = pthread_timedjoin_np(simulation->iter_th, NULL, &ts);
         simulation->iter_th_started = (ret == 0);
         if (ret != 0)
         {


### PR DESCRIPTION
Not the boolean values we use to determine if the thread values are valid.

Ticket: CFE-4281
Changelog: None