### PR TITLE
Fixed invalid read of size 8 in function FirstBackReference

### DIFF
--- a/libpromises/matching.c
+++ b/libpromises/matching.c
@@ -50,6 +50,16 @@ static char *FirstBackReference(Regex *regex, const char *teststring)
      * negative numbers are errors (incl. no match). */
     if (result > 0)
     {
+        uint32_t num_pairs = pcre2_get_ovector_count(match_data);
+        if (num_pairs <= 1)
+        {
+            /* There was no match */
+            strlcpy(backreference, "CF_NOMATCH", CF_MAXVARSIZE);
+            pcre2_match_data_free(match_data);
+            RegexDestroy(regex);
+            return backreference;
+        }
+
         size_t *ovector = pcre2_get_ovector_pointer(match_data);
         /* ovector[0] and ovector[1] are for the start and end of the whole
          * match, the capture groups follow in [2] and [3], etc. */


### PR DESCRIPTION
This memory issue caused segmentation faults in the
package_commands_useshell.cf acceptance test on SPARC Solaris 11 after
upgrading PCRE2 to version 10.45. The memory issue was found with the
help of valgrind.

Signed-off-by: Lars Erik Wik [lars.erik.wik@northern.tech](mailto:lars.erik.wik@northern.tech)
Back-ported to: https://github.com/cfengine/core/pull/5740