### PR TITLE
Fixed static-check to not configure when running autogen.

### DIFF
--- a/tests/static-check/run_checks.sh
+++ b/tests/static-check/run_checks.sh
@@ -56,7 +56,7 @@ failures=""
 # in jenkins the workdir is already autogen'd
 # in github it is not, so do that work here
 if [ ! -f configure ]; then
-  ./autogen.sh --enable-debug
+  NO_CONFIGURE=1 ./autogen.sh --enable-debug
 fi
 
 check_with_gcc              || { failures="${failures}FAIL: GCC check failed\n"; failure=1; }


### PR DESCRIPTION
Ticket: none
Changelog: none
