### PR TITLE
ENT-13126: valgrind-check: fix missing archives

### DIFF
--- a/tests/valgrind-check/Containerfile
+++ b/tests/valgrind-check/Containerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:24.04 AS build
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --fix-missing
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev libxml2-dev libpam0g-dev liblmdb-dev libacl1-dev libpcre2-dev librsync-dev
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 git flex bison byacc automake make autoconf libtool valgrind curl
 COPY masterfiles masterfiles


### PR DESCRIPTION
Unable to fetch some archives:

```
STEP 4/8: RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 git flex bison byacc automake make autoconf libtool valgrind curl
 ---snip---
Err:104 <http://security.ubuntu.com/ubuntu> noble-updates/main amd64 git-man all 1:2.43.0-1ubuntu7.2
  404  Not Found [IP: 91.189.91.81 80]
Err:105 <http://security.ubuntu.com/ubuntu> noble-updates/main amd64 git amd64 1:2.43.0-1ubuntu7.2
  404  Not Found [IP: 91.189.91.81 80]
 ---snip---
Err:115 <http://security.ubuntu.com/ubuntu> noble-updates/main amd64 libc6-dbg amd64 2.39-0ubuntu8.4
  404  Not Found [IP: 91.189.91.81 80]
 ---snip---
E: Failed to fetch <http://security.ubuntu.com/ubuntu/pool/main/g/git/git-man_2.43.0-1ubuntu7.2_all.deb>  404  Not Found [IP: 91.189.91.81 80]
E: Failed to fetch <http://security.ubuntu.com/ubuntu/pool/main/g/git/git_2.43.0-1ubuntu7.2_amd64.deb>  404  Not Found [IP: 91.189.91.81 80]
E: Failed to fetch <http://security.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dbg_2.39-0ubuntu8.4_amd64.deb>  404  Not Found [IP: 91.189.91.81 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: building at STEP "RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 git flex bison byacc automake make autoconf libtool valgrind curl": while running runtime: exit status 100
 ---snip---
```

The URL does in fact return 404:

```
$ curl http://security.ubuntu.com/ubuntu/pool/main/g/git/git-man_2.43.0-1ubuntu7.2_all.deb
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
<hr>
<address>Apache/2.4.52 (Ubuntu) Server at security.ubuntu.com Port 80</address>
</body></html>
```

Will try to add `--fix-missing` to the `apt-get update` as the error
message suggests.

Ticket: ENT-13126
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Running `static-checks` and `valgrind-checks` only:
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12381)](https://ci.cfengine.com/job/pr-pipeline/12381/)