### PR TITLE
ENT-8890: Added utility function to get time classes

### DIFF
--- a/libenv/time_classes.c
+++ b/libenv/time_classes.c
@@ -44,8 +44,7 @@ static void RemoveTimeClass(EvalContext *ctx, const char* tags)
     RlistDestroy(tags_rlist);
 }
 
-static void AddTimeClass(EvalContext *ctx, time_t time, const char* tags)
-{
+StringSet *GetTimeClasses(time_t time) {
     // The first element is the local timezone
     const char* tz_prefix[2] = { "", "GMT_" };
     const char* tz_function[2] = { "localtime_r", "gmtime_r" };
@@ -55,31 +54,29 @@ static void AddTimeClass(EvalContext *ctx, time_t time, const char* tags)
         gmtime_r(&time, &(tz_parsed_time[1]))
     };
 
+    StringSet *classes = StringSetNew();
+
     for (int tz = 0; tz < 2; tz++)
     {
-        char buf[CF_BUFSIZE];
         int day_text_index, quarter, interval_start, interval_end;
 
         if (tz_tm[tz] == NULL)
         {
             Log(LOG_LEVEL_ERR, "Unable to parse passed time. (%s: %s)", tz_function[tz], GetErrorStr());
-            return;
+            return NULL;
         }
 
 /* Lifecycle */
 
-        snprintf(buf, CF_BUFSIZE, "%sLcycle_%d", tz_prefix[tz], ((tz_parsed_time[tz].tm_year + 1900) % 3));
-        EvalContextClassPutHard(ctx, buf, tags);
+        StringSetAddF(classes, "%sLcycle_%d", tz_prefix[tz], ((tz_parsed_time[tz].tm_year + 1900) % 3));
 
 /* Year */
 
-        snprintf(buf, CF_BUFSIZE, "%sYr%04d", tz_prefix[tz], tz_parsed_time[tz].tm_year + 1900);
-        EvalContextClassPutHard(ctx, buf, tags);
+        StringSetAddF(classes, "%sYr%04d", tz_prefix[tz], tz_parsed_time[tz].tm_year + 1900);
 
 /* Month */
 
-        snprintf(buf, CF_BUFSIZE, "%s%s", tz_prefix[tz], MONTH_TEXT[tz_parsed_time[tz].tm_mon]);
-        EvalContextClassPutHard(ctx, buf, tags);
+        StringSetAddF(classes, "%s%s", tz_prefix[tz], MONTH_TEXT[tz_parsed_time[tz].tm_mon]);
 
 /* Day of week */
 
@@ -88,46 +85,55 @@ static void AddTimeClass(EvalContext *ctx, time_t time, const char* tags)
    ...
    Sunday  is 0 in tm_wday, 6 in DAY_TEXT */
         day_text_index = (tz_parsed_time[tz].tm_wday + 6) % 7;
-        snprintf(buf, CF_BUFSIZE, "%s%s", tz_prefix[tz], DAY_TEXT[day_text_index]);
-        EvalContextClassPutHard(ctx, buf, tags);
+        StringSetAddF(classes, "%s%s", tz_prefix[tz], DAY_TEXT[day_text_index]);
 
 /* Day */
 
-        snprintf(buf, CF_BUFSIZE, "%sDay%d", tz_prefix[tz], tz_parsed_time[tz].tm_mday);
-        EvalContextClassPutHard(ctx, buf, tags);
+        StringSetAddF(classes, "%sDay%d", tz_prefix[tz], tz_parsed_time[tz].tm_mday);
 
 /* Shift */
 
-        snprintf(buf, CF_BUFSIZE, "%s%s", tz_prefix[tz], SHIFT_TEXT[tz_parsed_time[tz].tm_hour / 6]);
-        EvalContextClassPutHard(ctx, buf, tags);
+        StringSetAddF(classes, "%s%s", tz_prefix[tz], SHIFT_TEXT[tz_parsed_time[tz].tm_hour / 6]);
 
 /* Hour */
 
-        snprintf(buf, CF_BUFSIZE, "%sHr%02d", tz_prefix[tz], tz_parsed_time[tz].tm_hour);
-        EvalContextClassPutHard(ctx, buf, tags);
-        snprintf(buf, CF_BUFSIZE, "%sHr%d", tz_prefix[tz], tz_parsed_time[tz].tm_hour);
-        EvalContextClassPutHard(ctx, buf, tags);
+        StringSetAddF(classes, "%sHr%02d", tz_prefix[tz], tz_parsed_time[tz].tm_hour);
+        StringSetAddF(classes, "%sHr%d", tz_prefix[tz], tz_parsed_time[tz].tm_hour);
 
 /* Quarter */
 
         quarter = tz_parsed_time[tz].tm_min / 15 + 1;
 
-        snprintf(buf, CF_BUFSIZE, "%sQ%d", tz_prefix[tz], quarter);
-        EvalContextClassPutHard(ctx, buf, tags);
-        snprintf(buf, CF_BUFSIZE, "%sHr%02d_Q%d", tz_prefix[tz], tz_parsed_time[tz].tm_hour, quarter);
-        EvalContextClassPutHard(ctx, buf, tags);
+        StringSetAddF(classes, "%sQ%d", tz_prefix[tz], quarter);
+        StringSetAddF(classes, "%sHr%02d_Q%d", tz_prefix[tz], tz_parsed_time[tz].tm_hour, quarter);
 
 /* Minute */
 
-        snprintf(buf, CF_BUFSIZE, "%sMin%02d", tz_prefix[tz], tz_parsed_time[tz].tm_min);
-        EvalContextClassPutHard(ctx, buf, tags);
+        StringSetAddF(classes, "%sMin%02d", tz_prefix[tz], tz_parsed_time[tz].tm_min);
 
         interval_start = (tz_parsed_time[tz].tm_min / 5) * 5;
         interval_end = (interval_start + 5) % 60;
 
-        snprintf(buf, CF_BUFSIZE, "%sMin%02d_%02d", tz_prefix[tz], interval_start, interval_end);
-        EvalContextClassPutHard(ctx, buf, tags);
+        StringSetAddF(classes, "%sMin%02d_%02d", tz_prefix[tz], interval_start, interval_end);
     }
+
+    return classes;
+}
+
+static void AddTimeClass(EvalContext *ctx, time_t time, const char* tags)
+{
+    StringSet *time_classes = GetTimeClasses(time);
+    if (time_classes == NULL) {
+        return;
+    }
+
+    StringSetIterator iter = StringSetIteratorInit(time_classes);
+    const char *time_class = NULL;
+    while ((time_class = StringSetIteratorNext(&iter)) != NULL) {
+        EvalContextClassPutHard(ctx, time_class, tags);
+    }
+
+    StringSetDestroy(time_classes);
 }
 
 void UpdateTimeClasses(EvalContext *ctx, time_t t)

--- a/libenv/time_classes.h
+++ b/libenv/time_classes.h
@@ -27,6 +27,20 @@
 
 #include <cf3.defs.h>
 
+/**
+ * @brief Get a string set of time classes based on a timestamp.
+ * @param time Unix timestamp
+ * @return Set of time classes or NULL in case of error.
+ * @note On success, returned value must be free'd using StringSetDestroy().
+ * @example GetTimeClasses(1716989621) in the GMT+2 timezone would return the
+ *          following classes: { 'Afternoon', 'Day29', 'GMT_Afternoon',
+ *          'GMT_Day29', 'GMT_Hr13', 'GMT_Hr13_Q3', 'GMT_Lcycle_2', 'GMT_May',
+ *          'GMT_Min30_35', 'GMT_Min33', 'GMT_Q3', 'GMT_Wednesday',
+ *          'GMT_Yr2024', 'Hr15', 'Hr15_Q3', 'Lcycle_2', 'May', 'Min30_35',
+ *          'Min33', 'Q3', 'Wednesday', 'Yr2024' }
+ */
+StringSet *GetTimeClasses(time_t time);
+
 void UpdateTimeClasses(EvalContext *ctx, time_t t);
 
 #endif

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -628,7 +628,7 @@ static ExpressionValue EvalTokenFromList(const char *token, void *param)
 
 /**********************************************************************/
 
-static bool EvalWithTokenFromList(const char *expr, StringSet *token_set)
+bool EvalWithTokenFromList(const char *expr, StringSet *token_set)
 {
     ParseResult res = ParseExpression(expr, 0, strlen(expr));
 

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -254,6 +254,14 @@ StringSet *ClassesMatchingLocal(const EvalContext *ctx, const char* regex, const
 bool EvalProcessResult(const char *process_result, StringSet *proc_attr);
 bool EvalFileResult(const char *file_result, StringSet *leaf_attr);
 
+/**
+ * @brief Evaluates a class expression based on a set of defined classes.
+ * @param expr Class expression (E.g. "GMT_Monday|GMT_Wednesday").
+ * @param token_set Set of defined classes.
+ * @return True if the class expression evaluates to true, otherwise false.
+ */
+bool EvalWithTokenFromList(const char *expr, StringSet *token_set);
+
 /* Various global options */
 void SetChecksumUpdatesDefault(EvalContext *ctx, bool enabled);
 bool GetChecksumUpdatesDefault(const EvalContext *ctx);


### PR DESCRIPTION
With the GetTimeClasses() function you can get a set of time classes
without the need for an EvalContext object.

Ticket: ENT-8890
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=10835)](https://ci.cfengine.com/job/pr-pipeline/10835/)