### PR TITLE
ENT-11840: Also ignore IPv6 interface info

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -721,6 +721,11 @@ static void FindV6InterfacesInfo(EvalContext *ctx, Rlist **interfaces, Rlist **h
             }
         }
 
+        if (IgnoreInterface(current_interface))
+        {
+            // Ignore interfaces listed in ignore_interfaces.rx
+            continue;
+        }
 
         const char *const stripped_ifconfig_line =
             TrimWhitespace(ifconfig_line);


### PR DESCRIPTION
Agent now also ignores interfaces listed in `ignore_interfaces.rx` when
looking for IPv6 interface info. Variables such as
`default:sys.hardware_mac[<INTERFACE>]` will no longer be defined for
ignored interfaces.
