### PR TITLE
Adjusted valgrind-check Containerfile to ensure apt update and install are linked and cached together in one layer

### DIFF
--- a/tests/valgrind-check/Containerfile
+++ b/tests/valgrind-check/Containerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:24.04 AS build
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --fix-missing
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev libxml2-dev libpam0g-dev liblmdb-dev libacl1-dev libpcre2-dev librsync-dev
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 git flex bison byacc automake make autoconf libtool valgrind curl
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --fix-missing && \
+ DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev libxml2-dev libpam0g-dev liblmdb-dev libacl1-dev libpcre2-dev librsync-dev python3 git flex bison byacc automake make autoconf libtool valgrind curl
 COPY masterfiles masterfiles
 COPY core core
 WORKDIR core


### PR DESCRIPTION
Otherwise, the update layer can be cached and have bad information for the subsequent two install command layers.

As the distribution changes package versions the install layers, if they are not cached, will fail.

Also combined the two install commands into one for brevity.

Ticket: ENT-13252
Changelog: none
