### PR TITLE
2025 03 06 static check fixes/3.24

### DIFF
--- a/.github/workflows/job-static-check.yml
+++ b/.github/workflows/job-static-check.yml
@@ -38,13 +38,7 @@ jobs:
     - name: Prepare Environment
       run: |
         sudo apt-get update && \
-        sudo apt-get install -y dpkg-dev debhelper g++ libncurses6 pkg-config \
-          build-essential libpam0g-dev fakeroot gcc make autoconf buildah \
-          liblmdb-dev libacl1-dev libcurl4-openssl-dev libyaml-dev libxml2-dev \
-          libssl-dev libpcre2-dev
-
-    - name: Run Autogen
-      run: NO_CONFIGURE=1 PROJECT=community ./buildscripts/build-scripts/autogen
+        sudo apt-get install -y buildah
 
     - name: Run The Test
       working-directory: ./core

--- a/cf-check/dump.c
+++ b/cf-check/dump.c
@@ -224,7 +224,7 @@ static void print_struct_persistent_class(
         /* Make a copy to ensure proper alignment. We cannot just copy data to a
          * local PersistentClassInfo variable because it contains a
          * variable-length string at the end (see the struct definition). */
-        PersistentClassInfo *class_info = malloc(value.mv_size);
+        PersistentClassInfo *class_info = xmalloc(value.mv_size);
         memcpy(class_info, value.mv_data, value.mv_size);
         const unsigned int expires = class_info->expires;
         const PersistentClassPolicy policy = class_info->policy;

--- a/libpromises/locks.c
+++ b/libpromises/locks.c
@@ -84,7 +84,7 @@ static CfLockStack *LOCK_STACK = NULL;
 
 static void PushLock(char *lock, char *last)
 {
-    CfLockStack *new_lock = malloc(sizeof(CfLockStack));
+    CfLockStack *new_lock = xmalloc(sizeof(CfLockStack));
     strlcpy(new_lock->lock, lock, CF_BUFSIZE);
     strlcpy(new_lock->last, last, CF_BUFSIZE);
 

--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -56,7 +56,7 @@ failures=""
 # in jenkins the workdir is already autogen'd
 # in github it is not, so do that work here
 if [ ! -f configure ]; then
-  ./autogen.sh --enable-debug
+  NO_CONFIGURE=1 ./autogen.sh --enable-debug
 fi
 
 check_with_gcc              || { failures="${failures}FAIL: GCC check failed\n"; failure=1; }


### PR DESCRIPTION
- Minimized resources for static-check (package dependencies) and added cppcheck version printout
- address static-check complaints
- bump libntech to master

Back ported from https://github.com/cfengine/core/pull/5706