### PR TITLE
ENT-13591: Fixed buffer overflow in cf-secret when using multiple keys of different sizes (3.24.x)

### DIFF
--- a/cf-secret/cf-secret.c
+++ b/cf-secret/cf-secret.c
@@ -343,13 +343,13 @@ static bool RSAEncrypt(Seq *rsa_keys, const char *input_path, const char *output
 
     const EVP_CIPHER *cipher = EVP_aes_256_cbc();
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
-    const int key_size = EVP_PKEY_size((EVP_PKEY*) SeqAt(evp_keys, 0));
 
     /* This sequence and the 'enc_key_sizes' array are both populated by the
      * EVP_SealInit() call below. */
     Seq *enc_keys = SeqNew(n_keys, free);
     for (size_t i = 0; i < n_keys; i++)
     {
+        const int key_size = EVP_PKEY_size((EVP_PKEY*) SeqAt(evp_keys, i));
         SeqAppend(enc_keys, xmalloc(key_size));
     }
     int enc_key_sizes[n_keys];


### PR DESCRIPTION
```
$ openssl genrsa -out small.priv 2048
$ openssl rsa -in small.priv -RSAPublicKey_out -out small.pub
writing RSA key
$ openssl genrsa -out large.priv 4096
$ openssl rsa -in large.priv -RSAPublicKey_out -out large.pub
writing RSA key
$ echo "Secret Data" > secret.txt
$ cf-secret encrypt -k small.pub,large.pub -o secret.enc secret.txt
free(): invalid next size (normal)
Aborted (core dumped)
```

Ticket: ENT-13591
Changelog: Title
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit b8d1e09f538fc4ea41c4d3262380b8624bdf8e9d)

Backported from https://github.com/cfengine/core/pull/5992