### PR TITLE
Added http_port and getattr selinux permissions as needed for selinux policy on rhel-8 and rhel-9 (3.24)

### DIFF
--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -91,6 +91,8 @@ require {
 	type ssh_exec_t;
 	type ssh_home_t;
 	type rpm_script_t;
+	type fsadm_exec_t;
+	type lvm_exec_t;
 	class lockdown { confidentiality integrity };
 	class tcp_socket { create ioctl read getattr lock write setattr append bind connect getopt setopt shutdown name_connect accept listen name_bind node_bind };
 	class mctp_socket { ioctl read write create getattr setattr lock relabelfrom relabelto append map bind connect listen accept getopt setopt shutdown recvfrom sendto recv_msg send_msg name_bind };
@@ -400,6 +402,10 @@ allow init_t cfengine_hub_t:process siginh;
 
 allow cfengine_hub_t cfengine_hub_exec_t:file entrypoint;
 allow cfengine_hub_t cfengine_hub_exec_t:file { ioctl read getattr lock map execute open };
+
+# the following file permissions for cf-hub are not needed if masterfiles includes fixes from ENT-12954 making inventory and paths standard library bundles agent instead of common.
+allow cfengine_hub_t fsadm_exec_t:file getattr;
+allow cfengine_hub_t lvm_exec_t:file getattr;
 
 # allow cf-hub to use/execute libpromises.so
 allow cfengine_hub_t cfengine_var_lib_t:file map;

--- a/misc/selinux/cfengine-enterprise.te.el9
+++ b/misc/selinux/cfengine-enterprise.te.el9
@@ -1,5 +1,6 @@
 require {
 	type systemd_userdbd_runtime_t;
+	type http_port_t;
 }
 
 # PAM module for dynamic users
@@ -8,3 +9,8 @@ allow cfengine_httpd_t systemd_userdbd_runtime_t:sock_file write;
 allow cfengine_httpd_t kernel_t:unix_stream_socket connectto;
 allow cfengine_reactor_t systemd_userdbd_runtime_t:dir { getattr open read search };
 allow cfengine_reactor_t systemd_userdbd_runtime_t:sock_file write;
+
+# selinux-policy 38.1.45 requires the following http_port permissions whereas 3.14.3 does not.
+# these permissions are not be needed if changes from ENT-12954 to masterfiles policy move inventory from common to an agent bundle are in place.
+allow cfengine_serverd_t http_port_t:tcp_socket name_connect;
+allow cfengine_execd_t http_port_t:tcp_socket name_connect;


### PR DESCRIPTION
http_port is needed in el9, selinux-policy version 38.1.45, for inventory policy common bundles.

getattr for fsadm_exec_t is needed in el9 and getattr for lvm_exec_t is needed in both el8 and el9.

Ticket: ENT-12954
Changelog: title
(cherry picked from commit 73ba3b410170f61bad3c1d5b623e8f511a7528ec)


[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12109)](https://ci.cfengine.com/job/pr-pipeline/12109/)

Packages: https://buildcache.cfengine.com/packages/testing-pr/jenkins-pr-pipeline-12109/