### PR TITLE
build-environment-check: deleted script

### DIFF
--- a/contrib/vagrant-ci/centos-9s-x64/Vagrantfile
+++ b/contrib/vagrant-ci/centos-9s-x64/Vagrantfile
@@ -92,7 +92,6 @@ cd /cfe
 ./buildscripts/build-scripts/autogen
 yum -q -y remove libtool libtool-ltdl
 ./buildscripts/build-scripts/clean-buildmachine
-./buildscripts/build-scripts/build-environment-check
 ./buildscripts/build-scripts/install-dependencies
 ./buildscripts/build-scripts/configure
 ./buildscripts/build-scripts/compile
@@ -100,7 +99,6 @@ yum -q -y remove libtool libtool-ltdl
 rm -rf /var/cfengine
 export TEST_MACHINE=chroot
 ./buildscripts/build-scripts/clean-buildmachine
-./buildscripts/build-scripts/build-environment-check
 ./buildscripts/build-scripts/install-dependencies
 ./buildscripts/build-scripts/test
 SHELL


### PR DESCRIPTION
The list of wanted/unwanted packages is outdated. It only handles redhat
and debian based systems. Nowadays we use the
cfengine-build-host-setup.cf as the single source of truth. It does
exactly what we want, it promises that the build host is setup
correctly. Hence, it's time we let this script go.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
