### PR TITLE
Added capture of masterfiles-stage log dc-scripts.log to cf-support

### DIFF
--- a/misc/cf-support
+++ b/misc/cf-support
@@ -381,6 +381,7 @@ fi
 echo "Captured output of $syslog_cmd filtered for cf-|CFEngine"
 
 gzip_add $WORKDIR/outputs/previous
+gzip_add $WORKDIR/outputs/dc-scripts.log # masterfiles-stage log
 file_add $WORKDIR/policy_server.dat
 
 if [ -f $WORKDIR/share/cf-support-nova-hub.sh ]; then


### PR DESCRIPTION
If something goes wrong with masterfiles-stage then /var/cfengine/outputs/dc-scripts.log will contain additional details about what happened.

This is a cumulative log so compress it.

Ticket: none
Changelog: none