### PR TITLE
changelog-generator: Emit markdown bullets without leading tabs

### DIFF
--- a/misc/changelog-generator/changelog-generator
+++ b/misc/changelog-generator/changelog-generator
@@ -254,12 +254,12 @@ for sha_entry in ENTRIES:
 if SORT_CHANGELOG:
     entry_list.sort()
 for entry in entry_list:
-    entry = "\t- " + entry
+    entry = "- " + entry
     # Blank lines look bad in changelog because entries don't have blank lines
     # between them, so remove that from commit messages.
     entry = re.sub("\n\n+", "\n", entry)
-    # Indent all lines.
-    entry = entry.replace("\n", "\n\t  ")
+    # Indent continuation lines to align with the bullet text.
+    entry = entry.replace("\n", "\n  ")
     print(entry)
 
 for missed in POSSIBLE_MISSED_TICKETS:


### PR DESCRIPTION
The CHANGELOG.md format no longer uses tab indentation for entries, so drop the tab from the bullet prefix and the continuation indent in `changelog-generator`. This makes the tool's output drop-in compatible with the current markdown CHANGELOG.md produced after ENT-13497.

Before:
```
	- Added foo (CFE-1234)
	- Added bar with
	  a continuation line (CFE-5678)
```

After:
```
- Added foo (CFE-1234)
- Added bar with
  a continuation line (CFE-5678)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)