### PR TITLE
qa: Added Alpine Linux support in ci/install.sh and friends

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -5,4 +5,11 @@ set -ex
 thisdir="$(dirname "$0")"
 cd "$thisdir"/..
 
-make -j8 CFLAGS="-Werror -Wall"
+source /etc/os-release
+CFLAGS="-Wall"
+if [ "$ID" != "alpine" ]; then
+  CFLAGS="$CFLAGS -Werror"
+  # on alpine, with lib musl, there are not re-entrant random functions e.g. srand48_r, lrand48_r see CFE-4654
+fi
+export CFLAGS
+make -j8

--- a/ci/configure.sh
+++ b/ci/configure.sh
@@ -6,7 +6,12 @@ thisdir="$(dirname "$0")"
 cd "$thisdir"/..
 OPTS="--enable-debug"
 
-if [ -n "$TERMUX_VERSION" ]; then
+source /etc/os-release
+if [ "$ID" = "alpine" ]; then
+    OPTS="" # we don't want --enable-debug so that libpromises/dbm_test_api is not built due to lack of srand48_r() and friends on alpine linux libmusl
+fi
+
+if [ -n "$TERMUX_VERSION" ] || [ "$ID" = "alpine" ]; then
     OPTS="$OPTS --without-pam"
 fi
 

--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -72,6 +72,9 @@ if [ -f /etc/os-release ]; then
             echo "Unsupported version of redhat for $0"
             exit 1
         fi
+        elif [ "$ID" = "alpine" ]; then
+            $GAINROOT apk update
+            $GAINROOT apk add alpine-sdk lmdb-dev openssl-dev bison flex-dev acl-dev pcre2-dev autoconf automake libtool git python3 gdb librsync-dev
     elif [ "$ID" = "debian" ] || [[ "$ID_LIKE" =~ "debian" ]]; then
         $GAINROOT apt update --yes
         $GAINROOT apt install --yes build-essential git libtool autoconf automake bison flex libssl-dev libpcre2-dev libbison-dev libacl1 libacl1-dev lmdb-utils liblmdb-dev libpam0g-dev libtool libyaml-dev libxml2-dev librsync-dev


### PR DESCRIPTION
This is to enable masterfiles github CI to run bootstrap policy tests on the latest core by checking it out and building it there instead of using cf-remote --version master install.

Ticket: CFE-4623
Changelog: none

with https://github.com/cfengine/masterfiles/pull/3119