### PR TITLE
[3.21.x] Fixed bug where default:sys.fqhost contained many spaces

### DIFF
--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -945,19 +945,26 @@ static void ResolveControlBody(EvalContext *ctx, GenericAgentConfig *config,
             Log(LOG_LEVEL_VERBOSE, "SET domain = %s", VDOMAIN);
 
             EvalContextVariableRemoveSpecial(ctx, SPECIAL_SCOPE_SYS, "domain");
-            EvalContextVariableRemoveSpecial(ctx, SPECIAL_SCOPE_SYS, "fqhost");
-
-            // We don't expect hostname or domain name longer than 255,
-            // warnings are printed in sysinfo.c.
-            // Here we support up to 511 bytes, just in case, because we can:
-            snprintf(VFQNAME, CF_MAXVARSIZE, "%511s.%511s", VUQNAME, VDOMAIN);
-            EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "fqhost",
-                                          VFQNAME, CF_DATA_TYPE_STRING,
-                                          "inventory,source=agent,attribute_name=Host name");
             EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "domain",
                                           VDOMAIN, CF_DATA_TYPE_STRING,
                                           "source=agent");
             EvalContextClassPutHard(ctx, VDOMAIN, "source=agent");
+
+            int ret = snprintf(VFQNAME, CF_MAXVARSIZE, "%s.%s", VUQNAME, VDOMAIN);
+            assert(ret >= 0 && ret < CF_MAXVARSIZE);
+            if (ret < 0 || ret >= CF_MAXVARSIZE)
+            {
+                Log(LOG_LEVEL_ERR,
+                    "Failed to update variable default:sys.fqhost to include domain name: "
+                    "Maximum variable size was exceeded (%d >= %d)", ret, CF_MAXVARSIZE);
+            }
+            else
+            {
+                EvalContextVariableRemoveSpecial(ctx, SPECIAL_SCOPE_SYS, "fqhost");
+                EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, "fqhost",
+                                              VFQNAME, CF_DATA_TYPE_STRING,
+                                              "inventory,source=agent,attribute_name=Host name");
+            }
         }
 
         if (strcmp(lval, CFG_CONTROLBODY[COMMON_CONTROL_IGNORE_MISSING_INPUTS].lval) == 0)

--- a/tests/acceptance/01_vars/01_basic/fqhost_domain.cf
+++ b/tests/acceptance/01_vars/01_basic/fqhost_domain.cf
@@ -1,0 +1,33 @@
+##############################################################
+#
+# Test default:sys.fqhost with domain CFE-4053
+#
+##############################################################
+
+body common control
+{
+  domain => "cfengine.com";
+  bundlesequence => { "check" };
+}
+
+bundle agent __main__
+{
+  methods:
+    "check";
+}
+
+##############################################################
+
+bundle agent check
+{
+  reports:
+    DEBUG::
+      "$(sys.fqhost), $(sys.uqhost).cfengine.com";
+
+    any::
+      "$(this.promise_filename) Pass"
+        if => strcmp( "$(sys.fqhost)", "$(sys.uqhost).cfengine.com" );
+
+      "$(this.promise_filename) FAIL"
+        unless => strcmp( "$(sys.fqhost)", "$(sys.uqhost).cfengine.com" );
+}


### PR DESCRIPTION
Fixed bug where `default:sys.fqhost` contained many spaces when domain is set in body common control.

Ticket: CFE-4053
Changelog: Commit
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 06e3eff4b15c4ac0965def1ac1aff741c3d77a81)