### PR TITLE
SELinux: Allow cf-serverd to set its own limits (3.21)

### DIFF
--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -341,6 +341,9 @@ allow cfengine_serverd_t unreserved_port_t:tcp_socket name_connect;
 allow cfengine_serverd_t cfengine_var_lib_t:sock_file { getattr write };
 allow cfengine_serverd_t cfengine_hub_t:unix_stream_socket connectto;
 
+# allow cf-serverd to set its own limits, e.g. def.control_server_maxconnections
+allow cfengine_serverd_t self:capability sys_resource;
+
 # TODO: this should not be needed
 allow cfengine_serverd_t ssh_port_t:tcp_socket name_connect;
 allow cfengine_serverd_t proc_xen_t:dir search;


### PR DESCRIPTION
In order to honor some settings like def.control_server_maxconnections we must allow self:capability sys_resource.

Ticket: ENT-12446
Changelog: title
(cherry picked from commit c05f25b1e776af00205ef3d21f03926bd63b36f6)
