### PR TITLE
ENT-12551: ensure that community CFEngine works well in a container without errors

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -1286,7 +1286,7 @@ static JsonElement* GetNetworkingStatsInfo(const char *filename)
     }
     else
     {
-        Log(LOG_LEVEL_ERROR, "netstat file not found at '%s'", filename);
+        Log(LOG_LEVEL_ERR, "netstat file not found at '%s'", filename);
     }
 
     return stats;
@@ -1395,7 +1395,7 @@ JsonElement* GetProcFileInfo(EvalContext *ctx, const char* filename, const char*
 void GetNetworkingInfo(EvalContext *ctx)
 {
     const char *procdir_root = GetRelocatedProcdirRoot();
-    int promiser_pid = (int) getpid();
+    int promiser_pid = GetProcdirPid();
 
     Buffer *pbuf = BufferNew();
 
@@ -1549,7 +1549,7 @@ void GetNetworkingInfo(EvalContext *ctx)
 JsonElement* GetNetworkingConnections(EvalContext *ctx)
 {
     const char *procdir_root = GetRelocatedProcdirRoot();
-    int promiser_pid = (int) getpid();
+    int promiser_pid = GetProcdirPid();
     JsonElement *json = JsonObjectCreate(5);
     const char* ports_regex = "^\\s*\\d+:\\s+(?<raw_local>[0-9A-F:]+)\\s+(?<raw_remote>[0-9A-F:]+)\\s+(?<raw_state>[0-9]+)";
 

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -1283,6 +1283,10 @@ static JsonElement* GetNetworkingStatsInfo(const char *filename)
 
         fclose(fin);
     }
+    else
+    {
+        Log(LOG_LEVEL_ERROR, "netstat file not found at '%s'", filename);
+    }
 
     return stats;
 }

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -1390,12 +1390,13 @@ JsonElement* GetProcFileInfo(EvalContext *ctx, const char* filename, const char*
 void GetNetworkingInfo(EvalContext *ctx)
 {
     const char *procdir_root = GetRelocatedProcdirRoot();
+    int promiser_pid = (int) getpid();
 
     Buffer *pbuf = BufferNew();
 
     JsonElement *inet = JsonObjectCreate(2);
 
-    BufferPrintf(pbuf, "%s/proc/net/netstat", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/netstat", procdir_root, promiser_pid);
     JsonElement *inet_stats = GetNetworkingStatsInfo(BufferData(pbuf));
 
     if (inet_stats != NULL)
@@ -1403,7 +1404,7 @@ void GetNetworkingInfo(EvalContext *ctx)
         JsonObjectAppendElement(inet, "stats", inet_stats);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/route", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/route", procdir_root, promiser_pid);
     JsonElement *routes = GetProcFileInfo(ctx, BufferData(pbuf),  NULL, NULL, &NetworkingRoutesPostProcessInfo, NULL,
                     // format: Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
                     //         eth0	00000000	0102A8C0	0003	0	0	1024	00000000	0	0	0
@@ -1451,7 +1452,7 @@ void GetNetworkingInfo(EvalContext *ctx)
 
     JsonElement *inet6 = JsonObjectCreate(3);
 
-    BufferPrintf(pbuf, "%s/proc/net/snmp6", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/snmp6", procdir_root, promiser_pid);
     JsonElement *inet6_stats = GetProcFileInfo(ctx, BufferData(pbuf), NULL, NULL, NULL, NULL,
                                                "^\\s*(?<key>\\S+)\\s+(?<value>\\d+)");
 
@@ -1477,7 +1478,7 @@ void GetNetworkingInfo(EvalContext *ctx)
         JsonDestroy(inet6_stats);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/ipv6_route", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/ipv6_route", procdir_root, promiser_pid);
     JsonElement *inet6_routes = GetProcFileInfo(ctx, BufferData(pbuf),  NULL, NULL, &NetworkingIPv6RoutesPostProcessInfo, NULL,
                     // format: dest                    dest_prefix source                source_prefix next_hop                         metric   refcnt   use      flags        interface
                     //         fe800000000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000000 00000000 00000001     eth0
@@ -1492,7 +1493,7 @@ void GetNetworkingInfo(EvalContext *ctx)
         JsonObjectAppendElement(inet6, "routes", inet6_routes);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/if_inet6", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/if_inet6", procdir_root, promiser_pid);
     JsonElement *inet6_addresses = GetProcFileInfo(ctx, BufferData(pbuf),  NULL, "interface", &NetworkingIPv6AddressesPostProcessInfo, &NetworkingIPv6AddressesTiebreaker,
                     // format: address device_number prefix_length scope flags interface_name
                     // 00000000000000000000000000000001 01 80 10 80       lo
@@ -1515,7 +1516,7 @@ void GetNetworkingInfo(EvalContext *ctx)
     //  face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
     //   eth0: 74850544807 75236137    0    0    0     0          0   1108775 63111535625 74696758    0    0    0     0       0          0
 
-    BufferPrintf(pbuf, "%s/proc/net/dev", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/dev", procdir_root, promiser_pid);
     JsonElement *interfaces_data =
     GetProcFileInfo(ctx, BufferData(pbuf), "interfaces_data", "device", NULL, NULL,
                     "^\\s*(?<device>[^:]+)\\s*:\\s*"
@@ -1543,34 +1544,35 @@ void GetNetworkingInfo(EvalContext *ctx)
 JsonElement* GetNetworkingConnections(EvalContext *ctx)
 {
     const char *procdir_root = GetRelocatedProcdirRoot();
+    int promiser_pid = (int) getpid();
     JsonElement *json = JsonObjectCreate(5);
     const char* ports_regex = "^\\s*\\d+:\\s+(?<raw_local>[0-9A-F:]+)\\s+(?<raw_remote>[0-9A-F:]+)\\s+(?<raw_state>[0-9]+)";
 
     JsonElement *data = NULL;
     Buffer *pbuf = BufferNew();
 
-    BufferPrintf(pbuf, "%s/proc/net/tcp", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/tcp", procdir_root, promiser_pid);
     data = GetProcFileInfo(ctx, BufferData(pbuf), NULL, NULL, &NetworkingPortsPostProcessInfo, NULL, ports_regex);
     if (data != NULL)
     {
         JsonObjectAppendElement(json, "tcp", data);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/tcp6", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/tcp6", procdir_root, promiser_pid);
     data = GetProcFileInfo(ctx, BufferData(pbuf), NULL, NULL, &NetworkingPortsPostProcessInfo, NULL, ports_regex);
     if (data != NULL)
     {
         JsonObjectAppendElement(json, "tcp6", data);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/udp", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/udp", procdir_root, promiser_pid);
     data = GetProcFileInfo(ctx, BufferData(pbuf), NULL, NULL, &NetworkingPortsPostProcessInfo, NULL, ports_regex);
     if (data != NULL)
     {
         JsonObjectAppendElement(json, "udp", data);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/udp6", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/udp6", procdir_root, promiser_pid);
     data = GetProcFileInfo(ctx, BufferData(pbuf), NULL, NULL, &NetworkingPortsPostProcessInfo, NULL, ports_regex);
     if (data != NULL)
     {

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -39,6 +39,7 @@
 #include <ip_address.h>
 #include <file_lib.h>
 #include <cleanup.h>
+#include <unix.h> /* GetRelocatedProcdirRoot() and GetProcdirPid() */
 
 #ifdef HAVE_SYS_JAIL_H
 # include <sys/jail.h>

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -199,7 +199,6 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
 Log(LOG_LEVEL_DEBUG, "Backgrounding for GenericCreatePipeAndFork()");
     if ((pid = fork()) == (pid_t) -1)
     {
-Log(LOG_LEVEL_DEBUG, "GenericCreatePipeAndFork(), Backgrounded child pid=%jd", (intmax_t) getpid());
         /* One pipe will be always here. */
         close(pipes[0].pipe_desc[0]);
         close(pipes[0].pipe_desc[1]);
@@ -224,6 +223,7 @@ Log(LOG_LEVEL_DEBUG, "GenericCreatePipeAndFork(), Backgrounded child pid=%jd", (
 
     if (pid == 0)                                               /* child */
     {
+Log(LOG_LEVEL_DEBUG, "GenericCreatePipeAndFork(), Backgrounded child pid=%jd", (intmax_t) getpid());
         /* WARNING only call async-signal-safe functions in child. */
 
         /* The fork()ed child is always single-threaded, but we are only

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -390,6 +390,7 @@ FILE *cf_popen_select(const char *command, const char *type, OutputSelect output
 
     if (pid == 0)                                               /* child */
     {
+Log(LOG_LEVEL_DEBUG, "cf_open_select() command '%s' child pid is %jd", command, (intmax_t) getpid());
         /* WARNING only call async-signal-safe functions in child. */
 
         switch (*type)
@@ -488,6 +489,7 @@ FILE *cf_popensetuid(const char *command, const Seq *arglist,
 
     if (pid == 0)                                               /* child */
     {
+Log(LOG_LEVEL_DEBUG, "cf_popensetuid() command '%s' child pid is %jd", command, (intmax_t) getpid());
         /* WARNING only call async-signal-safe functions in child. */
 
         switch (*type)
@@ -603,6 +605,7 @@ FILE *cf_popen_sh_select(const char *command, const char *type, OutputSelect out
 
     if (pid == 0)                                               /* child */
     {
+Log(LOG_LEVEL_DEBUG, "cf_popen_sh_select() command '%s' child pid is %jd", command, (intmax_t) getpid());
         /* WARNING only call async-signal-safe functions in child. */
 
         switch (*type)
@@ -691,6 +694,7 @@ FILE *cf_popen_shsetuid(const char *command, const char *type,
 
     if (pid == 0)                                               /* child */
     {
+Log(LOG_LEVEL_DEBUG, "cf_popen_shsetuid() command '%s' child pid is %jd", command, (intmax_t) getpid());
         /* WARNING only call async-signal-safe functions in child. */
 
         switch (*type)

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -199,6 +199,7 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
 Log(LOG_LEVEL_DEBUG, "Backgrounding for GenericCreatePipeAndFork()");
     if ((pid = fork()) == (pid_t) -1)
     {
+Log(LOG_LEVEL_DEBUG, "GenericCreatePipeAndFork(), Backgrounded child pid=%jd", (intmax_t) getpid());
         /* One pipe will be always here. */
         close(pipes[0].pipe_desc[0]);
         close(pipes[0].pipe_desc[1]);

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -196,6 +196,7 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
 
     pid_t pid = -1;
 
+Log(LOG_LEVEL_DEBUG, "Backgrounding for GenericCreatePipeAndFork()");
     if ((pid = fork()) == (pid_t) -1)
     {
         /* One pipe will be always here. */

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -186,6 +186,7 @@ Log(LOG_LEVEL_DEBUG, "Backgrounding for ShellCommandReturnsZero(), command = '%s
     else if (pid == 0)          /* child */
     {
         ALARM_PID = -1;
+Log(LOG_LEVEL_DEBUG, "ShellCommandReturnsZero(), Backgrounded child pid %jd", (intmax_t) getpid());
 
         if (shell == SHELL_TYPE_USE)
         {

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -177,6 +177,7 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
         return false;
     }
 
+Log(LOG_LEVEL_DEBUG, "Backgrounding for ShellCommandReturnsZero(), command = '%s'", command);
     if ((pid = fork()) < 0)
     {
         Log(LOG_LEVEL_ERR, "Failed to fork new process: %s", command);

--- a/libpromises/unix.h
+++ b/libpromises/unix.h
@@ -34,6 +34,17 @@ bool GetCurrentUserName(char *userName, int userNameLen);
 
 #ifndef __MINGW32__
 /**
+ * @brief For testing things against /proc, uses env var CFENGINE_TEST_OVERRIDE_PROCDIR
+ * @return the extra directory to add BEFORE /proc in the path
+ */
+const char* GetRelocatedProcdirRoot();
+/**
+ * @brief For testing things against /proc, use env var CFENGINE_TEST_OVERRIDE_PROCPID
+ * @return the fake pid to use in proc paths
+ */
+int GetProcdirPid();
+
+/**
  * Get user name for the user with UID #uid
  *
  * @param uid              UID of the user

--- a/tests/acceptance/00_basics/environment/proc-net-functions.cf
+++ b/tests/acceptance/00_basics/environment/proc-net-functions.cf
@@ -7,11 +7,35 @@ body common control
 
 ###########################################################
 
+bundle agent init
+{
+  vars:
+    "pid_for_testing" int => "11";
+
+  methods:
+    "" usebundle => dir_sync(
+      "$(this.promise_dirname)/proc",
+      "$(G.testdir)/proc"
+    );
+
+  commands:
+    "
+cd $(G.testdir)/proc/proc
+mkdir $(pid_for_testing)
+mv net $(pid_for_testing)/
+ln -s $(pid_for_testing) self
+ln -s self/net net
+"
+      comment => "Create a semi-real structure with symlinks and a pid dir",
+      contain => in_shell;
+}
+
+
 bundle agent test
 {
   meta:
       "test_skip_unsupported" string => "!linux";
 
   commands:
-      "$(G.env) CFENGINE_TEST_OVERRIDE_PROCDIR=$(this.promise_dirname)/proc $(sys.cf_agent) -DAUTO -f $(this.promise_filename).sub";
+      "$(G.env) CFENGINE_TEST_OVERRIDE_PROCPID=$(init.pid_for_testing) CFENGINE_TEST_OVERRIDE_PROCDIR=$(G.testdir)/proc $(sys.cf_agent) -DAUTO -f $(this.promise_filename).sub";
 }

--- a/tests/acceptance/00_basics/environment/proc-net.cf
+++ b/tests/acceptance/00_basics/environment/proc-net.cf
@@ -7,11 +7,34 @@ body common control
 
 ###########################################################
 
+bundle agent init
+{
+  vars:
+    "pid_for_testing" int => "11";
+
+  methods:
+    "" usebundle => dir_sync(
+      "$(this.promise_dirname)/proc",
+      "$(G.testdir)/proc"
+    );
+
+  commands:
+    "
+cd $(G.testdir)/proc/proc
+mkdir $(pid_for_testing)
+mv net $(pid_for_testing)/
+ln -s $(pid_for_testing) self
+ln -s self/net net
+"
+      comment => "Create a semi-real structure with symlinks and a pid dir",
+      contain => in_shell;
+}
+
 bundle agent test
 {
   meta:
       "test_skip_unsupported" string => "!linux";
 
   commands:
-      "$(G.env) CFENGINE_TEST_OVERRIDE_PROCDIR=$(this.promise_dirname)/proc $(sys.cf_agent) -DAUTO -f $(this.promise_filename).sub";
+      "$(G.env) CFENGINE_TEST_OVERRIDE_PROCPID=$(init.pid_for_testing) CFENGINE_TEST_OVERRIDE_PROCDIR=$(G.testdir)/proc $(sys.cf_agent) -DAUTO -f $(this.promise_filename).sub";
 }

--- a/tests/container/Dockerfile
+++ b/tests/container/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine
+RUN apk update && apk add alpine-sdk lmdb-dev openssl-dev bison flex-dev acl-dev pcre2-dev autoconf automake libtool git python3 gdb librsync-dev
+RUN mkdir /core /masterfiles
+COPY core /core
+COPY masterfiles /mpf
+WORKDIR /core
+RUN ./autogen.sh --without-pam
+RUN make install
+WORKDIR /mpf
+RUN ./autogen.sh
+RUN make install
+RUN apk add procps
+RUN /var/cfengine/bin/cf-key
+#RUN /var/cfengine/bin/cf-agent  --debug --bootstrap $(hostname -i)
+#RUN /var/cfengine/bin/cf-agent -KIf update.cf
+#RUN /var/cfengine/bin/cf-agent -KI
+#RUN /var/cfengine/bin/cf-agent -KI
+#RUN /var/cfengine/bin/cf-agent -KI
+CMD [ "sleep infinity" ]

--- a/tests/container/Dockerfile
+++ b/tests/container/Dockerfile
@@ -16,4 +16,4 @@ RUN /var/cfengine/bin/cf-key
 #RUN /var/cfengine/bin/cf-agent -KI
 #RUN /var/cfengine/bin/cf-agent -KI
 #RUN /var/cfengine/bin/cf-agent -KI
-CMD [ "sleep infinity" ]
+ENTRYPOINT [ "sleep infinity" ]

--- a/tests/container/compile-bootstrap-promise.sh
+++ b/tests/container/compile-bootstrap-promise.sh
@@ -51,7 +51,8 @@ if ! buildah run "$c" test -f /var/cfengine/ppkeys/localhost.pub; then
   buildah run "$c" /var/cfengine/bin/cf-key
 fi
 # bootstrap
-buildah run "$c" sh -c '/var/cfengine/bin/cf-agent --timestamp --debug --bootstrap $(hostname -i)' | tee bootstrap.log
+  buildah run "$c" apk add strace # debug bootstrap hanging on waiting for background process, track fork()
+buildah run "$c" sh -c 'strace /var/cfengine/bin/cf-agent --timestamp --debug --bootstrap $(hostname -i)' | tee bootstrap.log
 check_errors bootstrap.log
 
 # run update

--- a/tests/container/compile-bootstrap-promise.sh
+++ b/tests/container/compile-bootstrap-promise.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -ex
+
+function check_errors()
+{
+  log=$1
+  if grep error: "$log" >/dev/null; then
+    echo "FAIL: errors in $log"
+    grep error: "$log"
+    exit 1
+  fi
+}
+
+rm -f bootstrap.log
+rm -f update.log
+rm -f promise.log
+
+build_image=cfengine-core-alpine-build-image
+installed_image=cfengine-core-alpine-installed-image # cfengine built and installed
+
+# TODO: separate build_image from installed_image
+# e.g. install alpine-sdk/etc for build_image but then start fresh from alpine and installed bits in /var/cfengine?
+if ! buildah images "$build_image"; then
+  c=$(buildah from alpine)
+  buildah run "$c" apk update
+  buildah run "$c" apk add alpine-sdk lmdb-dev openssl-dev bison flex-dev acl-dev pcre2-dev autoconf automake libtool git python3 gdb librsync-dev
+  buildah commit $c "$build_image"
+fi
+
+
+if ! buildah images "$installed_image"; then
+  c=$(buildah from "$build_image")
+  buildah run --volume $(realpath ../../):/core --workingdir /core "$c" ./autogen.sh --without-pam
+  buildah run --volume $(realpath ../../):/core --workingdir /core "$c" make install
+  buildah run --volume $(realpath ../../../masterfiles):/mpf --workingdir /mpf "$c" ./autogen.sh
+  buildah run --volume $(realpath ../../../masterfiles):/mpf --workingdir /mpf "$c" make install
+  buildah commit "$c" "$installed_image"
+fi
+
+# run from a blank alpine container to save space and what not
+c=$(buildah from alpine)
+
+# python3 and procps are needed for running
+buildah run "$c" apk update
+buildah run "$c" apk add python3 procps lmdb-dev openssl-dev flex-dev acl-dev pcre2-dev librsync-dev
+buildah copy --from "$installed_image" "$c" /var/cfengine /var/cfengine
+
+
+# generate hostkey if needed (repeated runs should skip)
+if ! buildah run "$c" test -f /var/cfengine/ppkeys/localhost.pub; then
+  buildah run "$c" /var/cfengine/bin/cf-key
+fi
+# bootstrap
+buildah run "$c" sh -c '/var/cfengine/bin/cf-agent --timestamp --debug --bootstrap $(hostname -i)' | tee bootstrap.log
+check_errors bootstrap.log
+
+# run update
+buildah run "$c" sh -c '/var/cfengine/bin/cf-agent -KIf update.cf | tee update.log
+check_errors update.log
+
+# run promises
+buildah run "$c" sh -c '/var/cfengine/bin/cf-agent -KI | tee promise.log
+check_errors promise.log
+buildah run "$c" sh -c '/var/cfengine/bin/cf-agent -KI | tee -a promise.log
+check_errors promise.log
+buildah run "$c" sh -c '/var/cfengine/bin/cf-agent -KI | tee -a promise.log
+check_errors promise.log
+
+# TODO: remove run image, keep build and installed images
+
+# TODO maybe commit the installed/bootstrapped image for other uses

--- a/tests/container/compile-bootstrap-promise.sh
+++ b/tests/container/compile-bootstrap-promise.sh
@@ -52,6 +52,7 @@ if ! buildah run "$c" test -f /var/cfengine/ppkeys/localhost.pub; then
   buildah run "$c" /var/cfengine/bin/cf-key
 fi
 # workaround: during bootstrap, update policy starts cf-execd, cf-serverd and cf-monitord but this causes the bootstrap to "hang" waiting for these child processes to finish
+# nodaemons causes bootstrap to fail, but doesnt hang so thats a slight improvement?
 buildah copy "$c" nodaemons.json /var/cfengine/masterfiles/def.json
 # bootstrap
 #  buildah run "$c" apk add strace # debug bootstrap hanging on waiting for background process, track fork()

--- a/tests/container/compile-bootstrap-promise.sh
+++ b/tests/container/compile-bootstrap-promise.sh
@@ -51,6 +51,8 @@ buildah copy --from "$built_installed" "$c" /var/cfengine /var/cfengine
 if ! buildah run "$c" test -f /var/cfengine/ppkeys/localhost.pub; then
   buildah run "$c" /var/cfengine/bin/cf-key
 fi
+# workaround: during bootstrap, update policy starts cf-execd, cf-serverd and cf-monitord but this causes the bootstrap to "hang" waiting for these child processes to finish
+buildah copy "$c" nodaemons.json /var/cfengine/masterfiles/def.json
 # bootstrap
 #  buildah run "$c" apk add strace # debug bootstrap hanging on waiting for background process, track fork()
 buildah run "$c" sh -c '/var/cfengine/bin/cf-agent --timestamp --debug --bootstrap $(hostname -i)' | tee bootstrap.log

--- a/tests/container/compile-bootstrap-promise.sh
+++ b/tests/container/compile-bootstrap-promise.sh
@@ -31,7 +31,8 @@ fi
 
 if ! buildah images "$built_installed"; then
   c=$(buildah from "$build_host")
-  buildah run --volume $(realpath ../../):/core --workingdir /core "$c" ./autogen.sh --without-pam
+  # use --config-cache to speed up configuration by letting libntech re-use core's config cache
+  buildah run --volume $(realpath ../../):/core --workingdir /core "$c" ./autogen.sh --config-cache --without-pam
   buildah run --volume $(realpath ../../):/core --workingdir /core "$c" make install
   buildah run --volume $(realpath ../../../masterfiles):/mpf --workingdir /mpf "$c" ./autogen.sh
   buildah run --volume $(realpath ../../../masterfiles):/mpf --workingdir /mpf "$c" make install
@@ -53,7 +54,7 @@ if ! buildah run "$c" test -f /var/cfengine/ppkeys/localhost.pub; then
 fi
 # workaround: during bootstrap, update policy starts cf-execd, cf-serverd and cf-monitord but this causes the bootstrap to "hang" waiting for these child processes to finish
 # nodaemons causes bootstrap to fail, but doesnt hang so thats a slight improvement?
-buildah copy "$c" nodaemons.json /var/cfengine/masterfiles/def.json
+#buildah copy "$c" nodaemons.json /var/cfengine/masterfiles/def.json
 # bootstrap
 #  buildah run "$c" apk add strace # debug bootstrap hanging on waiting for background process, track fork()
 buildah run "$c" sh -c '/var/cfengine/bin/cf-agent --timestamp --debug --bootstrap $(hostname -i)' | tee bootstrap.log

--- a/tests/container/i
+++ b/tests/container/i
@@ -1,0 +1,5 @@
+# ../../../ e.g. NTECH_ROOT TODO
+docker build -t docker-cfe -f Dockerfile ../../../
+exit 0
+buildah rmi cfengine-core-alpine-built-installed || true
+./compile-bootstrap-promise.sh 2>&1 | tee log

--- a/tests/container/nodaemons.json
+++ b/tests/container/nodaemons.json
@@ -1,0 +1,7 @@
+{
+  "classes": {
+    "default:persistent_disable_cf_execd": [ "any::" ],
+    "default:persistent_disable_cf_serverd": [ "any::" ],
+    "default:persistent_disable_cf_monitord": [ "any::" ]
+  }
+}

--- a/tests/container/ntech-root-dockerignore
+++ b/tests/container/ntech-root-dockerignore
@@ -1,0 +1,13 @@
+**/.git
+**/tests/container
+mission-portal
+enterprise
+system-testing
+documentation
+nova
+buildscripts
+termux-packages
+website
+misc
+build-website
+packages

--- a/tests/container/test-docker.sh
+++ b/tests/container/test-docker.sh
@@ -1,0 +1,3 @@
+image=docker-cfe
+docker build -t docker-alpine-cfengine -f Dockerfile ../../../
+docker run docker-cfe sh '/var/cfengine/bin/cf-agent -IB $(hostname -i)'


### PR DESCRIPTION
- Minimized resources for static-check (package dependencies) and added cppcheck version printout
- address static-check complaints
- Added librsync-dev package dependency for alpine linux build from source
- Use current process ID to investigate proc filesystem to workaround in-container non-root owned symlinks
- Added error message when netstat file is not found during UNIX interface discovery.
- Move GetRelocatedProcdirRoot() from libntech and add GetProcdirPid()
- Added env var pid override in proc-net acceptance test
- sync with libntech pr commit, delete me after that is merged
- Added test for running community in alpine container
