### PR TITLE
CFE-4531: Fixed provenance metadata for Manjaro and other SetFlavor() calls

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1417,7 +1417,7 @@ static void OSClasses(EvalContext *ctx)
     else if (stat("/etc/arch-release", &statbuf) != -1)
     {
         Log(LOG_LEVEL_VERBOSE, "This appears to be an Arch Linux system.");
-        SetFlavor(ctx, "archlinux", NULL);
+        SetFlavor(ctx, "archlinux", "/etc/arch-release");
     }
 
     if (stat("/proc/vmware/version", &statbuf) != -1 || stat("/etc/vmware-release", &statbuf) != -1)

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -3087,11 +3087,17 @@ static void OpenVZ_Detect(EvalContext *ctx)
     if (stat(OPENVZ_HOST_FILENAME, &statbuf) != -1)
     {
         Log(LOG_LEVEL_VERBOSE, "This appears to be an OpenVZ/Virtuozzo/Parallels Cloud Server host system.\n");
-        EvalContextClassPutHard(ctx, "virt_host_vz", "inventory,attribute_name=Virtual host,source=agent");
+        EvalContextClassPutHard(
+            ctx, "virt_host_vz",
+            "inventory,attribute_name=Virtual host,source=agent,"
+            "derived-from-file=" OPENVZ_HOST_FILENAME);
         /* if the file /bin/vzps is there, it is safe to use the processes promise type */
         if (stat(OPENVZ_VZPS_FILE, &statbuf) != -1)
         {
-            EvalContextClassPutHard(ctx, "virt_host_vz_vzps", "inventory,attribute_name=Virtual host,source=agent");
+            EvalContextClassPutHard(
+                ctx, "virt_host_vz_vzps",
+                "inventory,attribute_name=Virtual host,source=agent,"
+                "derived-from-file=" OPENVZ_VZPS_FILE);
             /* here we must redefine the value of VPSHARDCLASS */
             for (int i = 0; i < PLATFORM_CONTEXT_MAX; i++)
             {
@@ -3110,7 +3116,10 @@ static void OpenVZ_Detect(EvalContext *ctx)
     else if (stat(OPENVZ_GUEST_FILENAME, &statbuf) != -1)
     {
         Log(LOG_LEVEL_VERBOSE, "This appears to be an OpenVZ/Virtuozzo/Parallels Cloud Server guest system.\n");
-        EvalContextClassPutHard(ctx, "virt_guest_vz", "inventory,attribute_name=Virtual host,source=agent");
+        EvalContextClassPutHard(
+            ctx, "virt_guest_vz",
+            "inventory,attribute_name=Virtual host,source=agent,"
+            "derived-from-file=" OPENVZ_GUEST_FILENAME);
     }
 }
 

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1387,7 +1387,9 @@ static void OSClasses(EvalContext *ctx)
     if (stat("/usr/bin/aptitude", &statbuf) != -1)
     {
         Log(LOG_LEVEL_VERBOSE, "This system seems to have the aptitude package system");
-        EvalContextClassPutHard(ctx, "have_aptitude", "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(
+            ctx, "have_aptitude", "inventory,attribute_name=none,source=agent,"
+            "derived-from-file=/usr/bin/aptitude");
     }
 
     if (stat("/etc/UnitedLinux-release", &statbuf) != -1)

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -3015,9 +3015,11 @@ static int VM_Version(EvalContext *ctx)
 static int Xen_Domain(EvalContext *ctx)
 {
     int sufficient = 0;
+    const char *tags = "inventory,attribute_name=Virtual host,source=agent,"
+        "derived-from-file=/proc/xen/capabilities";
 
     Log(LOG_LEVEL_VERBOSE, "This appears to be a xen pv system.");
-    EvalContextClassPutHard(ctx, "xen", "inventory,attribute_name=Virtual host,source=agent");
+    EvalContextClassPutHard(ctx, "xen", tags);
 
 /* xen host will have "control_d" in /proc/xen/capabilities, xen guest will not */
 
@@ -3047,14 +3049,14 @@ static int Xen_Domain(EvalContext *ctx)
 
             if (strstr(buffer, "control_d"))
             {
-                EvalContextClassPutHard(ctx, "xen_dom0", "inventory,attribute_name=Virtual host,source=agent");
+                EvalContextClassPutHard(ctx, "xen_dom0", tags);
                 sufficient = 1;
             }
         }
 
         if (!sufficient)
         {
-            EvalContextClassPutHard(ctx, "xen_domu_pv", "inventory,attribute_name=Virtual host,source=agent");
+            EvalContextClassPutHard(ctx, "xen_domu_pv", tags);
             sufficient = 1;
         }
 

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1412,7 +1412,7 @@ static void OSClasses(EvalContext *ctx)
     if (stat("/etc/manjaro-release", &statbuf) != -1)
     {
         Log(LOG_LEVEL_VERBOSE, "This appears to be a Manjaro Linux system.");
-        SetFlavor(ctx, "manjaro", NULL);
+        SetFlavor(ctx, "manjaro", "/etc/manjaro-release");
     }
     else if (stat("/etc/arch-release", &statbuf) != -1)
     {

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2923,28 +2923,28 @@ static int EOS_Version(EvalContext *ctx)
 /******************************************************************/
 
 static int MiscOS(EvalContext *ctx)
+{
+    char buffer[CF_BUFSIZE];
 
-{ char buffer[CF_BUFSIZE];
-
- // e.g. BIG-IP 10.1.0 Build 3341.1084
+    // e.g. BIG-IP 10.1.0 Build 3341.1084
 
     if (ReadLine("/etc/issue", buffer, sizeof(buffer)))
     {
-       if (strstr(buffer, "BIG-IP"))
-       {
-           const char *tags =  "inventory,attribute_name=none,source=agent,"
-           "derived-from-file=/etc/issue";
-           char version[256], build[256], class[CF_MAXVARSIZE];
-           EvalContextClassPutHard(ctx, "big_ip", tags);
-           sscanf(buffer, "%*s %255s %*s %255s", version, build);
-           CanonifyNameInPlace(version);
-           CanonifyNameInPlace(build);
-           snprintf(class, CF_MAXVARSIZE, "big_ip_%s", version);
-           EvalContextClassPutHard(ctx, class, tags);
-           snprintf(class, CF_MAXVARSIZE, "big_ip_%s_%s", version, build);
-           EvalContextClassPutHard(ctx, class, tags);
-           SetFlavor(ctx, "BIG-IP", NULL);
-       }
+        if (strstr(buffer, "BIG-IP"))
+        {
+            const char *tags =  "inventory,attribute_name=none,source=agent,"
+            "derived-from-file=/etc/issue";
+            char version[256], build[256], class[CF_MAXVARSIZE];
+            EvalContextClassPutHard(ctx, "big_ip", tags);
+            sscanf(buffer, "%*s %255s %*s %255s", version, build);
+            CanonifyNameInPlace(version);
+            CanonifyNameInPlace(build);
+            snprintf(class, CF_MAXVARSIZE, "big_ip_%s", version);
+            EvalContextClassPutHard(ctx, class, tags);
+            snprintf(class, CF_MAXVARSIZE, "big_ip_%s_%s", version, build);
+            EvalContextClassPutHard(ctx, class, tags);
+            SetFlavor(ctx, "BIG-IP", NULL);
+        }
     }
 
     return 0;

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1406,7 +1406,7 @@ static void OSClasses(EvalContext *ctx)
     if (stat("/etc/gentoo-release", &statbuf) != -1)
     {
         Log(LOG_LEVEL_VERBOSE, "This appears to be a gentoo system.");
-        SetFlavor(ctx, "gentoo", NULL);
+        SetFlavor(ctx, "gentoo", "/etc/gentoo-release");
     }
 
     if (stat("/etc/manjaro-release", &statbuf) != -1)

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1395,7 +1395,7 @@ static void OSClasses(EvalContext *ctx)
     if (stat("/etc/UnitedLinux-release", &statbuf) != -1)
     {
         Log(LOG_LEVEL_VERBOSE, "This appears to be a UnitedLinux system.");
-        SetFlavor(ctx, "UnitedLinux", NULL);
+        SetFlavor(ctx, "UnitedLinux", "/etc/UnitedLinux-release");
     }
 
     if (stat("/etc/alpine-release", &statbuf) != -1)

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2546,7 +2546,10 @@ static int Linux_Misc_Version(EvalContext *ctx)
 
             if (strstr(buffer, "Cumulus"))
             {
-                EvalContextClassPutHard(ctx, "cumulus", "inventory,attribute_name=none,source=agent");
+                EvalContextClassPutHard(
+                    ctx, "cumulus",
+                    "inventory,attribute_name=none,source=agent,"
+                    "derived-from-files=" LSB_RELEASE_FILENAME);
                 os = "cumulus";
             }
 
@@ -2565,7 +2568,7 @@ static int Linux_Misc_Version(EvalContext *ctx)
     if (os != NULL && version[0] != '\0')
     {
         snprintf(flavor, CF_MAXVARSIZE, "%s_%s", os, version);
-        SetFlavor(ctx, flavor, NULL);
+        SetFlavor(ctx, flavor, LSB_RELEASE_FILENAME);
         return 1;
     }
 
@@ -2929,15 +2932,17 @@ static int MiscOS(EvalContext *ctx)
     {
        if (strstr(buffer, "BIG-IP"))
        {
+           const char *tags =  "inventory,attribute_name=none,source=agent,"
+           "derived-from-file=/etc/issue";
            char version[256], build[256], class[CF_MAXVARSIZE];
-           EvalContextClassPutHard(ctx, "big_ip", "inventory,attribute_name=none,source=agent");
+           EvalContextClassPutHard(ctx, "big_ip", tags);
            sscanf(buffer, "%*s %255s %*s %255s", version, build);
            CanonifyNameInPlace(version);
            CanonifyNameInPlace(build);
            snprintf(class, CF_MAXVARSIZE, "big_ip_%s", version);
-           EvalContextClassPutHard(ctx, class, "inventory,attribute_name=none,source=agent");
+           EvalContextClassPutHard(ctx, class, tags);
            snprintf(class, CF_MAXVARSIZE, "big_ip_%s_%s", version, build);
-           EvalContextClassPutHard(ctx, class, "inventory,attribute_name=none,source=agent");
+           EvalContextClassPutHard(ctx, class, tags);
            SetFlavor(ctx, "BIG-IP", NULL);
        }
     }

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2196,7 +2196,7 @@ static int Linux_Redhat_Version(EvalContext *ctx)
 
         strcat(classbuf, strmajor);
 
-        SetFlavor(ctx, classbuf, NULL);
+        SetFlavor(ctx, classbuf, RH_REL_FILENAME);
 
         if (minor != -2)
         {

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2643,7 +2643,9 @@ static int Linux_Mandrake_Version(EvalContext *ctx)
     char *vendor = NULL;
 
     Log(LOG_LEVEL_VERBOSE, "This appears to be a mandrake system.");
-    EvalContextClassPutHard(ctx, "Mandrake", "inventory,attribute_name=none,source=agent");
+    EvalContextClassPutHard(ctx, "Mandrake",
+        "inventory,attribute_name=none,source=agent,derived-from-file="
+        MANDRAKE_REL_FILENAME);
 
     if (!ReadLine(MANDRAKE_REL_FILENAME, relstring, sizeof(relstring)))
     {
@@ -2687,10 +2689,13 @@ static int Linux_Mandriva_Version(EvalContext *ctx)
 
     char relstring[CF_MAXVARSIZE];
     char *vendor = NULL;
+    const char *tags =
+        "inventory,attribute_name=none,source=agent,derived-from-file="
+        MANDRIVA_REL_FILENAME;
 
     Log(LOG_LEVEL_VERBOSE, "This appears to be a mandriva system.");
-    EvalContextClassPutHard(ctx, "Mandrake", "inventory,attribute_name=none,source=agent");
-    EvalContextClassPutHard(ctx, "Mandriva", "inventory,attribute_name=none,source=agent");
+    EvalContextClassPutHard(ctx, "Mandrake", tags);
+    EvalContextClassPutHard(ctx, "Mandriva", tags);
 
     if (!ReadLine(MANDRIVA_REL_FILENAME, relstring, sizeof(relstring)))
     {
@@ -2741,22 +2746,27 @@ static int Linux_Mandriva_Version_Real(EvalContext *ctx, char *filename, char *r
         }
     }
 
+    char *tags = StringFormat(
+        "inventory,attribute_name=none,source=agent,derived-from-file=%s",
+        filename);
+
     if (major != -1 && minor != -1 && strcmp(vendor, ""))
     {
         char classbuf[CF_MAXVARSIZE];
         classbuf[0] = '\0';
         strcat(classbuf, vendor);
-        EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, classbuf, tags);
         strcat(classbuf, "_");
         strcat(classbuf, strmajor);
-        EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, classbuf, tags);
         if (minor != -2)
         {
             strcat(classbuf, "_");
             strcat(classbuf, strminor);
-            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, classbuf, tags);
         }
     }
+    free(tags);
 
     return 0;
 }

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1896,10 +1896,13 @@ static int Linux_Fedora_Version(EvalContext *ctx)
 
 /* The full string read in from fedora-release */
     char relstring[CF_MAXVARSIZE];
+    const char *tags =
+        "inventory,attribute_name=none,source=agent,derived-from-file="
+        FEDORA_REL_FILENAME;
 
     Log(LOG_LEVEL_VERBOSE, "This appears to be a fedora system.");
-    EvalContextClassPutHard(ctx, "redhat", "inventory,attribute_name=none,source=agent");
-    EvalContextClassPutHard(ctx, "fedora", "inventory,attribute_name=none,source=agent");
+    EvalContextClassPutHard(ctx, "redhat", tags);
+    EvalContextClassPutHard(ctx, "fedora", tags);
 
 /* Grab the first line from the file and then close it. */
 
@@ -1949,10 +1952,10 @@ static int Linux_Fedora_Version(EvalContext *ctx)
         char classbuf[CF_MAXVARSIZE];
         classbuf[0] = '\0';
         strcat(classbuf, vendor);
-        EvalContextClassPutHard(ctx,classbuf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, classbuf, tags);
         strcat(classbuf, "_");
         strcat(classbuf, strmajor);
-        SetFlavor(ctx, classbuf, NULL);
+        SetFlavor(ctx, classbuf, FEDORA_REL_FILENAME);
     }
 
     return 0;

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2441,11 +2441,16 @@ static int Linux_Slackware_Version(EvalContext *ctx, char *filename)
     char classname[CF_MAXVARSIZE] = "";
     char buffer[CF_MAXVARSIZE];
 
+    char *tags = StringFormat(
+        "inventory,attribute_name=none,source=agent,derived-from-file=%s",
+        filename);
+
     Log(LOG_LEVEL_VERBOSE, "This appears to be a slackware system.");
-    EvalContextClassPutHard(ctx, "slackware", "inventory,attribute_name=none,source=agent");
+    EvalContextClassPutHard(ctx, "slackware", tags);
 
     if (!ReadLine(filename, buffer, sizeof(buffer)))
     {
+        free(tags);
         return 1;
     }
 
@@ -2455,22 +2460,24 @@ static int Linux_Slackware_Version(EvalContext *ctx, char *filename)
     case 3:
         Log(LOG_LEVEL_VERBOSE, "This appears to be a Slackware %u.%u.%u system.", major, minor, release);
         snprintf(classname, CF_MAXVARSIZE, "slackware_%u_%u_%u", major, minor, release);
-        EvalContextClassPutHard(ctx, classname, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, classname, tags);
         /* Fall-through */
     case 2:
         Log(LOG_LEVEL_VERBOSE, "This appears to be a Slackware %u.%u system.", major, minor);
         snprintf(classname, CF_MAXVARSIZE, "slackware_%u_%u", major, minor);
-        EvalContextClassPutHard(ctx, classname, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, classname, tags);
         /* Fall-through */
     case 1:
         Log(LOG_LEVEL_VERBOSE, "This appears to be a Slackware %u system.", major);
         snprintf(classname, CF_MAXVARSIZE, "slackware_%u", major);
-        EvalContextClassPutHard(ctx, classname, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, classname, tags);
         break;
     case 0:
         Log(LOG_LEVEL_VERBOSE, "No Slackware version number found.");
+        free(tags);
         return 2;
     }
+    free(tags);
     return 0;
 }
 

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2609,13 +2609,13 @@ static int Linux_Debian_Version(EvalContext *ctx)
             classname,
             "inventory,attribute_name=none,source=agent,derived-from-file="DEBIAN_VERSION_FILENAME);
         snprintf(classname, CF_MAXVARSIZE, "debian_%u", major);
-        SetFlavor(ctx, classname, NULL);
+        SetFlavor(ctx, classname, DEBIAN_VERSION_FILENAME);
         break;
 
     case 1:
         Log(LOG_LEVEL_VERBOSE, "This appears to be a Debian %u system.", major);
         snprintf(classname, CF_MAXVARSIZE, "debian_%u", major);
-        SetFlavor(ctx, classname, NULL);
+        SetFlavor(ctx, classname, DEBIAN_VERSION_FILENAME);
         break;
 
     default:
@@ -2652,7 +2652,7 @@ static int Linux_Debian_Version(EvalContext *ctx)
             ctx,
             "debian",
             "inventory,attribute_name=none,source=agent,derived-from-file="DEBIAN_ISSUE_FILENAME);
-        SetFlavor(ctx, buffer, NULL);
+        SetFlavor(ctx, buffer, DEBIAN_ISSUE_FILENAME);
     }
     else if (strcmp(os, "Ubuntu") == 0)
     {
@@ -2661,7 +2661,7 @@ static int Linux_Debian_Version(EvalContext *ctx)
         nt_static_assert((sizeof(version)) > 255);
         sscanf(buffer, "%*s %255[^.].%255s", version, minor);
         snprintf(buffer, CF_MAXVARSIZE, "ubuntu_%s", version);
-        SetFlavor(ctx, buffer, NULL);
+        SetFlavor(ctx, buffer, DEBIAN_ISSUE_FILENAME);
         EvalContextClassPutHard(
             ctx,
             "ubuntu",

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2961,25 +2961,29 @@ static int VM_Version(EvalContext *ctx)
     int sufficient = 0;
 
     Log(LOG_LEVEL_VERBOSE, "This appears to be a VMware Server ESX/xSX system.");
-    EvalContextClassPutHard(ctx, "VMware", "inventory,attribute_name=Virtual host,source=agent");
+    EvalContextClassPutHard(
+        ctx, "VMware", "inventory,attribute_name=Virtual host,source=agent,"
+        "derived-from-file=/proc/vmware/version");
 
 /* VMware Server ESX >= 3 has version info in /proc */
     if (ReadLine("/proc/vmware/version", buffer, sizeof(buffer)))
     {
+        const char *tags = "inventory,attribute_name=none,source=agent,"
+            "derived-from-file=/proc/vmware/version";
         if (sscanf(buffer, "VMware ESX Server %d.%d.%d", &major, &minor, &bug) > 0)
         {
             snprintf(classbuf, CF_BUFSIZE, "VMware ESX Server %d", major);
-            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, classbuf, tags);
             snprintf(classbuf, CF_BUFSIZE, "VMware ESX Server %d.%d", major, minor);
-            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, classbuf, tags);
             snprintf(classbuf, CF_BUFSIZE, "VMware ESX Server %d.%d.%d", major, minor, bug);
-            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, classbuf, tags);
             sufficient = 1;
         }
         else if (sscanf(buffer, "VMware ESX Server %255s", version) > 0)
         {
             snprintf(classbuf, CF_BUFSIZE, "VMware ESX Server %s", version);
-            EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, classbuf, tags);
             sufficient = 1;
         }
     }
@@ -2989,14 +2993,16 @@ static int VM_Version(EvalContext *ctx)
     if (sufficient < 1 && (ReadLine("/etc/vmware-release", buffer, sizeof(buffer))
                            || ReadLine("/etc/issue", buffer, sizeof(buffer))))
     {
-        EvalContextClassPutHard(ctx, buffer, "inventory,attribute_name=none,source=agent");
+        const char *tags = "inventory,attribute_name=none,source=agent,"
+            "derived-from-file=/etc/vmware-release";
+        EvalContextClassPutHard(ctx, buffer, tags);
 
         /* Strip off the release code name e.g. "(Dali)" */
         if ((sp = strchr(buffer, '(')) != NULL)
         {
             *sp = 0;
             Chop(buffer, CF_EXPANDSIZE);
-            EvalContextClassPutHard(ctx, buffer, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, buffer, tags);
         }
         sufficient = 1;
     }

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1436,7 +1436,7 @@ static void OSClasses(EvalContext *ctx)
     if (stat("/etc/Eos-release", &statbuf) != -1)
     {
         EOS_Version(ctx);
-        SetFlavor(ctx, "Eos", NULL);
+        SetFlavor(ctx, "Eos", "/etc/Eos-release");
     }
 
     if (stat("/etc/issue", &statbuf) != -1)
@@ -2908,14 +2908,16 @@ static int EOS_Version(EvalContext *ctx)
     {
         if (strstr(buffer, "EOS"))
         {
+            const char *tags = "inventory,attribute_name=none,source=agent,"
+                "derived-from-file=/etc/Eos-release";
             char version[256], class[CF_MAXVARSIZE];
-            EvalContextClassPutHard(ctx, "eos", "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, "eos", tags);
             EvalContextClassPutHard(ctx, "arista", "source=agent");
             version[0] = '\0';
             sscanf(buffer, "%*s %*s %*s %255s", version);
             CanonifyNameInPlace(version);
             snprintf(class, CF_MAXVARSIZE, "eos_%s", version);
-            EvalContextClassPutHard(ctx, class, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, class, tags);
         }
     }
 

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1350,7 +1350,7 @@ static void OSClasses(EvalContext *ctx)
     if (stat("/etc/generic-release", &statbuf) != -1)
     {
         Log(LOG_LEVEL_VERBOSE, "This appears to be a sun cobalt system.");
-        SetFlavor(ctx, "SunCobalt", NULL);
+        SetFlavor(ctx, "SunCobalt", "/etc/generic-release");
     }
 
     if (stat("/etc/SuSE-release", &statbuf) != -1)

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2221,13 +2221,17 @@ static int Linux_Suse_Version(EvalContext *ctx)
     char classbuf[CF_MAXVARSIZE];
 
     Log(LOG_LEVEL_VERBOSE, "This appears to be a SUSE system.");
-    EvalContextClassPutHard(ctx, "SUSE", "inventory,attribute_name=none,source=agent");
-    EvalContextClassPutHard(ctx, "suse", "inventory,attribute_name=none,source=agent");
+    const char *tags =
+        "inventory,attribute_name=none,source=agent,derived-from-file="
+        SUSE_REL_FILENAME;
+
+    EvalContextClassPutHard(ctx, "SUSE", tags);
+    EvalContextClassPutHard(ctx, "suse", tags);
 
     /* The correct spelling for SUSE is "SUSE" but CFEngine used to use "SuSE".
      * Keep this for backwards compatibility until CFEngine 3.7
      */
-    EvalContextClassPutHard(ctx, "SuSE", "inventory,attribute_name=none,source=agent");
+    EvalContextClassPutHard(ctx, "SuSE", tags);
 
     /* Grab the first line from the SuSE-release file and then close it. */
     char relstring[CF_MAXVARSIZE];
@@ -2287,7 +2291,7 @@ static int Linux_Suse_Version(EvalContext *ctx)
     {
         classbuf[0] = '\0';
         strcat(classbuf, "SLES8");
-        EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, classbuf, tags);
     }
     else if (strncmp(relstring, "sles", 4) == 0)
     {
@@ -2295,13 +2299,13 @@ static int Linux_Suse_Version(EvalContext *ctx)
 
         nt_static_assert((sizeof(vbuf)) > 255);
         sscanf(relstring, "%255[-_a-zA-Z0-9]", vbuf);
-        EvalContextClassPutHard(ctx, vbuf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, vbuf, tags);
 
         list = SplitString(vbuf, '-');
 
         for (ip = list; ip != NULL; ip = ip->next)
         {
-            EvalContextClassPutHard(ctx, ip->name, "inventory,attribute_name=none,source=agent");
+            EvalContextClassPutHard(ctx, ip->name, tags);
         }
 
         DeleteItemList(list);
@@ -2316,7 +2320,7 @@ static int Linux_Suse_Version(EvalContext *ctx)
             if (!strncmp(relstring, vbuf, strlen(vbuf)))
             {
                 snprintf(classbuf, CF_MAXVARSIZE, "SLES%d", version);
-                EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+                EvalContextClassPutHard(ctx, classbuf, tags);
             }
             else
             {
@@ -2326,7 +2330,7 @@ static int Linux_Suse_Version(EvalContext *ctx)
                 if (!strncmp(relstring, vbuf, strlen(vbuf)))
                 {
                     snprintf(classbuf, CF_MAXVARSIZE, "SLED%d", version);
-                    EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+                    EvalContextClassPutHard(ctx, classbuf, tags);
                 }
             }
         }
@@ -2365,25 +2369,25 @@ static int Linux_Suse_Version(EvalContext *ctx)
             if (major != -1 && minor != -1)
             {
                 strcpy(classbuf, "SUSE");
-                EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+                EvalContextClassPutHard(ctx, classbuf, tags);
                 strcat(classbuf, "_");
                 strcat(classbuf, strmajor);
-                SetFlavor(ctx, classbuf, NULL);
+                SetFlavor(ctx, classbuf, SUSE_REL_FILENAME);
                 strcat(classbuf, "_");
                 strcat(classbuf, strminor);
-                EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+                EvalContextClassPutHard(ctx, classbuf, tags);
 
                 /* The correct spelling for SUSE is "SUSE" but CFEngine used to use "SuSE".
                  * Keep this for backwards compatibility until CFEngine 3.7
                  */
                 strcpy(classbuf, "SuSE");
-                EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+                EvalContextClassPutHard(ctx, classbuf, tags);
                 strcat(classbuf, "_");
                 strcat(classbuf, strmajor);
-                EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+                EvalContextClassPutHard(ctx, classbuf, tags);
                 strcat(classbuf, "_");
                 strcat(classbuf, strminor);
-                EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+                EvalContextClassPutHard(ctx, classbuf, tags);
 
                 Log(LOG_LEVEL_VERBOSE, "Discovered SUSE version %s", classbuf);
                 return 0;
@@ -2399,16 +2403,16 @@ static int Linux_Suse_Version(EvalContext *ctx)
             if (major != -1 && minor != -1)
             {
                 strcpy(classbuf, "SLES");
-                EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+                EvalContextClassPutHard(ctx, classbuf, tags);
                 strcat(classbuf, "_");
                 strcat(classbuf, strmajor);
-                EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+                EvalContextClassPutHard(ctx, classbuf, tags);
                 strcat(classbuf, "_");
                 strcat(classbuf, strminor);
-                EvalContextClassPutHard(ctx, classbuf, "inventory,attribute_name=none,source=agent");
+                EvalContextClassPutHard(ctx, classbuf, tags);
 
                 snprintf(classbuf, CF_MAXVARSIZE, "SUSE_%d", major);
-                SetFlavor(ctx, classbuf, NULL);
+                SetFlavor(ctx, classbuf, SUSE_REL_FILENAME);
 
                 /* The correct spelling for SUSE is "SUSE" but CFEngine used to use "SuSE".
                  * Keep this for backwards compatibility until CFEngine 3.7

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1854,7 +1854,11 @@ static void Linux_Oracle_Version(EvalContext *ctx)
 #define ORACLE_ID "Oracle Linux Server"
 
     Log(LOG_LEVEL_VERBOSE, "This appears to be Oracle Linux");
-    EvalContextClassPutHard(ctx, "oracle", "inventory,attribute_name=none,source=agent");
+    const char *tags =
+    "inventory,attribute_name=none,source=agent,derived-from-file="
+    ORACLE_REL_FILENAME;
+
+    EvalContextClassPutHard(ctx, "oracle", tags);
 
     if (!ReadLine(ORACLE_REL_FILENAME, relstring, sizeof(relstring)))
     {
@@ -1878,10 +1882,10 @@ static void Linux_Oracle_Version(EvalContext *ctx)
         char buf[CF_BUFSIZE];
 
         snprintf(buf, CF_BUFSIZE, "oracle_%d", major);
-        SetFlavor(ctx, buf, NULL);
+        SetFlavor(ctx, buf, ORACLE_REL_FILENAME);
 
         snprintf(buf, CF_BUFSIZE, "oracle_%d_%d", major, minor);
-        EvalContextClassPutHard(ctx, buf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
     }
 }
 

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2892,7 +2892,7 @@ static void Linux_Alpine_Version(EvalContext *ctx)
                 ",derived-from-file=/etc/alpine-release");
         }
     }
-    SetFlavor(ctx, "alpinelinux", NULL);
+    SetFlavor(ctx, "alpinelinux", "/etc/alpine-release");
 }
 
 /******************************************************************/

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -2841,11 +2841,11 @@ static void Linux_Amazon_Version(EvalContext *ctx)
                 EvalContextClassPutHard(ctx, class,
                     "inventory,attribute_name=none,source=agent"
                     ",derived-from-file=/etc/system-release");
-                SetFlavor(ctx, class, NULL);
+                SetFlavor(ctx, class, "/etc/system-release");
             }
             else
             {
-                SetFlavor(ctx, "amazon_linux", NULL);
+                SetFlavor(ctx, "amazon_linux", "/etc/system-release");
             }
             // We set this class for backwards compatibility
             EvalContextClassPutHard(ctx, "AmazonLinux",

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -1788,9 +1788,15 @@ static void Linux_Oracle_VM_Server_Version(EvalContext *ctx)
 #define ORACLE_VM_SERVER_REL_FILENAME "/etc/ovs-release"
 #define ORACLE_VM_SERVER_ID "Oracle VM server"
 
+    const char *tags =
+        "inventory,attribute_name=none,source=agent,derived-from-file="
+        ORACLE_VM_SERVER_REL_FILENAME;
+
     Log(LOG_LEVEL_VERBOSE, "This appears to be Oracle VM Server");
-    EvalContextClassPutHard(ctx, "redhat", "inventory,attribute_name=none,source=agent");
-    EvalContextClassPutHard(ctx, "oraclevmserver", "inventory,attribute_name=Virtual host,source=agent");
+    EvalContextClassPutHard(ctx, "redhat", tags);
+    EvalContextClassPutHard(ctx, "oraclevmserver",
+        "inventory,attribute_name=Virtual host,source=agent,derived-from-file="
+        ORACLE_VM_SERVER_REL_FILENAME);
 
     if (!ReadLine(ORACLE_VM_SERVER_REL_FILENAME, relstring, sizeof(relstring)))
     {
@@ -1816,7 +1822,7 @@ static void Linux_Oracle_VM_Server_Version(EvalContext *ctx)
         char buf[CF_BUFSIZE];
 
         snprintf(buf, CF_BUFSIZE, "oraclevmserver_%d", major);
-        SetFlavor(ctx, buf, NULL);
+        SetFlavor(ctx, buf, ORACLE_VM_SERVER_REL_FILENAME);
     }
 
     if (revcomps > 1)
@@ -1824,7 +1830,7 @@ static void Linux_Oracle_VM_Server_Version(EvalContext *ctx)
         char buf[CF_BUFSIZE];
 
         snprintf(buf, CF_BUFSIZE, "oraclevmserver_%d_%d", major, minor);
-        EvalContextClassPutHard(ctx, buf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
     }
 
     if (revcomps > 2)
@@ -1832,7 +1838,7 @@ static void Linux_Oracle_VM_Server_Version(EvalContext *ctx)
         char buf[CF_BUFSIZE];
 
         snprintf(buf, CF_BUFSIZE, "oraclevmserver_%d_%d_%d", major, minor, patch);
-        EvalContextClassPutHard(ctx, buf, "inventory,attribute_name=none,source=agent");
+        EvalContextClassPutHard(ctx, buf, tags);
     }
 }
 


### PR DESCRIPTION
- **Added tag 'derived-from-file' to Mandrake/Mandriva OS classes/variables**
- **sysinfo.c: SetFlavor() now optionally tags derived-from-file**
- **Added tag 'derived-from-file' to Fedora/Red Hat OS classes/variables**
- **Added tag 'derived-from-file' to Oracle VM Server/Red Hat OS classes/variables**
- **Added tag 'derived-from-file' to Oracle Linux OS classes/variables**
- **Added tag 'derived-from-file' to Sun Cobalt OS classes/variables**
- **Added tag 'derived-from-file' to SuSE OS classes/variables**
- **Added tag 'derived-from-file' to Amazon Linux OS classes/variables**
- **Added tag 'derived-from-file' to Slackware OS classes/variables**
- **Added tag 'derived-from-file' to Debian OS classes/variables**
- **Added tag 'derived-from-file' to misc OS classes/variables**
- **sysinfo.c: reformatted MiscOS function**
- **Added tag 'derived-from-file' to have_aptitude class**
- **Added tag 'derived-from-file' to United Linux OS classes/variables**
- **Added tag 'derived-from-file' to Alpine OS classes/variables**
- **Added tag 'derived-from-file' to Gentoo OS classes/variables**
- **Added tag 'derived-from-file' to Manjaro OS classes/variables**
- **Added tag 'derived-from-file' to Arch OS classes/variables**
- **Added tag 'derived-from-file' to VMware OS classes/variables**
- **Added tag 'derived-from-file' to Xen OS classes/variables**
- **Added tag 'derived-from-file' to EOS OS classes/variables**
- **Added tag 'derived-from-file' to OpenVZ OS classes/variables**
- **Added tag 'derived-from-file' to Red Hat OS classes/variables**
