### PR TITLE
Changed cf-apache systemd unit to reload configuration gracefully (3.18)

### DIFF
--- a/misc/systemd/cf-apache.service.in
+++ b/misc/systemd/cf-apache.service.in
@@ -10,6 +10,7 @@ PartOf=cfengine3.service
 Type=forking
 ExecStart=@workdir@/httpd/bin/apachectl start
 ExecStop=@workdir@/httpd/bin/apachectl stop
+ExecReload=@workdir@/httpd/bin/apachectl graceful
 PIDFile=@workdir@/httpd/httpd.pid
 Restart=always
 RestartSec=10


### PR DESCRIPTION
apachectl graceful doesn't close currently open connections.

Ticket: ENT-11526
Changelog: title
(cherry picked from commit d3e0ed02ad30c61707d80d6ba93ece8b96810cfb)
