### PR TITLE
ENT-13531: Fixed diskfree() returning garbage value

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -22,6 +22,8 @@
   included file COSL.txt.
 */
 
+#include <platform.h>
+
 #include <assert.h>
 #include <errno.h>
 #ifdef __sun
@@ -29,7 +31,6 @@
 #endif /* __sun */
 
 #include <limits.h>
-#include <platform.h>
 #include <evalfunction.h>
 
 #include <policy_server.h>

--- a/libpromises/storage_tools.c
+++ b/libpromises/storage_tools.c
@@ -22,6 +22,8 @@
   included file COSL.txt.
 */
 
+#include <platform.h>
+
 #include <cf3.defs.h>
 
 #ifdef HAVE_SYS_STATFS_H


### PR DESCRIPTION
Always include platform.h before system headers. Otherwise types such as
off_t will use 32-bit layout instead of the 64-bit layout required by
_FILE_OFFSET_BITS=64 on HP-UX.

Ticket: ENT-13531
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
