### PR TITLE
ENT-13699: Immediately collect report on bootstrap (3.24.x)

### DIFF
--- a/cf-serverd/cf-serverd-enterprise-stubs.c
+++ b/cf-serverd/cf-serverd-enterprise-stubs.c
@@ -106,6 +106,11 @@ ENTERPRISE_VOID_FUNC_0ARG_DEFINE_STUB(void, CollectCallMarkProcessed)
 {
 }
 
+ENTERPRISE_VOID_FUNC_1ARG_DEFINE_STUB(void, NotifyNewHostSeen,
+                                      ARG_UNUSED const char *, hostkey)
+{
+}
+
 ENTERPRISE_VOID_FUNC_1ARG_DEFINE_STUB(void, FprintAvahiCfengineTag, FILE *, fp)
 {
     fprintf(fp,"<name replace-wildcards=\"yes\" >CFEngine Community %s Policy Server on %s </name>\n", Version(), "%h");

--- a/cf-serverd/cf-serverd-enterprise-stubs.h
+++ b/cf-serverd/cf-serverd-enterprise-stubs.h
@@ -50,6 +50,8 @@ ENTERPRISE_VOID_FUNC_0ARG_DECLARE(void, CleanReportBookFilterSet);
 
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, FprintAvahiCfengineTag, FILE *, fp);
 
+ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, NotifyNewHostSeen, const char *, hostkey);
+
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, CollectCallStart, ARG_UNUSED int, interval);
 ENTERPRISE_VOID_FUNC_0ARG_DECLARE(void, CollectCallStop);
 ENTERPRISE_FUNC_0ARG_DECLARE(bool, CollectCallHasPending);

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -423,9 +423,9 @@ bool ServerSendWelcome(const ServerConnectionState *conn)
                            "USERNAME", conn->username);
         if (ret < 0)
         {
-            Log(LOG_LEVEL_ERR, 
+            Log(LOG_LEVEL_ERR,
                 "Unexpected failure from snprintf (%d - %s) while "
-                "constructing OK WELCOME message (ServerSendWelcome)", 
+                "constructing OK WELCOME message (ServerSendWelcome)",
                 errno, GetErrorStr());
             return false;
         }

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -537,6 +537,8 @@ bool BasicServerTLSSessionEstablish(ServerConnectionState *conn, SSL_CTX *ssl_ct
  */
 bool ServerTLSSessionEstablish(ServerConnectionState *conn, SSL_CTX *ssl_ctx)
 {
+    assert (conn != NULL);
+
     if (conn->conn_info->status == CONNECTIONINFO_STATUS_ESTABLISHED)
     {
         return true;
@@ -608,8 +610,13 @@ bool ServerTLSSessionEstablish(ServerConnectionState *conn, SSL_CTX *ssl_ctx)
     conn->user_data_set = true;
     conn->rsa_auth = true;
 
-    LastSaw1(conn->ipaddr, KeyPrintableHash(ConnectionInfoKey(conn->conn_info)),
-             LAST_SEEN_ROLE_ACCEPT);
+    const char *hostkey = KeyPrintableHash(ConnectionInfoKey(conn->conn_info));
+    bool is_new_host = LastSaw1(conn->ipaddr, hostkey, LAST_SEEN_ROLE_ACCEPT);
+    if (is_new_host)
+    {
+        /* This will trigger immediate report collection */
+        NotifyNewHostSeen(hostkey);
+    }
 
     ServerSendWelcome(conn);
     return true;

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -44,8 +44,13 @@ typedef enum
 bool Address2Hostkey(char *dst, size_t dst_size, const char *address);
 char *HostkeyToAddress(const char *hostkey);
 
-void LastSaw1(const char *ipaddress, const char *hashstr, LastSeenRole role);
-void LastSaw(const char *ipaddress, const unsigned char *digest, LastSeenRole role);
+/**
+ * @brief Record a host connection in the lastseen database.
+ * @return true if this is the first time the host has been seen (new host),
+ *         false if the host was already known.
+ */
+bool LastSaw1(const char *ipaddress, const char *hashstr, LastSeenRole role);
+bool LastSaw(const char *ipaddress, const unsigned char *digest, LastSeenRole role);
 
 bool DeleteIpFromLastSeen(const char *ip, char *digest, size_t digest_size);
 bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size, bool a_entry_required);

--- a/tests/load/lastseen_load.c
+++ b/tests/load/lastseen_load.c
@@ -21,7 +21,7 @@ static void tests_setup(void)
     mkdir(GetStateDir(), (S_IRWXU | S_IRWXG | S_IRWXO));
 }
 
-void UpdateLastSawHost(const char *hostkey, const char *address,
+bool UpdateLastSawHost(const char *hostkey, const char *address,
                        bool incoming, time_t timestamp);
 
 int main()

--- a/tests/load/lastseen_threaded_load.c
+++ b/tests/load/lastseen_threaded_load.c
@@ -35,7 +35,7 @@ pthread_mutex_t end_mtx = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
 pthread_cond_t end_cond = PTHREAD_COND_INITIALIZER;
 
 
-void UpdateLastSawHost(const char *hostkey, const char *address,
+bool UpdateLastSawHost(const char *hostkey, const char *address,
                        bool incoming, time_t timestamp);
 
 

--- a/tests/unit/lastseen_test.c
+++ b/tests/unit/lastseen_test.c
@@ -10,7 +10,7 @@
 
 char CFWORKDIR[CF_BUFSIZE];
 
-void UpdateLastSawHost(const char *hostkey, const char *address,
+bool UpdateLastSawHost(const char *hostkey, const char *address,
                        bool incoming, time_t timestamp);
 
 /* For abbreviation of tests. */


### PR DESCRIPTION
- **server_tls.c: fixed white space issues**
- **Immediately collect report on bootstrap**

Merge together with:
- https://github.com/cfengine/enterprise/pull/890
- https://github.com/cfengine/nova/pull/2559