### PR TITLE
ENT-13163: Atomic permissions during file copy

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -71,6 +71,7 @@
 #include <override_fsattrs.h>
 
 #include <cf-windows-functions.h>
+#include "cf3.defs.h"
 
 #define CF_RECURSION_LIMIT 100
 
@@ -1569,6 +1570,13 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, con
             mode = CF_PERMS_DEFAULT;
         }
         mode &= 0777; /* Never preserve SUID bit */
+
+        /* If perms are promised for this file, use those instead */
+        if ((attr->perms.plus != CF_SAMEMODE) && (attr->perms.minus != CF_SAMEMODE))
+        {
+            mode |= attr->perms.plus;
+            mode &= ~(attr->perms.minus);
+        }
 
         if (!CopyRegularFileNet(source, dest, ToChangesPath(new),
                                 sstat->st_size, attr->copy.encrypt, conn, mode))


### PR DESCRIPTION
Temporary file is now set to promised permissions before replacing it
with original during remote copy from.

Ticket: ENT-13163
Changelog: Commit
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Back ported to:
* https://github.com/cfengine/core/pull/5869
* https://github.com/cfengine/core/pull/5870