### PR TITLE
ENT-13532: findlocalusers.cf: soft fail on HP-UX

### DIFF
--- a/tests/acceptance/01_vars/02_functions/findlocalusers.cf
+++ b/tests/acceptance/01_vars/02_functions/findlocalusers.cf
@@ -28,7 +28,7 @@ bundle agent init
 bundle agent test 
 {
   meta:
-      "test_soft_fail" string => "windows|aix|solaris|redhat_10",
+      "test_soft_fail" string => "windows|aix|solaris|hpux|redhat_10",
         comment => "redhat_10 user name is 'Super User' not 'root'",
         meta => { "CFE-2318" };
 

--- a/tests/acceptance/01_vars/02_functions/unsafe/findlocalusers_unsafe.cf
+++ b/tests/acceptance/01_vars/02_functions/unsafe/findlocalusers_unsafe.cf
@@ -51,7 +51,7 @@ bundle agent init
 bundle agent test 
 {
   meta:
-      "test_soft_fail" string => "windows|aix|solaris|redhat_10",
+      "test_soft_fail" string => "windows|aix|solaris|hpux|redhat_10",
         comment => "RedHat 10 root user is named 'Super User' not 'root'",
         meta => { "CFE-2318" };
 


### PR DESCRIPTION
On HP-UX there appears to be two users with user ID 0

```
bash-4.3$ id root
uid=0(root) gid=3(sys)
bash-4.3$ id dfrench
uid=0(root) gid=20(users)
```

This test needs more work.

Ticket: ENT-13532
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
