### PR TITLE
[3.18.x] Try to acquire file lock when closing DB

### DIFF
--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -525,8 +525,14 @@ void CloseDB(DBHandle *handle)
         handle->refcount--;
         if (handle->refcount == 0)
         {
+            FileLock lock = EMPTY_FILE_LOCK;
+            bool locked = DBPathLock(&lock, handle->filename);
             DBPrivCloseDB(handle->priv);
             handle->open_tstamp = -1;
+            if (locked)
+            {
+                DBPathUnLock(&lock);
+            }
         }
     }
 


### PR DESCRIPTION
To prevent multiple processes from opening/closing the DB at the same time. From what we have seen, the *Invalid argument* issues only happen when multiple processes try to work with the DB, multiple threads inside a single process don't seem to hit the trigger.

Also, we have seen that the issues happen when LMDB tries to use a robust (shared inter-process) mutex that was already destroyed.

Ticket: ENT-11543
Changelog: CFEngine processes no longer suffer from the "Invalid
           argument" issues when working with LMDB