### PR TITLE
Soft fail rlist_test on AIX (3.24)

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -191,6 +191,10 @@ XFAIL_TESTS += mon_processes_test
 XFAIL_TESTS += rlist_test
 endif
 
+if AIX
+XFAIL_TESTS = rlist_test
+endif
+
 if HPUX
 XFAIL_TESTS = mon_load_test # Redmine #3569
 endif


### PR DESCRIPTION
For some reason rlist_test fails in AIX unit tests. The test seems to
`abort()` while it should trigger an assert so that
`expect_assert_failure()` can catch it. For some reason this is not
happening anymore.

```
rlist.c:135: Programming Error: Internal error: Rval contains type f instead of expected scalar
```

I created a ticket (CFE-4473) to follow-up on this.

Ticket: None
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 67ebf978d4a7feaa089661dfd0f7fea119f22f6c)
