### PR TITLE
ENT-13163: Atomic permissions during file copy (3.21.x)

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -70,6 +70,7 @@
 #include <unix.h>               /* GetGroupName(), GetUserName() */
 
 #include <cf-windows-functions.h>
+#include "cf3.defs.h"
 
 #define CF_RECURSION_LIMIT 100
 
@@ -1568,6 +1569,13 @@ bool CopyRegularFile(EvalContext *ctx, const char *source, const char *dest, con
             mode = CF_PERMS_DEFAULT;
         }
         mode &= 0777; /* Never preserve SUID bit */
+
+        /* If perms are promised for this file, use those instead */
+        if ((attr->perms.plus != CF_SAMEMODE) && (attr->perms.minus != CF_SAMEMODE))
+        {
+            mode |= attr->perms.plus;
+            mode &= ~(attr->perms.minus);
+        }
 
         if (!CopyRegularFileNet(source, ToChangesPath(new),
                                 sstat->st_size, attr->copy.encrypt, conn, mode))


### PR DESCRIPTION
Temporary file is now set to promised permissions before replacing it
with original during remote copy from.

Ticket: ENT-13163
Changelog: Commit
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit c1d8cd03137d8c678dbfaf92ba3dd604f4fcc65f)

Back ported from https://github.com/cfengine/core/pull/5868