### PR TITLE
ENT-12414: New network protocol v4 - SAFEGET

### DIFF
--- a/libcfnet/protocol_version.c
+++ b/libcfnet/protocol_version.c
@@ -33,6 +33,10 @@ ProtocolVersion ParseProtocolVersionPolicy(const char *const s)
     {
         return CF_PROTOCOL_COOKIE;
     }
+    else if (StringEqual(s, "4") || StringEqual(s, "safeget"))
+    {
+        return CF_PROTOCOL_SAFEGET;
+    }
     else if (StringEqual(s, "latest"))
     {
         return CF_PROTOCOL_LATEST;

--- a/libcfnet/protocol_version.h
+++ b/libcfnet/protocol_version.h
@@ -39,10 +39,11 @@ typedef enum
     /* --- Greater versions use TLS as secure communications layer --- */
     CF_PROTOCOL_TLS = 2,
     CF_PROTOCOL_COOKIE = 3,
+    CF_PROTOCOL_SAFEGET = 4, /* Here we fix a race condition in `GET <FILENAME>` */
 } ProtocolVersion;
 
 /* We use CF_PROTOCOL_LATEST as the default for new connections. */
-#define CF_PROTOCOL_LATEST CF_PROTOCOL_COOKIE
+#define CF_PROTOCOL_LATEST CF_PROTOCOL_SAFEGET
 
 static inline const char *ProtocolVersionString(const ProtocolVersion p)
 {
@@ -54,6 +55,8 @@ static inline const char *ProtocolVersionString(const ProtocolVersion p)
         return "tls";
     case CF_PROTOCOL_CLASSIC:
         return "classic";
+    case CF_PROTOCOL_SAFEGET:
+        return "safeget";
     default:
         return "undefined";
     }
@@ -87,6 +90,11 @@ static inline bool ProtocolIsClassic(const ProtocolVersion p)
 static inline bool ProtocolTerminateCSV(const ProtocolVersion p)
 {
     return (p < CF_PROTOCOL_COOKIE);
+}
+
+static inline bool ProtocolSafeGet(const ProtocolVersion p)
+{
+    return (p >= CF_PROTOCOL_SAFEGET);
 }
 
 /**


### PR DESCRIPTION
The current protocol (v3) uses a `STAT <FILENAME>` request to determine the file size (among other things), followed by a `GET <FILENAME>` request to fetch the file content. However, there is a race condition here. If the file size increases between the two requests, the client would think that the remaining data after the "file size" offset is a new response header.

Here, we introduce a new protocol-version "safeget" to address the race condition. PDUs from the response following a `GET <FILENAME>` request now contain a protocol header consisting of a NULL-byte terminated string of four unsigned integers (`uint64_t`). We will refer to the four integers as ERROR_CODE, FILE_SIZE, FILE_OFFSET, and PAYLOAD_SIZE. The integers will appear in this order in the protocol header.  Each integer is separated by a whitespace character.

A non-zero ERROR_CODE signals that an error occurred. Furthermore, the exact value of ERROR_CODE specifies what went wrong on the server side. FILE_SIZE and FILE_OFFSET are mainly used to determine when the last PDU is received (i.e., when FILE_SIZE = FILE_OFFSET + PAYLOAD_SIZE). However, FILE_SIZE is also used to detect if the file is modified at the source during transmission. The payload starts immediately after the NULL-terminating byte in the protocol header and consists of PAYLOAD_SIZE bytes.