### PR TITLE
ENT-13146: Fixed compilation error on Solaris 11

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -22,6 +22,7 @@
   included file COSL.txt.
 */
 
+#include <grp.h> /* must be included before pwd.h (see ENT-13146) */
 #include <limits.h>
 #include <platform.h>
 #include <evalfunction.h>


### PR DESCRIPTION
```
02:18:08 evalfunction.c:1452:11: error: too many arguments to function ‘getgrnam_r’
02:18:08      ret = getgrnam_r(group_name, &grp, gr_buf, GETGR_R_SIZE_MAX, &grent);
02:18:08            ^
```

Prior to Oracle Solaris 11.4, the default compilation environment
provided definitions of the getgrnam_r() and getgrgid_r() functions as
specified in POSIX.1c Draft 6. The final POSIX.1c standard changed the
interfaces for getgrnam_r() and getgrgid_r().

One of the implementations seem to be defined in pwd.h and the other in
grp.h. Hence, we need to make sure to include the correct one first.

Ticket: ENT-13146
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Build on Solaris
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12435)](https://ci.cfengine.com/job/pr-pipeline/12435/)