### PR TITLE
Fixed whitespace typo in message about Cannot open software_packages.csv (3.21)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -1807,7 +1807,7 @@ static bool GetLegacyPackagesMatching(pcre *matcher, JsonElement *json, const bo
             "Cannot open the %s packages inventory '%s' - "
             "This is not necessarily an error. "
             "Either the inventory policy has not been included, "
-            "or it has not had time to have an effect yet or you are using"
+            "or it has not had time to have an effect yet or you are using "
             "new package promise and check for legacy promise is made."
             "A future call may still succeed. (fopen: %s)",
             installed_mode ? "installed" : "available",


### PR DESCRIPTION
Ticket: ENT-12732
Changelog: none
(cherry picked from commit 2763daf2bc8bcc08c6e8359a98751d40eb104a74)
