### PR TITLE
Make expandrange able to output a single value

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -4558,9 +4558,11 @@ static FnCallResult FnCallExpandRange(EvalContext *ctx, ARG_UNUSED const Policy 
         sscanf(template, "%[^[\[][%d-%d]%[^\n]", before, &from, &to, after);
     }
 
-    if (step_size < 1 || abs(from-to) < step_size)
+    if (step_size < 1)
     {
-        FatalError(ctx, "EXPANDRANGE Step size cannot be less than 1 or greater than the interval");
+        assert(fp->name != NULL);
+        Log(LOG_LEVEL_ERR, "%s: Step size cannot be less than 1", fp->name);
+        return FnFailure();
     }
 
     if (from == CF_NOINT || to == CF_NOINT)

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -4539,6 +4539,8 @@ static FnCallResult FnCallMapList(EvalContext *ctx,
 
 static FnCallResult FnCallExpandRange(EvalContext *ctx, ARG_UNUSED const Policy *policy, ARG_UNUSED const FnCall *fp, const Rlist *finalargs)
 {
+    assert(fp != NULL);
+
     Rlist *newlist = NULL;
     const char *template = RlistScalarValue(finalargs);
     char *step = RlistScalarValue(finalargs->next);
@@ -4560,7 +4562,6 @@ static FnCallResult FnCallExpandRange(EvalContext *ctx, ARG_UNUSED const Policy 
 
     if (step_size < 1)
     {
-        assert(fp->name != NULL);
         Log(LOG_LEVEL_ERR, "%s: Step size cannot be less than 1", fp->name);
         return FnFailure();
     }

--- a/tests/acceptance/01_vars/02_functions/expand_range.cf
+++ b/tests/acceptance/01_vars/02_functions/expand_range.cf
@@ -1,0 +1,43 @@
+# data_regextract() test
+
+body common control
+{
+      inputs => { "../../default.cf.sub" };
+      bundlesequence => { default("$(this.promise_filename)") };
+}
+
+bundle agent test
+{
+  vars:
+    "case1"  slist  => expandrange("case1[1-3]", 1);
+    "case1s" string => format("%S", "case1");
+    "case2"  slist  => expandrange("case2[1-10]", 3);
+    "case2s" string => format("%S", "case2");
+    "case3"  slist  => expandrange("case3[1-1]", 3);
+    "case3s" string => format("%S", "case3");
+    "case4"  slist  => expandrange("case4[1-2]", 3);
+    "case4s" string => format("%S", "case4");
+}
+
+bundle agent check
+{
+  vars:
+      "actual" string => "
+1 $(test.case1s)
+2 $(test.case2s)
+3 $(test.case3s)
+4 $(test.case4s)
+";
+
+      "expected" string => '
+1 { \"case11\", \"case12\", \"case13\" }
+2 { \"case21\", \"case24\", \"case27\", \"case210\" }
+3 { \"case31\" }
+4 { \"case41\" }
+';
+
+  methods:
+      "" usebundle => dcs_check_strcmp($(actual), $(expected),
+                                      $(this.promise_filename),
+                                      "no");
+}


### PR DESCRIPTION
- Allow ranges with a unique value. It looks to me like an expected behavior compared to other implementations of ranges (python, etc.). This should not be a compatibility problem as it would currently crash the agent.
- Make invalid step a soft fail. I don't see a reason to stop the agent in case the value is invalid (but I may be missing something).

Rationale: This avoids some special case handling when computing ranges where the bounds are equal (or lower than the step), with a consistent interface.