### PR TITLE
ENT-11771: Adjust windows acceptance test job workflow to use only C: partition

### DIFF
--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           install: >-
+            rsync
             dos2unix
             diffutils
             util-linux
@@ -32,7 +33,7 @@ jobs:
       # and install it by msiexec running under powershell.
 
       - name: get CFEngine package
-        run: cf-remote --version master download 64 msi
+        run: cf-remote --version master download x86_64 msi
 
       - name: move CFEngine package to current workdir
         run: "mv $HOME/.cfengine/cf-remote/packages/*.msi cfengine.msi"
@@ -49,19 +50,18 @@ jobs:
       - name: run cf-agent
         run: "'/c/Program Files/Cfengine/bin/cf-agent.exe' --version"
 
-      # Note that msiexec install CFEngine onto the C: drive (/c/ partition),
-      # but testall expects it to be on the same partition as where all tests are located (D: drive),
-      # hence we just copy it over.
-      - name: copy CFEngine to workdir partition
-        run: 'cp -a "/c/Program Files/Cfengine" /d/a/'
+      # tests run easier if the core repo and CFEngine install are on the same partition: C:
+      - name: copy core checkout to main partition
+        run: 'rsync -avz /d/a/core/core /c/ || true'
 
       - name: prune platform independent tests to make the job more efficient
         run: 'Remove-Item -Recurse -Force 00_basics, 01_vars, 02_classes, 10_files, 14_reports, 15_control, 16_cf-serverd, 21_methods, 22_cf-runagent, 26_cf-net, 27_cf-secret, 28_inform_testing'
-        working-directory: "tests/acceptance"
+        working-directory: C:/core/tests/acceptance
         shell: pwsh
+
       - name: run the tests
-        run: './testall --bindir="/d/a/Cfengine/bin" --extraclasses=EXTRA'
-        working-directory: "tests/acceptance"
+        run: './testall --bindir="/c/Program Files/Cfengine/bin" --extraclasses=EXTRA ./05_processes/01_matching/process_count_found.cf '
+        working-directory: C:/core/tests/acceptance
         env:
           # env vars for testall script to properly detect environment
           USER: runneradmin
@@ -69,11 +69,19 @@ jobs:
 
       - name: print test.log
         run: 'cat ./tests/acceptance/test.log || true'
-        if: ${{ always() }}
-      - name: save test.log in artifacts
-        run: 'cp ./tests/acceptance/test.log /c/artifacts/test.log || true'
+        working-directory: C:/core
         if: ${{ always() }}
 
+      - name: save test.log in artifacts
+        run: 'cp ./tests/acceptance/test.log /c/artifacts/test.log || true'
+        working-directory: C:/core
+        if: ${{ always() }}
+
+      # make a tarball because otherwise there will be too many files and github won't save the artifact
+      - name: save workdir to artifacts
+        run: 'tar cfz /c/artifacts/workdir.tar.gz ./tests/acceptance/workdir || true'
+        working-directory: C:/core
+        if: ${{ always() }}
 
       - name: save artifacts
         if: success() || failure()


### PR DESCRIPTION
There was an issue with 3.18.x version of this job which required this change.

Ticket: ENT-11771
Changelog: none