### PR TITLE
Enable test for trailing newline on insert_tree promisers (3.21)

### DIFF
--- a/tests/acceptance/10_files/11_xml_edits/CFE-3806.cf
+++ b/tests/acceptance/10_files/11_xml_edits/CFE-3806.cf
@@ -29,10 +29,6 @@ bundle agent test
       "description" -> { "CFE-3806" }
         string => "Test that trailing newline on insert_tree promisers do not remove ending tag for select_xpath";
 
-      "test_soft_fail"
-        string => "any",
-        meta => { "CFE-3860" };
-
   files:
 
       "$(G.testfile)-1.xml"


### PR DESCRIPTION
libxml2-2.13.1 seems to be fixing this.

Ticket: CFE-3806
Changelog: Trailing newline on insert_tree promisers no longer removes ending tag for select_xpath
(cherry picked from commit cea0100fbac7a193c586c8b44b3b26df2d8187d1)
