### PR TITLE
Marked findlocalusers* tests (2) as soft fail on AIX

### DIFF
--- a/tests/acceptance/01_vars/02_functions/findlocalusers.cf
+++ b/tests/acceptance/01_vars/02_functions/findlocalusers.cf
@@ -28,7 +28,7 @@ bundle agent init
 bundle agent test 
 {
   meta:
-      "test_soft_fail" string => "windows",
+      "test_soft_fail" string => "windows|aix",
         meta => { "CFE-2318" };
 
   vars:

--- a/tests/acceptance/01_vars/02_functions/unsafe/findlocalusers_unsafe.cf
+++ b/tests/acceptance/01_vars/02_functions/unsafe/findlocalusers_unsafe.cf
@@ -51,7 +51,7 @@ bundle agent init
 bundle agent test 
 {
   meta:
-      "test_soft_fail" string => "windows",
+      "test_soft_fail" string => "windows|aix",
         meta => { "CFE-2318" };
 
   vars:


### PR DESCRIPTION
User management and default shell and other details are different on AIX than on Linux.

Ticket: ENT-12767
Changelog: none
