### PR TITLE
CFE-4605: getgroups.cf: test skip needs work - HP-UX

### DIFF
--- a/tests/acceptance/01_vars/02_functions/getgroups.cf
+++ b/tests/acceptance/01_vars/02_functions/getgroups.cf
@@ -17,7 +17,7 @@ bundle agent check
     "description" -> { "ENT-12722" }
       string => "Test whether the entries of getroups() are like the ones inside /etc/group";
     "test_skip_needs_work"
-      string => "suse_15|sles_15|aix|solaris",
+      string => "suse_15|sles_15|aix|solaris|hpux",
       comment => "expects first three groups are root, bin, daemon. However, on:
  - suse_15 they are root, shadow, trusted.
  - aix and solaris they are root, daemon, bin (i.e. different order)",


### PR DESCRIPTION
Ticket: CFE-4605
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
