### PR TITLE
CFE-4408: Fixed package promises with only promisers and no other attributes (3.21)

### DIFF
--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -208,7 +208,7 @@ PromiseResult VerifyPackagesPromise(EvalContext *ctx, const Promise *pp)
             break;
         case PACKAGE_PROMISE_TYPE_NEW_ERROR:
             cfPS_HELPER_0ARG(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, &a,
-                         "v1 package promise (package_method) failed sanity check.");
+                         "v2 package promise (package_method) failed sanity check.");
             break;
         case PACKAGE_PROMISE_TYPE_OLD_ERROR:
             cfPS_HELPER_0ARG(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, &a,

--- a/tests/acceptance/07_packages/default_package_module.cf
+++ b/tests/acceptance/07_packages/default_package_module.cf
@@ -1,0 +1,48 @@
+# Based on 07_package/package_module_path.cf
+
+body common control
+{
+    inputs => { "../default.cf.sub" };
+    bundlesequence => { default("$(this.promise_filename)") };
+    package_module => test_module; # important! part of this specific test
+}
+
+bundle agent init
+{
+  files:
+      "$(sys.workdir)/modules/packages/."
+        create => "true";
+      "$(sys.workdir)/modules/packages/test_module_script.sh"
+        copy_from => local_cp("$(this.promise_filename).module"),
+        perms => m("ugo+x");
+}
+
+body package_module test_module
+{
+    query_installed_ifelapsed => "60";
+    query_updates_ifelapsed => "14400";
+    default_options => { "$(G.testfile)" };
+    module_path => "$(sys.workdir)/modules/packages/test_module_script.sh";
+}
+
+bundle agent test
+{
+  meta:
+      "description"
+        string => "Test that a package with no attributes uses a configured common control package_module",
+        meta => { "CFE-4408" };
+      "test_soft_fail" string => "windows",
+        meta => { "ENT-10217" };
+
+  packages:
+      "first_pkg";
+      "second_pkg";
+}
+
+bundle agent check
+{
+  methods:
+      "any" usebundle => dcs_check_diff($(G.testfile),
+                                        "$(this.promise_filename).expected",
+                                        $(this.promise_filename));
+}

--- a/tests/acceptance/07_packages/default_package_module.cf.expected
+++ b/tests/acceptance/07_packages/default_package_module.cf.expected
@@ -1,0 +1,6 @@
+Name=first_pkg
+Version=1.0
+Architecture=generic
+Name=second_pkg
+Version=1.0
+Architecture=generic

--- a/tests/acceptance/07_packages/default_package_module.cf.module
+++ b/tests/acceptance/07_packages/default_package_module.cf.module
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+set -e
+
+remove_prefix()
+{
+    echo "$1" | sed "s/$2//"
+}
+
+case "$1" in
+    supports-api-version)
+        echo 1
+        ;;
+    get-package-data)
+        while read line; do
+            case "$line" in
+                File=*)
+                    echo PackageType=repo
+                    echo Name=`remove_prefix "${line}" "File="`
+                    ;;
+                *)
+                    true
+                    ;;
+            esac
+        done
+        ;;
+    list-installed)
+        while read line; do
+            case "$line" in
+                options=*)
+                    OUTPUT=`remove_prefix "${line}" "options="`
+                    ;;
+                *)
+                    exit 1
+                    ;;
+            esac
+        done
+        if [ -f "$OUTPUT" ]; then
+            cat "$OUTPUT"
+        fi
+        ;;
+    list-*)
+        # Drain input.
+        cat > /dev/null
+        ;;
+    repo-install)
+        while read line; do
+            case "$line" in
+                options=*)
+                    OUTPUT=`remove_prefix "${line}" "options="`
+                    ;;
+                Name=*)
+                    NAME=`remove_prefix "${line}" "Name="`
+                    ;;
+                *)
+                    exit 1
+                    ;;
+            esac
+        done
+        echo "Name=$NAME" >> "$OUTPUT"
+        echo "Version=1.0" >> "$OUTPUT"
+        echo "Architecture=generic" >> "$OUTPUT"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
CFE-4315 introduced a behavior change so that in the case of a simple package promise with only a promiser:

packages:
  "ed";

Things would just work in the case where there was no default package manager defined with package_module_knowledge.platform_default.

In the case where package_module_knowledge.platform_default was defined this simple case would cause errors.

This change fixes this second case as well as improves logging around the choosing of v1 and v2 package promise implementations.

Some of these changes fix CFE-4398 which noted that too many INFO level messages were produced. These messages are moved to DEBUG and VERBOSE level as appropriate.

Also added "packages" promises to list of exceptions so that a bare promiser-only package promise does not cause warnings.

Ticket: CFE-4408
Changelog: title
(cherry picked from commit 8961a77d292b7fd02f3675fd890c5e87d3a41382)

 Conflicts:
	libpromises/cf3parse_logic.h

3.21.x did not have ParserCheckPromiseLine()
