### PR TITLE
Fixed bug in getacls() where no ACLs caused error

### DIFF
--- a/libpromises/acl_tools_posix.c
+++ b/libpromises/acl_tools_posix.c
@@ -266,12 +266,16 @@ Rlist *GetACLs(const char *path, bool access)
     acl_t acl = acl_get_file(path, access ? ACL_TYPE_ACCESS : ACL_TYPE_DEFAULT);
     if (acl == NULL)
     {
+        Log(LOG_LEVEL_ERR, "Failed to get %s ACLs for '%s': %s",
+            access ? "access" : "default", path, GetErrorStr());
         return NULL;
     }
 
     char *text = acl_to_any_text(acl, NULL, ',', 0);
     if (text == NULL)
     {
+        Log(LOG_LEVEL_ERR, "Failed to translate %s ACLs for '%s' into string: %s",
+            access ? "access" : "default", path, GetErrorStr());
         acl_free(acl);
         return NULL;
     }

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -23,6 +23,7 @@
 */
 
 #include <assert.h>
+#include <errno.h>
 #ifdef __sun
 #define _POSIX_PTHREAD_SEMANTICS /* Required on Solaris 11 (see ENT-13146) */
 #endif /* __sun */
@@ -681,24 +682,11 @@ static FnCallResult FnCallGetACLs(
     assert(StringEqual(type, "default") || StringEqual(type, "access"));
 
 #ifdef _WIN32
-    /* TODO: Policy function to read Windows ACLs (ENT-13019) */
     Rlist *acls = NULL;
-    errno = ENOTSUP;
+    Log(LOG_LEVEL_VERBOSE, "Policy function %s() is not supported on this platform", fp->name);
 #else
     Rlist *acls = GetACLs(path, StringEqual(type, "access"));
-#endif /* _WIN32 */
-    if (acls == NULL)
-    {
-        Log((errno != ENOTSUP) ? LOG_LEVEL_ERR : LOG_LEVEL_VERBOSE,
-            "Function %s failed to get ACLs for '%s': %s",
-            fp->name, path, GetErrorStr());
-
-        if (errno != ENOTSUP)
-        {
-            return FnFailure();
-        } /* else we'll just return an empty list instead */
-    }
-
+#endif
     return (FnCallResult) { FNCALL_SUCCESS, { acls, RVAL_TYPE_LIST } };
 }
 


### PR DESCRIPTION

```
$ cat test.cf 
bundle agent __main__ {
  vars:
    "default_acls"
      slist => getacls("/etc", "default");
    "access_acls"
      slist => getacls("/tmp/bar", "access");
  reports:
    "Default acl: $(default_acls)";
    "Access acl: $(access_acls)";
}
$ sudo /var/cfengine/bin/cf-agent -KIf ~/test.cf 
R: Access acl: user::rwx
R: Access acl: group::rwx
R: Access acl: other::r-x
```