### PR TITLE
macos_unit_tests.yml: specified the deployment target to be macOS 15.4 (3.21)

### DIFF
--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -23,6 +23,6 @@ jobs:
         PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
         ./autogen.sh --enable-debug
     - name: Compile and link
-      run: make -j8 CFLAGS="-Werror -Wall"
+      run: MACOSX_DEPLOYMENT_TARGET=15.4 make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests
       run: make -C tests/unit check


### PR DESCRIPTION
The function 'strchrnul' has been marked as being introduced in macOS
15.4, although it seems to have been working for as long as we have been
testing on macOS. Since warnings are treated as errors, the build will
fail. Hence, the simplest way to silence the warning is, it to specify
the deployment target to be a minimum of macOS 15.4.

```
logging.c:651:28: error: 'strchrnul' is only available on macOS 15.4 or newer [-Werror,-Wunguarded-availability-new]
  651 |         char *next_token = strchrnul(token, ',');
  CC       queue.lo
      |                            ^~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_string.h:198:9: note: 'strchrnul' has been marked as being introduced in macOS 15.4 here, but the deployment target is macOS 15.0.0
  198 |         strchrnul(const char *__s, int __c);
  CC       rb-tree.lo
      |         ^
logging.c:651:28: note: enclose 'strchrnul' in a __builtin_available check to silence this warning
  651 |         char *next_token = strchrnul(token, ',');
      |                            ^~~~~~~~~
1 error generated.
```

It has been done similarly here: https://github.com/NorthernTechHQ/libntech/pull/255

Signed-off-by: Victor Moene <victor.moene@northern.tech>
(cherry picked from commit f1c9a913893bf7e5b72c1223ccaa94e2b928e7fc)
