### PR TITLE
Fixed some typos related fixes for ENT-9491 & ENT-11923 (3.21.x)

### DIFF
--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -795,8 +795,8 @@ static Seq *IterableToSeq(const void *v, DataType t)
  * #varname, where the left side of #varname is a bundle name and the right side
  * of #iterctx->pp->promiser begins with the right side of #varname. If all of
  * the constraints are fulfilled it swaps the '.' with '#' in both variables.
- * Furthermore, if the variable also contains a scope, it will mangle ':' with
- * '*'.
+ * Furthermore, if the variable also contains a namespace, it will mangle ':'
+ * with '*'.
  *
  * See ticket ENT-9491 & ENT-11923 for more info.
  */

--- a/tests/acceptance/01_vars/01_basic/double_expansion_list.cf
+++ b/tests/acceptance/01_vars/01_basic/double_expansion_list.cf
@@ -13,7 +13,7 @@ bundle agent test(parent_bundle)
 {
   meta:
     "description" -> { "ENT-9491", "CFE-1644" }
-      string => "Test double expension of list from remote bundle";
+      string => "Test double expansion of list from remote bundle";
 
   reports:
     "$($(parent_bundle).str)"

--- a/tests/acceptance/01_vars/01_basic/double_expansion_list_namespace.cf
+++ b/tests/acceptance/01_vars/01_basic/double_expansion_list_namespace.cf
@@ -13,7 +13,7 @@ bundle agent test(parent_namespace, parent_bundle)
 {
   meta:
     "description" -> { "ENT-11923" }
-      string => "Test double expension of list from remote bundle with namespace";
+      string => "Test double expansion of list from remote bundle with namespace";
 
   reports:
     "$($(parent_namespace):$(parent_bundle).str)"


### PR DESCRIPTION
(cherry picked from commit 7016c253863269c163f397c75ac309994da004cd)

Back-ported from https://github.com/cfengine/core/pull/5566
