### PR TITLE
Prevent systemctl from asking for password after installing unit files

### DIFF
--- a/misc/Makefile.am
+++ b/misc/Makefile.am
@@ -32,7 +32,7 @@ systemd_DATA  += systemd/cf-runalerts.service
 systemd_DATA  += systemd/cf-serverd.service
 
 install-data-hook:
-	-systemctl daemon-reload
+	-systemctl --no-ask-password daemon-reload
 
 endif
 dist_bin_SCRIPTS = cf-support


### PR DESCRIPTION
To prevent `make install` from hanging. The rule is fault-tolerant so if the authentication is required the command will fail and things will continue just fine. Authentication required means `make install` was not run neither with `sudo` nor as root so `systemctl daemon-reload` would not work anyway because this means the systemd units were not installed into the standard locations where only the root user has access to.