### PR TITLE
ENT-11988: Fixed bug where remote file copy always preserves source perms (3.24.x)

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -22,6 +22,7 @@
   included file COSL.txt.
 */
 
+#include <sys/types.h>
 #include <verify_files_utils.h>
 
 #include <actuator.h>
@@ -1551,8 +1552,25 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, con
             return false;
         }
 
+        /* Use perms from source file if preserve is true, otherwise use perms
+         * of destination file if it exists, otherwise use default perms. */
+        mode_t mode;
+        if (attr->copy.preserve)
+        {
+            mode = sstat->st_mode;
+        }
+        else if (dest_exists)
+        {
+            mode = dest_stat.st_mode;
+        }
+        else
+        {
+            mode = CF_PERMS_DEFAULT;
+        }
+        mode &= 0777; /* Never preserve SUID bit */
+
         if (!CopyRegularFileNet(source, ToChangesPath(new),
-                                sstat->st_size, attr->copy.encrypt, conn, sstat->st_mode))
+                                sstat->st_size, attr->copy.encrypt, conn, mode))
         {
             RecordFailure(ctx, pp, attr, "Failed to copy file '%s' from '%s'",
                           source, conn->remoteip);


### PR DESCRIPTION
Remote file copy with the 'copy_from' attribute now only preserves
source file permissions if the 'preserve' attribute in 'body copy_from'
is true. Otherwise it will use the permissions of the destination file
if it already exists and default permissions if it does not.

Ticket: ENT-11988
Changelog: Commit
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit e2021b555f62197e6a112ee09e5af23ee4a68b6f)

Back ported from https://github.com/cfengine/core/pull/5837