### PR TITLE
Support libntech's new efficient file/data copying

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   valgrind_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: core

--- a/configure.ac
+++ b/configure.ac
@@ -1254,6 +1254,25 @@ AC_CHECK_HEADERS(utmp.h)
 dnl POSIX way to get uptime
 AC_CHECK_HEADERS(utmpx.h)
 
+
+dnl ######################################################################
+dnl Fancy new Linux syscalls for file/data copying (config for libntech)
+dnl ######################################################################
+AC_CHECK_HEADERS([linux/fs.h])
+AC_CHECK_DECLS([FICLONE], [], [], [#include <linux/fs.h>])
+AC_CHECK_DECLS([SEEK_DATA], [], [], [
+#define _GNU_SOURCE
+#include <unistd.h>
+])
+AC_CHECK_DECLS([FALLOC_FL_PUNCH_HOLE], [], [], [
+#define _GNU_SOURCE
+#include <fcntl.h>
+])
+AC_CHECK_HEADERS([sys/sendfile.h])
+AC_CHECK_FUNCS([sendfile])
+AC_CHECK_FUNCS([copy_file_range])
+
+
 dnl #######################################################################
 dnl Newer BSD systems don't have a compatible rtentry - use ortentry
 dnl #######################################################################


### PR DESCRIPTION
We need to take care of the newly required checks in configure.ac because we are responsible for producing config.h usable for both us and libntech.

Ticket: CFE-4380
Changelog: File copying now uses more efficient implementation on
           Linux platforms

Merge together:
https://github.com/cfengine/core/pull/5490
https://github.com/NorthernTechHQ/libntech/pull/218