### PR TITLE
ENT-13699: Fixed "0 hosts" after bootstrap

### DIFF
--- a/cf-serverd/cf-serverd-enterprise-stubs.c
+++ b/cf-serverd/cf-serverd-enterprise-stubs.c
@@ -106,11 +106,6 @@ ENTERPRISE_VOID_FUNC_0ARG_DEFINE_STUB(void, CollectCallMarkProcessed)
 {
 }
 
-ENTERPRISE_VOID_FUNC_1ARG_DEFINE_STUB(void, NotifyNewHostSeen,
-                                      ARG_UNUSED const char *, hostkey)
-{
-}
-
 ENTERPRISE_VOID_FUNC_1ARG_DEFINE_STUB(void, FprintAvahiCfengineTag, FILE *, fp)
 {
     fprintf(fp,"<name replace-wildcards=\"yes\" >CFEngine Community %s Policy Server on %s </name>\n", Version(), "%h");

--- a/cf-serverd/cf-serverd-enterprise-stubs.h
+++ b/cf-serverd/cf-serverd-enterprise-stubs.h
@@ -50,8 +50,6 @@ ENTERPRISE_VOID_FUNC_0ARG_DECLARE(void, CleanReportBookFilterSet);
 
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, FprintAvahiCfengineTag, FILE *, fp);
 
-ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, NotifyNewHostSeen, const char *, hostkey);
-
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, CollectCallStart, ARG_UNUSED int, interval);
 ENTERPRISE_VOID_FUNC_0ARG_DECLARE(void, CollectCallStop);
 ENTERPRISE_FUNC_0ARG_DECLARE(bool, CollectCallHasPending);

--- a/cf-serverd/server_tls.c
+++ b/cf-serverd/server_tls.c
@@ -537,8 +537,6 @@ bool BasicServerTLSSessionEstablish(ServerConnectionState *conn, SSL_CTX *ssl_ct
  */
 bool ServerTLSSessionEstablish(ServerConnectionState *conn, SSL_CTX *ssl_ctx)
 {
-    assert (conn != NULL);
-
     if (conn->conn_info->status == CONNECTIONINFO_STATUS_ESTABLISHED)
     {
         return true;
@@ -610,13 +608,8 @@ bool ServerTLSSessionEstablish(ServerConnectionState *conn, SSL_CTX *ssl_ctx)
     conn->user_data_set = true;
     conn->rsa_auth = true;
 
-    const char *hostkey = KeyPrintableHash(ConnectionInfoKey(conn->conn_info));
-    bool is_new_host = LastSaw1(conn->ipaddr, hostkey, LAST_SEEN_ROLE_ACCEPT);
-    if (is_new_host)
-    {
-        /* This will trigger immediate report collection */
-        NotifyNewHostSeen(hostkey);
-    }
+    LastSaw1(conn->ipaddr, KeyPrintableHash(ConnectionInfoKey(conn->conn_info)),
+             LAST_SEEN_ROLE_ACCEPT);
 
     ServerSendWelcome(conn);
     return true;

--- a/libpromises/lastseen.c
+++ b/libpromises/lastseen.c
@@ -34,7 +34,7 @@
 #include <lmdb.h>
 #endif
 
-bool UpdateLastSawHost(const char *hostkey, const char *address,
+void UpdateLastSawHost(const char *hostkey, const char *address,
                        bool incoming, time_t timestamp);
 
 /*
@@ -80,40 +80,40 @@ bool UpdateLastSawHost(const char *hostkey, const char *address,
  * @brief Same as LastSaw() but the digest parameter is the hash as a
  *        "SHA=..." string, to avoid converting twice.
  */
-bool LastSaw1(const char *ipaddress, const char *hashstr,
+void LastSaw1(const char *ipaddress, const char *hashstr,
               LastSeenRole role)
 {
     const char *mapip = MapAddress(ipaddress);
-    return UpdateLastSawHost(hashstr, mapip, role == LAST_SEEN_ROLE_ACCEPT, time(NULL));
+    UpdateLastSawHost(hashstr, mapip, role == LAST_SEEN_ROLE_ACCEPT, time(NULL));
 }
 
-bool LastSaw(const char *ipaddress, const unsigned char *digest, LastSeenRole role)
+void LastSaw(const char *ipaddress, const unsigned char *digest, LastSeenRole role)
 {
     char databuf[CF_HOSTKEY_STRING_SIZE];
 
     if (strlen(ipaddress) == 0)
     {
         Log(LOG_LEVEL_INFO, "LastSeen registry for empty IP with role %d", role);
-        return false;
+        return;
     }
 
     HashPrintSafe(databuf, sizeof(databuf), digest, CF_DEFAULT_DIGEST, true);
 
     const char *mapip = MapAddress(ipaddress);
 
-    return UpdateLastSawHost(databuf, mapip, role == LAST_SEEN_ROLE_ACCEPT, time(NULL));
+    UpdateLastSawHost(databuf, mapip, role == LAST_SEEN_ROLE_ACCEPT, time(NULL));
 }
 
 /*****************************************************************************/
 
-bool UpdateLastSawHost(const char *hostkey, const char *address,
+void UpdateLastSawHost(const char *hostkey, const char *address,
                        bool incoming, time_t timestamp)
 {
     DBHandle *db = NULL;
     if (!OpenDB(&db, dbid_lastseen))
     {
         Log(LOG_LEVEL_ERR, "Unable to open last seen db");
-        return false;
+        return;
     }
 
     /* Update quality-of-connection entry */
@@ -127,8 +127,7 @@ bool UpdateLastSawHost(const char *hostkey, const char *address,
     };
 
     KeyHostSeen q;
-    bool host_existed = ReadDB(db, quality_key, &q, sizeof(q));
-    if (host_existed)
+    if (ReadDB(db, quality_key, &q, sizeof(q)))
     {
         newq.Q = QAverage(q.Q, newq.lastseen - q.lastseen, 0.4);
     }
@@ -154,7 +153,6 @@ bool UpdateLastSawHost(const char *hostkey, const char *address,
     WriteDB(db, address_key, hostkey, strlen(hostkey) + 1);
 
     CloseDB(db);
-    return !host_existed;
 }
 /*****************************************************************************/
 

--- a/libpromises/lastseen.h
+++ b/libpromises/lastseen.h
@@ -44,13 +44,8 @@ typedef enum
 bool Address2Hostkey(char *dst, size_t dst_size, const char *address);
 char *HostkeyToAddress(const char *hostkey);
 
-/**
- * @brief Record a host connection in the lastseen database.
- * @return true if this is the first time the host has been seen (new host),
- *         false if the host was already known.
- */
-bool LastSaw1(const char *ipaddress, const char *hashstr, LastSeenRole role);
-bool LastSaw(const char *ipaddress, const unsigned char *digest, LastSeenRole role);
+void LastSaw1(const char *ipaddress, const char *hashstr, LastSeenRole role);
+void LastSaw(const char *ipaddress, const unsigned char *digest, LastSeenRole role);
 
 bool DeleteIpFromLastSeen(const char *ip, char *digest, size_t digest_size);
 bool DeleteDigestFromLastSeen(const char *key, char *ip, size_t ip_size, bool a_entry_required);

--- a/tests/load/lastseen_load.c
+++ b/tests/load/lastseen_load.c
@@ -21,7 +21,7 @@ static void tests_setup(void)
     mkdir(GetStateDir(), (S_IRWXU | S_IRWXG | S_IRWXO));
 }
 
-bool UpdateLastSawHost(const char *hostkey, const char *address,
+void UpdateLastSawHost(const char *hostkey, const char *address,
                        bool incoming, time_t timestamp);
 
 int main()

--- a/tests/load/lastseen_threaded_load.c
+++ b/tests/load/lastseen_threaded_load.c
@@ -35,7 +35,7 @@ pthread_mutex_t end_mtx = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
 pthread_cond_t end_cond = PTHREAD_COND_INITIALIZER;
 
 
-bool UpdateLastSawHost(const char *hostkey, const char *address,
+void UpdateLastSawHost(const char *hostkey, const char *address,
                        bool incoming, time_t timestamp);
 
 

--- a/tests/unit/lastseen_test.c
+++ b/tests/unit/lastseen_test.c
@@ -10,7 +10,7 @@
 
 char CFWORKDIR[CF_BUFSIZE];
 
-bool UpdateLastSawHost(const char *hostkey, const char *address,
+void UpdateLastSawHost(const char *hostkey, const char *address,
                        bool incoming, time_t timestamp);
 
 /* For abbreviation of tests. */


### PR DESCRIPTION
## Summary

- Reverts the previous attempt at fixing the "0 hosts" bootstrap race (PR #888 on enterprise, matching cf-serverd change on core, and the lastseen changes here).

The actual fix lands in cfengine/enterprise and cfengine/nova; this PR only rolls core back so those repos can re-land on a clean base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)