### PR TITLE
Don't print license when initiating gdb from testall script

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -483,7 +483,7 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
             then
                 printf "\"$LIBTOOL\" --mode=execute " >> "$WORKDIR/runtest"
             fi
-            printf "gdb --args " >> "$WORKDIR/runtest"
+            printf "gdb -silent --args " >> "$WORKDIR/runtest"
         fi
 
         if [ -n "$USE_VALGRIND"  -a  $TEST_TYPE = errorexit ]


### PR DESCRIPTION
```
$ ./tests/acceptance/testall --gdb tests/acceptance/10_files/test.cf
======================================================================
Testsuite started at 2025-05-26 15:18:33
----------------------------------------------------------------------
Total tests: 1

        COMMON_TESTS: enabled
         TIMED_TESTS: enabled
          SLOW_TESTS: enabled
     ERROREXIT_TESTS: enabled
        SERIAL_TESTS: enabled
       NETWORK_TESTS: enabled
       LIBXML2_TESTS: enabled
       LIBCURL_TESTS: enabled
        UNSAFE_TESTS: disabled
       STAGING_TESTS: disabled

Test run is not parallel

./tests/acceptance/10_files/test.cf Reading symbols from /home/larsewi/ntech/core/cf-agent/.libs/cf-agent...
(gdb)
```
