### PR TITLE
changelog-generator: Fixed syntax error in regex

### DIFF
--- a/misc/changelog-generator/changelog-generator
+++ b/misc/changelog-generator/changelog-generator
@@ -189,7 +189,7 @@ for repo in repos:
                             del ENTRIES[linked_sha]
                     continue
 
-            match = re.match("^\(cherry picked from commit ([0-9a-f]+)\)", line, re.IGNORECASE)
+            match = re.match(r"^\(cherry picked from commit ([0-9a-f]+)\)", line, re.IGNORECASE)
             if match:
                 if log_entry:
                     add_entry(sha, log_entry)


### PR DESCRIPTION
Fixed syntax error in regex by changing it into a raw string.

```
$ misc/changelog-generator/changelog-generator --repo  3.25.0..master
/home/larsewi/ntech/cfengine/core/misc/changelog-generator/changelog-generator:192: SyntaxWarning: invalid escape sequence '\('
  match = re.match("^\(cherry picked from commit ([0-9a-f]+)\)", line, re.IGNORECASE)
```

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
