### PR TITLE
ENT-10699: Improve and re-enable windows acceptance test workflow (3.18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
   acceptance_tests:
     needs: unit_tests
     uses: ./.github/workflows/acceptance_tests.yml
+  windows_acceptance_tests:
+    needs: unit_tests
+    uses: ./.github/workflows/windows_acceptance_tests.yml
   macos_unit_tests:
     needs: unit_tests
     uses: ./.github/workflows/macos_unit_tests.yml

--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -11,9 +11,13 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: brew install lmdb automake openssl pcre
+      run: brew install lmdb automake openssl pcre autoconf libtool
+    - name: Check tools
+      run: command -v libtool && command -v automake && command -v autoconf
+    - name: Check tools versions
+      run: libtool -V && automake --version && autoconf --version
     - name: Run autotools / configure
-      run: ./autogen.sh --enable-debug
+      run: PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests

--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -17,7 +17,11 @@ jobs:
     - name: Check tools versions
       run: libtool -V && automake --version && autoconf --version
     - name: Run autotools / configure
-      run: PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" ./autogen.sh --enable-debug
+      run: >
+        LDFLAGS="-L`brew --prefix lmdb`/lib -L`brew --prefix openssl`/lib -L`brew --prefix pcre`/lib"
+        CPPFLAGS="-I`brew --prefix lmdb`/include -I`brew --prefix openssl`/include -I`brew --prefix pcre`/include"
+        PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
+        ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -32,7 +32,7 @@ jobs:
       # and install it by msiexec running under powershell.
 
       - name: get CFEngine package
-        run: cf-remote --version 3.18.x download 64 msi
+        run: cf-remote --version 3.18.x download x86_64 msi
 
       - name: move CFEngine package to current workdir
         run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -1,0 +1,83 @@
+name: Windows Acceptance Tests
+
+on:
+  workflow_call
+
+defaults:
+  run:
+    shell: msys2 {0}
+
+jobs:
+  windows_acceptance_tests:
+    runs-on: windows-latest
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          install: >-
+            dos2unix
+            diffutils
+            util-linux
+            python-pip
+
+      - name: Checkout Core
+        uses: actions/checkout@v3
+
+      - name: install cf-remote
+        run: pip install cf-remote
+
+      # Note that msiexec can't install packages when running under msys;
+      # But cf-remote currently can't run under powershell
+      # (because it requires `pwd` module which is Unix-only).
+      # Hence, we _download_ msi package using cf-remote under msys,
+      # and install it by msiexec running under powershell.
+
+      - name: get CFEngine package
+        run: cf-remote --version 3.18.x download 64 msi
+
+      - name: move CFEngine package to current workdir
+        run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
+
+      - name: install CFEngine
+        run: |
+          Get-Location # pwd
+          New-Item -Path "c:\" -Name "artifacts" -ItemType Directory
+          Start-Process msiexec.exe -Wait -ArgumentList '/quiet /qn /i cfengine.msi /L*V c:\tmp.log'
+          Get-Content c:\tmp.log | Set-Content -Encoding utf8 c:\artifacts\CFEngine-Install.log
+          file c:\artifacts\CFEngine-Install.log
+        shell: pwsh
+
+      - name: run cf-agent
+        run: "'/c/Program Files/Cfengine/bin/cf-agent.exe' --version"
+
+      # Note that msiexec install CFEngine onto the C: drive (/c/ partition),
+      # but testall expects it to be on the same partition as where all tests are located (D: drive),
+      # hence we just copy it over.
+      - name: copy CFEngine to workdir partition
+        run: 'cp -a "/c/Program Files/Cfengine" /d/a/'
+
+      - name: prune platform independent tests to make the job more efficient
+        run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
+        working-directory: "tests/acceptance"
+        shell: pwsh
+      - name: run the tests
+        run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA'
+        working-directory: "tests/acceptance"
+        env:
+          # env vars for testall script to properly detect environment
+          USER: runneradmin
+          OSTYPE: msys
+
+      - name: print test.log
+        run: 'cat ./tests/acceptance/test.log || true'
+        if: ${{ always() }}
+      - name: save test.log in artifacts
+        run: 'cp ./tests/acceptance/test.log /c/artifacts/test.log || true'
+        if: ${{ always() }}
+
+
+      - name: save artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: c:\artifacts


### PR DESCRIPTION
Ticket: ENT-10699
Changelog: none
(cherry picked from commit da214fa9593576926f11b553524958bc6680fee3)

 Conflicts:
	.github/workflows/ci.yml
	.github/workflows/windows_acceptance_tests.yml

Enabling windows acceptance test in 3.18.x but had to replace version in cf-remote install command.
Uses latest nightly.
