### PR TITLE
libenv/sysinfo: Fix detected os description

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -549,13 +549,9 @@ static void GetNameInfo3(EvalContext *ctx)
     bool found = false;
     for (i = 0; !found && (i < PLATFORM_CONTEXT_MAX); i++)
     {
-        char sysname[CF_BUFSIZE];
-        strlcpy(sysname, VSYSNAME.sysname, CF_BUFSIZE);
-        ToLowerStrInplace(sysname);
-
         /* FIXME: review those strcmps. Moved out from StringMatch */
-        if (!strcmp(CLASSATTRIBUTES[i][0], sysname)
-            || StringMatchFull(CLASSATTRIBUTES[i][0], sysname))
+        if (!strcmp(CLASSATTRIBUTES[i][0], VSYSNAME.sysname)
+            || StringMatchFull(CLASSATTRIBUTES[i][0], VSYSNAME.sysname))
         {
             if (!strcmp(CLASSATTRIBUTES[i][1], VSYSNAME.machine)
                 || StringMatchFull(CLASSATTRIBUTES[i][1], VSYSNAME.machine))
@@ -580,16 +576,10 @@ static void GetNameInfo3(EvalContext *ctx)
         }
     }
 
-    if (!found)
-    {
-        i = 0;
-    }
-
     Log(LOG_LEVEL_VERBOSE, "%s - ready", NameVersion());
     Banner("Environment discovery");
 
-    snprintf(workbuf, CF_BUFSIZE, "%s", CLASSTEXT[i]); // See: cppcheck_suppressions.txt
-
+    snprintf(workbuf, CF_BUFSIZE, "%s", CLASSTEXT[VSYSTEMHARDCLASS]);
 
     Log(LOG_LEVEL_VERBOSE, "Host name is: %s", VSYSNAME.nodename);
     Log(LOG_LEVEL_VERBOSE, "Operating System Type is %s", VSYSNAME.sysname);

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -549,6 +549,12 @@ static void GetNameInfo3(EvalContext *ctx)
     bool found = false;
     for (i = 0; !found && (i < PLATFORM_CONTEXT_MAX); i++)
     {
+#ifndef NDEBUG
+        for (const char *ch = VSYSNAME.sysname; *ch != '\0'; ch++)
+        {
+            assert(islower(*ch));
+        }
+#endif /* NDEBUG */
         /* FIXME: review those strcmps. Moved out from StringMatch */
         if (!strcmp(CLASSATTRIBUTES[i][0], VSYSNAME.sysname)
             || StringMatchFull(CLASSATTRIBUTES[i][0], VSYSNAME.sysname))

--- a/tests/static-check/cppcheck_suppressions.txt
+++ b/tests/static-check/cppcheck_suppressions.txt
@@ -1,9 +1,6 @@
 // suppress warnings for access to individual bytes of a uint32 in platform.h
 objectIndex:libntech/libutils/platform.h
 
-// cppcheck is not clever enough to see that if (i >= PLATFORM_CONTEXT_MAX) then 'found' is false
-arrayIndexOutOfBounds:libenv/sysinfo.c:587
-
 // 'psin' is assigned to 'ai->ai_addr' and 'ai' is returned to the caller
 memleak:libntech/libcompat/getaddrinfo.c:153
 


### PR DESCRIPTION
Use platform context variable also for logging the os class description. Before this change, it were using loop counter variable, which is incremented again. This led to verbose logging message:
 verbose: CFEngine detected operating system description is qnx
on Darwin/macOS.

Also use already lowercased sysname from utsname struct.

Fixes: e2c9f00c0 ("Use a proper 'bool' variable for a condition in GetNameInfo3()")