### PR TITLE
Suppressed possible null pointer dereference

### DIFF
--- a/tests/static-check/cppcheck_suppressions.txt
+++ b/tests/static-check/cppcheck_suppressions.txt
@@ -27,3 +27,6 @@ returnDanglingLifetime:libpromises/enterprise_stubs.c:153
 returnDanglingLifetime:libpromises/enterprise_stubs.c:159
 returnDanglingLifetime:libpromises/enterprise_stubs.c:165
 returnDanglingLifetime:libpromises/enterprise_stubs.c:172
+
+// generated file not in our control
+nullPointer:libpromises/cf3lex.c


### PR DESCRIPTION
Suppressed possible null pointer dereference static check warning in generated file cf3lex.c. This file is generated by bison, and is not really in our control.
