### PR TITLE
tests/static: Install extra tools in build image

### DIFF
--- a/tests/static-check/run.sh
+++ b/tests/static-check/run.sh
@@ -16,7 +16,7 @@ fi
 
 function create_image() {
   local c=$(buildah from -q $BASE_IMG)
-  buildah run $c -- dnf -q -y install "@C Development Tools and Libraries" clang cppcheck which >/dev/null 2>&1
+  buildah run $c -- dnf -q -y install "@C Development Tools and Libraries" clang cppcheck which diffutils file >/dev/null 2>&1
   buildah run $c -- dnf -q -y install pcre-devel pcre2-devel openssl-devel libxml2-devel pam-devel lmdb-devel libacl-devel libyaml-devel curl-devel libvirt-devel >/dev/null 2>&1
   buildah run $c -- dnf clean all >/dev/null 2>&1
   buildah commit $c cfengine-static-checker-f$STATIC_CHECKS_FEDORA_VERSION >/dev/null 2>&1


### PR DESCRIPTION
Install extra tools in build image to get rid of errors in GH workflow

./configure: line 8045: cmp: command not found
./configure: line 8224: /usr/bin/file: No such file or directory
./configure: line 9811: diff: command not found