### PR TITLE
ENT-12766: Fixed ODR violations in ASAN Unit Tests (3.24.x)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -10311,6 +10311,9 @@ static const FnCallArg DATATYPE_ARGS[] =
 
 /* see fncall.h enum FnCallType */
 
+/* In evalfunction_test.c we both include this file and link with libpromises.
+ * This guard makes sure we don't get a duplicate definition of this symbol */
+#ifndef CFENGINE_EVALFUNCTION_TEST_C
 const FnCallType CF_FNCALL_TYPES[] =
 {
     FnCallTypeNew("accessedbefore", CF_DATA_TYPE_CONTEXT, ACCESSEDBEFORE_ARGS, &FnCallIsAccessedBefore, "True if arg1 was accessed before arg2 (atime)",
@@ -10715,3 +10718,4 @@ const FnCallType CF_FNCALL_TYPES[] =
 
     FnCallTypeNewNull()
 };
+#endif // CFENGINE_EVALFUNCTION_TEST_C

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -188,6 +188,7 @@ if MACOSX
 XFAIL_TESTS = set_domainname_test
 XFAIL_TESTS += process_test
 XFAIL_TESTS += mon_processes_test
+XFAIL_TESTS += rlist_test
 endif
 
 if HPUX

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -52,15 +52,7 @@ AM_CFLAGS = $(PTHREAD_CFLAGS)
 
 
 check_LTLIBRARIES = libtest.la
-libtest_la_SOURCES = cmockery.c cmockery.h schema.h test.c test.h \
-	../../libntech/libutils/alloc.c \
-	../../libpromises/patches.c \
-	../../libpromises/constants.c \
-	../../libntech/libutils/known_dirs.c \
-	../../libntech/libutils/map.c \
-	../../libntech/libutils/array_map.c \
-	../../libntech/libutils/hash.c \
-	../../libntech/libutils/hash_map.c
+libtest_la_SOURCES = cmockery.c cmockery.h schema.h test.c test.h
 
 libtest_la_LIBADD = ../../libntech/libcompat/libcompat.la
 
@@ -271,7 +263,7 @@ db_concurrent_test_LDADD = libdb.la
 lastseen_test_SOURCES = lastseen_test.c \
 	../../libntech/libutils/statistics.c
 #lastseen_test_CPPFLAGS = $(libdb_la_CPPFLAGS)
-lastseen_test_LDADD = libdb.la ../../libpromises/libpromises.la
+lastseen_test_LDADD = libtest.la ../../libpromises/libpromises.la
 
 lastseen_migration_test_SOURCES = lastseen_migration_test.c
 #lastseen_migration_test_CPPFLAGS = $(libdb_la_CPPFLAGS)
@@ -298,7 +290,10 @@ files_copy_test_LDADD    = libtest.la ../../libpromises/libpromises.la
 sort_test_SOURCES = sort_test.c
 sort_test_LDADD = libtest.la ../../libpromises/libpromises.la
 
-logging_test_SOURCES = logging_test.c ../../libpromises/syslog_client.c
+logging_test_SOURCES = logging_test.c \
+	../../libpromises/syslog_client.c \
+	../../libpromises/patches.c \
+	../../libpromises/constants.c
 logging_test_LDADD = libtest.la ../../libntech/libutils/libutils.la
 
 connection_management_test_SOURCES = connection_management_test.c \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -269,18 +269,13 @@ db_concurrent_test_SOURCES = db_concurrent_test.c
 db_concurrent_test_LDADD = libdb.la
 
 lastseen_test_SOURCES = lastseen_test.c \
-	../../libpromises/item_lib.c \
-	../../libpromises/lastseen.c \
 	../../libntech/libutils/statistics.c
 #lastseen_test_CPPFLAGS = $(libdb_la_CPPFLAGS)
 lastseen_test_LDADD = libdb.la ../../libpromises/libpromises.la
 
-lastseen_migration_test_SOURCES = lastseen_migration_test.c \
-	../../libpromises/lastseen.c \
-	../../libntech/libutils/statistics.c \
-	../../libpromises/item_lib.c
+lastseen_migration_test_SOURCES = lastseen_migration_test.c
 #lastseen_migration_test_CPPFLAGS = $(libdb_la_CPPFLAGS)
-lastseen_migration_test_LDADD = libdb.la ../../libpromises/libpromises.la
+lastseen_migration_test_LDADD = ../../libpromises/libpromises.la
 
 CLEANFILES = *.gcno *.gcda cfengine-enterprise.so
 
@@ -313,8 +308,7 @@ connection_management_test_LDADD = ../../libpromises/libpromises.la \
 	 libtest.la \
 	../../cf-serverd/libcf-serverd.la
 
-rlist_test_SOURCES = rlist_test.c \
-	../../libpromises/rlist.c
+rlist_test_SOURCES = rlist_test.c
 rlist_test_LDADD = libtest.la ../../libpromises/libpromises.la
 # Workaround for object file basename conflicts, search the web for
 # "automake created with both libtool and without"

--- a/tests/unit/evalfunction_test.c
+++ b/tests/unit/evalfunction_test.c
@@ -1,5 +1,9 @@
 #include <test.h>
 
+/* Protect against duplicate definition of symbol CF_FNCALL_TYPES since we are
+ * including evalfunction.c */
+#define CFENGINE_EVALFUNCTION_TEST_C
+
 #include <eval_context.h>
 #include <evalfunction.c>
 

--- a/tests/unit/lastseen_test.c
+++ b/tests/unit/lastseen_test.c
@@ -664,11 +664,7 @@ void FatalError(ARG_UNUSED char *s, ...)
     exit(42);
 }
 
-HashMethod CF_DEFAULT_DIGEST;
 pthread_mutex_t *cft_output;
-char VIPADDRESS[CF_MAX_IP_LEN];
-RSA *PUBKEY;
-bool MINUSF;
 
 char *HashPrintSafe(ARG_UNUSED char *dst, ARG_UNUSED size_t dst_size,
                     ARG_UNUSED const unsigned char *digest,

--- a/tests/unit/rlist_test.c
+++ b/tests/unit/rlist_test.c
@@ -825,7 +825,6 @@ const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *lval, D
     fail();
 }
 
-pthread_mutex_t *cft_lock;
 int __ThreadLock(pthread_mutex_t *name)
 {
     return true;

--- a/tests/unit/set_domainname_test.c
+++ b/tests/unit/set_domainname_test.c
@@ -7,11 +7,6 @@
 #include <rlist.h>
 #include <enterprise_extension.h>
 
-/* Global variables we care about */
-
-char VFQNAME[CF_MAXVARSIZE];
-char VUQNAME[CF_MAXVARSIZE / 2];
-char VDOMAIN[CF_MAXVARSIZE / 2];
 
 static struct hostent h = {
     .h_name = "laptop.intra.cfengine.com"


### PR DESCRIPTION
Ticket: ENT-12766
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 88e6052728345daa18d9cb59478ea6b8f2771423)

Back-ported from https://github.com/cfengine/core/pull/5656