### PR TITLE
Allow depth_search on non-directory files

### DIFF
--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -446,16 +446,11 @@ static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promi
     }
     else
     {
-        if (!S_ISDIR(osb.st_mode))
+        if (!S_ISDIR(osb.st_mode) && a.havedepthsearch)
         {
-            if (a.havedepthsearch)
-            {
-                /* TODO: PROMISE_RESULT_DENIED */
-                Log(LOG_LEVEL_DEBUG,
-                    "depth_search (recursion) is promised for a base object '%s' that is not a directory",
-                    path);
-                goto exit;
-            }
+            Log(LOG_LEVEL_WARNING,
+                "depth_search (recursion) is promised for a base object '%s' that is not a directory",
+                path);
         }
 
         exists = true;


### PR DESCRIPTION
So that policy using depth_search with a promiser that is a file
simply handles the file itself. A warning is issued, though.

Ticket: ENT-8996
Changelog: depth_search acting on a non-directory promiser now
           handles such file as if the promise didn't use
           depth_search issuing a warning