### PR TITLE
ENT-12511: Now `cf-net get` no longer unlinks original file

### DIFF
--- a/libcfnet/file_stream.c
+++ b/libcfnet/file_stream.c
@@ -853,6 +853,7 @@ static bool RecvDelta(
     char in_buf[PROTOCOL_MESSAGE_SIZE * 2], out_buf[PROTOCOL_MESSAGE_SIZE];
 
     /* Open/create the destination file */
+    unlink(dest);
     int new = safe_open_create_perms(
         dest, O_WRONLY | O_CREAT | O_TRUNC | O_EXCL | O_BINARY, perms);
     if (new == -1)


### PR DESCRIPTION
The command `cf-net get <FILENAME>` now writes to `<FILENAME>.cfnew`
followed by replacing `<FILENAME>` with `<FILENAME>.cfnew`. Previously
it would unlink and re-create the original file.

With the new `"filestream"` protocol, we need the original file in order
to compute its signature, so that we can save bandwidth using the RSYNC
protocol. Furthermore, unlinking the original file, causes a brief
moment when it either does not exist or is incomplete. This can be
problematic if other processes depend on it.

Ticket: ENT-12511
Changelog: Title
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=11550)](https://ci.cfengine.com/job/pr-pipeline/11550/) together with https://github.com/NorthernTechHQ/libntech/pull/231

 - [x] Manually tested on Windows Server 2019 & Ubuntu 24