### PR TITLE
Adjusted package_method to allow package names with whitespace in the middle

### DIFF
--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -3461,7 +3461,7 @@ static bool PrependPatchItem(
     char vbuff[CF_MAXVARSIZE];
 
     strlcpy(vbuff, ExtractFirstReference(a->packages.package_patch_name_regex, item), CF_MAXVARSIZE);
-    sscanf(vbuff, "%s", name);  /* trim */
+    name = TrimWhitespace(vbuff);
     strlcpy(vbuff, ExtractFirstReference(a->packages.package_patch_version_regex, item), CF_MAXVARSIZE);
     sscanf(vbuff, "%s", version);       /* trim */
 


### PR DESCRIPTION
On Windows with winget package names often have spaces.

The previous implementation used sscanf to grab the first space-delimited token as the name.

This change uses libntech string_lib TrimWhitespace() to only remove leading and trailing whitespace.

Ticket: CFE-4397
Changelog: title
