### PR TITLE
generic_agent: Close log on exit

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1486,6 +1486,7 @@ bool GenericAgentArePromisesValid(const GenericAgentConfig *config)
 static void OpenLog(int facility)
 {
     openlog(CF_PROGRAM_NAME, LOG_PID | LOG_NOWAIT | LOG_ODELAY, facility);
+    RegisterCleanupFunction(&CloseLog);
 }
 #endif
 


### PR DESCRIPTION
Albeit optional to closelog(), ensure to closelog() on exit. Otherwise valgrind --track-fds=yes complains in case e.g. cf-promises is run but can't find its policy file.

```
% valgrind --track-fds=yes cf-promises -f nonexistent.cf
==4177819== Memcheck, a memory error detector
==4177819== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==4177819== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==4177819== Command: cf-promises -f nonexistent.cf
==4177819==
   error: Can't stat file '/home/btriller/.cfagent/inputs/nonexistent.cf' for parsing. (stat: No such file or directory)
==4177819==
==4177819== FILE DESCRIPTORS: 4 open (3 std) at exit.
==4177819== Open AF_UNIX socket 3: <unknown>
==4177819==    at 0x4ACADB7: socket (syscall-template.S:120)
==4177819==    by 0x4AC0D20: openlog_internal (syslog.c:347)
==4177819==    by 0x4AC1395: __vsyslog_internal (syslog.c:279)
==4177819==    by 0x4AC1575: syslog (syslog.c:91)
==4177819==    by 0x4907E34: LogToSystemLog (logging.c:284)
==4177819==    by 0x4907F70: LogToSystemLogStructured (logging.c:343)
==4177819==    by 0x4908339: VLogNoFormat (logging.c:508)
==4177819==    by 0x49081B6: Log (logging.c:559)
==4177819==    by 0x48D8C9B: Cf3ParseFile (loading.c:87)
==4177819==    by 0x48D8F4F: LoadPolicyFile (loading.c:343)
==4177819==    by 0x48D9535: LoadPolicy (loading.c:503)
==4177819==    by 0x10A851: main (cf-promises.c:156)
==4177819==
==4177819==
==4177819== HEAP SUMMARY:
==4177819==     in use at exit: 328,524 bytes in 6,335 blocks
==4177819==   total heap usage: 23,282 allocs, 16,947 frees, 8,495,524 bytes allocated
==4177819==
==4177819== LEAK SUMMARY:
==4177819==    definitely lost: 0 bytes in 0 blocks
==4177819==    indirectly lost: 0 bytes in 0 blocks
==4177819==      possibly lost: 0 bytes in 0 blocks
==4177819==    still reachable: 328,524 bytes in 6,335 blocks
==4177819==         suppressed: 0 bytes in 0 blocks
==4177819== Rerun with --leak-check=full to see details of leaked memory
==4177819==
==4177819== For lists of detected and suppressed errors, rerun with: -s
==4177819== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```