### PR TITLE
ENT-13508: Fixed struct stat layout mismatch on HP-UX due to include order

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -22,6 +22,7 @@
   included file COSL.txt.
 */
 
+#include <platform.h>
 #include <stddef.h>
 #include <sys/types.h>
 #include <verify_files_utils.h>


### PR DESCRIPTION
On HP-UX IA-64, verify_files_utils.c included <sys/types.h> before
config.h was loaded, causing struct stat and off_t to use 32-bit layout
instead of the 64-bit layout required by _FILE_OFFSET_BITS=64.

This resulted in st_size being read from the wrong offset, producing
garbage values (e.g., 236662833 instead of 821 bytes) and "file
corrupted in transit" errors during local file copies.

Fixed by including platform.h first to ensure _FILE_OFFSET_BITS=64 is
defined before any system headers.

Ticket: ENT-13508
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
