### PR TITLE
Fixed failure to install cf-remote

### DIFF
--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: install cf-remote
-        run: pip install cf-remote
+        run: pip install cf-remote --break-system-packages
 
       # Note that msiexec can't install packages when running under msys;
       # But cf-remote currently can't run under powershell


### PR DESCRIPTION
```
error: externally-managed-environment
```

Since this is a container, it should be OK to potentially break system
packages.

Ticket: None
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
