### PR TITLE
CFE-3429: Use current process ID to investigate proc filesystem to workaround in-container non-root owned symlinks (3.24)

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -1283,6 +1283,10 @@ static JsonElement* GetNetworkingStatsInfo(const char *filename)
 
         fclose(fin);
     }
+    else
+    {
+        Log(LOG_LEVEL_VERBOSE, "netstat file not found at '%s'", filename);
+    }
 
     return stats;
 }

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -1390,12 +1390,13 @@ JsonElement* GetProcFileInfo(EvalContext *ctx, const char* filename, const char*
 void GetNetworkingInfo(EvalContext *ctx)
 {
     const char *procdir_root = GetRelocatedProcdirRoot();
+    int promiser_pid = (int) getpid();
 
     Buffer *pbuf = BufferNew();
 
     JsonElement *inet = JsonObjectCreate(2);
 
-    BufferPrintf(pbuf, "%s/proc/net/netstat", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/netstat", procdir_root, promiser_pid);
     JsonElement *inet_stats = GetNetworkingStatsInfo(BufferData(pbuf));
 
     if (inet_stats != NULL)
@@ -1403,7 +1404,7 @@ void GetNetworkingInfo(EvalContext *ctx)
         JsonObjectAppendElement(inet, "stats", inet_stats);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/route", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/route", procdir_root, promiser_pid);
     JsonElement *routes = GetProcFileInfo(ctx, BufferData(pbuf),  NULL, NULL, &NetworkingRoutesPostProcessInfo, NULL,
                     // format: Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
                     //         eth0	00000000	0102A8C0	0003	0	0	1024	00000000	0	0	0
@@ -1451,7 +1452,7 @@ void GetNetworkingInfo(EvalContext *ctx)
 
     JsonElement *inet6 = JsonObjectCreate(3);
 
-    BufferPrintf(pbuf, "%s/proc/net/snmp6", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/snmp6", procdir_root, promiser_pid);
     JsonElement *inet6_stats = GetProcFileInfo(ctx, BufferData(pbuf), NULL, NULL, NULL, NULL,
                                                "^\\s*(?<key>\\S+)\\s+(?<value>\\d+)");
 
@@ -1477,7 +1478,7 @@ void GetNetworkingInfo(EvalContext *ctx)
         JsonDestroy(inet6_stats);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/ipv6_route", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/ipv6_route", procdir_root, promiser_pid);
     JsonElement *inet6_routes = GetProcFileInfo(ctx, BufferData(pbuf),  NULL, NULL, &NetworkingIPv6RoutesPostProcessInfo, NULL,
                     // format: dest                    dest_prefix source                source_prefix next_hop                         metric   refcnt   use      flags        interface
                     //         fe800000000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000000 00000000 00000001     eth0
@@ -1492,7 +1493,7 @@ void GetNetworkingInfo(EvalContext *ctx)
         JsonObjectAppendElement(inet6, "routes", inet6_routes);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/if_inet6", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/if_inet6", procdir_root, promiser_pid);
     JsonElement *inet6_addresses = GetProcFileInfo(ctx, BufferData(pbuf),  NULL, "interface", &NetworkingIPv6AddressesPostProcessInfo, &NetworkingIPv6AddressesTiebreaker,
                     // format: address device_number prefix_length scope flags interface_name
                     // 00000000000000000000000000000001 01 80 10 80       lo
@@ -1515,7 +1516,7 @@ void GetNetworkingInfo(EvalContext *ctx)
     //  face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
     //   eth0: 74850544807 75236137    0    0    0     0          0   1108775 63111535625 74696758    0    0    0     0       0          0
 
-    BufferPrintf(pbuf, "%s/proc/net/dev", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/dev", procdir_root, promiser_pid);
     JsonElement *interfaces_data =
     GetProcFileInfo(ctx, BufferData(pbuf), "interfaces_data", "device", NULL, NULL,
                     "^\\s*(?<device>[^:]+)\\s*:\\s*"
@@ -1543,34 +1544,35 @@ void GetNetworkingInfo(EvalContext *ctx)
 JsonElement* GetNetworkingConnections(EvalContext *ctx)
 {
     const char *procdir_root = GetRelocatedProcdirRoot();
+    int promiser_pid = (int) getpid();
     JsonElement *json = JsonObjectCreate(5);
     const char* ports_regex = "^\\s*\\d+:\\s+(?<raw_local>[0-9A-F:]+)\\s+(?<raw_remote>[0-9A-F:]+)\\s+(?<raw_state>[0-9]+)";
 
     JsonElement *data = NULL;
     Buffer *pbuf = BufferNew();
 
-    BufferPrintf(pbuf, "%s/proc/net/tcp", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/tcp", procdir_root, promiser_pid);
     data = GetProcFileInfo(ctx, BufferData(pbuf), NULL, NULL, &NetworkingPortsPostProcessInfo, NULL, ports_regex);
     if (data != NULL)
     {
         JsonObjectAppendElement(json, "tcp", data);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/tcp6", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/tcp6", procdir_root, promiser_pid);
     data = GetProcFileInfo(ctx, BufferData(pbuf), NULL, NULL, &NetworkingPortsPostProcessInfo, NULL, ports_regex);
     if (data != NULL)
     {
         JsonObjectAppendElement(json, "tcp6", data);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/udp", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/udp", procdir_root, promiser_pid);
     data = GetProcFileInfo(ctx, BufferData(pbuf), NULL, NULL, &NetworkingPortsPostProcessInfo, NULL, ports_regex);
     if (data != NULL)
     {
         JsonObjectAppendElement(json, "udp", data);
     }
 
-    BufferPrintf(pbuf, "%s/proc/net/udp6", procdir_root);
+    BufferPrintf(pbuf, "%s/proc/%d/net/udp6", procdir_root, promiser_pid);
     data = GetProcFileInfo(ctx, BufferData(pbuf), NULL, NULL, &NetworkingPortsPostProcessInfo, NULL, ports_regex);
     if (data != NULL)
     {

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -1395,7 +1395,7 @@ JsonElement* GetProcFileInfo(EvalContext *ctx, const char* filename, const char*
 void GetNetworkingInfo(EvalContext *ctx)
 {
     const char *procdir_root = GetRelocatedProcdirRoot();
-    int promiser_pid = (int) getpid();
+    int promiser_pid = GetProcdirPid();
 
     Buffer *pbuf = BufferNew();
 
@@ -1549,7 +1549,7 @@ void GetNetworkingInfo(EvalContext *ctx)
 JsonElement* GetNetworkingConnections(EvalContext *ctx)
 {
     const char *procdir_root = GetRelocatedProcdirRoot();
-    int promiser_pid = (int) getpid();
+    int promiser_pid = GetProcdirPid();
     JsonElement *json = JsonObjectCreate(5);
     const char* ports_regex = "^\\s*\\d+:\\s+(?<raw_local>[0-9A-F:]+)\\s+(?<raw_remote>[0-9A-F:]+)\\s+(?<raw_state>[0-9]+)";
 

--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -39,6 +39,7 @@
 #include <ip_address.h>
 #include <file_lib.h>
 #include <cleanup.h>
+#include <unix.h> /* GetRelocatedProcdirRoot() and GetProcdirPid() */
 
 #ifdef HAVE_SYS_JAIL_H
 # include <sys/jail.h>

--- a/libpromises/unix.h
+++ b/libpromises/unix.h
@@ -34,6 +34,17 @@ bool GetCurrentUserName(char *userName, int userNameLen);
 
 #ifndef __MINGW32__
 /**
+ * @brief For testing things against /proc, uses env var CFENGINE_TEST_OVERRIDE_PROCDIR
+ * @return the extra directory to add BEFORE /proc in the path
+ */
+const char* GetRelocatedProcdirRoot();
+/**
+ * @brief For testing things against /proc, use env var CFENGINE_TEST_OVERRIDE_PROCPID
+ * @return the fake pid to use in proc paths
+ */
+int GetProcdirPid();
+
+/**
  * Get user name for the user with UID #uid
  *
  * @param uid              UID of the user

--- a/tests/acceptance/00_basics/environment/proc-net-functions.cf
+++ b/tests/acceptance/00_basics/environment/proc-net-functions.cf
@@ -7,11 +7,35 @@ body common control
 
 ###########################################################
 
+bundle agent init
+{
+  vars:
+    "pid_for_testing" int => "11";
+
+  methods:
+    "" usebundle => dir_sync(
+      "$(this.promise_dirname)/proc",
+      "$(G.testdir)/proc"
+    );
+
+  commands:
+    "
+cd $(G.testdir)/proc/proc
+mkdir $(pid_for_testing)
+mv net $(pid_for_testing)/
+ln -s $(pid_for_testing) self
+ln -s self/net net
+"
+      comment => "Create a semi-real structure with symlinks and a pid dir",
+      contain => in_shell;
+}
+
+
 bundle agent test
 {
   meta:
       "test_skip_unsupported" string => "!linux";
 
   commands:
-      "$(G.env) CFENGINE_TEST_OVERRIDE_PROCDIR=$(this.promise_dirname)/proc $(sys.cf_agent) -DAUTO -f $(this.promise_filename).sub";
+      "$(G.env) CFENGINE_TEST_OVERRIDE_PROCPID=$(init.pid_for_testing) CFENGINE_TEST_OVERRIDE_PROCDIR=$(G.testdir)/proc $(sys.cf_agent) -DAUTO -f $(this.promise_filename).sub";
 }

--- a/tests/acceptance/00_basics/environment/proc-net.cf
+++ b/tests/acceptance/00_basics/environment/proc-net.cf
@@ -7,11 +7,34 @@ body common control
 
 ###########################################################
 
+bundle agent init
+{
+  vars:
+    "pid_for_testing" int => "11";
+
+  methods:
+    "" usebundle => dir_sync(
+      "$(this.promise_dirname)/proc",
+      "$(G.testdir)/proc"
+    );
+
+  commands:
+    "
+cd $(G.testdir)/proc/proc
+mkdir $(pid_for_testing)
+mv net $(pid_for_testing)/
+ln -s $(pid_for_testing) self
+ln -s self/net net
+"
+      comment => "Create a semi-real structure with symlinks and a pid dir",
+      contain => in_shell;
+}
+
 bundle agent test
 {
   meta:
       "test_skip_unsupported" string => "!linux";
 
   commands:
-      "$(G.env) CFENGINE_TEST_OVERRIDE_PROCDIR=$(this.promise_dirname)/proc $(sys.cf_agent) -DAUTO -f $(this.promise_filename).sub";
+      "$(G.env) CFENGINE_TEST_OVERRIDE_PROCPID=$(init.pid_for_testing) CFENGINE_TEST_OVERRIDE_PROCDIR=$(G.testdir)/proc $(sys.cf_agent) -DAUTO -f $(this.promise_filename).sub";
 }


### PR DESCRIPTION
- Use current process ID to investigate proc filesystem to workaround in-container non-root owned symlinks
- Added error message when netstat file is not found during UNIX interface discovery.
- Move GetRelocatedProcdirRoot() from libntech and add GetProcdirPid()
- Added env var pid override in proc-net acceptance test To align with change to reading /proc/<pid>/...
- bump libntech to master
