### PR TITLE
Enable test for trailing newline on insert_tree promisers

### DIFF
--- a/tests/acceptance/10_files/11_xml_edits/CFE-3806.cf
+++ b/tests/acceptance/10_files/11_xml_edits/CFE-3806.cf
@@ -29,10 +29,6 @@ bundle agent test
       "description" -> { "CFE-3806" }
         string => "Test that trailing newline on insert_tree promisers do not remove ending tag for select_xpath";
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "CFE-3860" };
-
   files:
 
       "$(G.testfile)-1.xml"


### PR DESCRIPTION
libxml2-2.13.1 seems to be fixing this.

Ticket: CFE-3806
Changelog: Trailing newline on insert_tree promisers no longer removes ending tag for select_xpath

Merge together:
https://github.com/cfengine/buildscripts/pull/1471
https://github.com/cfengine/core/pull/5556