### PR TITLE
ENT-11574: Link cf-agent and cf-serverd with leech if available

### DIFF
--- a/cf-agent/Makefile.am
+++ b/cf-agent/Makefile.am
@@ -35,7 +35,8 @@ AM_CPPFLAGS = -I$(srcdir)/../libpromises -I$(srcdir)/../libntech/libutils \
 	$(POSTGRESQL_CPPFLAGS) \
 	$(MYSQL_CPPFLAGS) \
 	$(LIBXML2_CPPFLAGS) \
-	$(PAM_CPPFLAGS)
+	$(PAM_CPPFLAGS) \
+	$(LEECH_CPPFLAGS)
 
 AM_CFLAGS = \
 	@CFLAGS@ \
@@ -46,7 +47,8 @@ AM_CFLAGS = \
 	$(POSTGRESQL_CFLAGS) \
 	$(MYSQL_CFLAGS) \
 	$(LIBXML2_CFLAGS) \
-	$(PAM_CFLAGS)
+	$(PAM_CFLAGS) \
+	$(LEECH_CFLAGS)
 
 AM_LDFLAGS = \
 	@LDFLAGS@ \
@@ -56,7 +58,8 @@ AM_LDFLAGS = \
 	$(POSTGRESQL_LDFLAGS) \
 	$(MYSQL_LDFLAGS) \
 	$(LIBXML2_LDFLAGS) \
-	$(PAM_LDFLAGS)
+	$(PAM_LDFLAGS) \
+	$(LEECH_LDFLAGS)
 
 if FREEBSD
     AM_LDFLAGS += -lutil
@@ -69,7 +72,8 @@ libcf_agent_la_LIBADD = ../libpromises/libpromises.la \
 	$(POSTGRESQL_LIBS) \
 	$(MYSQL_LIBS) \
 	$(LIBXML2_LIBS) \
-	$(PAM_LIBS)
+	$(PAM_LIBS) \
+	$(LEECH_LIBS)
 
 libcf_agent_la_SOURCES = \
 	agent-diagnostics.c agent-diagnostics.h \

--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -103,6 +103,9 @@
 
 #include <ornaments.h>
 
+#if HAVE_LEECH_H
+#include <leech.h>
+#endif
 
 extern int PR_KEPT;
 extern int PR_REPAIRED;
@@ -270,6 +273,10 @@ static PromiseResult DefaultVarPromiseWrapper(EvalContext *ctx, const Promise *p
 
 int main(int argc, char *argv[])
 {
+#if HAVE_LIBLEECH
+    LCH_Version();
+#endif
+
     SetupSignalsForAgent();
 #ifdef HAVE_LIBXML2
         xmlInitParser();

--- a/cf-serverd/Makefile.am
+++ b/cf-serverd/Makefile.am
@@ -29,14 +29,18 @@ AM_CPPFLAGS = -I$(srcdir)/../libpromises -I$(srcdir)/../libntech/libutils \
 	-I$(srcdir)/../libenv \
 	$(OPENSSL_CPPFLAGS) \
 	$(PCRE2_CPPFLAGS) \
-	$(ENTERPRISE_CPPFLAGS)
+	$(ENTERPRISE_CPPFLAGS) \
+	$(LEECH_CPPFLAGS)
 
 AM_CFLAGS = \
 	$(OPENSSL_CFLAGS) \
 	$(PTHREAD_CFLAGS) \
-	$(ENTERPRISE_CFLAGS)
+	$(ENTERPRISE_CFLAGS) \
+	$(LEECH_CFLAGS)
 
-libcf_serverd_la_LIBADD = ../libpromises/libpromises.la
+AM_LDFLAGS = $(LEECH_LDFLAGS)
+
+libcf_serverd_la_LIBADD = ../libpromises/libpromises.la $(LEECH_LIBS)
 
 libcf_serverd_la_SOURCES = \
 	cf-serverd.c \

--- a/configure.ac
+++ b/configure.ac
@@ -521,6 +521,17 @@ CF3_WITH_LIBRARY(pcre2, [
   )]
 )
 
+dnl leech is required in enterprise, but we need to link it in core
+
+AC_ARG_WITH([leech], [AS_HELP_STRING([--with-leech[[=PATH]]], [Enable Leech])], [], [with_leech=check])
+
+if test "x$with_leech" != xno; then
+   CF3_WITH_LIBRARY(leech, [
+      AC_CHECK_HEADERS(leech.h, [], [if test "x$with_leech" != xcheck; then AC_MSG_ERROR(Cannot find leech library headers); fi])
+      AC_CHECK_LIB(leech, LCH_Version, [], [if test "x$with_leech" != xcheck; then AC_MSG_ERROR(Cannot find leech library); fi])
+   ])
+fi
+
 dnl librsync
 
 AC_ARG_WITH([librsync], [AS_HELP_STRING([--with-librsync[[=PATH]]], [Specify librsync path])], [], [with_librsync=yes])


### PR DESCRIPTION
In order to use leech in the enterprise plugin, we need to link with
leech in core. I added code in configure.ac to link with leech if it is
available. A community version of CFEngine will work just fine without
it. However, an enterprise version will require it.
