### PR TITLE
valgrind-check: Fixed missing curl

### DIFF
--- a/tests/valgrind-check/Containerfile
+++ b/tests/valgrind-check/Containerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04 AS build
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev libxml2-dev libpam0g-dev liblmdb-dev libacl1-dev libpcre2-dev librsync-dev
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 git flex bison byacc automake make autoconf libtool valgrind
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 git flex bison byacc automake make autoconf libtool valgrind curl
 COPY masterfiles masterfiles
 COPY core core
 WORKDIR core


### PR DESCRIPTION
Error message from PR pipeline:

```
  notice: Q: ".../cf-execd"":    error: Proposed executable file '/usr/bin/curl' doesn't exist
Q: ".../cf-execd"":    error: execresult '/usr/bin/curl -s -X PUT "<http://169.254.169.254/latest/api/token>" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"' is assumed to be executable but isn't
```

Ticket: ENT-13124
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
