### PR TITLE
Prevented rendering of empty output box in documentation?

### DIFF
--- a/examples/main.cf
+++ b/examples/main.cf
@@ -8,7 +8,6 @@ bundle agent main
 }
 
 #@ The policy promises to report the name of the current bundle, and produces this output:
-
 #+begin_src example_output
 #@ ```
 #@ R: Hello, main bundle.


### PR DESCRIPTION
This blank line between rendered markdown and the example output block results
in an empty output box in the rendered docs.