### PR TITLE
Added option to print rsync performance stats in cf-net

### DIFF
--- a/libcfnet/client_code.c
+++ b/libcfnet/client_code.c
@@ -796,7 +796,7 @@ bool CopyRegularFileNet(const char *source, const char *basis, const char *dest,
 
     const ProtocolVersion version = ConnectionInfoProtocolVersion(conn->conn_info);
     if (ProtocolSupportsFileStream(version)) {
-        return FileStreamFetch(conn->conn_info->ssl, basis, dest, mode);
+        return FileStreamFetch(conn->conn_info->ssl, basis, dest, mode, false);
     }
 
     int dd = safe_open_create_perms(dest, O_WRONLY | O_CREAT | O_TRUNC | O_EXCL | O_BINARY, mode);

--- a/libcfnet/file_stream.c
+++ b/libcfnet/file_stream.c
@@ -1022,8 +1022,8 @@ bool FileStreamFetch(
     assert(basis != NULL);
     assert(dest != NULL);
 
-    /* Let's make sure the basis file exists */
-    FILE *file = safe_fopen_create_perms(basis, "wb", perms);
+    /* Let's make sure the basis file exists, but don't truncate it */
+    FILE *file = safe_fopen_create_perms(basis, "ab+", perms);
     if (file != NULL)
     {
         fclose(file);

--- a/libcfnet/file_stream.h
+++ b/libcfnet/file_stream.h
@@ -93,12 +93,17 @@ bool FileStreamServe(SSL *conn, const char *filename);
  * @param basis The name of the basis file
  * @param dest The name of the destination file
  * @param perms The desired permissions of the destination file
+ * @param print_stats Print performance statistics
  * @return true on success, otherwise false
  *
  * @note If the destination file is a symlink, this function fetches the
  *       contents into the symlink target.
  */
 bool FileStreamFetch(
-    SSL *conn, const char *basis, const char *dest, mode_t perms);
+    SSL *conn,
+    const char *basis,
+    const char *dest,
+    mode_t perms,
+    bool print_stats);
 
 #endif // FILE_STREAM_H

--- a/libcfnet/protocol.c
+++ b/libcfnet/protocol.c
@@ -92,7 +92,8 @@ Seq *ProtocolOpenDir(AgentConnection *conn, const char *path)
 }
 
 bool ProtocolGet(AgentConnection *conn, const char *remote_path,
-                 const char *local_path, const uint32_t file_size, int perms)
+                 const char *local_path, const uint32_t file_size, int perms,
+                 bool print_stats)
 {
     assert(conn != NULL);
     assert(remote_path != NULL);
@@ -128,7 +129,8 @@ bool ProtocolGet(AgentConnection *conn, const char *remote_path,
     if (ProtocolSupportsFileStream(version))
     {
         /* Use file stream API if it is available */
-        if (!FileStreamFetch(conn->conn_info->ssl, local_path, dest, perms))
+        if (!FileStreamFetch(conn->conn_info->ssl, local_path, dest, perms,
+                             print_stats))
         {
             /* Error is already logged */
             success = false;
@@ -222,7 +224,7 @@ bool ProtocolGet(AgentConnection *conn, const char *remote_path,
 }
 
 bool ProtocolStatGet(AgentConnection *conn, const char *remote_path,
-                     const char *local_path, int perms)
+                     const char *local_path, int perms, bool print_stats)
 {
     assert(conn != NULL);
     assert(remote_path != NULL);
@@ -237,7 +239,7 @@ bool ProtocolStatGet(AgentConnection *conn, const char *remote_path,
         return false;
     }
 
-    return ProtocolGet(conn, remote_path, local_path, sb.st_size, perms);
+    return ProtocolGet(conn, remote_path, local_path, sb.st_size, perms, print_stats);
 }
 
 bool ProtocolStat(AgentConnection *const conn, const char *const remote_path,

--- a/libcfnet/protocol.h
+++ b/libcfnet/protocol.h
@@ -84,6 +84,7 @@ Seq *ProtocolOpenDir(AgentConnection *conn, const char *path);
  * @param [in] local_path   Path of received file
  * @param [in] file_size    Size of file to get
  * @param [in] perms        Permissions of local file
+ * @param [in] print_stats  Print RSYNC performance statistics
  * @return True if file was successfully transferred, false otherwise
  *
  * Example (for printing each directory entry):
@@ -104,7 +105,8 @@ Seq *ProtocolOpenDir(AgentConnection *conn, const char *path);
  *     Translated to: GET /var/cfengine/masterfiles/update.cf
  */
 bool ProtocolGet(AgentConnection *conn, const char *remote_path,
-                 const char *local_path, const uint32_t file_size, int perms);
+                 const char *local_path, const uint32_t file_size, int perms,
+                 bool print_stats);
 
 
 /**
@@ -114,7 +116,7 @@ bool ProtocolGet(AgentConnection *conn, const char *remote_path,
  * it.
  */
 bool ProtocolStatGet(AgentConnection *conn, const char *remote_path,
-                     const char *local_path, int perms);
+                     const char *local_path, int perms, bool print_stats);
 
 /**
  * Receives statistics about a remote file.


### PR DESCRIPTION
The performance stats are also logged. This way we can also study the
performance through `cf-agent`'s debug logs.

The following is an example of running `cf-net` with the `--stats` option:

```
$ sudo /var/cfengine/bin/cf-net --stats --host 192.168.56.10 get /var/cfengine/masterfiles/promises.cf
Send signature statistics:
  16970 bytes in (read from 'promises.cf')
  2424 bytes out (sent to server)
Receive delta statistics:
  9 bytes in (received from server)
  16970 bytes out (written to 'promises.cf.cfnew')
```

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=11640)](https://ci.cfengine.com/job/pr-pipeline/11640/)