### PR TITLE
ENT-11988: Atomic copy_from in files promise (3.21.x)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
         
       - name: Install dependencies (C)
         if: ${{ matrix.language == 'cpp' }}
-        run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl
+        run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl libpcre3-dev
 
       - name: Build (C)
         if: ${{ matrix.language == 'cpp' }}

--- a/.github/workflows/job-static-check.yml
+++ b/.github/workflows/job-static-check.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Prepare Environment
       run: |
         sudo apt-get update && \
-        sudo apt-get install -y dpkg-dev debhelper g++ libncurses5 pkg-config \
+        sudo apt-get install -y dpkg-dev debhelper g++ libncurses6 pkg-config \
           build-essential libpam0g-dev fakeroot gcc make autoconf buildah \
           liblmdb-dev libacl1-dev libcurl4-openssl-dev libyaml-dev libxml2-dev \
           libssl-dev libpcre3-dev

--- a/.github/workflows/windows_acceptance_tests.yml
+++ b/.github/workflows/windows_acceptance_tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: install cf-remote
-        run: pip install cf-remote
+        run: pip install cf-remote --break-system-packages
 
       # Note that msiexec can't install packages when running under msys;
       # But cf-remote currently can't run under powershell

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -1552,7 +1552,7 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, con
         }
 
         if (!CopyRegularFileNet(source, ToChangesPath(new),
-                                sstat->st_size, attr->copy.encrypt, conn))
+                                sstat->st_size, attr->copy.encrypt, conn, sstat->st_mode))
         {
             RecordFailure(ctx, pp, attr, "Failed to copy file '%s' from '%s'",
                           source, conn->remoteip);
@@ -1712,7 +1712,7 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, con
                 }
             }
 
-            if (rename(dest, changes_backup) == 0)
+            if (CopyRegularFileDisk(dest, changes_backup))
             {
                 RecordChange(ctx, pp, attr, "Backed up '%s' as '%s'", dest, backup);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_CHANGE);

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -751,7 +751,7 @@ static void FlushFileStream(int sd, int toget)
 /* TODO finalise socket or TLS session in all cases that this function fails
  * and the transaction protocol is out of sync. */
 bool CopyRegularFileNet(const char *source, const char *dest, off_t size,
-                        bool encrypt, AgentConnection *conn)
+                        bool encrypt, AgentConnection *conn, mode_t mode)
 {
     char *buf, workbuf[CF_BUFSIZE], cfchangedstr[265];
     const int buf_size = 2048;
@@ -775,7 +775,7 @@ bool CopyRegularFileNet(const char *source, const char *dest, off_t size,
 
     unlink(dest);                /* To avoid link attacks */
 
-    int dd = safe_open_create_perms(dest, O_WRONLY | O_CREAT | O_TRUNC | O_EXCL | O_BINARY, CF_PERMS_DEFAULT);
+    int dd = safe_open_create_perms(dest, O_WRONLY | O_CREAT | O_TRUNC | O_EXCL | O_BINARY, mode);
     if (dd == -1)
     {
         Log(LOG_LEVEL_ERR,

--- a/libcfnet/client_code.h
+++ b/libcfnet/client_code.h
@@ -48,7 +48,7 @@ void DisconnectServer(AgentConnection *conn);
 
 bool CompareHashNet(const char *file1, const char *file2, bool encrypt, AgentConnection *conn);
 bool CopyRegularFileNet(const char *source, const char *dest, off_t size,
-                        bool encrypt, AgentConnection *conn);
+                        bool encrypt, AgentConnection *conn, mode_t mode);
 Item *RemoteDirList(const char *dirname, bool encrypt, AgentConnection *conn);
 
 int TLSConnectCallCollect(ConnectionInfo *conn_info, const char *username);

--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -21,6 +21,8 @@ function check_with_clang() {
 
 function check_with_cppcheck() {
   rm -f config.cache
+  make clean
+  make -C libpromises/ bootstrap.inc # needed by libpromises/bootstrap.c
   ./configure -C --enable-debug
 
   # cppcheck options:


### PR DESCRIPTION
Changes to `files` promise in `copy_from` attribute:

- The new file (i.e., `<FILENAME>.cfnew`) is now created with correct
  permission during remote copy. Previously it would be created with
  default permissions.
- The destination file (i.e., `<FILENAME>`) is no longer deleted on
  backup during file copy.  Previously it would be renamed to
  `<FILENAME>.cfsaved`, causing the original file to dissappear. Now an
  actual copy of the original file with the same permissions is created
  instead.

As a result, there will no longer be a brief moment where the original
file is inaccessible.

Back-ported from https://github.com/cfengine/core/pull/5611/
