### PR TITLE
Upgraded valgrind check container to Ubuntu 24

### DIFF
--- a/tests/valgrind-check/Containerfile
+++ b/tests/valgrind-check/Containerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS build
+FROM ubuntu:24.04 AS build
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev libxml2-dev libpam0g-dev liblmdb-dev libacl1-dev libpcre2-dev librsync-dev
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 git flex bison byacc automake make autoconf libtool valgrind


### PR DESCRIPTION
Recently we've seen segmentation faults while compiling core in valgrind
checks. I'll try to upgrade the container image to Ubuntu 24 to see if
that resolves the issue.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=11587)](https://ci.cfengine.com/job/pr-pipeline/11587/)
