### PR TITLE
ENT-12466: SELinux fixes for kernel policy version 33 on rhel-9 hubs

### DIFF
--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -412,7 +412,7 @@ allow cfengine_hub_t cfengine_var_lib_t:sock_file { create unlink };
 
 allow cfengine_hub_t bin_t:file map;
 allow cfengine_hub_t bin_t:file { execute execute_no_trans };
-allow cfengine_hub_t cert_t:dir search;
+allow cfengine_hub_t cert_t:dir { search getattr };
 allow cfengine_hub_t cert_t:file { getattr open read };
 allow cfengine_hub_t crontab_exec_t:file getattr;
 allow cfengine_hub_t devlog_t:lnk_file read;
@@ -501,7 +501,7 @@ allow cfengine_postgres_t cfengine_var_lib_t:dir { add_name getattr open create 
 
 allow cfengine_postgres_t postgresql_port_t:tcp_socket name_bind;
 
-allow cfengine_postgres_t cert_t:dir search;
+allow cfengine_postgres_t cert_t:dir { search getattr };
 allow cfengine_postgres_t cert_t:file { getattr open read };
 allow cfengine_postgres_t hugetlbfs_t:file map;
 allow cfengine_postgres_t hugetlbfs_t:file { read write };
@@ -563,7 +563,7 @@ allow init_t cfengine_httpd_t:process siginh;
 allow cfengine_httpd_t cfengine_httpd_exec_t:file entrypoint;
 allow cfengine_httpd_t cfengine_httpd_exec_t:file { ioctl read getattr lock map execute open };
 
-allow cfengine_httpd_t cert_t:dir search;
+allow cfengine_httpd_t cert_t:dir { search getattr };
 allow cfengine_httpd_t cert_t:file { getattr open read };
 allow cfengine_httpd_t cert_t:lnk_file read;
 allow cfengine_httpd_t cfengine_httpd_exec_t:file execute_no_trans;
@@ -767,7 +767,7 @@ allow cfengine_reactor_t fs_t:filesystem getattr;
 allow cfengine_reactor_t shell_exec_t:file map;
 allow cfengine_reactor_t shell_exec_t:file { execute execute_no_trans };
 
-allow cfengine_reactor_t cert_t:dir search;
+allow cfengine_reactor_t cert_t:dir { search getattr };
 allow cfengine_reactor_t cert_t:file { getattr open read };
 allow cfengine_reactor_t cert_t:lnk_file read;
 
@@ -861,7 +861,7 @@ allow cfengine_cfbs_t bin_t:file { map execute };
 allow cfengine_cfbs_t shell_exec_t:file map;
 allow cfengine_cfbs_t shell_exec_t:file { execute execute_no_trans };
 
-allow cfengine_cfbs_t cert_t:dir search;
+allow cfengine_cfbs_t cert_t:dir { search getattr };
 allow cfengine_cfbs_t cert_t:file { getattr open read };
 allow cfengine_cfbs_t cert_t:lnk_file read;
 allow cfengine_cfbs_t http_port_t:tcp_socket name_connect;

--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -405,7 +405,7 @@ allow cfengine_hub_t cfengine_postgres_t:unix_stream_socket connectto;
 allow cfengine_hub_t unreserved_port_t:tcp_socket name_connect;
 
 allow cfengine_hub_t cfengine_log_t:dir getattr;
-allow cfengine_hub_t cfengine_var_lib_t:dir { add_name getattr open read search write remove_name };
+allow cfengine_hub_t cfengine_var_lib_t:dir { add_name create getattr open read search write remove_name };
 allow cfengine_hub_t cfengine_var_lib_t:file { create ioctl lock write unlink };
 allow cfengine_hub_t cfengine_var_lib_t:lnk_file { getattr read };
 allow cfengine_hub_t cfengine_var_lib_t:sock_file { create unlink };


### PR DESCRIPTION
- Added getattr capability for cert_t:dir as needed to CFEngine components in cfengine-enterprise SELinux policy
- Added create capability on cfengine_var_lib_t:dir to cf-hub
