### PR TITLE
Workaround cppcheck ignoring `-i libpromises/cf3lex.c`

### DIFF
--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -21,6 +21,8 @@ function check_with_clang() {
 
 function check_with_cppcheck() {
   rm -f config.cache
+  make clean
+  make -C libpromises/ bootstrap.inc # needed by libpromises/bootstrap.c
   ./configure -C --enable-debug
 
   # cppcheck options:


### PR DESCRIPTION
When running cppcheck in static checks, we use `-i libpromises/cf3lex.c` in order to make cppcheck ignore the generated cf3lex.c file. However, the new version of cppcheck ignores this option and fails on issues found in the file.

However, we don't want this file or any other generated files except for bootstrap.inc which contains the bootstrap policy. So we can run `make clean` and `make -C libpromise/ boostrap.inc` before running cppcheck to get a cleaner environment.