### PR TITLE
Adjusted CFEngine SELinux policy to allow cf-execd to run ps command with policy version 33 (3.24)

### DIFF
--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -229,6 +229,7 @@ allow cfengine_execd_t cfengine_reactor_exec_t:file getattr;
 allow cfengine_execd_t cfengine_var_lib_t:sock_file { create unlink getattr setattr };
 
 allow cfengine_execd_t self:capability sys_ptrace;
+allow cfengine_execd_t self:cap_userns sys_ptrace;
 
 allow cfengine_execd_t crontab_exec_t:file getattr;
 allow cfengine_execd_t dmidecode_exec_t:file getattr;


### PR DESCRIPTION
Apparently, ps command running with SELinux kernel policy version 33 requires self:cap_userns sys_ptrace.

Ticket: ENT-12446
Changelog: title
(cherry picked from commit 45ea0fe542f73e8c4358d7c0e23049dee34056d3)
