### PR TITLE
Replaced GitHub CI platforms with Ubuntu 24 (3.24)

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   acceptance_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/asan_unit_tests.yml
+++ b/.github/workflows/asan_unit_tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   asan_unit_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/job-static-check.yml
+++ b/.github/workflows/job-static-check.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   static_check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Core
       uses: actions/checkout@v3

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   unit_tests:
     name: Run shellcheck on shell scripts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   unit_tests:
     name: Run Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   valgrind_tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: core


### PR DESCRIPTION
This commit was added while working on implementing the File Stream API
in ticket ENT-12414. The File Stream API utilizes librsync.  To begin
with I had `AC_CHECK_HEADERS([librsync_export.h], [],
AC_MSG_ERROR(Cannot find librsync))` in configure.ac. This file did not
exist in earlier versions of librync. Hence, I upgraded the Ubuntu
platforms in GitHub CI to make configure work. Later a realized that I
should remove that line enirely to make CFEngine compatible with earlier
versions. However, it does not hurt to upgrade the Ubuntu platforms, so
decided on keeping this commit.

Ticket: None
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 758e0657dba1646b4851f1b87064a4d5cf73e9a6)
