### PR TITLE
Added exception for solaris platform for findlocalusers* tests

### DIFF
--- a/tests/acceptance/01_vars/02_functions/findlocalusers.cf
+++ b/tests/acceptance/01_vars/02_functions/findlocalusers.cf
@@ -28,7 +28,7 @@ bundle agent init
 bundle agent test 
 {
   meta:
-      "test_soft_fail" string => "windows|aix",
+      "test_soft_fail" string => "windows|aix|solaris",
         meta => { "CFE-2318" };
 
   vars:

--- a/tests/acceptance/01_vars/02_functions/unsafe/findlocalusers_unsafe.cf
+++ b/tests/acceptance/01_vars/02_functions/unsafe/findlocalusers_unsafe.cf
@@ -51,7 +51,7 @@ bundle agent init
 bundle agent test 
 {
   meta:
-      "test_soft_fail" string => "windows|aix",
+      "test_soft_fail" string => "windows|aix|solaris",
         meta => { "CFE-2318" };
 
   vars:


### PR DESCRIPTION
The test needs work.
The expected data is not accurate for solaris as well as windows and aix.

Ticket: ENT-12767
Changelog: none

Solaris only build: [![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12071)](https://ci.cfengine.com/job/pr-pipeline/12071/)