### PR TITLE
CFE-4605: getgroups.cf: soft fail test on Solaris

### DIFF
--- a/tests/acceptance/01_vars/02_functions/getgroups.cf
+++ b/tests/acceptance/01_vars/02_functions/getgroups.cf
@@ -17,10 +17,10 @@ bundle agent check
     "description" -> { "ENT-12722" }
       string => "Test whether the entries of getroups() are like the ones inside /etc/group";
     "test_skip_needs_work"
-      string => "suse_15|sles_15|aix",
+      string => "suse_15|sles_15|aix|solaris",
       comment => "expects first three groups are root, bin, daemon. However, on:
  - suse_15 they are root, shadow, trusted.
- - aix they are root, daemon, bin (i.e. different order).",
+ - aix and solaris they are root, daemon, bin (i.e. different order)",
       meta => { "ENT-13504", "CFE-4605" };
 
     "test_skip_unsupported"


### PR DESCRIPTION
The test expects the three first groups to be root, bin, daemon (in that
order). On Solaris (similar to AIX), they are root, daemon, bin (i.e.,
different order).

Ticket: CFE-4605
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
