### PR TITLE
ENT-11526: Changed cf-apache systemd unit to reload configuration gracefully

### DIFF
--- a/misc/systemd/cf-apache.service.in
+++ b/misc/systemd/cf-apache.service.in
@@ -10,6 +10,7 @@ PartOf=cfengine3.service
 Type=forking
 ExecStart=@workdir@/httpd/bin/apachectl start
 ExecStop=@workdir@/httpd/bin/apachectl stop
+ExecReload=@workdir@/httpd/bin/apachectl graceful
 PIDFile=@workdir@/httpd/httpd.pid
 Restart=always
 RestartSec=10


### PR DESCRIPTION
apachectl graceful doesn't close currently open connections.

Ticket: ENT-11526
Changelog: title

with https://github.com/cfengine/masterfiles/pull/2864