### PR TITLE
ENT-11345: Added container chroot agent materials to contrib

### DIFF
--- a/contrib/container-chroot-agent/Dockerfile-cfengine-chroot-agent
+++ b/contrib/container-chroot-agent/Dockerfile-cfengine-chroot-agent
@@ -1,0 +1,5 @@
+FROM debian:11
+COPY ./dunfell-cfengine-nova.tar.gz /
+COPY ./liblmdb.tar.gz /
+COPY ./entrypoint-agent.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/contrib/container-chroot-agent/README
+++ b/contrib/container-chroot-agent/README
@@ -1,0 +1,20 @@
+# CFEngine container chroot agent
+
+The goal of the files in this directory is to install an agent in a container on a host system which for various reasons we don't want to or can't install and run the CFEngine agent.
+
+- Torizon Core/Yocto hosts providing docker
+- Kubernetes Nodes
+
+# Usage
+
+On a host system you have access to place these files and execute run.sh
+
+See the other .sh files for various purposes:
+
+- clean.sh - cleans the cfengine-chroot-agent container and image
+- shell.sh - shells into the cfengine-chroot-agent container
+- chrootshell.sh - shells into the chroot inside the cfengine-chroot-agent container, this is where CFEngine is available and running
+
+# Impact on host
+
+Since the chroot has the host systems root filesystem mounted it can affect many changes and execute many programs.

--- a/contrib/container-chroot-agent/chrootshell.sh
+++ b/contrib/container-chroot-agent/chrootshell.sh
@@ -1,0 +1,1 @@
+docker exec -it cfengine-chroot-agent chroot /chroot /bin/bash

--- a/contrib/container-chroot-agent/clean.sh
+++ b/contrib/container-chroot-agent/clean.sh
@@ -1,0 +1,7 @@
+set -ex
+name=cfengine-chroot-agent
+# run this script on the host, /var/cfengine/bin should only exist inside the chroot inside the agent container
+test ! -d /var/cfengine/bin
+docker stop $name
+docker rm $name
+docker rmi $name

--- a/contrib/container-chroot-agent/entrypoint-agent.sh
+++ b/contrib/container-chroot-agent/entrypoint-agent.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -ex
+
+# mount FSs from the host VM to /chroot folder
+for i in proc sys run dev; do mkdir -p /chroot/$i; done
+# special filesystem type: proc
+mount --types proc /rootproc /chroot/proc
+# for the following: sys, dev and run we only want changes to come from host to chroot, not the other way, so we use --make-slave
+mount --bind /rootsys /chroot/sys
+mount --make-slave /chroot/sys
+mount --bind /rootdev /chroot/dev
+mount --make-slave /chroot/dev
+mount --bind /rootrun /chroot/run
+mount --make-slave /chroot/run
+for i in bin lib lib64 sbin; do test -d /rootfs/$i && cp -a /rootfs/$i /chroot/; done
+
+# hack to install cfengine-nova, logged ticket ENT-11403 to make quick-install script used later for installation
+# for now, contact sales if you are interested in acquiring needed tarballs
+if [ -f /dunfell-cfengine-nova.tar.gz ]; then
+  cd /chroot
+  tar xf /dunfell-cfengine-nova.tar.gz
+  cd /chroot/cfengine
+  tar xf /liblmdb.tar.gz
+fi
+
+for i in $(ls -1 /rootfs/ | grep -v -E "bin|dev|lib|lib64|proc|run|sbin|sys|var"); do
+  test -d /rootfs/$i && mkdir /chroot/$i && mount -o bind /rootfs/$i /chroot/$i
+done
+# /var is a special case as we will install CFEngine at /var/cfengine inside chroot
+# so bind mount everything INSIDE /var on host to /chroot/var/. so /var/cfengine is only in the chroot
+mkdir /chroot/var
+for i in $(ls -1 /rootfs/var/); do
+  test -d /rootfs/$i && mkdir /chroot/var/$i && mount -o bind /rootfs/var/$i /chroot/var/$i
+done
+
+# CFENGINE_HUB_IP should be provided as an ENV var from the docker run command
+
+
+# entrypoint script for installing and running the agent to be executed from chroot jail
+cat > /chroot/entry.sh << EOF
+#!/bin/bash
+
+set -ex
+
+if [ -d /cfengine ]; then
+  mkdir /var/cfengine
+  mount -o bind /cfengine /var/cfengine
+fi
+if [ ! -f /var/cfengine/bin/cf-agent ]; then
+  cd /tmp
+  curl -O https://s3.amazonaws.com/cfengine.packages/quick-install-cfengine-enterprise.sh && bash ./quick-install-cfengine-enterprise.sh agent
+fi
+
+if ! /var/cfengine/bin/cf-key -p; then
+  /var/cfengine/bin/cf-key # generate a new hostkey if none present already
+fi
+/var/cfengine/bin/cf-agent --bootstrap ${CFENGINE_HUB_IP} --log-level info
+/var/cfengine/bin/cf-agent -KIf update.cf
+/var/cfengine/bin/cf-agent -KI
+/var/cfengine/bin/cf-agent -KI
+
+while true; do sleep 3600; done
+EOF
+chmod +x /chroot/entry.sh
+
+chroot /chroot/ /entry.sh | tee /entry.log

--- a/contrib/container-chroot-agent/run.sh
+++ b/contrib/container-chroot-agent/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -ex
+test ! -d /var/cfengine/bin
+PWD=$(pwd)
+
+name=cfengine-chroot-agent
+docker build -t "$name" -f "${PWD}/Dockerfile-cfengine-chroot-agent" "${PWD}"
+
+# TODO fill in an appropriate IP address for your hub
+CFENGINE_HUB_IP=192.168.1.196
+export CFENGINE_HUB_IP
+
+# warning: running --privileged on a linux system that is using a GUI will bring down the GUI most likely
+docker run -d --env CFENGINE_HUB_IP --privileged \
+  -v "/:/rootfs" \
+  -v "/proc:/rootproc" \
+  -v "/sys:/rootsys" \
+  -v "/dev:/rootdev" \
+  -v "/run:/rootrun" \
+  --name "$name" \
+  "$name"
+sleep 3
+if ! docker ps | grep $name; then
+  docker logs $name
+fi

--- a/contrib/container-chroot-agent/shell.sh
+++ b/contrib/container-chroot-agent/shell.sh
@@ -1,0 +1,1 @@
+docker exec -it cfengine-chroot-agent bash


### PR DESCRIPTION
Working towards providing visibility in and around containers this provides a way to bring up a container which mounts the hosting root filesystem and then installs CFEngine and runs it inside of chroot in that container.

It should not affect the host other than creating an empty /var/cfengine directory.

Ticket: ENT-11345
Changelog: none
