### PR TITLE
[3.18.x] Allow httpd to open tmp files

### DIFF
--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -637,7 +637,7 @@ allow cfengine_httpd_t sssd_var_lib_t:dir search;
 allow cfengine_httpd_t sssd_var_lib_t:sock_file write;
 allow cfengine_httpd_t syslogd_var_run_t:dir search;
 allow cfengine_httpd_t tmp_t:sock_file write;
-allow cfengine_httpd_t tmp_t:file { create setattr unlink write rename };
+allow cfengine_httpd_t tmp_t:file { create setattr unlink write rename open };
 allow cfengine_httpd_t tmp_t:dir { add_name remove_name write read };
 allow cfengine_httpd_t var_t:dir read;
 


### PR DESCRIPTION
This is needed for successful uploads of custom action scripts.

(cherry picked from commit b80cceed6fddbd32d77521e950fb6d91a2ed3050)