### PR TITLE
ENT-13658: 013.cf: Added reference to test skip

### DIFF
--- a/tests/acceptance/10_files/01_create/013.cf
+++ b/tests/acceptance/10_files/01_create/013.cf
@@ -32,7 +32,8 @@ body delete init_delete
 bundle agent test
 {
   meta:
-    "test_skip_needs_work" string => "hpux";
+    "test_skip_needs_work" -> { "ENT-13658" }
+      string => "hpux";
 
   vars:
       "owner" string => "nobody";

--- a/tests/acceptance/10_files/01_create/013.cf
+++ b/tests/acceptance/10_files/01_create/013.cf
@@ -33,7 +33,7 @@ bundle agent test
 {
   meta:
     "test_skip_needs_work" -> { "ENT-13658" }
-      string => "hpux";
+      string => "hpux|aix";
 
   vars:
       "owner" string => "nobody";


### PR DESCRIPTION
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Relates to:
- https://github.com/cfengine/core/pull/6009
- https://github.com/cfengine/core/pull/5996

Back ported to https://github.com/cfengine/core/pull/6011