### PR TITLE
ENT-11765: Changed cf-execd's sleep behavior so it attempts to wake up at the beginning of every minute

### DIFF
--- a/cf-execd/cf-execd.c
+++ b/cf-execd/cf-execd.c
@@ -434,6 +434,23 @@ void ThisAgentInit(void)
     umask(077);
 }
 
+// Return 2 to 62 seconds depending on how much time is left until the next
+// minute starts. Since cf-execd wakes up "every minute" to evaluate its
+// schedule, we want to do this at the start of the minute, to avoid
+// accidentally skipping any runs if things are slow.
+//
+// Why +2? Why not 0 to 60? Not a very good reason, but:
+// Sleep at least 2 seconds to avoid 2 agent runs very close together
+// Target waking up at :02 seconds, to reduce the chances of waking
+// up at :59 in the previous minute, and unintentionally having 2
+// agent runs in the same minute
+static inline time_t GetPulseTime()
+{
+    const time_t current_second = (time(NULL) % CFPULSETIME);
+    const time_t remaining_seconds = CFPULSETIME - current_second;
+    return remaining_seconds + 2;
+}
+
 /*****************************************************************************/
 
 
@@ -534,6 +551,7 @@ static bool HandleRequestsOrSleep(time_t seconds, const char *reason,
     return false;
 }
 
+// Non-windows version of main loop:
 static void CFExecdMainLoop(EvalContext *ctx, Policy **policy, GenericAgentConfig *config,
                             ExecdConfig **execd_config, ExecConfig **exec_config,
                             int runagent_socket)
@@ -564,7 +582,7 @@ static void CFExecdMainLoop(EvalContext *ctx, Policy **policy, GenericAgentConfi
             }
         }
         /* 1 Minute resolution is enough */
-        terminate = HandleRequestsOrSleep(CFPULSETIME, "pulse time", runagent_socket,
+        terminate = HandleRequestsOrSleep(GetPulseTime(), "pulse time", runagent_socket,
                                           (*execd_config)->local_run_command);
         if (terminate)
         {
@@ -699,6 +717,7 @@ static inline unsigned int MaybeSleepLog(LogLevel level, const char *msg_format,
     return sleep(seconds);
 }
 
+// Windows version of main loop:
 static void CFExecdMainLoop(EvalContext *ctx, Policy **policy, GenericAgentConfig *config,
                             ExecdConfig **execd_config, ExecConfig **exec_config,
                             ARG_UNUSED int runagent_socket)
@@ -724,8 +743,8 @@ static void CFExecdMainLoop(EvalContext *ctx, Policy **policy, GenericAgentConfi
                 LocalExec(*exec_config);
             }
         }
-        /* 1 Minute resolution is enough */
-        MaybeSleepLog(LOG_LEVEL_VERBOSE, "Sleeping for pulse time %u seconds...", CFPULSETIME);
+        // This is not just a log message, it maybe sleeps and maybe logs something:
+        MaybeSleepLog(LOG_LEVEL_VERBOSE, "Sleeping for pulse time %u seconds...", GetPulseTime());
     }
 }
 #endif  /* ! __MINGW32__ */


### PR DESCRIPTION
This could fix issues if things are slow and agent runs end up getting skipped if cf-execd wakes up too late.

TODO:

- [ ] Manually test