### PR TITLE
ENT-13551: Fixed potential buffer overflow when computing chroot path

### DIFF
--- a/libpromises/changes_chroot.c
+++ b/libpromises/changes_chroot.c
@@ -215,7 +215,7 @@ void PrepareChangesChroot(const char *path)
                 continue;
             }
             char entry_path[PATH_MAX];
-            strcpy(entry_path, path);
+            strlcpy(entry_path, path, sizeof(entry_path));
             JoinPaths(entry_path, PATH_MAX, entry->d_name);
             PrepareChangesChroot(entry_path);
         }


### PR DESCRIPTION
Ticket: ENT-13551
Changelog: Title
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Backported to https://github.com/cfengine/core/pull/5999