### PR TITLE
ENT-11900: Fixed packagesmatching() function segfaulting on Windows platform (3.21)

### DIFF
--- a/libpromises/dbm_api.c
+++ b/libpromises/dbm_api.c
@@ -170,7 +170,15 @@ char *DBIdToSubPath(dbid id, const char *subdb_name)
 
 Seq *SearchExistingSubDBNames(const dbid id)
 {
+    // On Windows, GetStateDir() used in DBIdToSubPath() has backslashes
+    // GlobFileList() won't work with backslashes in 3.21.x so workaround this issue
+#ifdef _WIN32
+    char *const broken_pattern = DBIdToSubPath(id, "*");
+    char *const glob_pattern = SearchAndReplace(broken_pattern, "\\", "/");
+    free(broken_pattern);
+#else
     char *const glob_pattern = DBIdToSubPath(id, "*");
+#endif
     StringSet *const db_paths = GlobFileList(glob_pattern);
     free(glob_pattern);
 


### PR DESCRIPTION
The packagesmatching() function searches for lmdb databases with GlobFileList() which is known to segfault on absolute paths on Windows with backslashes.

The fix is only needed in 3.21.x because changes in master core+libntech improve the situation in a more thorough way.

Ticket: ENT-11900
Changelog: title

together:
https://github.com/cfengine/core/pull/5558
https://github.com/cfengine/enterprise/pull/802
