### PR TITLE
Fixed assertion triggered in OS detection code

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -555,9 +555,13 @@ static void GetNameInfo3(EvalContext *ctx)
     bool found = false;
     for (i = 0; !found && (i < PLATFORM_CONTEXT_MAX); i++)
     {
+        char sysname[CF_BUFSIZE];
+        strlcpy(sysname, VSYSNAME.sysname, CF_BUFSIZE);
+        ToLowerStrInplace(sysname);
+
         /* FIXME: review those strcmps. Moved out from StringMatch */
-        if (!strcmp(CLASSATTRIBUTES[i][0], VSYSNAME.sysname)
-            || StringMatchFull(CLASSATTRIBUTES[i][0], VSYSNAME.sysname))
+        if (!strcmp(CLASSATTRIBUTES[i][0], sysname)
+            || StringMatchFull(CLASSATTRIBUTES[i][0], sysname))
         {
             if (!strcmp(CLASSATTRIBUTES[i][1], VSYSNAME.machine)
                 || StringMatchFull(CLASSATTRIBUTES[i][1], VSYSNAME.machine))

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -555,12 +555,6 @@ static void GetNameInfo3(EvalContext *ctx)
     bool found = false;
     for (i = 0; !found && (i < PLATFORM_CONTEXT_MAX); i++)
     {
-#ifndef NDEBUG
-        for (const char *ch = VSYSNAME.sysname; *ch != '\0'; ch++)
-        {
-            assert(islower(*ch));
-        }
-#endif /* NDEBUG */
         /* FIXME: review those strcmps. Moved out from StringMatch */
         if (!strcmp(CLASSATTRIBUTES[i][0], VSYSNAME.sysname)
             || StringMatchFull(CLASSATTRIBUTES[i][0], VSYSNAME.sysname))


### PR DESCRIPTION
- **Revert "libenv/sysinfo: Check on lowercase"**
- **Fixed bug in system detection code caused by wrong assumption**
