### PR TITLE
Fix early git revision comparison in masterfiles-stage.sh

### DIFF
--- a/contrib/masterfiles-stage/common.sh
+++ b/contrib/masterfiles-stage/common.sh
@@ -94,6 +94,10 @@ git_deploy_refspec() {
   mkdir -p "$(dirname "$1")" || error_exit "Failed to mkdir -p dirname $1"
     # We don't mkdir $1 directly, just its parent dir if that doesn't exist.
 
+  if git_check_is_in_sync "${local_mirrored_repo}" "$1" "$2"; then
+    return 0
+  fi
+
   ########################## 1. CREATE EMPTY TEMP DIR
   # Put staging dir right next to deploy dir to ensure it's on same filesystem
   local temp_stage
@@ -111,10 +115,6 @@ git_deploy_refspec() {
   # Grab HEAD so it can be used to populate cf_promises_release_id
   mkdir -p "${temp_stage}/.git"
   cp "${local_mirrored_repo}/HEAD" "${temp_stage}/.git/"
-
-  if git_check_is_in_sync "${local_mirrored_repo}" "${temp_stage}" "$2"; then
-    return 0
-  fi
 
   ########################## 3. SET PERMISSIONS ON POLICY SET
   chown -R root:root "${temp_stage}" || error_exit "Unable to chown '${temp_stage}'"
@@ -211,6 +211,10 @@ git_cfbs_deploy_refspec() {
   mkdir -p "$(dirname "$1")" || error_exit "Failed to mkdir -p dirname $1"
     # We don't mkdir $1 directly, just its parent dir if that doesn't exist.
 
+  if git_check_is_in_sync "${local_mirrored_repo}" "$1" "$2"; then
+    return 0
+  fi
+
   ########################## 1. CREATE EMPTY TEMP DIR
   # Put staging dir right next to deploy dir to ensure it's on same filesystem
   local temp_stage
@@ -237,10 +241,6 @@ git_cfbs_deploy_refspec() {
   # Grab HEAD so it can be used to populate cf_promises_release_id
   mkdir -p "${temp_stage}/out/masterfiles/.git"
   cp "${local_mirrored_repo}/HEAD" "${temp_stage}/out/masterfiles/.git/"
-
-  if git_check_is_in_sync "${local_mirrored_repo}" "${temp_stage}/out/masterfiles" "$2"; then
-    return 0
-  fi
 
   ########################## 3. SET PERMISSIONS ON POLICY SET
   chown -R root:root "${temp_stage}" || error_exit "Unable to chown '${temp_stage}'"


### PR DESCRIPTION
We need to compare the revision in the mirror against the target deploy directory, not the temporary checkout from the mirror. And we can do this earlier in the process.

Ticket: ENT-11970
Changelog: None

Merge together:
https://github.com/cfengine/core/pull/5579
https://github.com/cfengine/nova/pull/2284