### PR TITLE
ENT-12033: Made multiple changes to increase robustness of remote file copying

### DIFF
--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -579,12 +579,6 @@ static bool EncryptCopyRegularFileNet(const char *source, const char *dest, off_
 
     snprintf(cfchangedstr, 255, "%s%s", CF_CHANGEDSTR1, CF_CHANGEDSTR2);
 
-    if ((strlen(dest) > CF_BUFSIZE - 20))
-    {
-        Log(LOG_LEVEL_ERR, "Filename too long");
-        return false;
-    }
-
     unlink(dest);                /* To avoid link attacks */
 
     int dd = safe_open_create_perms(dest, O_WRONLY | O_CREAT | O_TRUNC | O_EXCL | O_BINARY, CF_PERMS_DEFAULT);
@@ -768,12 +762,6 @@ bool CopyRegularFileNet(const char *source, const char *dest, off_t size,
 
     NDEBUG_UNUSED int rc = snprintf(cfchangedstr, 255, "%s%s", CF_CHANGEDSTR1, CF_CHANGEDSTR2);
     assert(rc >= 0 && rc < sizeof(cfchangedstr));
-
-    if ((strlen(dest) > CF_BUFSIZE - 20))
-    {
-        Log(LOG_LEVEL_ERR, "Filename too long");
-        return false;
-    }
 
     unlink(dest);                /* To avoid link attacks */
 

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -864,7 +864,11 @@ bool CopyRegularFileNet(const char *source, const char *dest, off_t size,
         /* Check for mismatch between encryption here and on server. */
 
         int value = -1;
-        sscanf(buf, "t %d", &value);
+        rc = sscanf(buf, "t %d", &value);
+        if (rc != 1)
+        {
+            value = -1;
+        }
 
         if ((value > 0) && (strncmp(buf + CF_INBAND_OFFSET, "BAD: ", 5) == 0))
         {

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -598,8 +598,6 @@ static bool EncryptCopyRegularFileNet(const char *source, const char *dest, off_
         return true;
     }
 
-    workbuf[0] = '\0';
-
     NDEBUG_UNUSED int rc = snprintf(in, CF_BUFSIZE - CF_PROTO_OFFSET, "GET dummykey %s", source);
     assert(rc >= 0 && rc < sizeof(in));
     cipherlen = EncryptString(out, sizeof(out), in, strlen(in) + 1, conn->encryption_type, conn->session_key);
@@ -775,7 +773,6 @@ bool CopyRegularFileNet(const char *source, const char *dest, off_t size,
         return false;
     }
 
-    workbuf[0] = '\0';
     int tosend = snprintf(workbuf, CF_BUFSIZE, "GET %d %s", buf_size, source);
     if (tosend <= 0 || tosend >= CF_BUFSIZE)
     {

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -749,7 +749,7 @@ static void FlushFileStream(int sd, int toget)
     }
 }
 
-/* TODO finalise socket or TLS session in all cases that this function fails
+/* TODO finalize socket or TLS session in all cases that this function fails
  * and the transaction protocol is out of sync. */
 bool CopyRegularFileNet(const char *source, const char *dest, off_t size,
                         bool encrypt, AgentConnection *conn, mode_t mode)

--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -606,7 +606,8 @@ static bool EncryptCopyRegularFileNet(const char *source, const char *dest, off_
 
     workbuf[0] = '\0';
 
-    snprintf(in, CF_BUFSIZE - CF_PROTO_OFFSET, "GET dummykey %s", source);
+    NDEBUG_UNUSED int rc = snprintf(in, CF_BUFSIZE - CF_PROTO_OFFSET, "GET dummykey %s", source);
+    assert(rc >= 0 && rc < sizeof(in));
     cipherlen = EncryptString(out, sizeof(out), in, strlen(in) + 1, conn->encryption_type, conn->session_key);
 
     tosend = cipherlen + CF_PROTO_OFFSET;
@@ -621,7 +622,8 @@ static bool EncryptCopyRegularFileNet(const char *source, const char *dest, off_
                          tosend, sizeof(workbuf));
     }
 
-    snprintf(workbuf, CF_BUFSIZE, "SGET %4d %4d", cipherlen, blocksize);
+    rc = snprintf(workbuf, CF_BUFSIZE, "SGET %4d %4d", cipherlen, blocksize);
+    assert(rc >= 0 && rc < sizeof(workbuf));
     memcpy(workbuf + CF_PROTO_OFFSET, out, cipherlen);
 
 /* Send proposition C0 - query */
@@ -764,7 +766,8 @@ bool CopyRegularFileNet(const char *source, const char *dest, off_t size,
         return EncryptCopyRegularFileNet(source, dest, size, conn);
     }
 
-    snprintf(cfchangedstr, 255, "%s%s", CF_CHANGEDSTR1, CF_CHANGEDSTR2);
+    NDEBUG_UNUSED int rc = snprintf(cfchangedstr, 255, "%s%s", CF_CHANGEDSTR1, CF_CHANGEDSTR2);
+    assert(rc >= 0 && rc < sizeof(cfchangedstr));
 
     if ((strlen(dest) > CF_BUFSIZE - 20))
     {

--- a/libcfnet/client_code.h
+++ b/libcfnet/client_code.h
@@ -47,8 +47,24 @@ AgentConnection *ServerConnection(const char *server, const char *port, const Rl
 void DisconnectServer(AgentConnection *conn);
 
 bool CompareHashNet(const char *file1, const char *file2, bool encrypt, AgentConnection *conn);
+
+/**
+ * @brief Copy regular file over network.
+ * @param source The source filename.
+ * @param dest The destination filename.
+ * @param size The source file size.
+ * @param encrypt Whether or not to encrypt the transmission.
+ * @param conn The connection object to communicate with server.
+ * @param mode The source file mode (perms) to be used when creating the
+ *             destination file.
+ * @return %true on success, %false on error.
+ * @note Note that the #encrypt parameter only has an effect on the CLASSIC
+ *       protocol (used in CFEngine Community). The TLS protocol (used in
+ *       CFEngine Enterprise) is always encrypted.
+ */
 bool CopyRegularFileNet(const char *source, const char *dest, off_t size,
                         bool encrypt, AgentConnection *conn, mode_t mode);
+
 Item *RemoteDirList(const char *dirname, bool encrypt, AgentConnection *conn);
 
 int TLSConnectCallCollect(ConnectionInfo *conn_info, const char *username);


### PR DESCRIPTION
Initially I was trying to reproduce a bug reported in ENT-12033. However, I was not able to reproduce it. While statically analyzing the code, I made some changes to make it more robust. 

- **Added doc string to CopyRegularFileNet**
- **Added assert to check return code of snprintf**
- **Fixed typo in comment for CopyRegularFileNet**
- **Removed check for filename too long**
- **Removed unnecessary assignment of NULL-byte to buffer**
- **Check return code of sscanf**
- **Added sanity check in CopyRegularFileNet**
- **Allocate receive buffer on stack instead of heap**
- **cf-serverd now stats file every read on network transition**
- **Added filestream flushing on error in EncryptCopyRegularFileNet**

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=11328)](https://ci.cfengine.com/job/pr-pipeline/11328/)