### PR TITLE
ENT-13535: Users management commands are no longer run in a shell (3.24.x)

### DIFF
--- a/cf-agent/verify_users_pam.c
+++ b/cf-agent/verify_users_pam.c
@@ -993,13 +993,13 @@ static bool EqualGid(const char *key, const struct group *entry)
 {
     assert(entry != NULL);
 
-    unsigned long gid; 
+    unsigned long gid;
     int ret = StringToUlong(key, &gid);
     if (ret != 0)
     {
         LogStringToLongError(key, "EqualGid", ret);
         return false;
-    }   
+    }
 
     return (gid == entry->gr_gid);
 }
@@ -1146,16 +1146,16 @@ static void TransformGidsToGroups(StringSet **list)
     StringSetDestroy(old_list);
 }
 
-static bool VerifyIfUserNeedsModifs(const char *puser, const User *u, 
+static bool VerifyIfUserNeedsModifs(const char *puser, const User *u,
                                     const struct passwd *passwd_info,
-                                    uint32_t *changemap, 
-                                    StringSet *groups_to_set, 
+                                    uint32_t *changemap,
+                                    StringSet *groups_to_set,
                                     StringSet *current_secondary_groups)
 {
     assert(u != NULL);
     assert(passwd_info != NULL);
 
-    if (u->description != NULL && 
+    if (u->description != NULL &&
         !StringEqual(u->description, passwd_info->pw_gecos))
     {
         CFUSR_SETBIT(*changemap, i_comment);
@@ -1205,17 +1205,17 @@ static bool VerifyIfUserNeedsModifs(const char *puser, const User *u,
 
     if (SafeStringLength(u->group_primary) != 0)
     {
-        bool group_could_be_gid = (strlen(u->group_primary) == 
+        bool group_could_be_gid = (strlen(u->group_primary) ==
                                    strspn(u->group_primary, "0123456789"));
 
         // We try name first, even if it looks like a gid. Only fall back to gid.
         errno = 0;
-        struct group *group_info = GetGrEntry(u->group_primary, 
+        struct group *group_info = GetGrEntry(u->group_primary,
                                               &EqualGroupName);
         if (group_info == NULL && errno != 0)
         {
-            Log(LOG_LEVEL_ERR, 
-                "Could not obtain information about group '%s': %s", 
+            Log(LOG_LEVEL_ERR,
+                "Could not obtain information about group '%s': %s",
                 u->group_primary, GetErrorStr());
             CFUSR_SETBIT(*changemap, i_group);
         }
@@ -1227,7 +1227,7 @@ static bool VerifyIfUserNeedsModifs(const char *puser, const User *u,
                 int ret = StringToUlong(u->group_primary, &gid);
                 if (ret != 0)
                 {
-                    LogStringToLongError(u->group_primary, 
+                    LogStringToLongError(u->group_primary,
                                          "VerifyIfUserNeedsModifs", ret);
                     CFUSR_SETBIT(*changemap, i_group);
                 }

--- a/tests/acceptance/17_users/unsafe/user_command.cf
+++ b/tests/acceptance/17_users/unsafe/user_command.cf
@@ -1,0 +1,61 @@
+##############################################################################
+#
+#  See ticket ENT-13535 for info.
+#
+##############################################################################
+
+body common control
+{
+  bundlesequence  => { "init", "test", "check", "clean" };
+}
+
+body delete tidy
+{
+  dirlinks => "delete";
+  rmdirs   => "true";
+}
+
+##############################################################################
+
+bundle agent init
+{
+  users:
+      "test_user"
+        policy => "absent";
+
+  files:
+      "/tmp/some-random-file.txt"
+        delete => tidy;
+}
+
+##############################################################################
+
+bundle agent test
+{
+  meta:
+      "description" -> { "ENT-13535" }
+        string => "See ticket ENT-13535 for info";
+      "test_skip_unsupported"
+        string => "windows",
+        comment => "Not applicable for Windows since it uses a C API";
+
+  users:
+    linux::
+      "test_user; echo 'Hello CFEngine' > /tmp/some-random-file.txt"
+        policy => "present";
+}
+
+##############################################################################
+
+bundle agent check
+{
+  reports:
+      "$(this.promise_filename) $(with)"
+        with => ifelse(fileexists("/tmp/some-random-file.txt"), "FAIL", "Pass");
+}
+
+bundle agent clean
+{
+  methods:
+      "init";
+}


### PR DESCRIPTION
- **See ticket for info**
- **verify_users_pam.c: fixed whitespace issues**
- **Execute users commands directly instead through a shell**

Backported from https://github.com/cfengine/core/pull/5966