### PR TITLE
Fix VCS_TYPE docs in masterfiles-stage/README.org

### DIFF
--- a/contrib/masterfiles-stage/README.org
+++ b/contrib/masterfiles-stage/README.org
@@ -38,10 +38,10 @@ simple environments this will be =$(sys.masterdir)= (typically
 :ID:       328afa2e-3e6d-4e87-87bc-0db71b009763
 :END:
 - Supported upstreams
-  - =VCS_TYPE="GIT"=
-  - =VCS_TYPE="GIT_CFBS"= :: Like GIT, but instead of deploying policy from the root of a git repo directly, cfbs is used to first build the policy.
-  - =VCS_TYPE="GIT_POLICY_CHANNELS"=
-  - =VCS_TYPE="SVN"=
+  - ~VCS_TYPE="GIT"~
+  - ~VCS_TYPE="GIT_CFBS"~ :: Like GIT, but instead of deploying policy from the root of a git repo directly, [[https://pypi.org/project/cfbs/][cfbs]] is used to first build the policy.
+  - ~VCS_TYPE="GIT_POLICY_CHANNELS"~
+  - ~VCS_TYPE="SVN"~
 
 * Dependencies
 :PROPERTIES:


### PR DESCRIPTION
Use ~code~ instead of =verbatim= to avoid issues with the highlighted content containing =.

Also link cfbs website for people to easily find out what cfbs is and what it does.