### PR TITLE
ENT-7541: Added skip for run_lastseen_threaded_load.sh test on HP/UX (3.24.x)

### DIFF
--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -22,6 +22,7 @@
   included file COSL.txt.
 */
 
+#include <platform.h>
 #include <stddef.h>
 #include <sys/types.h>
 #include <verify_files_utils.h>

--- a/libpromises/storage_tools.c
+++ b/libpromises/storage_tools.c
@@ -22,6 +22,8 @@
   included file COSL.txt.
 */
 
+#include <platform.h>
+
 #include <cf3.defs.h>
 
 #ifdef HAVE_SYS_STATFS_H

--- a/tests/load/run_lastseen_threaded_load.sh
+++ b/tests/load/run_lastseen_threaded_load.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-if [ "x$label" = "xPACKAGES_x86_64_solaris_10" ] ;
-then
-    echo "Skipping lastseen_threaded_load on $label"
+for skip_label in PACKAGES_x86_64_solaris_10 PACKAGES_ia64_hpux_11.23; do
+  if [ "$label" = "$skip_label" ]; then
+    echo "Skipping $0 on label $skip_label"
     exit 0;
-fi
+  fi
+done
 
 echo "Starting run_lastseen_threaded_load.sh test"
 


### PR DESCRIPTION
Backported from https://github.com/cfengine/core/pull/5947

Build HP-UX only:
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=13074)](https://ci.cfengine.com/job/pr-pipeline/13074/)