### PR TITLE
ENT-12712: Fixed incorrect exit code handling in cf-runagent (3.24.x)

### DIFF
--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
                     if (fork() == 0)    /* child process */
                     {
                         int remote_exit_code = HailServer(ctx, config, RlistScalarValue(rp));
-                        DoCleanupAndExit(remote_exit_code  > 0 ? remote_exit_code : CF_RA_EXIT_CODE_OTHER_ERR);
+                        DoCleanupAndExit(remote_exit_code >= 0 ? remote_exit_code : CF_RA_EXIT_CODE_OTHER_ERR);
                     }
                     else        /* parent process */
                     {


### PR DESCRIPTION
ChangeLog: Title

Ticket: ENT-12712
Signed-off-by: Ihor Aleksandrychiev <ihor.aleksandrychiev@northern.tech>
(cherry picked from commit 79a2165877dbda5ae1ce5b8a6d050fb10edb44af)