### PR TITLE
Add Arch to the list of OSes recognized by SysOSNameHuman

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -3496,6 +3496,12 @@ static void SysOSNameHuman(EvalContext *ctx)
                                       "Amazon", CF_DATA_TYPE_STRING,
                                       "source=agent,derived-from=amazon_linux");
     }
+    else if (EvalContextClassGet(ctx, NULL, "arch") != NULL)
+    {
+        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,
+                                      "Arch", CF_DATA_TYPE_STRING,
+                                      "source=agent,derived-from=arch");
+    }
     else
     {
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,


### PR DESCRIPTION
Running cf-agent on my Arch produces the warning: `warning: Operating System not properly recognized, setting sys.os_name_human to "Unknown", please submit a bug report for us to fix this`.

Not really sure what's going on with this, but added Arch to the list in `SysOSNameHuman()`.
