### PR TITLE
Handle sys.os_name_human on gentoo

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -3685,6 +3685,12 @@ static void SysOSNameHuman(EvalContext *ctx)
                                       "Alpine", CF_DATA_TYPE_STRING,
                                       "source=agent,derived-from=alpine");
     }
+    else if (EvalContextClassGet(ctx, NULL, "gentoo") != NULL)
+    {
+        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,
+                                      "Gentoo", CF_DATA_TYPE_STRING,
+                                      "source=agent,derived-from=gentoo");
+    }
     else
     {
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,


### PR DESCRIPTION
On my Gentoo I got:
warning: Operating System not properly recognized, setting sys.os_name_human to "Unknown", please submit a bug report for us to fix this

This patch permit to set sys.os_name_human to Gentoo