### PR TITLE
Define the "suse" class on SLED systems

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1188,7 +1188,8 @@ static void OSReleaseParse(EvalContext *ctx, const char *file_path)
                 alias = "redhat";
             }
             else if (StringEqual(os_release_id, "opensuse") ||
-                     StringEqual(os_release_id, "sles"))
+                     StringEqual(os_release_id, "sles") ||
+                     StringEqual(os_release_id, "sled"))
             {
                 alias = "suse";
             }


### PR DESCRIPTION
When running the agent on a SLED (SUSE Linux Enterprise Desktop), we get:

```
CFEngine(common)  Operating System not properly recognized, setting sys.os_name_human to "Unknown", please submit a bug report for us to fix this
```

This is caused by the OS detection skipping the `suse` alias on SLED systems.