### PR TITLE
Define the "suse" class on SLED systems (3.24.x)

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1182,7 +1182,7 @@ static void OSReleaseParse(EvalContext *ctx, const char *file_path)
             {
                 alias = "redhat";
             }
-            else if (StringEqual(os_release_id, "opensuse") || 
+            else if (StringEqual(os_release_id, "opensuse") ||
                      StringEqual(os_release_id, "sles"))
             {
                 alias = "suse";
@@ -3540,13 +3540,13 @@ static void SysOSNameHuman(EvalContext *ctx)
 
 /**
  * Find next integer from string in place. Leading zero's are included.
- * 
+ *
  * @param [in]  str string to extract next integer from
  * @param [out] num pointer to start of next integer or %NULL if no integer
  *                  number was found
- * 
+ *
  * @return pointer to the remaining string in `str` or %NULL if no remainder
- * 
+ *
  * @note `str` will be mutated
  */
 static char *FindNextInteger(char *str, char **num)
@@ -3614,8 +3614,8 @@ static void SysOsVersionMajor(EvalContext *ctx)
     }
     else
     {
-        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, 
-                                      "os_version_major", major, 
+        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS,
+                                      "os_version_major", major,
                                       CF_DATA_TYPE_STRING,
                                       "source=agent,derived-from=flavor");
     }

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1183,7 +1183,8 @@ static void OSReleaseParse(EvalContext *ctx, const char *file_path)
                 alias = "redhat";
             }
             else if (StringEqual(os_release_id, "opensuse") ||
-                     StringEqual(os_release_id, "sles"))
+                     StringEqual(os_release_id, "sles") ||
+                     StringEqual(os_release_id, "sled"))
             {
                 alias = "suse";
             }


### PR DESCRIPTION
- **sysinfo.c: Removed trailing whitespace**
- **Define suse class on SLED systems**

Back-ported from https://github.com/cfengine/core/pull/5773/