### PR TITLE
Fixed error in static checks

### DIFF
--- a/.github/workflows/job-static-check.yml
+++ b/.github/workflows/job-static-check.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Prepare Environment
       run: |
         sudo apt-get update && \
-        sudo apt-get install -y dpkg-dev debhelper g++ libncurses5 pkg-config \
+        sudo apt-get install -y dpkg-dev debhelper g++ libncurses6 pkg-config \
           build-essential libpam0g-dev fakeroot gcc make autoconf buildah \
           liblmdb-dev libacl1-dev libcurl4-openssl-dev libyaml-dev libxml2-dev \
           libssl-dev libpcre2-dev


### PR DESCRIPTION
libncurses5 was not available in the noble repository, but maybe
libncurses6 will work.

```
E: Unable to locate package libncurses5
```

Ticket: None
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
