### PR TITLE
ENT-11771: Fixed missing cf.events.dll in acceptance tests on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,25 +7,25 @@ on:
     branches: [ master, 3.18.x, 3.15.x ]
 
 jobs:
-  unit_tests:
-    uses: ./.github/workflows/unit_tests.yml
-  shellcheck_tests:
-    uses: ./.github/workflows/shellcheck.yml
-  asan_unit_tests:
-    needs: unit_tests
-    uses: ./.github/workflows/asan_unit_tests.yml
-  acceptance_tests:
-    needs: unit_tests
-    uses: ./.github/workflows/acceptance_tests.yml
+#  unit_tests:
+#    uses: ./.github/workflows/unit_tests.yml
+#  shellcheck_tests:
+#    uses: ./.github/workflows/shellcheck.yml
+#  asan_unit_tests:
+#    needs: unit_tests
+#    uses: ./.github/workflows/asan_unit_tests.yml
+#  acceptance_tests:
+#    needs: unit_tests
+#    uses: ./.github/workflows/acceptance_tests.yml
   windows_acceptance_tests:
-    needs: unit_tests
+#    needs: unit_tests
     uses: ./.github/workflows/windows_acceptance_tests.yml
-  macos_unit_tests:
-    needs: unit_tests
-    uses: ./.github/workflows/macos_unit_tests.yml
-  valgrind_check:
-    needs: unit_tests
-    uses: ./.github/workflows/job-valgrind-check.yml
-  static_check:
-    needs: unit_tests
-    uses: ./.github/workflows/job-static-check.yml
+#  macos_unit_tests:
+#    needs: unit_tests
+#    uses: ./.github/workflows/macos_unit_tests.yml
+#  valgrind_check:
+#    needs: unit_tests
+#    uses: ./.github/workflows/job-valgrind-check.yml
+#  static_check:
+#    needs: unit_tests
+#    uses: ./.github/workflows/job-static-check.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
   acceptance_tests:
     needs: unit_tests
     uses: ./.github/workflows/acceptance_tests.yml
+  windows_acceptance_tests:
+    needs: unit_tests
+    uses: ./.github/workflows/windows_acceptance_tests.yml
   macos_unit_tests:
     needs: unit_tests
     uses: ./.github/workflows/macos_unit_tests.yml

--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -11,9 +11,13 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: brew install lmdb automake openssl pcre
+      run: brew install lmdb automake openssl pcre autoconf libtool
+    - name: Check tools
+      run: command -v libtool && command -v automake && command -v autoconf
+    - name: Check tools versions
+      run: libtool -V && automake --version && autoconf --version
     - name: Run autotools / configure
-      run: ./autogen.sh --enable-debug
+      run: PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests

--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -17,7 +17,11 @@ jobs:
     - name: Check tools versions
       run: libtool -V && automake --version && autoconf --version
     - name: Run autotools / configure
-      run: PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" ./autogen.sh --enable-debug
+      run: >
+        LDFLAGS="-L`brew --prefix lmdb`/lib -L`brew --prefix openssl`/lib -L`brew --prefix pcre`/lib"
+        CPPFLAGS="-I`brew --prefix lmdb`/include -I`brew --prefix openssl`/include -I`brew --prefix pcre`/include"
+        PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
+        ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -53,8 +53,9 @@ jobs:
       # Note that msiexec install CFEngine onto the C: drive (/c/ partition),
       # but testall expects it to be on the same partition as where all tests are located (D: drive),
       # hence we just copy it over.
-      - name: copy CFEngine to workdir partition
-        run: 'rsync -avz /d/a/core /c/ || true'
+# must copy /da/core/core as /d/a/core is just the root/workdir and github checks out core inside there so two cores, /core/core
+      - name: copy core checkout to main partition
+        run: 'rsync -avz /d/a/core/core /c/ || true'
       - name: check with msys the copy
         run: 'ls -l /c; ls -l /c/core'
 

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Checkout Core
         uses: actions/checkout@v3
 
-#      - name: install cf-remote
-#        run: pip install cf-remote
+      - name: install cf-remote
+        run: pip install cf-remote
 
       # Note that msiexec can't install packages when running under msys;
       # But cf-remote currently can't run under powershell
@@ -31,29 +31,20 @@ jobs:
       # Hence, we _download_ msi package using cf-remote under msys,
       # and install it by msiexec running under powershell.
 
-#      - name: get CFEngine package
-#        run: cf-remote --version 3.18.x download x86_64 msi
-#
-#      - name: move CFEngine package to current workdir
-#        run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
+      - name: get CFEngine package
+        run: cf-remote --version 3.18.x download x86_64 msi
 
-      - name: Download yesterdays nightly package
-        run: 'pwd && wget http://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-753/PACKAGES_i386_mingw/cfengine-nova-3.18.8a-33042-i686.msi -o /c/cfengine.msi'
-
-      - name: check download
-        run: 'ls -l /c/cfengine.msi'
+      - name: move CFEngine package to current workdir
+        run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
 
       - name: install CFEngine
         run: |
           Get-Location # pwd
           New-Item -Path "c:\" -Name "artifacts" -ItemType Directory
-          Start-Process msiexec.exe -Wait -ArgumentList '/quiet /qn /i c:\cfengine.msi /L*V c:\tmp.log'
+          Start-Process msiexec.exe -Wait -ArgumentList '/quiet /qn /i cfengine.msi /L*V c:\tmp.log'
           Get-Content c:\tmp.log | Set-Content -Encoding utf8 c:\artifacts\CFEngine-Install.log
           file c:\artifacts\CFEngine-Install.log
         shell: pwsh
-
-      - name: check install
-        run: "ls -l '/c/Program Files'"
 
       - name: run cf-agent
         run: "'/c/Program Files/Cfengine/bin/cf-agent.exe' --version"
@@ -68,8 +59,8 @@ jobs:
         run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
         working-directory: "tests/acceptance"
         shell: pwsh
-      - name: debug contents of copied Cfengine/bin
-        run: 'ls -l /d/a/Cfengine/bin'
+      - name: check copied cfengine contents
+        run: "ls -l /d/a/Cfengine/bin"
 
       - name: run the tests
         run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA'

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -32,7 +32,7 @@ jobs:
       # and install it by msiexec running under powershell.
 
       - name: get CFEngine package
-        run: cf-remote --version 3.18.x download 64 msi
+        run: cf-remote --version 3.18.x download x86_64 msi
 
       - name: move CFEngine package to current workdir
         run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -59,6 +59,9 @@ jobs:
         run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
         working-directory: "tests/acceptance"
         shell: pwsh
+      - name: debug contents of copied Cfengine/bin
+        run: 'ls -l /d/a/Cfengine/bin'
+
       - name: run the tests
         run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA'
         working-directory: "tests/acceptance"

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -1,0 +1,83 @@
+name: Windows Acceptance Tests
+
+on:
+  workflow_call
+
+defaults:
+  run:
+    shell: msys2 {0}
+
+jobs:
+  windows_acceptance_tests:
+    runs-on: windows-latest
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          install: >-
+            dos2unix
+            diffutils
+            util-linux
+            python-pip
+
+      - name: Checkout Core
+        uses: actions/checkout@v3
+
+      - name: install cf-remote
+        run: pip install cf-remote
+
+      # Note that msiexec can't install packages when running under msys;
+      # But cf-remote currently can't run under powershell
+      # (because it requires `pwd` module which is Unix-only).
+      # Hence, we _download_ msi package using cf-remote under msys,
+      # and install it by msiexec running under powershell.
+
+      - name: get CFEngine package
+        run: cf-remote --version 3.18.x download 64 msi
+
+      - name: move CFEngine package to current workdir
+        run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
+
+      - name: install CFEngine
+        run: |
+          Get-Location # pwd
+          New-Item -Path "c:\" -Name "artifacts" -ItemType Directory
+          Start-Process msiexec.exe -Wait -ArgumentList '/quiet /qn /i cfengine.msi /L*V c:\tmp.log'
+          Get-Content c:\tmp.log | Set-Content -Encoding utf8 c:\artifacts\CFEngine-Install.log
+          file c:\artifacts\CFEngine-Install.log
+        shell: pwsh
+
+      - name: run cf-agent
+        run: "'/c/Program Files/Cfengine/bin/cf-agent.exe' --version"
+
+      # Note that msiexec install CFEngine onto the C: drive (/c/ partition),
+      # but testall expects it to be on the same partition as where all tests are located (D: drive),
+      # hence we just copy it over.
+      - name: copy CFEngine to workdir partition
+        run: 'cp -a "/c/Program Files/Cfengine" /d/a/'
+
+      - name: prune platform independent tests to make the job more efficient
+        run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
+        working-directory: "tests/acceptance"
+        shell: pwsh
+      - name: run the tests
+        run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA'
+        working-directory: "tests/acceptance"
+        env:
+          # env vars for testall script to properly detect environment
+          USER: runneradmin
+          OSTYPE: msys
+
+      - name: print test.log
+        run: 'cat ./tests/acceptance/test.log || true'
+        if: ${{ always() }}
+      - name: save test.log in artifacts
+        run: 'cp ./tests/acceptance/test.log /c/artifacts/test.log || true'
+        if: ${{ always() }}
+
+
+      - name: save artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: c:\artifacts

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -59,6 +59,7 @@ jobs:
         run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
         working-directory: "tests/acceptance"
         shell: pwsh
+
       - name: check copied cfengine contents
         run: "ls -l /d/a/Cfengine/bin"
 
@@ -73,9 +74,14 @@ jobs:
       - name: print test.log
         run: 'cat ./tests/acceptance/test.log || true'
         if: ${{ always() }}
+
       - name: save test.log in artifacts
         run: 'cp ./tests/acceptance/test.log /c/artifacts/test.log || true'
         if: ${{ always() }}
+      - name: save workdir to artifacts
+        run: 'cp -a ./tests/acceptance/workdir /c/artifacts/workdir || true'
+        if: ${{ always() }}
+
 
 
       - name: save artifacts

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -43,12 +43,14 @@ jobs:
       - name: install CFEngine
         run: |
           Get-Location # pwd
-          dir
           New-Item -Path "c:\" -Name "artifacts" -ItemType Directory
           Start-Process msiexec.exe -Wait -ArgumentList '/quiet /qn /i cfengine.msi /L*V c:\tmp.log'
           Get-Content c:\tmp.log | Set-Content -Encoding utf8 c:\artifacts\CFEngine-Install.log
           file c:\artifacts\CFEngine-Install.log
         shell: pwsh
+
+      - name: check install
+        run: "find '/c/Program Files/Cfengine"
 
       - name: run cf-agent
         run: "'/c/Program Files/Cfengine/bin/cf-agent.exe' --version"

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -53,7 +53,7 @@ jobs:
       # but testall expects it to be on the same partition as where all tests are located (D: drive),
       # hence we just copy it over.
       - name: copy CFEngine to workdir partition
-        run: 'cp -a /d/a/core /c/'
+        run: 'rsync -avz /d/a/core /c/'
       - name: check with msys the copy
         run: 'ls -l /c; ls -l /c/core'
 

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -54,7 +54,7 @@ jobs:
       # but testall expects it to be on the same partition as where all tests are located (D: drive),
       # hence we just copy it over.
       - name: copy CFEngine to workdir partition
-        run: 'rsync -avz /d/a/core /c/'
+        run: 'rsync -avz /d/a/core /c/ || true'
       - name: check with msys the copy
         run: 'ls -l /c; ls -l /c/core'
 

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -78,8 +78,9 @@ jobs:
       - name: save test.log in artifacts
         run: 'cp ./tests/acceptance/test.log /c/artifacts/test.log || true'
         if: ${{ always() }}
+      # make a tarball because otherwise there will be too many files and github won't save in the artifact
       - name: save workdir to artifacts
-        run: 'cp -a ./tests/acceptance/workdir /c/artifacts/workdir || true'
+        run: 'tar cfz /c/artifacts/workdir.tar.gz ./tests/acceptance/workdir || true'
         if: ${{ always() }}
 
 

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -56,17 +56,17 @@ jobs:
 # must copy /da/core/core as /d/a/core is just the root/workdir and github checks out core inside there so two cores, /core/core
       - name: copy core checkout to main partition
         run: 'rsync -avz /d/a/core/core /c/ || true'
-      - name: check with msys the copy
-        run: 'ls -l /c; ls -l /c/core'
-
-      - name: check the copy of core
-        run: 'dir'
-        working-directory: C:/
-
-      - name: check inside copy of core
-        run: 'dir'
-        working-directory: C:/core
-
+#      - name: check with msys the copy
+#        run: 'ls -l /c; ls -l /c/core'
+#
+#      - name: check the copy of core
+#        run: 'dir'
+#        working-directory: C:/
+#
+#      - name: check inside copy of core
+#        run: 'dir'
+#        working-directory: C:/core
+#
       - name: prune platform independent tests to make the job more efficient
         run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
         working-directory: C:/core/tests/acceptance
@@ -76,7 +76,7 @@ jobs:
 #        run: "ls -l /d/a/Cfengine/bin"
 #
       - name: run the tests
-        run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA ./05_processes/01_matching/process_count_found.cf '
+        run: './testall --bindir="/c/Program Files/Cfengine/bin" --extraclasses=EXTRA ./05_processes/01_matching/process_count_found.cf '
         working-directory: C:/core/tests/acceptance
         env:
           # env vars for testall script to properly detect environment

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Checkout Core
         uses: actions/checkout@v3
 
-      - name: install cf-remote
-        run: pip install cf-remote
+#      - name: install cf-remote
+#        run: pip install cf-remote
 
       # Note that msiexec can't install packages when running under msys;
       # But cf-remote currently can't run under powershell
@@ -31,11 +31,14 @@ jobs:
       # Hence, we _download_ msi package using cf-remote under msys,
       # and install it by msiexec running under powershell.
 
-      - name: get CFEngine package
-        run: cf-remote --version 3.18.x download x86_64 msi
+#      - name: get CFEngine package
+#        run: cf-remote --version 3.18.x download x86_64 msi
+#
+#      - name: move CFEngine package to current workdir
+#        run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
 
-      - name: move CFEngine package to current workdir
-        run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
+      - name: Download yesterdays nightly package
+        run: 'wget https://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-751/PACKAGES_x86_64_mingw/cfengine-nova-3.18.8a-32986-x86_64.msi -o cfengine.msi'
 
       - name: install CFEngine
         run: |

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           install: >-
+            rsync
             dos2unix
             diffutils
             util-linux

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Download yesterdays nightly package
         run: 'pwd && wget https://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-751/PACKAGES_x86_64_mingw/cfengine-nova-3.18.8a-32986-x86_64.msi -o cfengine.msi'
 
+      - name: check download
+        run: 'ls -l /d/a/core/core/cfengine.msi'
+
       - name: install CFEngine
         run: |
           Get-Location # pwd
@@ -50,7 +53,7 @@ jobs:
         shell: pwsh
 
       - name: check install
-        run: "find '/c/Program Files/Cfengine'"
+        run: "find / -iname '*cfengine*'"
 
       - name: run cf-agent
         run: "'/c/Program Files/Cfengine/bin/cf-agent.exe' --version"

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -65,7 +65,7 @@ jobs:
 #
       - name: run the tests
         run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA ./05_processes/01_matching/process_count_found.cf '
-        working-directory: "C:\core\tests\acceptance"
+        working-directory: C:\core\tests\acceptance
         env:
           # env vars for testall script to properly detect environment
           USER: runneradmin
@@ -73,18 +73,18 @@ jobs:
 
       - name: print test.log
         run: 'cat ./tests/acceptance/test.log || true'
-        working-directory: "C:\core"
+        working-directory: C:\core
         if: ${{ always() }}
 
       - name: save test.log in artifacts
         run: 'cp ./tests/acceptance/test.log /c/artifacts/test.log || true'
-        working-directory: "C:\core"
+        working-directory: C:\core
         if: ${{ always() }}
 
       # make a tarball because otherwise there will be too many files and github won't save in the artifact
       - name: save workdir to artifacts
         run: 'tar cfz /c/artifacts/workdir.tar.gz ./tests/acceptance/workdir || true'
-        working-directory: "C:\core"
+        working-directory: C:\core
         if: ${{ always() }}
 
 

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -55,6 +55,14 @@ jobs:
       - name: copy CFEngine to workdir partition
         run: 'cp -a /d/a/core /c/'
 
+      - name: check the copy of core
+        run: 'dir'
+        working-directory: C:\
+
+      - name: check inside copy of core
+        run: 'dir'
+        working-directory: C:\core
+
       - name: prune platform independent tests to make the job more efficient
         run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
         working-directory: C:\core\tests\acceptance

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: prune platform independent tests to make the job more efficient
         run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
-        working-directory: "/c/core/tests/acceptance"
+        working-directory: C:\core\tests\acceptance
         shell: pwsh
 
 #      - name: check copied cfengine contents

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -38,16 +38,16 @@ jobs:
 #        run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
 
       - name: Download yesterdays nightly package
-        run: 'pwd && wget http://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-753/PACKAGES_i386_mingw/cfengine-nova-3.18.8a-33042-i686.msi -o cfengine.msi'
+        run: 'pwd && wget http://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-753/PACKAGES_i386_mingw/cfengine-nova-3.18.8a-33042-i686.msi -o /c/cfengine.msi'
 
       - name: check download
-        run: 'ls -l /d/a/core/core/cfengine.msi'
+        run: 'ls -l /c/cfengine.msi'
 
       - name: install CFEngine
         run: |
           Get-Location # pwd
           New-Item -Path "c:\" -Name "artifacts" -ItemType Directory
-          Start-Process msiexec.exe -Wait -ArgumentList '/quiet /qn /i cfengine.msi /L*V c:\tmp.log'
+          Start-Process msiexec.exe -Wait -ArgumentList '/quiet /qn /i c:\cfengine.msi /L*V c:\tmp.log'
           Get-Content c:\tmp.log | Set-Content -Encoding utf8 c:\artifacts\CFEngine-Install.log
           file c:\artifacts\CFEngine-Install.log
         shell: pwsh

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -53,7 +53,7 @@ jobs:
         shell: pwsh
 
       - name: check install
-        run: "find / -iname '*cfengine*'"
+        run: "ls -l '/c/Program Files'"
 
       - name: run cf-agent
         run: "'/c/Program Files/Cfengine/bin/cf-agent.exe' --version"

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -54,18 +54,20 @@ jobs:
       # hence we just copy it over.
       - name: copy CFEngine to workdir partition
         run: 'cp -a /d/a/core /c/'
+      - name: check with msys the copy
+        run: 'ls -l /c; ls -l /c/core'
 
       - name: check the copy of core
         run: 'dir'
-        working-directory: C:\
+        working-directory: C:/
 
       - name: check inside copy of core
         run: 'dir'
-        working-directory: C:\core
+        working-directory: C:/core
 
       - name: prune platform independent tests to make the job more efficient
         run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
-        working-directory: C:\core\tests\acceptance
+        working-directory: C:/core/tests/acceptance
         shell: pwsh
 
 #      - name: check copied cfengine contents
@@ -73,7 +75,7 @@ jobs:
 #
       - name: run the tests
         run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA ./05_processes/01_matching/process_count_found.cf '
-        working-directory: C:\core\tests\acceptance
+        working-directory: C:/core/tests/acceptance
         env:
           # env vars for testall script to properly detect environment
           USER: runneradmin
@@ -81,18 +83,18 @@ jobs:
 
       - name: print test.log
         run: 'cat ./tests/acceptance/test.log || true'
-        working-directory: C:\core
+        working-directory: C:/core
         if: ${{ always() }}
 
       - name: save test.log in artifacts
         run: 'cp ./tests/acceptance/test.log /c/artifacts/test.log || true'
-        working-directory: C:\core
+        working-directory: C:/core
         if: ${{ always() }}
 
       # make a tarball because otherwise there will be too many files and github won't save in the artifact
       - name: save workdir to artifacts
         run: 'tar cfz /c/artifacts/workdir.tar.gz ./tests/acceptance/workdir || true'
-        working-directory: C:\core
+        working-directory: C:/core
         if: ${{ always() }}
 
 

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -38,11 +38,12 @@ jobs:
 #        run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
 
       - name: Download yesterdays nightly package
-        run: 'wget https://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-751/PACKAGES_x86_64_mingw/cfengine-nova-3.18.8a-32986-x86_64.msi -o cfengine.msi'
+        run: 'pwd && wget https://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-751/PACKAGES_x86_64_mingw/cfengine-nova-3.18.8a-32986-x86_64.msi -o cfengine.msi'
 
       - name: install CFEngine
         run: |
           Get-Location # pwd
+          dir
           New-Item -Path "c:\" -Name "artifacts" -ItemType Directory
           Start-Process msiexec.exe -Wait -ArgumentList '/quiet /qn /i cfengine.msi /L*V c:\tmp.log'
           Get-Content c:\tmp.log | Set-Content -Encoding utf8 c:\artifacts\CFEngine-Install.log

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -38,7 +38,7 @@ jobs:
 #        run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
 
       - name: Download yesterdays nightly package
-        run: 'pwd && wget http://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-753/PACKAGES_x86_64_mingw/cfengine-nova-3.18.8a-33048-x86_64.msi -o cfengine.msi'
+        run: 'pwd && wget http://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-753/PACKAGES_i386_mingw/cfengine-nova-3.18.8a-33042-i686.msi -o cfengine.msi'
 
       - name: check download
         run: 'ls -l /d/a/core/core/cfengine.msi'

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -65,7 +65,7 @@ jobs:
 #
       - name: run the tests
         run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA ./05_processes/01_matching/process_count_found.cf '
-        working-directory: "/c/core/tests/acceptance"
+        working-directory: "C:\core\tests\acceptance"
         env:
           # env vars for testall script to properly detect environment
           USER: runneradmin
@@ -73,18 +73,18 @@ jobs:
 
       - name: print test.log
         run: 'cat ./tests/acceptance/test.log || true'
-        working-directory: "/c/core"
+        working-directory: "C:\core"
         if: ${{ always() }}
 
       - name: save test.log in artifacts
         run: 'cp ./tests/acceptance/test.log /c/artifacts/test.log || true'
-        working-directory: "/c/core"
+        working-directory: "C:\core"
         if: ${{ always() }}
 
       # make a tarball because otherwise there will be too many files and github won't save in the artifact
       - name: save workdir to artifacts
         run: 'tar cfz /c/artifacts/workdir.tar.gz ./tests/acceptance/workdir || true'
-        working-directory: "/c/core"
+        working-directory: "C:\core"
         if: ${{ always() }}
 
 

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -53,19 +53,19 @@ jobs:
       # but testall expects it to be on the same partition as where all tests are located (D: drive),
       # hence we just copy it over.
       - name: copy CFEngine to workdir partition
-        run: 'cp -a "/c/Program Files/Cfengine" /d/a/'
+        run: 'cp -a /d/a/core /c/'
 
       - name: prune platform independent tests to make the job more efficient
         run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
-        working-directory: "tests/acceptance"
+        working-directory: "/c/core/tests/acceptance"
         shell: pwsh
 
-      - name: check copied cfengine contents
-        run: "ls -l /d/a/Cfengine/bin"
-
+#      - name: check copied cfengine contents
+#        run: "ls -l /d/a/Cfengine/bin"
+#
       - name: run the tests
-        run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA'
-        working-directory: "tests/acceptance"
+        run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA ./05_processes/01_matching/process_count_found.cf '
+        working-directory: "/c/core/tests/acceptance"
         env:
           # env vars for testall script to properly detect environment
           USER: runneradmin
@@ -73,14 +73,18 @@ jobs:
 
       - name: print test.log
         run: 'cat ./tests/acceptance/test.log || true'
+        working-directory: "/c/core"
         if: ${{ always() }}
 
       - name: save test.log in artifacts
         run: 'cp ./tests/acceptance/test.log /c/artifacts/test.log || true'
+        working-directory: "/c/core"
         if: ${{ always() }}
+
       # make a tarball because otherwise there will be too many files and github won't save in the artifact
       - name: save workdir to artifacts
         run: 'tar cfz /c/artifacts/workdir.tar.gz ./tests/acceptance/workdir || true'
+        working-directory: "/c/core"
         if: ${{ always() }}
 
 

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -50,7 +50,7 @@ jobs:
         shell: pwsh
 
       - name: check install
-        run: "find '/c/Program Files/Cfengine"
+        run: "find '/c/Program Files/Cfengine'"
 
       - name: run cf-agent
         run: "'/c/Program Files/Cfengine/bin/cf-agent.exe' --version"

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -38,7 +38,7 @@ jobs:
 #        run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
 
       - name: Download yesterdays nightly package
-        run: 'pwd && wget https://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-751/PACKAGES_x86_64_mingw/cfengine-nova-3.18.8a-32986-x86_64.msi -o cfengine.msi'
+        run: 'pwd && wget http://buildcache.cfengine.com/packages/testing-pr/jenkins-3.18.x-nightly-pipeline-753/PACKAGES_x86_64_mingw/cfengine-nova-3.18.8a-33048-x86_64.msi -o cfengine.msi'
 
       - name: check download
         run: 'ls -l /d/a/core/core/cfengine.msi'

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -x
 #
 #  Copyright 2021 Northern.tech AS
 #


### PR DESCRIPTION
- Improve and re-enable windows acceptance test workflow
- Adjusted 3.18.x tags for cfengine package
- GH Actions macOS: Fixed installation and PATH for libtool and autoconf
- GH Actions macOS: Use brew --prefix to locate LMDB, OpenSSL, and pcre
