### PR TITLE
Added logging CFEngine component related SELinux denials in cf-support (3.21)

### DIFF
--- a/misc/cf-support
+++ b/misc/cf-support
@@ -378,6 +378,11 @@ else
 fi
 echo "Captured output of $syslog_cmd filtered for cf-|CFEngine"
 
+# cf- component related SELinux denials
+if command -v ausearch >/dev/null; then
+  ausearch -m avc -su cfengine > "$tmpdir"/ausearch-cfengine-avcs.log
+fi
+
 gzip_add $WORKDIR/outputs/previous
 file_add $WORKDIR/policy_server.dat
 


### PR DESCRIPTION
Ticket: ENT-12137
Changelog: title
(cherry picked from commit ea77c55bbf419b7862d68b361ef54da83779d480)
