### PR TITLE
ENT-12751: Fixed bug in parsing process_select for Windows (3.24.x)

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -98,6 +98,7 @@ libdb_la_LIBADD = libstr.la ../../libntech/libutils/libutils.la
 libdb_la_CFLAGS = $(AM_CFLAGS)
 
 check_PROGRAMS = \
+	processes_select_test \
 	arg_split_test \
 	assoc_test \
 	getopt_test \
@@ -194,6 +195,10 @@ endif
 if HPUX
 XFAIL_TESTS = mon_load_test # Redmine #3569
 endif
+
+
+processes_select_test_SOURCES = processes_select_test.c
+processes_select_test_LDADD = libtest.la ../../libpromises/libpromises.la
 
 #
 # OS X uses real system calls instead of our stubs unless this option is used

--- a/tests/unit/processes_select_test.c
+++ b/tests/unit/processes_select_test.c
@@ -1,0 +1,45 @@
+#include <test.h>
+
+#include <item_lib.h>
+#include <cf3.defs.h>
+#include <processes_select.c>
+
+static void test_SplitProcLine_windows(void)
+{
+
+    char buf[CF_BUFSIZE];
+    snprintf(buf, sizeof(buf), "%-20s %5s %s %s %8s %8s %-3s %s %s %5s %s",
+             "USER", "PID", "%CPU", "%MEM", "VSZ", "RSS", "TTY", "STAT", "START", "TIME", "COMMAND");
+
+    char *names[CF_PROCCOLS] = {0};
+    int start[CF_PROCCOLS];
+    int end[CF_PROCCOLS];
+
+    GetProcessColumnNames(buf, names, start, end);
+
+    const char *const proc_line = "NETWORK SERVICE        540  0.0  0.3     5092     11180 ?   ?    Apr28 00:00 C:\\Windows\\system32\\svchost.exe -k RPCSS -p";
+    time_t pstime = time(NULL);
+
+    char *column[CF_PROCCOLS] = {0};
+
+    bool ret = SplitProcLine(proc_line, pstime, names, start, end, PCA_AllColumnsPresent, column);
+    assert_true(ret);
+    assert_string_equal(column[0], "NETWORK SERVICE");
+
+    for (int i = 0; i < CF_PROCCOLS; i++)
+    {
+        free(names[i]);
+        free(column[i]);
+    }
+}
+
+int main()
+{
+    PRINT_TEST_BANNER();
+    const UnitTest tests[] =
+    {
+          unit_test(test_SplitProcLine_windows),
+    };
+
+    return run_tests(tests);
+}


### PR DESCRIPTION
- **Fixed bug in parsing process_select for Windows**

Back-ported from https://github.com/cfengine/core/pull/5786