### PR TITLE
Fixed soft_fail 05_processes/01_matching/select_without_result.cf for windows meta data

### DIFF
--- a/tests/acceptance/05_processes/01_matching/select_without_result.cf
+++ b/tests/acceptance/05_processes/01_matching/select_without_result.cf
@@ -35,8 +35,9 @@ bundle agent test
 {
   meta:
       # This test exposes a known issue with processes on the Windows platform.
-      "test_soft_fail" -> {"ENT-12751"}
-        string => "windows";
+      "test_soft_fail"
+        string => "windows",
+        meta => {"ENT-12751"};
 
       "description" -> {"CFE-4511"}
         string => "process_select body without process_result";


### PR DESCRIPTION
The test_soft_fail ticket was added improperly.
A meta attribute instead of a promisee.

https://docs.cfengine.com/docs/3.24/reference-language-concepts.html

Ticket: CFE-4511
Changelog: none

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12084)](https://ci.cfengine.com/job/pr-pipeline/12084/)