### PR TITLE
Added stale workflow to label and close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+# For more information, see:
+# https://github.com/actions/stale
+name: Label and close stale pull requests
+
+on:
+  schedule:
+  - cron: '31 19 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'Marking this PR as stale due to inactivity; it will be closed in 7 days.'
+        stale-pr-label: 'stale'
+        days-before-stale: 30
+        days-before-close: 7
+        close-pr-message: "Closing PR due to inactivity. Feel free to open a new PR if necessary."
+        


### PR DESCRIPTION
I'd like old and inactive PRs to be closed automatically. We have a release checklist to try to go over all open PRs before each release and there's (IMO) too much noise.