### PR TITLE
ENT-11838: Fixed perpetual warnings that a deleted host has checked in

### DIFF
--- a/cf-check/db_structs.h
+++ b/cf-check/db_structs.h
@@ -17,6 +17,7 @@
 // Struct used for quality entries in /var/cfengine/state/cf_lastseen.lmdb:
 typedef struct
 {
+    bool acknowledged;
     time_t lastseen;
     QPoint Q;
 } KeyHostSeen; // Keep in sync with lastseen.h

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -107,6 +107,7 @@ static void print_struct_lastseen_quality(
         memcpy(&quality, value.mv_data, sizeof(quality));
         const time_t lastseen = quality.lastseen;
         const QPoint Q = quality.Q;
+        bool acknowledged = quality.acknowledged;
 
         JsonElement *q_json = JsonObjectCreate(4);
         JsonObjectAppendReal(q_json, "q", Q.q);
@@ -115,6 +116,7 @@ static void print_struct_lastseen_quality(
         JsonObjectAppendReal(q_json, "dq", Q.dq);
 
         JsonElement *top_json = JsonObjectCreate(2);
+        JsonObjectAppendBool(top_json, "acknowledged", acknowledged);
         JsonObjectAppendInteger(top_json, "lastseen", lastseen);
         JsonObjectAppendObject(top_json, "Q", q_json);
 

--- a/libpromises/dbm_lmdb.c
+++ b/libpromises/dbm_lmdb.c
@@ -69,6 +69,7 @@ struct DBCursorPriv_
     MDB_cursor *mc;
     MDB_val delkey;
     void *curkv;
+    size_t curks;
     bool pending_delete;
 };
 
@@ -1290,6 +1291,7 @@ bool DBPrivAdvanceCursor(
         }
         cursor->curkv = xmalloc(keybuf_size + data.mv_size);
         memcpy(cursor->curkv, mkey.mv_data, mkey.mv_size);
+        cursor->curks = mkey.mv_size;
         *key = cursor->curkv;
         *key_size = mkey.mv_size;
         *value_size = data.mv_size;
@@ -1355,7 +1357,7 @@ bool DBPrivWriteCursorEntry(
     {
         MDB_val curkey;
         curkey.mv_data = cursor->curkv;
-        curkey.mv_size = sizeof(cursor->curkv);
+        curkey.mv_size = cursor->curks;
 
         rc = mdb_cursor_put(cursor->mc, &curkey, &data, MDB_CURRENT);
         CheckLMDBUsable(rc, cursor->db->env);

--- a/libpromises/dbm_migration.c
+++ b/libpromises/dbm_migration.c
@@ -30,7 +30,7 @@
 extern const DBMigrationFunction dbm_migration_plan_lastseen[];
 
 
-#ifdef LMDB
+#ifndef LMDB
 bool DBMigrate(ARG_UNUSED DBHandle *db, ARG_UNUSED  dbid id)
 {
     return true;

--- a/libpromises/dbm_migration.c
+++ b/libpromises/dbm_migration.c
@@ -26,6 +26,7 @@
 
 #include <lastseen.h>
 #include <string_lib.h>
+#include <backup.h>
 
 extern const DBMigrationFunction dbm_migration_plan_lastseen[];
 
@@ -64,6 +65,11 @@ bool DBMigrate(DBHandle *db, dbid id)
         {
             if (step_version == DBVersion(db))
             {
+                Seq *seq = SeqNew(1, free);
+                SeqAppend(seq, DBIdToPath(id));
+                backup_files_copy(seq);
+                SeqDestroy(seq);
+
                 if (!(*step)(db))
                 {
                     return false;

--- a/libpromises/dbm_migration_lastseen.c
+++ b/libpromises/dbm_migration_lastseen.c
@@ -48,138 +48,19 @@ typedef struct
 
 static bool LastseenMigrationVersion0(DBHandle *db)
 {
-    bool errors = false;
-    DBCursor *cursor;
-
-    if (!NewDBCursor(db, &cursor))
-    {
-        return false;
-    }
-
-    char *key;
-    void *value;
-    int ksize, vsize;
-
-    while (NextDB(cursor, &key, &ksize, &value, &vsize))
-    {
-        if (ksize == 0)
-        {
-            Log(LOG_LEVEL_INFO, "LastseenMigrationVersion0: Database structure error -- zero-length key.");
-            continue;
-        }
-
-        /* Only look for old [+-]kH -> IP<QPoint> entries */
-        if ((key[0] != '+') && (key[0] != '-'))
-        {
-            /* Warn about completely unexpected keys */
-
-            if ((key[0] != 'q') && (key[0] != 'k') && (key[0] != 'a'))
-            {
-                Log(LOG_LEVEL_INFO, "LastseenMigrationVersion0: Malformed key found '%s'", key);
-            }
-
-            continue;
-        }
-
-        bool incoming = key[0] == '-';
-        const char *hostkey = key + 1;
-
-        /* Only migrate sane data */
-        if (vsize != QPOINT0_OFFSET + sizeof(QPoint0))
-        {
-            Log(LOG_LEVEL_INFO,
-                "LastseenMigrationVersion0: invalid value size for key '%s', entry is deleted",
-                key);
-            DBCursorDeleteEntry(cursor);
-            continue;
-        }
-
-        /* Properly align the data */
-        const char *old_data_address = (const char *) value;
-        QPoint0 old_data_q;
-        memcpy(&old_data_q, (const char *) value + QPOINT0_OFFSET,
-               sizeof(QPoint0));
-
-        char hostkey_key[CF_BUFSIZE];
-        snprintf(hostkey_key, CF_BUFSIZE, "k%s", hostkey);
-
-        if (!WriteDB(db, hostkey_key, old_data_address, strlen(old_data_address) + 1))
-        {
-            Log(LOG_LEVEL_INFO, "Unable to write version 1 lastseen entry for '%s'", key);
-            errors = true;
-            continue;
-        }
-
-        char address_key[CF_BUFSIZE];
-        snprintf(address_key, CF_BUFSIZE, "a%s", old_data_address);
-
-        if (!WriteDB(db, address_key, hostkey, strlen(hostkey) + 1))
-        {
-            Log(LOG_LEVEL_INFO, "Unable to write version 1 reverse lastseen entry for '%s'", key);
-            errors = true;
-            continue;
-        }
-
-        char quality_key[CF_BUFSIZE];
-        snprintf(quality_key, CF_BUFSIZE, "q%c%s", incoming ? 'i' : 'o', hostkey);
-
-        /*
-           Ignore malformed connection quality data
-        */
-
-        if ((!isfinite(old_data_q.q))
-            || (old_data_q.q < 0)
-            || (!isfinite(old_data_q.expect))
-            || (!isfinite(old_data_q.var)))
-        {
-            Log(LOG_LEVEL_INFO, "Ignoring malformed connection quality data for '%s'", key);
-            DBCursorDeleteEntry(cursor);
-            continue;
-        }
-
-        KeyHostSeen data = {
-            .lastseen = (time_t)old_data_q.q,
-            .Q = {
-                /*
-                   Previously .q wasn't stored in database, but was calculated
-                   every time as a difference between previous timestamp and a
-                   new timestamp. Given we don't have this information during
-                   the database upgrade, just assume that last reading is an
-                   average one.
-                */
-                .q = old_data_q.expect,
-                .dq = 0,
-                .expect = old_data_q.expect,
-                .var = old_data_q.var,
-            }
-        };
-
-        if (!WriteDB(db, quality_key, &data, sizeof(data)))
-        {
-            Log(LOG_LEVEL_INFO, "Unable to write version 1 connection quality key for '%s'", key);
-            errors = true;
-            continue;
-        }
-
-        if (!DBCursorDeleteEntry(cursor))
-        {
-            Log(LOG_LEVEL_INFO, "Unable to delete version 0 lastseen entry for '%s'", key);
-            errors = true;
-        }
-    }
-
-    if (DeleteDBCursor(cursor) == false)
-    {
-        Log(LOG_LEVEL_ERR, "LastseenMigrationVersion0: Unable to close cursor");
-        errors = true;
-    }
-
-    if ((!errors) && (!WriteDB(db, "version", "1", sizeof("1"))))
-    {
-        errors = true;
-    }
-
-    return !errors;
+    /* For some reason DB migration for LMDB was disabled in 2014 (in commit
+     * 8611970bfa33be7b3cf0724eb684833e08582850). Unfortunately there is no
+     * mention as to why this was done. Maybe it was not working?
+     *
+     * However, we're re-enabling it now (10 years later). Since this
+     * migration function has not been active for the last 10 years, the
+     * safest thing is to remove the migration logic, and only update the
+     * version number.
+     *
+     * If you have not upgraded CFEngine in the last 10 years, this will be
+     * the least of your problems.
+     */
+    return WriteDB(db, "version", "1", sizeof("1"));
 }
 
 const DBMigrationFunction dbm_migration_plan_lastseen[] =

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -766,3 +766,54 @@ int RemoveKeysFromLastSeen(const char *input, bool must_be_coherent,
 
     return 0;
 }
+
+static bool OnlyRewriteIfChanged(KeyHostSeen *entry, ARG_UNUSED size_t size, KeyHostSeen *new)
+{
+    assert(entry != NULL);
+    assert(new != NULL);
+
+    if (entry->acknowledged)
+    {
+        return false;
+    }
+
+    new->acknowledged = true;
+    new->lastseen = entry->lastseen;
+    new->Q = entry->Q;
+
+    return true;
+}
+
+bool LastSeenHostAcknowledge(const char *host_key, bool incoming)
+{
+    DBHandle *db = NULL;
+    if (!OpenDB(&db, dbid_lastseen))
+    {
+        Log(LOG_LEVEL_ERR, "Unable to open lastseen DB");
+        return false;
+    }
+
+    // Update quality-of-connection entry
+    char key[CF_BUFSIZE];
+    NDEBUG_UNUSED int ret = snprintf(key, CF_BUFSIZE, "q%c%s", incoming ? 'i' : 'o', host_key);
+    assert(ret > 0 && ret < CF_BUFSIZE);
+
+    KeyHostSeen value;
+    value.lastseen = 0; /* To distinguish between entry not found and error */
+    if (OverwriteDB(db, key, &value, sizeof(value), (OverwriteCondition)OnlyRewriteIfChanged, &value))
+    {
+        Log(LOG_LEVEL_DEBUG, "Acknowledged observation of key '%s' to lastseen DB", key);
+    }
+    else if (value.lastseen != 0 /* was found */ &&
+             !value.acknowledged /* should update */)
+    {
+        /* In this case, the entry was found and should have been updated.
+         * However, false was returned. Hence, this must be due to error. */
+        Log(LOG_LEVEL_ERR, "Unable to overwrite key '%s' to lastseen DB", key);
+        CloseDB(db);
+        return false;
+    }
+
+    CloseDB(db);
+    return true;
+}

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -121,7 +121,10 @@ void UpdateLastSawHost(const char *hostkey, const char *address,
     char quality_key[CF_BUFSIZE];
     snprintf(quality_key, CF_BUFSIZE, "q%c%s", incoming ? 'i' : 'o', hostkey);
 
-    KeyHostSeen newq = { .lastseen = timestamp };
+    KeyHostSeen newq = {
+        .acknowledged = false,
+        .lastseen = timestamp,
+    };
 
     KeyHostSeen q;
     if (ReadDB(db, quality_key, &q, sizeof(q)))

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -29,6 +29,7 @@
 
 typedef struct
 {
+    bool acknowledged; // True when acknowledged by cf-hub, false when updated
     time_t lastseen;
     QPoint Q; // Average time between connections (rolling weighted average)
 } KeyHostSeen;

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -63,4 +63,12 @@ bool IsLastSeenCoherent(void);
 int RemoveKeysFromLastSeen(const char *input, bool must_be_coherent,
                            char *equivalent, size_t equivalent_size);
 
+/**
+ * @brief Acknowledge that lastseen host entry is observed.
+ * @param host_key The host key of the lastseen entry.
+ * @param incoming Whether it is an incoming or outgoing entry.
+ * @return true if host entry was successfully acknowledged, otherwise false.
+ */
+bool LastSeenHostAcknowledge(const char *host_key, bool incoming);
+
 #endif

--- a/tests/unit/lastseen_test.c
+++ b/tests/unit/lastseen_test.c
@@ -70,6 +70,7 @@ static void test_newentry(void)
     KeyHostSeen q;
     assert_int_equal(ReadDB(db, "qiSHA-12345", &q, sizeof(q)), true);
 
+    assert_false(q.acknowledged);
     assert_int_equal(q.lastseen, 666);
     assert_double_close(q.Q.q, 0.0);
     assert_double_close(q.Q.dq, 0.0);
@@ -102,6 +103,7 @@ static void test_update(void)
     KeyHostSeen q;
     assert_int_equal(ReadDB(db, "qiSHA-12345", &q, sizeof(q)), true);
 
+    assert_false(q.acknowledged);
     assert_int_equal(q.lastseen, 1110);
     assert_double_close(q.Q.q, 555.0);
     assert_double_close(q.Q.dq, 555.0);


### PR DESCRIPTION
- [Added acknowledge field to lastseen DB](https://github.com/cfengine/core/pull/5617/commits/5d148d3b9bf907b3d3c50c7f5494b46f2c417396)
- [Added acknowledge function for lastseen entries](https://github.com/cfengine/core/pull/5617/commits/80e9540c2028de3880c1672512cbf5383d2a3808)

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=11319)](https://ci.cfengine.com/job/pr-pipeline/11319/)