### PR TITLE
CFE-4620: Adapt date constraints to allow dates after Y2038

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -848,6 +848,11 @@ AC_CHECK_TYPES(socklen_t, [], [], [[
 #include <sys/socket.h>
 ]])
 
+AC_CHECK_SIZEOF(time_t)
+if test "x$ac_cv_sizeof_time_t" = "x8"; then
+	AC_DEFINE(HAVE_64BIT_TIME_T, 1, [Define if time_t is 64-bit])
+fi
+
 dnl ######################################################################
 dnl Checks for typedefs, structures, and compiler characteristics.
 dnl ######################################################################

--- a/libpromises/cf3.defs.h
+++ b/libpromises/cf3.defs.h
@@ -562,7 +562,12 @@ typedef enum
 
 #define CF_BOOL      "true,false,yes,no,on,off"
 #define CF_LINKRANGE "symlink,hardlink,relative,absolute"
-#define CF_TIMERANGE "0,2147483647" /* i.e. "0,0x7fffffff" */
+
+#ifdef HAVE_64BIT_TIME_T
+# define CF_TIMERANGE "0,99999999999" /* Same as other max int values */
+#else
+# define CF_TIMERANGE "0,2147483647" /* i.e. "0,0x7fffffff" */
+#endif
 
 /* Syntax checker accepts absurdly big numbers for backwards
  * compatibility. WARNING: internally they are stored as longs, possibly

--- a/tests/acceptance/00_basics/03_bodies/file-select-Y2038.cf
+++ b/tests/acceptance/00_basics/03_bodies/file-select-Y2038.cf
@@ -1,0 +1,34 @@
+body common control
+{
+      inputs => {
+                  "../../default.cf.sub",
+      };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  commands:
+      # Ensure there is a file with a date in the future beyond 2038
+      "/usr/bin/touch -t 204201010000 $(this.promise_filename).sub.file-with-mtime-after-2038";
+}
+
+bundle agent test
+{
+  meta:
+      "description" string => "Test that the agent does not crash on dates after 2038.";
+
+}
+
+bundle agent check
+{
+  meta:
+      "test_skip_unsupported" string => "!64_bit";
+
+  classes:
+      "ok" expression => "class_defined_from_included_bundle";
+  methods:
+      "" usebundle => dcs_passif_output(".*Pass.*", "", "$(sys.cf_agent) -Kf $(this.promise_filename).sub", $(this.promise_filename));
+
+}

--- a/tests/acceptance/00_basics/03_bodies/file-select-Y2038.cf.sub
+++ b/tests/acceptance/00_basics/03_bodies/file-select-Y2038.cf.sub
@@ -1,0 +1,32 @@
+bundle agent main {
+  files:
+
+  "$(this.promise_filename).sub.file-with-mtime-after-2038"
+    file_select => y2042,
+    perms => m( "o+r" ),
+    classes => kept_or_repaired("y2038_ok");
+
+  reports:
+    y2038_ok::
+      "Pass";
+}
+
+body file_select y2042 {
+ # January 1, 2042 at 12:00:00 AM December 31, 2042 at 11:59:59 PM
+ mtime => irange(2272896000, 2304431999);
+ file_result => "mtime.leaf_name";
+}
+
+body perms m (x)
+{
+  mode => "$(x)";
+}
+
+body classes kept_or_repaired(x)
+{
+  promise_repaired => { "$(x)" };
+  promise_kept => { "$(x)" };
+  repair_failed => { "NOT_$(x)" };
+  repair_denied => { "NOT_$(x)" };
+  repair_timeout => { "NOT_$(x)" };
+}


### PR DESCRIPTION
Detect `time_t` size at compile time and set the date range accordingly.