### PR TITLE
CFE-4315: Modified package promise default. If platform_default is present use that package module. (3.18)

### DIFF
--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -189,21 +189,17 @@ PromiseResult VerifyPackagesPromise(EvalContext *ctx, const Promise *pp)
     switch (package_promise_type)
     {
         case PACKAGE_PROMISE_TYPE_NEW:
-            Log(LOG_LEVEL_VERBOSE, "Using new package promise.");
+            Log(LOG_LEVEL_VERBOSE, "Using v2 package promises (package_module)");
 
             result = HandleNewPackagePromiseType(ctx, pp, &a);
             break;
 
         case PACKAGE_PROMISE_TYPE_OLD:
-            Log(LOG_LEVEL_VERBOSE,
-                "Using old package promise. Please note that this old "
-                "implementation is being phased out. The old "
-                "implementation will continue to work, but forward development "
-                "will be directed toward the new implementation.");
+            Log(LOG_LEVEL_VERBOSE, "Using v1 package promises (package_method)");
 
             result = HandleOldPackagePromiseType(ctx, pp, &a);
 
-            /* Update new package promise cache in case we have mixed old and new
+            /* Update v2 package promise cache in case we have mixed v2 and v1
              * package promises in policy. */
             if (result == PROMISE_RESULT_CHANGE || result == PROMISE_RESULT_FAIL)
             {
@@ -212,15 +208,15 @@ PromiseResult VerifyPackagesPromise(EvalContext *ctx, const Promise *pp)
             break;
         case PACKAGE_PROMISE_TYPE_NEW_ERROR:
             cfPS_HELPER_0ARG(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, &a,
-                         "New package promise failed sanity check.");
+                         "v1 package promise (package_method) failed sanity check.");
             break;
         case PACKAGE_PROMISE_TYPE_OLD_ERROR:
             cfPS_HELPER_0ARG(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, &a,
-                         "Old package promise failed sanity check.");
+                         "v1 package promise (package_method) failed sanity check.");
             break;
         case PACKAGE_PROMISE_TYPE_MIXED:
             cfPS_HELPER_0ARG(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, &a,
-                         "Mixed old and new package promise attributes inside "
+                         "Mixed v1 and v2 package promise attributes inside "
                          "one package promise.");
             break;
         default:


### PR DESCRIPTION
Previously if a policy that only specified the promiser:

packages:
  "ed";

It will default to package_method generic in our C code.

Now it will look for package_module_knowledge.platform_default and if present make the package promise use package module instead.

Ticket: CFE-4315
Changelog: title

Co-authored-by: Lars Erik Wik <53906608+larsewi@users.noreply.github.com>
(cherry picked from commit f23e268255b189465cf67135e9c1e77f36c92f20)
