### PR TITLE
libpromises/evalfunction: Do not crash w/o arguments (3.24.x)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -5730,6 +5730,14 @@ static FnCallResult FnCallFormat(EvalContext *ctx, ARG_UNUSED const Policy *poli
 static FnCallResult FnCallIPRange(EvalContext *ctx, ARG_UNUSED const Policy *policy,
                                   const FnCall *fp, const Rlist *finalargs)
 {
+    assert(fp != NULL);
+
+    if (finalargs == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Function '%s' requires at least one argument", fp->name);
+        return FnFailure();
+    }
+
     const char *range   = RlistScalarValue(finalargs);
     const Rlist *ifaces = finalargs->next;
 
@@ -5794,6 +5802,14 @@ static FnCallResult FnCallIsIpInSubnet(ARG_UNUSED EvalContext *ctx,
                                        ARG_UNUSED const Policy *policy,
                                        const FnCall *fp, const Rlist *finalargs)
 {
+    assert(fp != NULL);
+
+    if (finalargs == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Function '%s' requires at least one argument", fp->name);
+        return FnFailure();
+    }
+
     const char *range = RlistScalarValue(finalargs);
     const Rlist *ips  = finalargs->next;
 
@@ -6911,6 +6927,12 @@ static FnCallResult FnCallEval(EvalContext *ctx, ARG_UNUSED const Policy *policy
 
 static FnCallResult FnCallReadFile(ARG_UNUSED EvalContext *ctx, ARG_UNUSED const Policy *policy, ARG_UNUSED const FnCall *fp, const Rlist *finalargs)
 {
+    if (finalargs == NULL)
+    {
+        Log(LOG_LEVEL_ERR, "Function 'readfile' requires at least one argument");
+        return FnFailure();
+    }
+
     char *filename = RlistScalarValue(finalargs);
     const Rlist *next = finalargs->next; // max_size argument, default to inf:
     long maxsize = next ? IntFromString(RlistScalarValue(next)) : IntFromString("inf");


### PR DESCRIPTION
Do not crash cf-promises if no argument is given for following
functions:
* readfile
* iprange
* isipinsubnet

(cherry picked from commit e040d7f0526230b3a9f8d4b2780c27167184545e)
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
