### PR TITLE
ENT-13522: verify_databases.c: Various bug fixes in CreateTableColumns()

### DIFF
--- a/cf-agent/cf_sql.c
+++ b/cf-agent/cf_sql.c
@@ -384,7 +384,7 @@ void CfCloseDB(CfdbConn *cfdb)
 
 /*****************************************************************************/
 
-void CfVoidQueryDB(CfdbConn *cfdb, char *query)
+void CfVoidQueryDB(CfdbConn *cfdb, const char *query)
 {
     if (!cfdb->connected)
     {
@@ -398,7 +398,7 @@ void CfVoidQueryDB(CfdbConn *cfdb, char *query)
 
 /*****************************************************************************/
 
-void CfNewQueryDB(CfdbConn *cfdb, char *query)
+void CfNewQueryDB(CfdbConn *cfdb, const char *query)
 {
     cfdb->result = false;
     cfdb->row = 0;

--- a/cf-agent/cf_sql.h
+++ b/cf-agent/cf_sql.h
@@ -42,8 +42,8 @@ typedef struct
 
 void CfConnectDB(CfdbConn *cfdb, DatabaseType dbtype, char *remotehost, char *dbuser, char *passwd, char *db);
 void CfCloseDB(CfdbConn *cfdb);
-void CfVoidQueryDB(CfdbConn *cfdb, char *query);
-void CfNewQueryDB(CfdbConn *cfdb, char *query);
+void CfVoidQueryDB(CfdbConn *cfdb, const char *query);
+void CfNewQueryDB(CfdbConn *cfdb, const char *query);
 char **CfFetchRow(CfdbConn *cfdb);
 char *CfFetchColumn(CfdbConn *cfdb, int col);
 void CfDeleteQuery(CfdbConn *cfdb);

--- a/cf-agent/verify_databases.c
+++ b/cf-agent/verify_databases.c
@@ -748,7 +748,7 @@ static bool CreateTableColumns(CfdbConn *cfdb, char *table, Rlist *columns)
     char **name_table, **type_table;
     int no_of_cols = RlistLen(columns);
 
-    Log(LOG_LEVEL_ERR, "Trying to create table '%s'", table);
+    Log(LOG_LEVEL_VERBOSE, "Trying to create table '%s'", table);
 
     if (!NewSQLColumns(table, columns, &name_table, &type_table, &size_table, &done))
     {


### PR DESCRIPTION
- **Changed severity of log level in CreateTableColumns()**
- **Fixed use of uninitialized buffer in CreateTableColumns()**
- **Fixed buffer overflow in CreateTableColumns()**
- **cf_sql.{c,h}: constified arguments in DB query functions**

Backported to:
- https://github.com/cfengine/core/pull/5976
- https://github.com/cfengine/core/pull/5977