### PR TITLE
ENT-12619, CFE-4605, CFE-4606: Various fixes to acceptance tests and CI scripts

### DIFF
--- a/ci/configure.sh
+++ b/ci/configure.sh
@@ -7,7 +7,7 @@ cd "$thisdir"/..
 OPTS="--enable-debug"
 
 if [ -n "$TERMUX_VERSION" ]; then
-  OPTS="$OPTS --without-pam"
+    OPTS="$OPTS --without-pam"
 fi
 
 ./autogen.sh $OPTS

--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -61,10 +61,10 @@ if [ -f /etc/os-release ]; then
                 # fakeroot is only needed for running tests but can be worked around by using GAINROOT=env with tests/acceptance/testall script
             else
                 # here we assume no subscription and so must build those two dependencies from source :)
-                $GAINROOT yum groups install -y 'Development Tools'
+                $GAINROOT yum groups install --assumeyes 'Development Tools'
                 $GAINROOT yum update --assumeyes
                 # cmake is for building librsync
-                $GAINROOT yum install -y gcc gdb make git libtool autoconf automake byacc flex openssl-devel pcre2-devel pam-devel libxml2-devel cmake
+                $GAINROOT yum install --assumeyes gcc gdb make git libtool autoconf automake byacc flex openssl-devel pcre2-devel pam-devel libxml2-devel cmake
                 build_lmdb
                 build_librsync
             fi
@@ -73,8 +73,8 @@ if [ -f /etc/os-release ]; then
             exit 1
         fi
     elif [ "$ID" = "debian" ] || [[ "$ID_LIKE" =~ "debian" ]]; then
-        $GAINROOT apt update -y
-        $GAINROOT apt install -y build-essential git libtool autoconf automake bison flex libssl-dev libpcre2-dev libbison-dev libacl1 libacl1-dev lmdb-utils liblmdb-dev libpam0g-dev libtool libyaml-dev libxml2-dev librsync-dev
+        $GAINROOT apt update --yes
+        $GAINROOT apt install --yes build-essential git libtool autoconf automake bison flex libssl-dev libpcre2-dev libbison-dev libacl1 libacl1-dev lmdb-utils liblmdb-dev libpam0g-dev libtool libyaml-dev libxml2-dev librsync-dev
     else
         echo "Unsupported distribution based on /etc/os-release."
     fi

--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -22,7 +22,8 @@ if [ -f /etc/os-release ]; then
         $GAINROOT subscription-manager config --rhsm.manage_repos=1
         $GAINROOT subscription-manager repos --enable codeready-builder-for-rhel-"$VERSION_MAJOR"-"$(uname -m)"-rpms
         $GAINROOT dnf install --assumeyes https://dl.fedoraproject.org/pub/epel/epel-release-latest-"$VERSION_MAJOR".noarch.rpm
-        $GAINROOT dnf install --assumeyes flex-devel lmdb-devel librsync-devel fakeroot # only available via subscription with codeready-builder installed
+        $GAINROOT dnf install --assumeyes autoconf automake
+        $GAINROOT dnf install --assumeyes gcc gdb make git libtool autoconf automake byacc flex openssl-devel pcre2-devel lmdb-devel pam-devel flex-devel libyaml-devel fakeroot libxml2-devel librsync-devel
         # flex-devel, libyaml-devel and fakeroot are also only available easily from codeready-builder but are not critical to building CFEngine usable enough to configure a build host.
         # fakeroot is only needed for running tests but can be worked around by using GAINROOT=env with tests/acceptance/testall script
       else

--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -4,84 +4,83 @@ set -ex
 
 GAINROOT=""
 if [ "$(id -u)" != "0" ]; then
-  GAINROOT="sudo"
-  if ! command -v sudo >/dev/null; then
-    echo "Sorry, either run $0 as root or install sudo."
-    exit 1
-  fi
+    GAINROOT="sudo"
+    if ! command -v sudo >/dev/null; then
+        echo "Sorry, either run $0 as root or install sudo."
+        exit 1
+    fi
 fi
 
 build_lmdb() {
-if [ -f /usr/include/lmdb.h ]; then
-  echo lmdb libraries already installed, no-op.
-  return
-fi
-        tmpdir="$(mktemp -d)"
-echo building lmdb in "$tmpdir"
-        (
-          cd "$tmpdir"
-          git clone --recursive --depth 1 https://github.com/LMDB/lmdb
-          cd lmdb/libraries/liblmdb
-          make
-          $GAINROOT make install prefix=/usr
-        )
+    if [ -f /usr/include/lmdb.h ]; then
+        echo lmdb libraries already installed, no-op.
+        return
+    fi
+    tmpdir="$(mktemp -d)"
+    echo building lmdb in "$tmpdir"
+    (
+        cd "$tmpdir"
+        git clone --recursive --depth 1 https://github.com/LMDB/lmdb
+        cd lmdb/libraries/liblmdb
+        make
+        $GAINROOT make install prefix=/usr
+    )
 }
 
 build_librsync() {
-tmpdir="$(mktemp -d)"
-echo building librsync in "$tmpdir"
-(
-cd "$tmpdir"
-          git clone --recursive --depth 1 https://github.com/librsync/librsync
-          cd librsync
-          cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release .
-          make
-          $GAINROOT make install
-)
+    tmpdir="$(mktemp -d)"
+    echo building librsync in "$tmpdir"
+    (
+        cd "$tmpdir"
+        git clone --recursive --depth 1 https://github.com/librsync/librsync
+        cd librsync
+        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release .
+        make
+        $GAINROOT make install
+    )
 }
 
 # limited support here, focused on rhel-like on aarch64 which has no previous CFEngine version to leverage: ENT-13016
 if [ -f /etc/os-release ]; then
-  source /etc/os-release
-  VERSION_MAJOR=${VERSION_ID%.*}
-  if [[ "$ID_LIKE" =~ "suse" ]]; then
-    $GAINROOT zypper -qn install gdb gcc make lmdb autoconf automake libtool git python3 pcre2-devel libopenssl-devel pam-devel cmake flex byacc
-    build_lmdb
-    build_librsync
-  elif [ "$ID" = "rhel" ] || [[ "$ID_LIKE" =~ "rhel" ]]; then
-    if [ "$VERSION_MAJOR" -ge "10" ]; then
-      # note that having a redhat subscription makes things easier: lmdb-devel and librsync-devel are available from codeready-builder repo
-      if subscription-manager status; then
-        $GAINROOT subscription-manager config --rhsm.manage_repos=1
-        $GAINROOT subscription-manager repos --enable codeready-builder-for-rhel-"$VERSION_MAJOR"-"$(uname -m)"-rpms
-        $GAINROOT dnf install --assumeyes https://dl.fedoraproject.org/pub/epel/epel-release-latest-"$VERSION_MAJOR".noarch.rpm
-        $GAINROOT dnf install --assumeyes autoconf automake
-        $GAINROOT dnf install --assumeyes gcc gdb make git libtool autoconf automake byacc flex openssl-devel pcre2-devel lmdb-devel pam-devel flex-devel libyaml-devel fakeroot libxml2-devel librsync-devel
-        # flex-devel, libyaml-devel and fakeroot are also only available easily from codeready-builder but are not critical to building CFEngine usable enough to configure a build host.
-        # fakeroot is only needed for running tests but can be worked around by using GAINROOT=env with tests/acceptance/testall script
-      else
-        # here we assume no subscription and so must build those two dependencies from source :)
-        $GAINROOT yum groups install -y 'Development Tools'
-        $GAINROOT yum update --assumeyes
-        # cmake is for building librsync
-        $GAINROOT yum install -y gcc gdb make git libtool autoconf automake byacc flex openssl-devel pcre2-devel pam-devel libxml2-devel cmake
+    source /etc/os-release
+    VERSION_MAJOR=${VERSION_ID%.*}
+    if [[ "$ID_LIKE" =~ "suse" ]]; then
+        $GAINROOT zypper -qn install gdb gcc make lmdb autoconf automake libtool git python3 pcre2-devel libopenssl-devel pam-devel cmake flex byacc
         build_lmdb
         build_librsync
-      fi
+    elif [ "$ID" = "rhel" ] || [[ "$ID_LIKE" =~ "rhel" ]]; then
+        if [ "$VERSION_MAJOR" -ge "10" ]; then
+            # note that having a redhat subscription makes things easier: lmdb-devel and librsync-devel are available from codeready-builder repo
+            if subscription-manager status; then
+                $GAINROOT subscription-manager config --rhsm.manage_repos=1
+                $GAINROOT subscription-manager repos --enable codeready-builder-for-rhel-"$VERSION_MAJOR"-"$(uname -m)"-rpms
+                $GAINROOT dnf install --assumeyes https://dl.fedoraproject.org/pub/epel/epel-release-latest-"$VERSION_MAJOR".noarch.rpm
+                $GAINROOT dnf install --assumeyes autoconf automake
+                $GAINROOT dnf install --assumeyes gcc gdb make git libtool autoconf automake byacc flex openssl-devel pcre2-devel lmdb-devel pam-devel flex-devel libyaml-devel fakeroot libxml2-devel librsync-devel
+                # flex-devel, libyaml-devel and fakeroot are also only available easily from codeready-builder but are not critical to building CFEngine usable enough to configure a build host.
+                # fakeroot is only needed for running tests but can be worked around by using GAINROOT=env with tests/acceptance/testall script
+            else
+                # here we assume no subscription and so must build those two dependencies from source :)
+                $GAINROOT yum groups install -y 'Development Tools'
+                $GAINROOT yum update --assumeyes
+                # cmake is for building librsync
+                $GAINROOT yum install -y gcc gdb make git libtool autoconf automake byacc flex openssl-devel pcre2-devel pam-devel libxml2-devel cmake
+                build_lmdb
+                build_librsync
+            fi
+        else
+            echo "Unsupported version of redhat for $0"
+            exit 1
+        fi
+    elif [ "$ID" = "debian" ] || [[ "$ID_LIKE" =~ "debian" ]]; then
+        $GAINROOT apt update -y
+        $GAINROOT apt install -y build-essential git libtool autoconf automake bison flex libssl-dev libpcre2-dev libbison-dev libacl1 libacl1-dev lmdb-utils liblmdb-dev libpam0g-dev libtool libyaml-dev libxml2-dev librsync-dev
     else
-      echo "Unsupported version of redhat for $0"
-      exit 1
+        echo "Unsupported distribution based on /etc/os-release."
     fi
-  elif [ "$ID" = "debian" ] || [[ "$ID_LIKE" =~ "debian" ]]; then
-    $GAINROOT apt update -y
-    $GAINROOT apt install -y build-essential git libtool autoconf automake bison flex libssl-dev libpcre2-dev libbison-dev libacl1 libacl1-dev lmdb-utils liblmdb-dev libpam0g-dev libtool libyaml-dev libxml2-dev librsync-dev
-  else
-    echo "Unsupported distribution based on /etc/os-release."
-  fi
 elif [ -n "$TERMUX_VERSION" ]; then
-  pkg install build-essential git autoconf automake bison flex liblmdb openssl pcre2 libacl libyaml
+    pkg install build-essential git autoconf automake bison flex liblmdb openssl pcre2 libacl libyaml
 else
-  echo "Unsupported operating system for $0"
-  exit 1
+    echo "Unsupported operating system for $0"
+    exit 1
 fi
-

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -8,13 +8,13 @@ thisdir=$(dirname $0)
 cd "$thisdir"/..
 GAINROOT=""
 if [ ! -n "$TERMUX_VERSION" ]; then
-  if [ "$(id -u)" != "0" ]; then
-    if ! command -v sudo >/dev/null; then
-      echo "Sorry, run $0 as root or install and configure sudo."
-      exit 1
+    if [ "$(id -u)" != "0" ]; then
+        if ! command -v sudo >/dev/null; then
+            echo "Sorry, run $0 as root or install and configure sudo."
+            exit 1
+        fi
+        GAINROOT="sudo"
     fi
-    GAINROOT="sudo"
-  fi
 fi
 
 $GAINROOT make install

--- a/tests/acceptance/01_vars/01_basic/policy_release_id.cf
+++ b/tests/acceptance/01_vars/01_basic/policy_release_id.cf
@@ -1,11 +1,18 @@
 body common control
 {
-  bundlesequence => { "test" };
+  inputs => { "../../default.cf.sub" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
 }
 
 
 bundle agent test
 {
+  meta:
+    "test_skip_needs_work"
+      string => "aix",
+      meta => { "CFE-4606" };
+
   vars:
     "release_id_list" slist => variablesmatching("default:sys.policy_release_id");
     "escaped" string => escape("$(sys.policy_entry_dirname)");

--- a/tests/acceptance/01_vars/02_functions/findlocalgroups.cf
+++ b/tests/acceptance/01_vars/02_functions/findlocalgroups.cf
@@ -35,7 +35,7 @@ bundle agent test
 {
   meta:
     "test_soft_fail"
-      string => "!linux|(termux|android)",
+      string => "(!linux&!solaris)|(termux|android)",
       meta => { "CFE-2318" };
   vars:
     "glist1"

--- a/tests/acceptance/01_vars/02_functions/findlocalusers.cf
+++ b/tests/acceptance/01_vars/02_functions/findlocalusers.cf
@@ -28,7 +28,8 @@ bundle agent init
 bundle agent test 
 {
   meta:
-      "test_soft_fail" string => "windows|aix|solaris",
+      "test_soft_fail" string => "windows|aix|solaris|redhat_10",
+        comment => "redhat_10 user name is 'Super User' not 'root'",
         meta => { "CFE-2318" };
 
   vars:

--- a/tests/acceptance/01_vars/02_functions/getgroups.cf
+++ b/tests/acceptance/01_vars/02_functions/getgroups.cf
@@ -17,9 +17,11 @@ bundle agent check
     "description" -> { "ENT-12722" }
       string => "Test whether the entries of getroups() are like the ones inside /etc/group";
     "test_skip_needs_work"
-      string => "suse_15|sles_15",
-      comment => "expects first three groups are root, bin, daemon but on suse_15 they are root, shadow, trusted.",
-      meta => { "ENT-13504" };
+      string => "suse_15|sles_15|aix",
+      comment => "expects first three groups are root, bin, daemon. However, on:
+ - suse_15 they are root, shadow, trusted.
+ - aix they are root, daemon, bin (i.e. different order).",
+      meta => { "ENT-13504", "CFE-4605" };
 
     "test_skip_unsupported"
       string => "windows";

--- a/tests/acceptance/01_vars/02_functions/getgroups.cf
+++ b/tests/acceptance/01_vars/02_functions/getgroups.cf
@@ -16,6 +16,11 @@ bundle agent check
   meta:
     "description" -> { "ENT-12722" }
       string => "Test whether the entries of getroups() are like the ones inside /etc/group";
+    "test_skip_needs_work"
+      string => "suse_15|sles_15",
+      comment => "expects first three groups are root, bin, daemon but on suse_15 they are root, shadow, trusted.",
+      meta => { "ENT-13504" };
+
     "test_skip_unsupported"
       string => "windows";
   vars:

--- a/tests/acceptance/01_vars/02_functions/getgroups.cf
+++ b/tests/acceptance/01_vars/02_functions/getgroups.cf
@@ -7,7 +7,7 @@
 body common control
 {
   inputs => { "../../default.cf.sub" };
-  bundlesequence => { check };
+  bundlesequence => { default("$(this.promise_filename)") };
   version => "1.0";
 }
 

--- a/tests/acceptance/01_vars/02_functions/unsafe/findlocalusers_unsafe.cf
+++ b/tests/acceptance/01_vars/02_functions/unsafe/findlocalusers_unsafe.cf
@@ -51,7 +51,8 @@ bundle agent init
 bundle agent test 
 {
   meta:
-      "test_soft_fail" string => "windows|aix|solaris",
+      "test_soft_fail" string => "windows|aix|solaris|redhat_10",
+        comment => "RedHat 10 root user is named 'Super User' not 'root'",
         meta => { "CFE-2318" };
 
   vars:

--- a/tests/acceptance/05_processes/01_matching/select_without_result.cf
+++ b/tests/acceptance/05_processes/01_matching/select_without_result.cf
@@ -36,8 +36,8 @@ bundle agent test
   meta:
       # This test exposes a known issue with processes on the Windows platform.
       "test_soft_fail"
-        string => "windows",
-        meta => {"ENT-12751"};
+        string => "windows|solaris",
+        meta => { "ENT-12751", "ENT-13505" };
 
       "description" -> {"CFE-4511"}
         string => "process_select body without process_result";

--- a/tests/acceptance/16_cf-serverd/serial/copy_from_ciphers_success.cf
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_ciphers_success.cf
@@ -8,8 +8,8 @@ body common control
 bundle agent test
 {
   meta:
-      "test_soft_fail" string => "windows",
-        meta => { "ENT-10401" };
+      "test_soft_fail" string => "windows|redhat_10",
+        meta => { "ENT-10401", "ENT-13494" };
 
   methods:
       # source file

--- a/tests/load/run_lastseen_threaded_load.sh
+++ b/tests/load/run_lastseen_threaded_load.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-if [ "x$label" = "xPACKAGES_x86_64_solaris_10" ] ;
-then
-    echo "Skipping lastseen_threaded_load on $label"
+for skip_label in PACKAGES_x86_64_solaris_10 PACKAGES_ia64_hpux_11.23; do
+  if [ "$label" = "$skip_label" ]; then
+    echo "Skipping $0 on label $skip_label"
     exit 0;
-fi
+  fi
+done
 
 echo "Starting run_lastseen_threaded_load.sh test"
 


### PR DESCRIPTION
- **Added skip for run_lastseen_threaded_load.sh test on HP/UX**
- **Fixed ci/dependencies.sh for use on a subscribed rhel host**
- **Added RedHat 10 soft fail for findlocalusers tests**
- **Added suse_15 skip needs work to getgroups.cf test**
- **Added support for suse platform in ci/dependencies.sh**
- **Used shfmt to format ci/*.sh scripts**
- **Adjusted findlocalgroups soft fail platforms to include solaris which now passes**
- **Marked select_without_result test as soft fail on solaris**
- **Added soft fail marker to copy_from_ciphers_success test on RedHat 10**
- **Improved ci script by using long readable options**
- **Added aix skip needs work to getgroups.cf test**

Together with:
 - https://github.com/cfengine/masterfiles/pull/3074