### PR TITLE
ENT-9980: Properly handle promise locking with edit line (3.21.x)

### DIFF
--- a/cf-agent/files_edit.c
+++ b/cf-agent/files_edit.c
@@ -33,6 +33,7 @@
 #include <files_editxml.h>
 #include <item_lib.h>
 #include <policy.h>
+#include <cf3.defs.h>
 
 /*****************************************************************************/
 

--- a/cf-agent/files_edit.c
+++ b/cf-agent/files_edit.c
@@ -103,9 +103,9 @@ EditContext *NewEditContext(char *filename, const Attributes *a)
 /*****************************************************************************/
 
 void FinishEditContext(EvalContext *ctx, EditContext *ec, const Attributes *a, const Promise *pp,
-                       PromiseResult *result)
+                       PromiseResult *result, bool save_file)
 {
-    if ((*result != PROMISE_RESULT_NOOP) && (*result != PROMISE_RESULT_CHANGE))
+    if (!save_file || ((*result != PROMISE_RESULT_NOOP) && (*result != PROMISE_RESULT_CHANGE)))
     {
         // Failure or skipped. Don't update the file.
         goto end;

--- a/cf-agent/files_edit.h
+++ b/cf-agent/files_edit.h
@@ -57,7 +57,7 @@ typedef struct
 EditContext *NewEditContext(char *filename, const Attributes *a);
 void FinishEditContext(EvalContext *ctx, EditContext *ec,
                        const Attributes *a, const Promise *pp,
-                       PromiseResult *result);
+                       PromiseResult *result, bool save_file);
 
 #ifdef HAVE_LIBXML2
 bool LoadFileAsXmlDoc(xmlDocPtr *doc, const char *file, EditDefaults ed, bool only_checks);

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -59,6 +59,7 @@
 #include <known_dirs.h>
 #include <evalfunction.h>
 #include <changes_chroot.h>     /* PrepareChangesChroot(), RecordFileChangedInChroot() */
+#include <cf3.defs.h>
 
 static PromiseResult FindFilePromiserObjects(EvalContext *ctx, const Promise *pp);
 static PromiseResult VerifyFilePromise(EvalContext *ctx, char *path, const Promise *pp);

--- a/cf-agent/verify_files.c
+++ b/cf-agent/verify_files.c
@@ -748,7 +748,7 @@ static PromiseResult RenderTemplateCFEngine(EvalContext *ctx,
     {
         if (!file_exists && !CfCreateFile(ctx, edcontext->changes_filename,
                                           pp, attr, &result))
-        { 
+        {
             RecordFailure(ctx, pp, attr,
                           "Failed to create file '%s' for rendering cfengine template '%s'",
                           edcontext->filename, attr->edit_template);
@@ -860,7 +860,7 @@ static PromiseResult RenderTemplateMustache(EvalContext *ctx,
                 if (!file_exists && !CfCreateFile(ctx,
                                                   edcontext->changes_filename,
                                                   pp, attr, &result))
-                { 
+                {
                     RecordFailure(ctx, pp, attr,
                                   "Failed to create file '%s' for rendering mustache template '%s'",
                                   edcontext->filename, message);


### PR DESCRIPTION
- **verify_files.c: Added missing include for cf3.defs.h**
- **files_edit.c: Added missing include for cf3.defs.h**
- **verify_files.c: Removed trailing white space**
- **Properly handle promise locking with edit line**

Back-ported from https://github.com/cfengine/core/pull/5815