### PR TITLE
Adjusted peer related examples in regards to hostname -f versus sys.fqhost (3.21)

### DIFF
--- a/examples/peerleader.cf
+++ b/examples/peerleader.cf
@@ -25,7 +25,8 @@
 #@ echo beta >> /tmp/cfe_hostlist
 #@ echo gamma >> /tmp/cfe_hostlist
 #@ echo "Set HOSTNAME appropriately beforehand"
-#@ echo "$(hostname -f)" | tr 'A-Z' 'a-z' >> /tmp/cfe_hostlist
+#@ touch $CFENGINE_TEST_OVERRIDE_WORKDIR/inputs/promises.cf # to enable cf-promises to run
+#@ bash -c "${CF_PROMISES} --show-vars=sys.fqhost | grep fqhost | awk '{print \$2}' | tr 'A-Z' 'a-z' 2>&1 >> /tmp/cfe_hostlist"
 #@ echo "Delta Delta Delta may I help ya help ya help ya"
 #@ echo delta1 >> /tmp/cfe_hostlist
 #@ echo delta2 >> /tmp/cfe_hostlist

--- a/examples/peerleaders.cf
+++ b/examples/peerleaders.cf
@@ -25,7 +25,8 @@
 #@ echo beta >> /tmp/cfe_hostlist
 #@ echo gamma >> /tmp/cfe_hostlist
 #@ echo "Set HOSTNAME appropriately beforehand"
-#@ echo "$(hostname -f)" | tr 'A-Z' 'a-z' >> /tmp/cfe_hostlist
+#@ touch $CFENGINE_TEST_OVERRIDE_WORKDIR/inputs/promises.cf # to enable cf-promises to run
+#@ bash -c "${CF_PROMISES} --show-vars=sys.fqhost | grep fqhost | awk '{print \$2}' | tr 'A-Z' 'a-z' 2>&1 >> /tmp/cfe_hostlist"
 #@ echo "Delta Delta Delta may I help ya help ya help ya"
 #@ echo delta1 >> /tmp/cfe_hostlist
 #@ echo delta2 >> /tmp/cfe_hostlist

--- a/examples/peers.cf
+++ b/examples/peers.cf
@@ -25,7 +25,8 @@
 #@ echo beta >> /tmp/cfe_hostlist
 #@ echo gamma >> /tmp/cfe_hostlist
 #@ echo "Set HOSTNAME appropriately beforehand"
-#@ echo "$(hostname -f)" | tr 'A-Z' 'a-z' >> /tmp/cfe_hostlist
+#@ touch $CFENGINE_TEST_OVERRIDE_WORKDIR/inputs/promises.cf # to enable cf-promises to run
+#@ bash -c "${CF_PROMISES} --show-vars=sys.fqhost | grep fqhost | awk '{print \$2}' | tr 'A-Z' 'a-z' 2>&1 >> /tmp/cfe_hostlist"
 #@ echo "Delta Delta Delta may I help ya help ya help ya"
 #@ echo delta1 >> /tmp/cfe_hostlist
 #@ echo delta2 >> /tmp/cfe_hostlist


### PR DESCRIPTION
This was breaking on some systems in a way that doesn't benefit the test.

Instead of assuming that `hostname -f` is equal to `sys.fqhost` just use `sys.fqhost` in the first place.

Ticket: ENT-12437
Changelog: none
(cherry picked from commit 471dc0f4b5d468b989b0e42cb0cf3dd0275e7acc)
