### PR TITLE
Fixed incorrect sed command for cf-support filtering syslog output

### DIFF
--- a/misc/cf-support
+++ b/misc/cf-support
@@ -376,7 +376,7 @@ if [ "$OS" = "aix" ]; then
   echo "r !errpt -a
 g/cfengine/?---?,/---/p" | ed > "$_syslog_filtered" || true
 else
-  $syslog_cmd | sed -n '/cfe/p;/cf-/p' | gzip -c > "$_syslog_filtered" || true
+  $syslog_cmd | sed -n '/[Cc][Ff][Ee-]/p' | gzip -c > "$_syslog_filtered" || true
 fi
 echo "Captured output of $syslog_cmd filtered for cf-|CFEngine"
 


### PR DESCRIPTION
sed -n '/cfe/p;/cf-/p' would cause any line matching both expressions to be printed twice

Ticket: CFE-4337
Changelog: none
