### PR TITLE
changelog-generator: Emit markdown bullets without leading tabs (3.27.x)

### DIFF
--- a/misc/changelog-generator/changelog-generator
+++ b/misc/changelog-generator/changelog-generator
@@ -254,12 +254,12 @@ for sha_entry in ENTRIES:
 if SORT_CHANGELOG:
     entry_list.sort()
 for entry in entry_list:
-    entry = "\t- " + entry
+    entry = "- " + entry
     # Blank lines look bad in changelog because entries don't have blank lines
     # between them, so remove that from commit messages.
     entry = re.sub("\n\n+", "\n", entry)
-    # Indent all lines.
-    entry = entry.replace("\n", "\n\t  ")
+    # Indent continuation lines to align with the bullet text.
+    entry = entry.replace("\n", "\n  ")
     print(entry)
 
 for missed in POSSIBLE_MISSED_TICKETS:


### PR DESCRIPTION
The CHANGELOG.md format no longer uses tab indentation for entries, so
drop the tab from the bullet prefix and continuation indent.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 8e4d7bec6df941468b13d99d893ac36c3dab0d7d)
