### PR TITLE
ENT-13146: Fixed compilation error on Solaris 11

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -22,6 +22,10 @@
   included file COSL.txt.
 */
 
+#ifdef __sun
+#define _POSIX_PTHREAD_SEMANTICS /* Required on Solaris 11 (see ENT-13146) */
+#endif /* __sun */
+
 #include <limits.h>
 #include <platform.h>
 #include <evalfunction.h>


### PR DESCRIPTION
Build on Solaris
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12437)](https://ci.cfengine.com/job/pr-pipeline/12437/)