### PR TITLE
Adjusted configure.ac for finding workdir, logdir and piddir on windows platform (3.21)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,12 +207,12 @@ AS_IF([test x"$enable_fhs" = xyes], [
     prefix=/var/cfengine
     case "$target_os" in
       mingw*)
-        WORKDIR=$(cmd /c "echo %PROGRAMFILES%\\Cfengine" | sed 's/\\/\\\\/g')
+        WORKDIR=$(wine cmd.exe /c "echo %PROGRAMFILES%\\Cfengine" 2>/dev/null |  sed 's/\\/\\\\/g')
         MASTERDIR=default
         INPUTDIR=default
         DATADIR=default
-        LOGDIR=$(cmd /c "echo %PROGRAMFILES%\\Cfengine" | sed 's/\\/\\\\/g')
-        PIDDIR=$(cmd /c "echo %PROGRAMFILES%\\Cfengine" | sed 's/\\/\\\\/g')
+        LOGDIR=$(wine cmd.exe /c "echo %PROGRAMFILES%\\Cfengine" 2>/dev/null |  sed 's/\\/\\\\/g')
+        PIDDIR=$(wine cmd.exe /c "echo %PROGRAMFILES%\\Cfengine" 2>/dev/null |  sed 's/\\/\\\\/g')
         STATEDIR=default
       ;;
       *)


### PR DESCRIPTION
Ticket: ENT-12594
Changelog: none
(cherry picked from commit f027c17136d268363d4a916d467045c26b4cdaa1)

 Conflicts:
	configure.ac

3.21.x doesn't have MODULEDIR and KEYDIR changes from 44ded36442bb5a1accb67baa1b717da31fe2aa71 and e974758c8e4f9d97127509f8c0a5fa222861ffd6
