### PR TITLE
ENT-11341: Fixed implicit declaration due to missing include

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -28,6 +28,7 @@
 #include <policy_server.h>
 #include <promises.h>
 #include <dir.h>
+#include <file_lib.h>
 #include <dbm_api.h>
 #include <lastseen.h>
 #include <files_copy.h>


### PR DESCRIPTION
Attempt to fix the following error found in todays nightlies:
```
12:56:18 dbm_api.c: In function ‘SearchExistingSubDBNames’:
12:56:18 dbm_api.c:174:33: error: implicit declaration of function ‘GlobFileList’ [-Werror=implicit-function-declaration]
12:56:18   174 |     StringSet *const db_paths = GlobFileList(glob_pattern);
12:56:18       |                                 ^~~~~~~~~~~~
12:56:18 dbm_api.c:174:33: warning: initialization of ‘StringSet * const’ {aka ‘struct <anonymous> * const’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
12:56:18 cc1: some warnings being treated as errors
12:56:18 make[3]: *** [Makefile:957: dbm_api.lo] Error 1
 ---snip---
12:56:19 evalfunction.c: In function ‘FnCallSysctlValue’:
12:56:19 evalfunction.c:1048:26: error: implicit declaration of function ‘GlobFileList’ [-Werror=implicit-function-declaration]
12:56:19  1048 |     StringSet *sysctls = GlobFileList(BufferData(filematchbuf));
12:56:19       |                          ^~~~~~~~~~~~
12:56:19 evalfunction.c:1048:26: warning: initialization of ‘StringSet *’ {aka ‘struct <anonymous> *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
12:56:19 evalfunction.c: In function ‘FnCallFindfiles’:
12:56:19 evalfunction.c:4769:28: warning: initialization of ‘StringSet *’ {aka ‘struct <anonymous> *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
12:56:19  4769 |         StringSet *found = GlobFileList(pattern);
12:56:19       |                            ^~~~~~~~~~~~
12:56:19 evalfunction.c: In function ‘FnCallFindfilesUp’:
12:56:19 evalfunction.c:8805:30: warning: initialization of ‘StringSet *’ {aka ‘struct <anonymous> *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
12:56:19  8805 |         StringSet *matches = GlobFileList(filepath);
12:56:19       |                              ^~~~~~~~~~~~
```