### PR TITLE
CFE-3152: Adjusted openssl ifdefs to support building on OpenBSD (3.18)

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -127,6 +127,14 @@ For SELinux support you will need selinux-policy-devel package and specify `--wi
 
 $ sudo apt-get install -y build-essential git libtool autoconf automake bison flex libssl-dev libpcre3-dev libbison-dev libacl1 libacl1-dev lmdb-utils liblmdb-dev libpam0g-dev libtool libyaml-dev libxml2-dev
 
+* OpenBSD (7.4 2024-02-15)
+
+doas pkg_add git automake-1.16.5 autoconf-2.71 bison pcre2 m4 libtool lmdb gmake
+
+$ MAKE=/usr/local/bin/gmake LDFLAGS=-L/usr/local/lib CPPFLAGS=-I/usr/local/include AUTOMAKE_VERSION=1.16 AUTOCONF_VERSION=2.71 ./autogen.sh --enable-debug
+$ gmake -j8
+$ doas gmake install
+
 * FreeBSD (12.1 2020-04-07)
 
 See docs/BSD.md

--- a/libpromises/crypto.c
+++ b/libpromises/crypto.c
@@ -869,11 +869,13 @@ static void SetupOpenSSLThreadLocks(void)
     }
 
 #ifndef __MINGW32__
+#if OPENSSL_VERSION_NUMBER < 0x10100000
     CRYPTO_set_id_callback((unsigned long (*)())ThreadId_callback);
 #endif
-    // This is a no-op macro for OpenSSL >= 1.1.0
-    // The callback function is not used (or defined) then
+#endif
+#if OPENSSL_VERSION_NUMBER < 0x10100000
     CRYPTO_set_locking_callback((void (*)())OpenSSLLock_callback);
+#endif
 }
 
 static void CleanupOpenSSLThreadLocks(void)
@@ -881,7 +883,9 @@ static void CleanupOpenSSLThreadLocks(void)
     const int numLocks = CRYPTO_num_locks();
     CRYPTO_set_locking_callback(NULL);
 #ifndef __MINGW32__
+#if OPENSSL_VERSION_NUMBER < 0x10100000
     CRYPTO_set_id_callback(NULL);
+#endif
 #endif
 
     for (int i = 0; i < numLocks; i++)


### PR DESCRIPTION
- Adjusted INSTALL instructions for OpenBSD 7.4
- Adjusted openssl ifdefs to support building on OpenBSD
