### PR TITLE
GH Actions macOS fixes (3.18)

### DIFF
--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -11,9 +11,13 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: brew install lmdb automake openssl pcre
+      run: brew install lmdb automake openssl pcre autoconf libtool
+    - name: Check tools
+      run: command -v libtool && command -v automake && command -v autoconf
+    - name: Check tools versions
+      run: libtool -V && automake --version && autoconf --version
     - name: Run autotools / configure
-      run: ./autogen.sh --enable-debug
+      run: PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests

--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -17,7 +17,11 @@ jobs:
     - name: Check tools versions
       run: libtool -V && automake --version && autoconf --version
     - name: Run autotools / configure
-      run: PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" ./autogen.sh --enable-debug
+      run: >
+        LDFLAGS="-L`brew --prefix lmdb`/lib -L`brew --prefix openssl`/lib -L`brew --prefix pcre`/lib"
+        CPPFLAGS="-I`brew --prefix lmdb`/include -I`brew --prefix openssl`/include -I`brew --prefix pcre`/include"
+        PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
+        ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests


### PR DESCRIPTION
- GH Actions macOS: Fixed installation and PATH for libtool and autoconf
- GH Actions macOS: Use brew --prefix to locate LMDB, OpenSSL, and pcre
