### PR TITLE
ENT-11923: Fixed bug in double expansion of foreign list variables with namespaces (3.21.x)

### DIFF
--- a/tests/acceptance/01_vars/01_basic/double_expansion_list_namespace.cf
+++ b/tests/acceptance/01_vars/01_basic/double_expansion_list_namespace.cf
@@ -1,0 +1,65 @@
+##############################################################################
+#
+# Test double expansion of list from remote bundle with namespace (ENT-11923)
+#
+##############################################################################
+
+body common control
+{
+  bundlesequence => { "bogus:check" };
+}
+
+bundle agent test(parent_namespace, parent_bundle)
+{
+  meta:
+    "description" -> { "ENT-11923" }
+      string => "Test double expension of list from remote bundle with namespace";
+
+  reports:
+    "$($(parent_namespace):$(parent_bundle).str)"
+      comment => "Double expansion of remote string works prior to fix",
+      bundle_return_value_index => "foo";
+
+    "$($(parent_namespace):$(parent_bundle).lst)"
+      comment => "But double expansion of remote list does not work prior to fix",
+      bundle_return_value_index => "bar";
+
+    "$(bogus:check.lst)"
+      comment => "Single expansion of remote list works prior to fix",
+      bundle_return_value_index => "baz";
+}
+
+body file control
+{
+  namespace => "bogus";
+}
+
+bundle agent check
+{
+  vars:
+    "str"
+      string => "EXPANDED";
+    "lst"
+      slist => { "EXPANDED" };
+
+  methods:
+    "holder"
+      usebundle => default:test("$(this.namespace)", "$(this.bundle)"),
+      useresult => "ret";
+
+  reports:
+      "$(this.promise_filename) Pass"
+        if => and(strcmp("$(ret[foo])", "EXPANDED"),
+                  strcmp("$(ret[bar])", "EXPANDED"),
+                  strcmp("$(ret[baz])", "EXPANDED"));
+
+      "$(this.promise_filename) FAIL"
+        unless => and(strcmp("$(ret[foo])", "EXPANDED"),
+                      strcmp("$(ret[bar])", "EXPANDED"),
+                      strcmp("$(ret[baz])", "EXPANDED"));
+
+    default:DEBUG::
+      "$(const.dollar)($(const.dollar)(parent_namespace):$(const.dollar)(parent_bundle).str) => $(ret[foo])";
+      "$(const.dollar)($(const.dollar)(parent_namespace):$(const.dollar)(parent_bundle).lst) => $(ret[bar])";
+      "$(const.dollar)(default:check.lst)                        => $(ret[baz])";
+}


### PR DESCRIPTION
Prior to fix, the added acceptance test had the following output:

```
R: /home/larsewi/ntech/cfengine/core/tests/acceptance/01_vars/01_basic/double_expansion_list_namespace.cf FAIL
R: $($(parent_namespace):$(parent_bundle).str) => EXPANDED
R: $($(parent_namespace):$(parent_bundle).lst) => $(bogus:check.lst)
R: $(default:check.lst)                        => EXPANDED
```

Ticket: ENT-11923
Changelog: Title
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 5e8ccbd6831e346b4242816df6ef90a762928975)

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=11041)](https://ci.cfengine.com/job/pr-pipeline/11041/)

Back-ported from https://github.com/cfengine/core/pull/5564