### PR TITLE
CFE-4315: Modified package promise default. If platform_default is present use that package module. (3.21)

### DIFF
--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -189,21 +189,17 @@ PromiseResult VerifyPackagesPromise(EvalContext *ctx, const Promise *pp)
     switch (package_promise_type)
     {
         case PACKAGE_PROMISE_TYPE_NEW:
-            Log(LOG_LEVEL_VERBOSE, "Using new package promise.");
+            Log(LOG_LEVEL_VERBOSE, "Using v2 package promises (package_module)");
 
             result = HandleNewPackagePromiseType(ctx, pp, &a);
             break;
 
         case PACKAGE_PROMISE_TYPE_OLD:
-            Log(LOG_LEVEL_VERBOSE,
-                "Using old package promise. Please note that this old "
-                "implementation is being phased out. The old "
-                "implementation will continue to work, but forward development "
-                "will be directed toward the new implementation.");
+            Log(LOG_LEVEL_VERBOSE, "Using v1 package promises (package_method)");
 
             result = HandleOldPackagePromiseType(ctx, pp, &a);
 
-            /* Update new package promise cache in case we have mixed old and new
+            /* Update v2 package promise cache in case we have mixed v2 and v1
              * package promises in policy. */
             if (result == PROMISE_RESULT_CHANGE || result == PROMISE_RESULT_FAIL)
             {
@@ -212,15 +208,15 @@ PromiseResult VerifyPackagesPromise(EvalContext *ctx, const Promise *pp)
             break;
         case PACKAGE_PROMISE_TYPE_NEW_ERROR:
             cfPS_HELPER_0ARG(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, &a,
-                         "New package promise failed sanity check.");
+                         "v1 package promise (package_method) failed sanity check.");
             break;
         case PACKAGE_PROMISE_TYPE_OLD_ERROR:
             cfPS_HELPER_0ARG(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, &a,
-                         "Old package promise failed sanity check.");
+                         "v1 package promise (package_method) failed sanity check.");
             break;
         case PACKAGE_PROMISE_TYPE_MIXED:
             cfPS_HELPER_0ARG(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, &a,
-                         "Mixed old and new package promise attributes inside "
+                         "Mixed v1 and v2 package promise attributes inside "
                          "one package promise.");
             break;
         default:

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -1158,6 +1158,7 @@ Packages GetPackageConstraints(const EvalContext *ctx, const Promise *pp)
         if (bodies_and_args != NULL &&
             SeqLength(bodies_and_args) > 0)
         {
+            Log(LOG_LEVEL_INFO, "Package promise had no package_method attribute so it's being assigned a value of 'generic' as default.");
             const Body *bp = SeqAt(bodies_and_args, 0); // guaranteed to be non-NULL
             CopyBodyConstraintsToPromise((EvalContext*)ctx, (Promise*)pp, bp);
             has_generic_package_method = true;
@@ -1251,10 +1252,26 @@ NewPackages GetNewPackageConstraints(const EvalContext *ctx, const Promise *pp)
     p.package_options = PromiseGetConstraintAsList(ctx, "options", pp);
 
     p.is_empty = (memcmp(&p, &empty, sizeof(NewPackages)) == 0);
+
+    bool have_policy = PromiseBundleOrBodyConstraintExists(ctx, "policy", pp);
+    bool have_package_policy = PromiseBundleOrBodyConstraintExists(ctx, "package_policy", pp);
+    if (!have_policy && !have_package_policy)
+    {
+        Log(LOG_LEVEL_DEBUG, "Package promise has no policy or package_policy attribute. Checking if package_module_knowledge.platform_default is defined to default the policy attribute to 'present' and force use of v2 package promise (package_module).");
+
+        VarRef *ref = VarRefParseFromScope("package_module_knowledge.platform_default", NULL);
+        const void *ret = EvalContextVariableGet(ctx, ref, NULL);
+        if (ret != NULL)
+        {
+            Log(LOG_LEVEL_INFO, "Package promise had no policy or package_policy attribute and package_module_knowledge.platform_default is defined so defaulting to v2 package promise (package_module) and setting 'policy' attribute to 'present'.");
+            PromiseAppendConstraint((Promise*)pp, "policy", (Rval) {xstrdup("present"), RVAL_TYPE_SCALAR }, false);
+        }
+        VarRefDestroy(ref);
+    }
     p.package_policy = GetNewPackagePolicy(PromiseGetConstraintAsRval(pp, "policy", RVAL_TYPE_SCALAR),
                                            new_packages_actions);
 
-    /* We can have only policy specified in new package promise definition. */
+    /* We can have only policy specified in v2 package promise (package_module) definition. */
     if (p.package_policy != NEW_PACKAGE_ACTION_NONE)
     {
         p.is_empty = false;


### PR DESCRIPTION
Previously if a policy that only specified the promiser:

packages:
  "ed";

It will default to package_method generic in our C code.

Now it will look for package_module_knowledge.platform_default and if present make the package promise use package module instead.

Ticket: CFE-4315
Changelog: title

Co-authored-by: Lars Erik Wik <53906608+larsewi@users.noreply.github.com>
(cherry picked from commit f23e268255b189465cf67135e9c1e77f36c92f20)
