### PR TITLE
CFE-4508: Fixed valgrind errors in cf-check

### DIFF
--- a/cf-check/diagnose.c
+++ b/cf-check/diagnose.c
@@ -615,7 +615,7 @@ size_t diagnose_files(
 
         if (symlink_target != NULL)
         {
-            int usage;
+            int usage = 0;
             bool needs_rotation = lmdb_file_needs_rotation(symlink_target, &usage);
             Log(LOG_LEVEL_INFO,
                 "Status of '%s' -> '%s': %s [%d%% usage%s]\n",
@@ -627,7 +627,7 @@ size_t diagnose_files(
         }
         else
         {
-            int usage;
+            int usage = 0;
             bool needs_rotation = lmdb_file_needs_rotation(filename, &usage);
             Log(LOG_LEVEL_INFO,
                 "Status of '%s': %s [%d%% usage%s]\n",

--- a/tests/valgrind-check/valgrind.sh
+++ b/tests/valgrind-check/valgrind.sh
@@ -37,7 +37,7 @@ function check_valgrind_output {
     fi
     echo "Looking for problems in $1:"
     grep -i "ERROR SUMMARY: 0 errors" "$1"
-    cat $1 | sed -e "/ 0 errors/d" -e "/and suppressed error/d" -e "/a memory error detector/d" -e "/This database contains unknown binary data/d" > filtered.txt
+    cat $1 | sed -e "/ 0 errors/d" -e "/and suppressed error/d" -e "/a memory error detector/d" -e "/This database contains unknown binary data/d" -e "/error: Problems detected in 1\/1 databases/d" -e "/error: Failed to stat() 'no-such-file.lmdb'/d" -e "/Status of 'no-such-file.lmdb': SYSTEM_ERROR 2/d" > filtered.txt
     no_errors filtered.txt
     set +e
     grep -i "at 0x" filtered.txt

--- a/tests/valgrind-check/valgrind.sh
+++ b/tests/valgrind-check/valgrind.sh
@@ -98,6 +98,10 @@ echo "Running cf-check diagnose --validate on all databases:"
 valgrind $VG_OPTS /var/cfengine/bin/cf-check diagnose --validate 2>&1 | tee cf_check_validate_all_1.txt
 check_valgrind_output cf_check_validate_all_1.txt
 
+echo "Running cf-check diagnose --validate on non-existent file:"
+valgrind $VG_OPTS /var/cfengine/bin/cf-check diagnose --validate no-such-file.lmdb 2>&1 | tee cf_check_validate_non_existent.txt
+check_valgrind_output cf_check_validate_non_existent.txt
+
 check_masterfiles_and_inputs
 
 print_ps


### PR DESCRIPTION
- **Added leak check for running cf-check on non-existent file**
- **Fixed memory leak when running cf-check on non-existent file**
- **Fixed conditional jump or move depends on uninitialised value**
- **Silence error from cf-check when checking for valgrind errors**
