### PR TITLE
Adjusted local settings in masterfiles stage common script to handle more cases (3.18)

### DIFF
--- a/contrib/masterfiles-stage/common.sh
+++ b/contrib/masterfiles-stage/common.sh
@@ -190,7 +190,16 @@ git_cfbs_deploy_refspec() {
   #    (See long comment at end of function def.)
 
   # The chipmunk in cfbs output breaks things without this or similar
-  export LC_ALL=en_US.utf-8
+  # The chipmunk in cfbs output breaks things without this or similar
+  if [ -f "/etc/locale.conf" ]; then
+    source "/etc/locale.conf"
+    export LC_ALL="$LANG" # retrieved from locale.conf
+  else
+    _LOCALE=$(locale -a | grep -i utf | head -1)
+    if [ -n "$_LOCALE" ]; then
+      export LC_ALL="$_LOCALE"
+    fi
+  fi
 
   # Ensure absolute pathname is given
   [ "${1:0:1}" = / ] ||


### PR DESCRIPTION
On Debian-9 and possibly other older or minimal systems en-US.utf-8 may not be a locale which is available.

In any case, default to the first utf locale found via `locale -a` which seems to include something general first regardless.

Ticket: ENT-11885
Changelog: title
(cherry picked from commit b99fa9a7f10b77ce31bf738b9de8883b64ff2dfc)
