### PR TITLE
ENT-12592: Fixed error: pthread-compatible library is required to build CFEngine

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl libyaml-dev librsync-dev
+      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl libyaml-dev librsync-dev autoconf-archive
     - name: Run autotools / configure
       run: ./autogen.sh --enable-debug
     - name: Compile and link (make)

--- a/.github/workflows/asan_unit_tests.yml
+++ b/.github/workflows/asan_unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl librsync-dev
+      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl librsync-dev autoconf-archive
     - name: Run autotools / configure
       run: ./autogen.sh --enable-debug
     - name: Compile and link (make)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
         
       - name: Install dependencies (C)
         if: ${{ matrix.language == 'cpp' }}
-        run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl librsync-dev
+        run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl librsync-dev autoconf-archive
 
       - name: Build (C)
         if: ${{ matrix.language == 'cpp' }}

--- a/.github/workflows/job-static-check.yml
+++ b/.github/workflows/job-static-check.yml
@@ -41,7 +41,7 @@ jobs:
         sudo apt-get install -y dpkg-dev debhelper g++ libncurses6 pkg-config \
           build-essential libpam0g-dev fakeroot gcc make autoconf buildah \
           liblmdb-dev libacl1-dev libcurl4-openssl-dev libyaml-dev libxml2-dev \
-          libssl-dev libpcre2-dev librsync-dev
+          libssl-dev libpcre2-dev librsync-dev autoconf-archive
 
     - name: Run Autogen
       run: NO_CONFIGURE=1 PROJECT=community ./buildscripts/build-scripts/autogen

--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: brew install lmdb automake openssl pcre2 autoconf libtool librsync
+      run: brew install lmdb automake openssl pcre2 autoconf libtool librsync autoconf-archive
     - name: Check tools
       run: command -v libtool && command -v automake && command -v autoconf
     - name: Check tools versions

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl shellcheck librsync-dev
+      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl shellcheck librsync-dev autoconf-archive
     - name: Run autotools / configure
       run: ./autogen.sh --enable-debug
     - name: Run shellcheck

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl librsync-dev
+      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl librsync-dev autoconf-archive
     - name: Run autotools / configure
       run: ./autogen.sh --enable-debug
     - name: Compile and link (make)

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -27,7 +27,7 @@ jobs:
         path: masterfiles
         submodules: recursive
     - name: Install dependencies
-      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl libyaml-dev valgrind librsync-dev
+      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl libyaml-dev valgrind librsync-dev autoconf-archive
     - name: Run autotools / configure
       run: ./autogen.sh --enable-debug --with-systemd-service
     - name: Compile and link (make)

--- a/configure.ac
+++ b/configure.ac
@@ -163,7 +163,7 @@ if test "x$with_pthreads" != x && test "x$with_pthreads" != "xyes" && test "x$wi
    CPPFLAGS="-I$with_pthreads/include $CPPFLAGS"
 fi
 
-ACX_PTHREAD([],
+AX_PTHREAD([],
             [AC_MSG_ERROR(pthread-compatible library is required to build CFEngine)])
 
 CC="$PTHREAD_CC"

--- a/tests/valgrind-check/Containerfile
+++ b/tests/valgrind-check/Containerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04 AS build
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev libxml2-dev libpam0g-dev liblmdb-dev libacl1-dev libpcre2-dev librsync-dev
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 git flex bison byacc automake make autoconf libtool valgrind
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 git flex bison byacc automake make autoconf libtool autoconf-archive valgrind
 COPY masterfiles masterfiles
 COPY core core
 WORKDIR core


### PR DESCRIPTION
- **Fixed warning `AC_LANG_C' is obsolete**
- **Added autoconf-archive dependency to get AX_PTHREAD**

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=11726)](https://ci.cfengine.com/job/pr-pipeline/11726/)