### PR TITLE
ENT-10817: Added standard OS name & version variables for Amazon Linux

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2661,7 +2661,7 @@ static void Linux_Amazon_Version(EvalContext *ctx)
 {
     char buffer[CF_BUFSIZE];
 
-    // Amazon Linux AMI release 2016.09
+    // Amazon Linux release 2 (Karoo)
 
     if (ReadLine("/etc/system-release", buffer, sizeof(buffer)))
     {
@@ -2672,7 +2672,7 @@ static void Linux_Amazon_Version(EvalContext *ctx)
                 ",derived-from-file=/etc/system-release");
 
             char version[128];
-            if (sscanf(buffer, "%*s %*s %*s %*s %127s", version) == 1)
+            if (sscanf(buffer, "%*s %*s %*s %127s", version) == 1)
             {
                 char class[CF_MAXVARSIZE];
 
@@ -2681,8 +2681,16 @@ static void Linux_Amazon_Version(EvalContext *ctx)
                 EvalContextClassPutHard(ctx, class,
                     "inventory,attribute_name=none,source=agent"
                     ",derived-from-file=/etc/system-release");
+                SetFlavor(ctx, class);
             }
-            SetFlavor(ctx, "AmazonLinux");
+            else
+            {
+                SetFlavor(ctx, "amazon_linux");
+            }
+            // We set this class for backwards compatibility
+            EvalContextClassPutHard(ctx, "AmazonLinux",
+                    "inventory,attribute_name=none,source=agent,"
+                    "derived-from=sys.flavor");
         }
     }
 }
@@ -3481,6 +3489,12 @@ static void SysOSNameHuman(EvalContext *ctx)
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,
                                       "Solaris", CF_DATA_TYPE_STRING,
                                       "source=agent,derived-from=solaris");
+    }
+    else if (EvalContextClassGet(ctx, NULL, "amazon_linux") != NULL)
+    {
+        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,
+                                      "Amazon", CF_DATA_TYPE_STRING,
+                                      "source=agent,derived-from=amazon_linux");
     }
     else
     {

--- a/tests/acceptance/01_vars/01_basic/os_name_human.cf
+++ b/tests/acceptance/01_vars/01_basic/os_name_human.cf
@@ -48,6 +48,8 @@ bundle agent test
       "expected" string => "macOS";
     solaris::
       "expected" string => "Solaris";
+    amazon_linux::
+      "expected" string => "Amazon";
 }
 
 bundle agent check


### PR DESCRIPTION
Added `sys.os_name_human` and `sys.os_version_major`. Additionally
changed value of `sys.flavor` from `AmazonLinux` to `amazon_linux_2`, so
that it is similar to other supported Linux distros. This change was
necessary, due to the fact that the `sys.os_version_major` variable is
derived from it. However, the `AmazonLinux` class previously derived
from `sys.flavor` is still defined for backwards compatibility.
