### PR TITLE
Support process_select bodies without process_result attribute

### DIFF
--- a/cf-agent/verify_processes.c
+++ b/cf-agent/verify_processes.c
@@ -93,13 +93,6 @@ static bool ProcessSanityChecks(const Attributes *a, const Promise *pp)
         ret = false;
     }
 
-    if ((a->haveselect) && (!a->process_select.process_result))
-    {
-        Log(LOG_LEVEL_ERR, "Process select constraint body promised no result (check body definition)");
-        PromiseRef(LOG_LEVEL_ERR, pp);
-        ret = false;
-    }
-
     // CF_NOINT is the value assigned when match_range is not specified
     if ((a->haveprocess_count) && ((a->process_count.min_range == CF_NOINT) || (a->process_count.max_range == CF_NOINT)))
     {
@@ -114,7 +107,6 @@ static bool ProcessSanityChecks(const Attributes *a, const Promise *pp)
         PromiseRef(LOG_LEVEL_ERR, pp);
         ret = false;
     }
-
 
     return ret;
 }

--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -1317,15 +1317,9 @@ ProcessSelect GetProcessFilterConstraints(const EvalContext *ctx, const Promise 
 {
     ProcessSelect p;
     char *value;
-    int entries = 0;
 
     // get constraint process ID
     value = PromiseGetConstraintAsRval(pp, "pid", RVAL_TYPE_SCALAR);
-    if (value)
-    {
-        entries++;
-    }
-
     if (!IntegerRangeFromString(value, &p.min_pid, &p.max_pid))
     {
         PromiseRef(LOG_LEVEL_ERR, pp);
@@ -1334,11 +1328,6 @@ ProcessSelect GetProcessFilterConstraints(const EvalContext *ctx, const Promise 
 
     // get constraint parent process ID
     value = PromiseGetConstraintAsRval(pp, "ppid", RVAL_TYPE_SCALAR);
-    if (value)
-    {
-        entries++;
-    }
-
     if (!IntegerRangeFromString(value, &p.min_ppid, &p.max_ppid))
     {
         PromiseRef(LOG_LEVEL_ERR, pp);
@@ -1347,11 +1336,6 @@ ProcessSelect GetProcessFilterConstraints(const EvalContext *ctx, const Promise 
 
     // get constraint process group ID
     value = PromiseGetConstraintAsRval(pp, "pgid", RVAL_TYPE_SCALAR);
-    if (value)
-    {
-        entries++;
-    }
-
     if (!IntegerRangeFromString(value, &p.min_pgid, &p.max_pgid))
     {
         PromiseRef(LOG_LEVEL_ERR, pp);
@@ -1360,11 +1344,6 @@ ProcessSelect GetProcessFilterConstraints(const EvalContext *ctx, const Promise 
 
     // get constraint resident set size
     value = PromiseGetConstraintAsRval(pp, "rsize", RVAL_TYPE_SCALAR);
-    if (value)
-    {
-        entries++;
-    }
-
     if (!IntegerRangeFromString(value, &p.min_rsize, &p.max_rsize))
     {
         PromiseRef(LOG_LEVEL_ERR, pp);
@@ -1373,11 +1352,6 @@ ProcessSelect GetProcessFilterConstraints(const EvalContext *ctx, const Promise 
 
     // get constraint VM size
     value = PromiseGetConstraintAsRval(pp, "vsize", RVAL_TYPE_SCALAR);
-    if (value)
-    {
-        entries++;
-    }
-
     if (!IntegerRangeFromString(value, &p.min_vsize, &p.max_vsize))
     {
         PromiseRef(LOG_LEVEL_ERR, pp);
@@ -1386,11 +1360,6 @@ ProcessSelect GetProcessFilterConstraints(const EvalContext *ctx, const Promise 
 
     // get constraint cumulated CPU time
     value = PromiseGetConstraintAsRval(pp, "ttime_range", RVAL_TYPE_SCALAR);
-    if (value)
-    {
-        entries++;
-    }
-
     if (!IntegerRangeFromString(value, (long *) &p.min_ttime, (long *) &p.max_ttime))
     {
         PromiseRef(LOG_LEVEL_ERR, pp);
@@ -1399,11 +1368,6 @@ ProcessSelect GetProcessFilterConstraints(const EvalContext *ctx, const Promise 
 
     // get constraint start time
     value = PromiseGetConstraintAsRval(pp, "stime_range", RVAL_TYPE_SCALAR);
-    if (value)
-    {
-        entries++;
-    }
-
     if (!IntegerRangeFromString(value, (long *) &p.min_stime, (long *) &p.max_stime))
     {
         PromiseRef(LOG_LEVEL_ERR, pp);
@@ -1412,11 +1376,6 @@ ProcessSelect GetProcessFilterConstraints(const EvalContext *ctx, const Promise 
 
     // get constraint priority
     value = PromiseGetConstraintAsRval(pp, "priority", RVAL_TYPE_SCALAR);
-    if (value)
-    {
-        entries++;
-    }
-
     if (!IntegerRangeFromString(value, &p.min_pri, &p.max_pri))
     {
         PromiseRef(LOG_LEVEL_ERR, pp);
@@ -1425,11 +1384,6 @@ ProcessSelect GetProcessFilterConstraints(const EvalContext *ctx, const Promise 
 
     // get constraint threads
     value = PromiseGetConstraintAsRval(pp, "threads", RVAL_TYPE_SCALAR);
-    if (value)
-    {
-        entries++;
-    }
-
     if (!IntegerRangeFromString(value, &p.min_thread, &p.max_thread))
     {
         PromiseRef(LOG_LEVEL_ERR, pp);
@@ -1442,20 +1396,8 @@ ProcessSelect GetProcessFilterConstraints(const EvalContext *ctx, const Promise 
     p.command = PromiseGetConstraintAsRval(pp, "command", RVAL_TYPE_SCALAR);
     p.tty = PromiseGetConstraintAsRval(pp, "tty", RVAL_TYPE_SCALAR);
 
-    // check if file_result is needed
-    if ((p.owner) || (p.status) || (p.command) || (p.tty))
-    {
-        entries = true;
-    }
-
     // get constraint process_result
-    if ((p.process_result = PromiseGetConstraintAsRval(pp, "process_result", RVAL_TYPE_SCALAR)) == NULL)
-    {
-        if (entries)
-        {
-            Log(LOG_LEVEL_ERR, "process_select body missing its process_result return value");
-        }
-    }
+    p.process_result = PromiseGetConstraintAsRval(pp, "process_result", RVAL_TYPE_SCALAR);
 
     return p;
 }

--- a/tests/acceptance/05_processes/01_matching/select_without_result.cf
+++ b/tests/acceptance/05_processes/01_matching/select_without_result.cf
@@ -1,0 +1,90 @@
+#######################################################
+#
+# Check process_select bodies without process_result attribute.
+#
+# If process_select bodies do not have a process_result attribute, its
+# given attributes should be AND'ed together for process filtering.
+#
+# Tests:
+#
+# 1.  Negative: using a highly unlikely virtual memory size range.
+#
+# 2.  Positive: using a virtual memory size range, that should match
+#               all processes
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+      "dummy" string => "dummy";
+}
+
+#######################################################
+
+bundle agent test
+{
+  meta:
+      # This test exposes a known issue with processes on the Windows platform.
+      "test_soft_fail" -> {"ENT-12751"}
+        string => "windows";
+
+      "description" -> {"CFE-4511"}
+        string => "process_select body without process_result";
+
+  processes:
+      ### Expect zero processes on a tty with a highly unlikely name.
+      ".*"
+        handle         => "expect_none",
+        process_select => test_without_process_result("1"),
+        process_count  => test_range("0", "0", "pass_bad_vsize", "fail_bad_vsize");
+
+      ### Expect to find one or more processes on these ttys.
+      ".*"
+        handle         => "expect_some",
+        process_select => test_without_process_result("inf"),
+        process_count  => test_range("1", "inf", "pass_good_vsize", "fail_good_vsize");
+
+}
+
+body process_select test_without_process_result(vsize)
+{
+     vsize => "1,$(vsize)";
+     ppid  => "1,1";
+}
+
+body process_count test_range(min, max, class_good, class_bad)
+{
+      match_range => irange("$(min)", "$(max)");
+      in_range_define => { "$(class_good)" };
+      out_of_range_define => { "$(class_bad)" };
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok" and => {
+        "pass_good_vsize", "pass_bad_vsize",
+        "!fail_good_vsize", "!fail_bad_vsize",
+      };
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 30


### PR DESCRIPTION
Currently process_select bodies are expected to have a process_result attribute. However documentation states, that in case the process_result attribute is missing, all set attributes are AND'ed together. This commit adds necessary changes to allow process_select bodies without process_result attribute and removes all error logging too.

Ticket: CFE-4511