### PR TITLE
ENT-11854: Fixed doc build (3.21)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,12 +2,12 @@
 	- Added warning log message when OS is not recognized (CFE-4342)
 	- Adjusted package module inventory to include quotes around fields when needed
 	  (CFE-4341)
-	- Added `sys.os_name_human` and `sys.os_version_major`. Additionally
-	  changed value of `sys.flavor` from `AmazonLinux` to `amazon_linux_2`, so
+	- Added 'sys.os_name_human' and 'sys.os_version_major'. Additionally
+	  changed value of 'sys.flavor' from 'AmazonLinux' to 'amazon_linux_2', so
 	  that it is similar to other supported Linux distros. This change was
-	  necessary, due to the fact that the `sys.os_version_major` variable is
-	  derived from it. However, the `AmazonLinux` class previously derived
-	  from `sys.flavor` is still defined for backwards compatibility.
+	  necessary, due to the fact that the 'sys.os_version_major' variable is
+	  derived from it. However, the 'AmazonLinux' class previously derived
+	  from 'sys.flavor' is still defined for backwards compatibility.
 	  (ENT-10817)
 	- CFEngine processes no longer suffer from the "Invalid argument" issues when
 	  working with LMDB (ENT-11543)
@@ -21,7 +21,7 @@
 	- cf-agent has two new options --no-augments and --no-host-specific-data to skip
 	  loading augments (def.json or def_preferred.json) and host-specific data
 	  (host_specific.json), respectively (ENT-10792)
-	- Fixed bug where `default:sys.fqhost` contained many spaces when domain is
+	- Fixed bug where 'default:sys.fqhost' contained many spaces when domain is
 	  set in body common control (CFE-4053)
 
 3.21.4:


### PR DESCRIPTION
Markdown in the changelog (especially single backticks around words) cause the
doc build to break with failure to resolve automatic links. Here we simply
replaced backticks with single quotes.

Ticket: ENT-11854
Changelog: None