### PR TITLE
ENT-11854: Fixed doc build (3.18)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,12 +1,12 @@
 3.18.8:
 	- Adjusted package module inventory to include quotes around fields when needed
 	  (CFE-4341)
-	- Added `sys.os_name_human` and `sys.os_version_major`. Additionally
-	  changed value of `sys.flavor` from `AmazonLinux` to `amazon_linux_2`, so
+	- Added 'sys.os_name_human' and 'sys.os_version_major'. Additionally
+	  changed value of 'sys.flavor' from 'AmazonLinux' to 'amazon_linux_2', so
 	  that it is similar to other supported Linux distros. This change was
-	  necessary, due to the fact that the `sys.os_version_major` variable is
-	  derived from it. However, the `AmazonLinux` class previously derived
-	  from `sys.flavor` is still defined for backwards compatibility.
+	  necessary, due to the fact that the 'sys.os_version_major' variable is
+	  derived from it. However, the 'AmazonLinux' class previously derived
+	  from 'sys.flavor' is still defined for backwards compatibility.
 	  (ENT-10817)
 	- CFEngine processes no longer suffer from the "Invalid argument" issues when
 	  working with LMDB (ENT-11543)
@@ -14,7 +14,7 @@
 	  (ENT-11526)
 	- Modified package promise default. If platform_default is present use that
 	  package module. (CFE-4315)
-	- Fixed bug where `default:sys.fqhost` contained many spaces when domain is
+	- Fixed bug where 'default:sys.fqhost' contained many spaces when domain is
 	   set in body common control (CFE-4053)
 
 3.18.7:


### PR DESCRIPTION
The documentation build tries and fails to resolve automatic backtick links,
this change simply switches from backticks to single quotes to allow doc builds
to function properly.

Ticket: ENT-11854
Changelog: None