### PR TITLE
Formatted recently introduced examples according to style guide

### DIFF
--- a/examples/findlocalusers.cf
+++ b/examples/findlocalusers.cf
@@ -1,22 +1,28 @@
 #+begin_src cfengine3
 body common control
 {
-    bundlesequence => { "example" };
+  bundlesequence => { "example" };
 }
+
 bundle agent example
 {
-    vars:
-        "root_filter" slist => {"gid=0", "name=root"};
-        "root_container" data => findlocalusers("@(root_filter)");
-        "root_list" slist => getindices("root_container");
+  vars:
+    "root_filter"
+      slist => {"gid=0", "name=root"};
+    "root_container"
+      data => findlocalusers("@(root_filter)");
+    "root_list"
+      slist => getindices("root_container");
+    "bin_filter"
+      data => '["name=bin"]';
+    "bin_container"
+      data => findlocalusers("@(bin_filter)");
+    "bin_list"
+      slist => getindices("bin_container");
 
-        "bin_filter" data => '["name=bin"]';
-        "bin_container" data => findlocalusers("@(bin_filter)");
-        "bin_list" slist => getindices("bin_container");
-
-    reports:
-        "List: $(root_list)";
-        "List: $(bin_list)";
+  reports:
+    "List: $(root_list)";
+    "List: $(bin_list)";
 }
 
 #+end_src

--- a/examples/getbundlemetatags.cf
+++ b/examples/getbundlemetatags.cf
@@ -1,21 +1,28 @@
 #+begin_src cfengine3
 body common control
 {
-      bundlesequence => { "example" };
+  bundlesequence => { "example" };
 }
 
 bundle agent example
 {
   meta:
-      "tags" slist => { "autorun", "myOtherTag", "contact=Some Person <some.person@northern.tech>"};
+    "tags"
+      slist => {
+        "autorun",
+        "myOtherTag",
+        "contact=Some Person <some.person@northern.tech>",
+      };
 
   vars:
-      "bundle_tags" slist => getbundlemetatags("default:example");
-      "contact_tag" slist => getbundlemetatags("default:example", "contact");
+    "bundle_tags"
+      slist => getbundlemetatags("default:example");
+    "contact_tag"
+      slist => getbundlemetatags("default:example", "contact");
 
   reports:
-      "Found tags: $(bundle_tags)"; 
-      "Contact tag: $(contact_tag)";
+    "Found tags: $(bundle_tags)";
+    "Contact tag: $(contact_tag)";
 }
 #+end_src
 ###############################################################################

--- a/examples/hostswithgroup.cf
+++ b/examples/hostswithgroup.cf
@@ -1,20 +1,19 @@
 body common control
 {
-      bundlesequence => { "example" };
-      inputs => { "$(sys.libdir)/stdlib.cf" };
+  bundlesequence => { "example" };
+  inputs => { "$(sys.libdir)/stdlib.cf" };
 }
-
 
 bundle agent example
 {
   vars:
-
     am_policy_hub::
-      "host_list" slist => hostswithgroup( "Linux", "name" );
+      "host_list"
+        slist => hostswithgroup("Linux", "name");
 
   files:
     am_policy_hub::
       "/tmp/master_config.cfg"
-      edit_line => insert_lines("host=$(host_list)"),
-      create => "true";
+        edit_line => insert_lines("host=$(host_list)"),
+        create => "true";
 }

--- a/examples/is_type.cf
+++ b/examples/is_type.cf
@@ -1,34 +1,35 @@
 #+begin_src cfengine3
 body common control
 {
-      bundlesequence => { "example" };
+  bundlesequence => { "example" };
 }
 
 bundle agent example
 {
   vars:
-      "foo"
-        data => '{ "bar": true }';    
-      "a" string => "hello";
-  classes:
-      "isdata"
-        expression => is_type("foo", "data");
-      "isdata_boolean"
-        expression => is_type("foo[bar]", "data boolean");
-      "isstring"
-        expression => is_type("a", "string");
-      "isint"
-        expression => is_type("a", "int");
+    "foo"
+      data => '{ "bar": true }';
+    "a"
+      string => "hello";
 
+  classes:
+    "isdata"
+      expression => is_type("foo", "data");
+    "isdata_boolean"
+      expression => is_type("foo[bar]", "data boolean");
+    "isstring"
+      expression => is_type("a", "string");
+    "isint"
+      expression => is_type("a", "int");
 
   reports:
-      isdata::
+    isdata::
 	    "'foo' is of type 'data'";
-      isdata_boolean::
+    isdata_boolean::
 	    "'foo[bar]' is of type 'data boolean'";
-      isstring::
+    isstring::
         "'a' is of type 'string'";
-      isint::
+    isint::
 	    "'a' is of type 'int'";
 }
 

--- a/examples/isconnectable.cf
+++ b/examples/isconnectable.cf
@@ -1,34 +1,13 @@
-#  Copyright 2025 Northern.tech AS
-
-#  This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
-
-#  This program is free software; you can redistribute it and/or modify it
-#  under the terms of the GNU General Public License as published by the
-#  Free Software Foundation; version 3.
-
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
-
-# To the extent this program is licensed as part of the Enterprise
-# versions of Cfengine, the applicable Commercial Open Source License
-# (COSL) may apply to this file if you as a licensee so wish it. See
-# included file COSL.txt.
-
-#+begin_src cfengine3
 body common control
 {
   bundlesequence => { "example" };
 }
+
 bundle agent example
 {
   classes:
-    "isconnectable" expression => isconnectable("localhost", 22, "30");
+    "isconnectable"
+      expression => isconnectable("localhost", 22, "30");
 
   reports:
     isconnectable::
@@ -36,4 +15,3 @@ bundle agent example
     !isconnectable::
       "Port is not connectable";
 }
-#+end_src

--- a/examples/useringroup.cf
+++ b/examples/useringroup.cf
@@ -1,18 +1,20 @@
 #+begin_src cfengine3
 body common control 
 {
-    bundlesequence => { "example" };
+  bundlesequence => { "example" };
 }
+
 bundle agent example
 {
-    classes:
-        "root_in_root" expression => useringroup("root", "root");
+  classes:
+    "root_in_root"
+      expression => useringroup("root", "root");
 
-    reports:
-        root_in_root::
-            "root is indeed in the root group";
-        !root_in_root::
-            "something went wrong";
+  reports:
+    root_in_root::
+      "root is indeed in the root group";
+    !root_in_root::
+      "something went wrong";
 }
 #+end_src
 #############################################################################


### PR DESCRIPTION
I noticed some inconsistencies in our recently published examples from docs, so made some adjustments.

Policy style guide:
https://docs.cfengine.com/docs/3.24/examples-tutorials-writing-and-serving-policy-policy-style.html