### PR TITLE
WIP: CFE-4401: Adjusted use of pthreads for Android/Termux platform

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,7 @@ fi
 
 dnl ######################################################################
 dnl Use pthreads if available
+AC_CHECK_FUNCS([pthread_cancel])
 dnl ######################################################################
 
 AC_ARG_WITH([pthreads],

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -8668,7 +8668,11 @@ static FnCallResult FnCallIsReadable(ARG_UNUSED EvalContext *const ctx,
                 "Read operation timed out, exceeded %ld seconds.", path,
                 timeout);
 
+#ifdef HAVE_PTHREAD_CANCEL
             ret = pthread_cancel(thread_data.thread);
+#else
+            ret = pthread_kill(thread_data.thread, 0);
+#endif
             if (ret != 0)
             {
                 Log(LOG_LEVEL_ERR, "Failed to cancel thread");
@@ -8700,10 +8704,12 @@ static FnCallResult FnCallIsReadable(ARG_UNUSED EvalContext *const ctx,
         return FnFailure();
     }
 
+#ifdef HAVE_PTHREAD_CANCEL
     if (status == PTHREAD_CANCELED)
     {
         Log(LOG_LEVEL_DEBUG, "Thread was canceled");
     }
+#endif
 
     return result;
 }


### PR DESCRIPTION
Android/Termux doesn't have pthread_cancel so use pthred_kill instead

Ticket: CFE-4401
Changelog: title