### PR TITLE
Carefully handle symlinks at the last phase of VerifyFilePromise()

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -599,9 +599,9 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
 
 // Once more in case a file has been created as a result of editing or copying
 
-    exists = (stat(changes_path, &osb) != -1);
+    exists = (lstat(changes_path, &osb) != -1);
 
-    if (exists && (S_ISREG(osb.st_mode))
+    if (exists && (S_ISREG(osb.st_mode) || S_ISLNK(osb.st_mode))
         && (!a.haveselect || SelectLeaf(ctx, path, &osb, &(a.select))))
     {
         VerifyFileLeaf(ctx, path, &osb, &a, pp, &result);

--- a/tests/acceptance/10_files/10_links/owner-mismatch-link-and-target.cf
+++ b/tests/acceptance/10_files/10_links/owner-mismatch-link-and-target.cf
@@ -28,13 +28,7 @@ bundle agent test
       "description" -> { "CFE-3116" }
         string => "Test that promising ownership of symlinks is not confused by target";
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "CFE-3116" };
-
-      # this test isn't super comprehensive, once the issue is fixed, it will
-      # need to be skipped on various platforms, at least windows.
-      # "test_skip_unsupported" string => "windows";
+      "test_skip_unsupported" string => "windows";
 
   files:
        "/tmp/symlink"

--- a/tests/acceptance/28_inform_testing/01_files/perms.cf
+++ b/tests/acceptance/28_inform_testing/01_files/perms.cf
@@ -33,16 +33,6 @@ bundle agent setup
     "$(G.testdir)/foobar/."
       create => "true",
       comment => "A directory";
-
-# See ticket CFE-4148:
-#
-#   "$(G.testdir)/foobaz/."
-#     create => "true",
-#     comment => "A directory symlink taget";
-#
-#   "$(G.testdir)/barbaz/."
-#     link_from => link_info("$(G.testdir)/foobaz"),
-#     comment => "A symbolic link to a directory";
 }
 
 bundle agent main
@@ -56,9 +46,4 @@ bundle agent main
 
       "$(G.testdir)/foobar"
         perms => m(777);
-
-# See ticket CFE-4148:
-#
-#     "$(G.testdir)/barbaz/."
-#       perms => m(777);
 }

--- a/tests/acceptance/28_inform_testing/01_files/perms.cf.expected
+++ b/tests/acceptance/28_inform_testing/01_files/perms.cf.expected
@@ -1,3 +1,2 @@
     info: Regular file '/tmp/TESTDIR.cfengine/foo' had permissions 0600, changed it to 0777
-    info: Symbolic link to regular file '/tmp/TESTDIR.cfengine/baz' had permissions 0600, changed it to 0777
     info: Directory '/tmp/TESTDIR.cfengine/foobar' had permissions 0700, changed it to 0777


### PR DESCRIPTION
If the promiser is a symlink, `lstat()` and `stat()` give different results. We need to use `lstat()` to get info about the promiser (symlink) itself.

Also, we need to call `VerifyFileLeaf()` on symlinks as well as on regular files.

Ticket: ENT-11235
Changelog: None