### PR TITLE
ENT-9980: Properly handle promise locking with edit line (3.24.x)

### DIFF
--- a/cf-agent/files_edit.c
+++ b/cf-agent/files_edit.c
@@ -33,6 +33,7 @@
 #include <files_editxml.h>
 #include <item_lib.h>
 #include <policy.h>
+#include <cf3.defs.h>
 
 /*****************************************************************************/
 

--- a/cf-agent/files_edit.c
+++ b/cf-agent/files_edit.c
@@ -103,9 +103,9 @@ EditContext *NewEditContext(char *filename, const Attributes *a)
 /*****************************************************************************/
 
 void FinishEditContext(EvalContext *ctx, EditContext *ec, const Attributes *a, const Promise *pp,
-                       PromiseResult *result)
+                       PromiseResult *result, bool save_file)
 {
-    if ((*result != PROMISE_RESULT_NOOP) && (*result != PROMISE_RESULT_CHANGE))
+    if (!save_file || ((*result != PROMISE_RESULT_NOOP) && (*result != PROMISE_RESULT_CHANGE)))
     {
         // Failure or skipped. Don't update the file.
         goto end;

--- a/cf-agent/files_edit.h
+++ b/cf-agent/files_edit.h
@@ -57,7 +57,7 @@ typedef struct
 EditContext *NewEditContext(char *filename, const Attributes *a);
 void FinishEditContext(EvalContext *ctx, EditContext *ec,
                        const Attributes *a, const Promise *pp,
-                       PromiseResult *result);
+                       PromiseResult *result, bool save_file);
 
 #ifdef HAVE_LIBXML2
 bool LoadFileAsXmlDoc(xmlDocPtr *doc, const char *file, EditDefaults ed, bool only_checks);

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -59,6 +59,7 @@
 #include <known_dirs.h>
 #include <evalfunction.h>
 #include <changes_chroot.h>     /* PrepareChangesChroot(), RecordFileChangedInChroot() */
+#include <cf3.defs.h>
 
 static PromiseResult FindFilePromiserObjects(EvalContext *ctx, const Promise *pp);
 static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promise *pp);

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -749,7 +749,7 @@ static PromiseResult RenderTemplateCFEngine(EvalContext *ctx,
     {
         if (!file_exists && !CfCreateFile(ctx, edcontext->changes_filename,
                                           pp, attr, &result))
-        { 
+        {
             RecordFailure(ctx, pp, attr,
                           "Failed to create file '%s' for rendering cfengine template '%s'",
                           edcontext->filename, attr->edit_template);
@@ -861,7 +861,7 @@ static PromiseResult RenderTemplateMustache(EvalContext *ctx,
                 if (!file_exists && !CfCreateFile(ctx,
                                                   edcontext->changes_filename,
                                                   pp, attr, &result))
-                { 
+                {
                     RecordFailure(ctx, pp, attr,
                                   "Failed to create file '%s' for rendering mustache template '%s'",
                                   edcontext->filename, message);

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -736,7 +736,8 @@ static PromiseResult RenderTemplateCFEngine(EvalContext *ctx,
                                             const Rlist *bundle_args,
                                             const Attributes *attr,
                                             EditContext *edcontext,
-                                            bool file_exists)
+                                            bool file_exists,
+                                            bool *save_file)
 {
     assert(edcontext != NULL);
     assert(attr != NULL);
@@ -761,7 +762,7 @@ static PromiseResult RenderTemplateCFEngine(EvalContext *ctx,
         EvalContextStackPushBundleFrame(ctx, bp, bundle_args, a.edits.inherit);
         BundleResolve(ctx, bp);
 
-        ScheduleEditLineOperations(ctx, bp, &a, pp, edcontext);
+        *save_file = ScheduleEditLineOperations(ctx, bp, &a, pp, edcontext);
 
         EvalContextStackPopFrame(ctx);
 
@@ -972,6 +973,7 @@ PromiseResult ScheduleEditOperation(EvalContext *ctx, char *filename,
     Rlist *args = NULL;
     char edit_bundle_name[CF_BUFSIZE], lockname[CF_BUFSIZE];
     CfLock thislock;
+    bool save_file = true;
 
     snprintf(lockname, CF_BUFSIZE - 1, "fileedit-%s", filename);
     thislock = AcquireLock(ctx, lockname, VUQNAME, CFSTARTTIME, a->transaction.ifelapsed, a->transaction.expireafter, pp, false);
@@ -1074,7 +1076,8 @@ PromiseResult ScheduleEditOperation(EvalContext *ctx, char *filename,
             PromiseResult render_result = RenderTemplateCFEngine(ctx, pp,
                                                                  args, a,
                                                                  edcontext,
-                                                                 file_exists);
+                                                                 file_exists,
+                                                                 &save_file);
             result = PromiseResultUpdate(result, render_result);
         }
     }
@@ -1106,7 +1109,7 @@ PromiseResult ScheduleEditOperation(EvalContext *ctx, char *filename,
     }
 
 exit:
-    FinishEditContext(ctx, edcontext, a, pp, &result);
+    FinishEditContext(ctx, edcontext, a, pp, &result, save_file);
     YieldCurrentLock(thislock);
     if (result == PROMISE_RESULT_CHANGE)
     {


### PR DESCRIPTION
- **verify_files.c: Added missing include for cf3.defs.h**
- **files_edit.c: Added missing include for cf3.defs.h**
- **verify_files.c: Removed trailing white space**
- **Properly handle promise locking with edit line**

Back-ported from https://github.com/cfengine/core/pull/5815