### PR TITLE
[3.21.x] Carefully handle symlinks at the last phase of VerifyFilePromise()

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -599,9 +599,9 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
 
 // Once more in case a file has been created as a result of editing or copying
 
-    exists = (stat(changes_path, &osb) != -1);
+    exists = (lstat(changes_path, &osb) != -1);
 
-    if (exists && (S_ISREG(osb.st_mode))
+    if (exists && (S_ISREG(osb.st_mode) || S_ISLNK(osb.st_mode))
         && (!a.haveselect || SelectLeaf(ctx, path, &osb, &(a.select))))
     {
         VerifyFileLeaf(ctx, path, &osb, &a, pp, &result);

--- a/tests/acceptance/10_files/10_links/owner-mismatch-link-and-target.cf
+++ b/tests/acceptance/10_files/10_links/owner-mismatch-link-and-target.cf
@@ -28,13 +28,7 @@ bundle agent test
       "description" -> { "CFE-3116" }
         string => "Test that promising ownership of symlinks is not confused by target";
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "CFE-3116" };
-
-      # this test isn't super comprehensive, once the issue is fixed, it will
-      # need to be skipped on various platforms, at least windows.
-      # "test_skip_unsupported" string => "windows";
+      "test_skip_unsupported" string => "windows";
 
   files:
        "/tmp/symlink"


### PR DESCRIPTION
If the promiser is a symlink, `lstat()` and `stat()` give different results. We need to use `lstat()` to get info about the promiser (symlink) itself.

Also, we need to call `VerifyFileLeaf()` on symlinks as well as on regular files.

Ticket: ENT-11235
Changelog: Ownership of symlinks is now handled properly (cherry picked from commit 84b67836aa7dcaa2e949c8a03ea80fadac0568d7)

Conflicts:
  tests/acceptance/28_inform_testing/01_files/perms.cf.expected