### PR TITLE
Added filesystem and files unconfined access to cf-monitord in cfengine-enterprise SELinux policy

### DIFF
--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -278,6 +278,9 @@ allow cfengine_monitord_t cfengine_hub_exec_t:file getattr;
 allow cfengine_monitord_t cfengine_reactor_exec_t:file getattr;
 
 allow cfengine_monitord_t var_log_t:file { open read };
+# cf-monitord collects arbitrary system data so needs complete access to filesystems and files
+fs_unconfined(cfengine_monitord_t)
+files_unconfined(cfengine_monitord_t)
 
 allow cfengine_monitord_t self:capability { dac_override dac_read_search sys_ptrace };
 allow cfengine_monitord_t self:cap_userns sys_ptrace;


### PR DESCRIPTION
It was found in some situations that cf-monitord was attempting access to files and dirs with the user_home_dir_t type and being blocked.
cf-monitord needs full access to all filesystems and files.

Ticket: ENT-12446
Changelog: title
