### PR TITLE
classfilterdata: Fix inconsistent results (3.27.x)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -8276,7 +8276,7 @@ static bool ClassFilterDataObject(
         break;
     }
 
-    return true;
+    return false;
 }
 
 static FnCallResult FnCallClassFilterData(

--- a/tests/acceptance/01_vars/02_functions/classfilterdata_foo.cf
+++ b/tests/acceptance/01_vars/02_functions/classfilterdata_foo.cf
@@ -1,0 +1,59 @@
+body common control
+{
+  bundlesequence => { "check" };
+}
+
+bundle agent check
+{
+  vars:
+    "object_of_arrays"
+      data => '{
+        "bar": "!foo",
+        "foo": [ "!foo", "foo&bar", "foo|bar" ],
+      }';
+    "object_of_arrays_filtered"
+      data => classfilterdata("object_of_arrays", "object_of_arrays", "0");
+
+    "object_of_objects"
+      data => '{
+        "bar": "!foo",
+        "foo": { "foo": "!bar", "key": "value" },
+      }';
+    "object_of_objects_filtered"
+      data => classfilterdata("object_of_objects", "object_of_objects", "foo");
+
+    "array_of_arrays"
+      data => '[
+        "bar",
+        [ "baz", "!baz", "foo&baz", "foo|baz" ],
+      ]';
+    "array_of_arrays_filtered"
+      data => classfilterdata("array_of_arrays", "array_of_arrays", "0");
+
+    "array_of_objects"
+      data => '[
+        "bar",
+        { "baz": "!baz", "key": "value" },
+      ]';
+    "array_of_objects_filtered"
+      data => classfilterdata("array_of_objects", "array_of_objects", "baz");
+
+  classes:
+    "ok" not => or(
+        isvariable("array_of_arrays_filtered"),
+        isvariable("array_of_objects_filtered"),
+        isvariable("object_of_arrays_filtered"),
+        isvariable("object_of_objects_filtered")
+        );
+
+  reports:
+      "Object of Objects filtered: $(with)" with => string(@(object_of_objects_filtered));
+      "Object of Arrays filtered: $(with)" with => string(@(object_of_arrays_filtered));
+      "Array of Arrays filtered: $(with)" with => string(@(array_of_arrays_filtered));
+      "Array of Objects filtered: $(with)" with => string(@(array_of_objects_filtered));
+
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}


### PR DESCRIPTION
Currently, classfilterdata() does not return a variable for
array_of_XXXs if given data structure's value do not comply completely
to given array_of_XXXs parameter.
On the other hand, classfilterdata() does return a variable when given
object_of_XXXs even if this variable does not completely comply to
object_of_XXXs.

This patch changes classfilterdata() to not return a variable as well
for object_of_XXXs in case given data structure's does not comply.
Also add an acceptance test for it.
This patch also fixes a compiler warning mayby-uninitialized of variable
remove in FnCallClassFilterData() in case parent is of type JSON object.

(cherry picked from commit f53bee0e2b4ff158c03de3c7f432d3d1af917388)
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Back ported from https://github.com/cfengine/core/pull/6021