### PR TITLE
Fixed whitespace typo in message about Cannot open software_packages.csv

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -2143,7 +2143,7 @@ static bool GetLegacyPackagesMatching(Regex *matcher, JsonElement *json, const b
             "Cannot open the %s packages inventory '%s' - "
             "This is not necessarily an error. "
             "Either the inventory policy has not been included, "
-            "or it has not had time to have an effect yet or you are using"
+            "or it has not had time to have an effect yet or you are using "
             "new package promise and check for legacy promise is made."
             "A future call may still succeed. (fopen: %s)",
             installed_mode ? "installed" : "available",


### PR DESCRIPTION
Ticket: ENT-12732
Changelog: none
