### PR TITLE
Added comments to explain image recreation logic

### DIFF
--- a/tests/static-check/run.sh
+++ b/tests/static-check/run.sh
@@ -22,7 +22,8 @@ function create_image() {
   buildah run $c -- dnf -q -y install pcre-devel pcre2-devel openssl-devel libxml2-devel pam-devel lmdb-devel libacl-devel libyaml-devel curl-devel libvirt-devel >/dev/null 2>&1
   buildah run $c -- dnf clean all >/dev/null 2>&1
 
-  # Copy checksum of this file into container
+  # Copy checksum of this file into container. We use the checksum to detect
+  # whether or not this file has changed and we should recreate the image
   sha256sum $0 > $SUM_FILE
   buildah copy $c $SUM_FILE >/dev/null
   rm $SUM_FILE
@@ -36,13 +37,17 @@ set -x
 if buildah inspect cfengine-static-checker-f$STATIC_CHECKS_FEDORA_VERSION >/dev/null 2>&1; then
   c=$(buildah from cfengine-static-checker-f$STATIC_CHECKS_FEDORA_VERSION)
 
-  # Recreate the image if the checksum of this file has changed 
+  # Recreate the image if the checksum of this file has changed or if the
+  # checksum file is missing from the container
   if [[ `buildah run $c ls $SUM_FILE` == $SUM_FILE ]]; then
     SUM_A=$(sha256sum $0)
     SUM_B=$(buildah run $c cat $SUM_FILE)
     if [[ $SUM_A != $SUM_B ]]; then
       echo "Recreating image due to mismatching checksum..."
       IMAGE_ID=$(buildah inspect $c | jq -r '.FromImageID')
+      # The --force option will cause Buildah to remove all containers that
+      # are using the image before removing the image from the system. Hence,
+      # there is no need to manually remove these containers
       buildah rmi --force $IMAGE_ID >/dev/null
       c=$(create_image)
     fi


### PR DESCRIPTION
I added some comments to explain the logic behind recreating the image in static checks.