### PR TITLE
[3.24.x] Log errors for commands promises with exit codes not matching any _returncodes

### DIFF
--- a/cf-agent/retcode.c
+++ b/cf-agent/retcode.c
@@ -86,7 +86,7 @@ bool VerifyCommandRetcode(EvalContext *ctx, int retcode, const Attributes *a, co
 
         if (!matched)
         {
-            cfPS(ctx, info_or_verbose, PROMISE_RESULT_FAIL, pp, a,
+            cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a,
                  "Command related to promiser '%s' returned code '%d' not defined as promise kept, not kept or repaired; setting to failed",
                  pp->promiser, retcode);
             *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);


### PR DESCRIPTION
They are marked as failed with the following message:

  Command related to promiser '...' returned code '1' not defined as promise kept, not kept or repaired; setting to failed

Failed promises should log errors not just info
messages. Otherwise running without `--info` or more detailed logging fails silently.

Ticket: CFE-4429
Ticket: ENT-12103
Changelog: commands promises with exit codes not matching any
           _returncodes attributes from classes body now log and
           error message not just an info message
(cherry picked from commit 41214f7b5de59729d8c723a4976c67d1dde5d48c)