### PR TITLE
Fixed assertion error in classfilterdata()

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -8068,8 +8068,8 @@ static FnCallResult FnCallClassFilterData(
     if (parent == NULL)
     {
         Log(LOG_LEVEL_VERBOSE,
-            "Function %s(): Expected parent element to be of container type array, found %s",
-            fp->name, JsonGetTypeAsString(parent));
+            "Function %s(): Expected parent element to be of type data container",
+            fp->name);
         return FnFailure();
     }
 


### PR DESCRIPTION
An assertion was triggered if the variable name or inline JSON failed to
expand when calling classfilterdata().

Changelog: Commit
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
