### PR TITLE
Revert "changelog-generator: Emit markdown bullets without leading tabs" (3.24.x)

### DIFF
--- a/misc/changelog-generator/changelog-generator
+++ b/misc/changelog-generator/changelog-generator
@@ -254,12 +254,12 @@ for sha_entry in ENTRIES:
 if SORT_CHANGELOG:
     entry_list.sort()
 for entry in entry_list:
-    entry = "- " + entry
+    entry = "\t- " + entry
     # Blank lines look bad in changelog because entries don't have blank lines
     # between them, so remove that from commit messages.
     entry = re.sub("\n\n+", "\n", entry)
-    # Indent continuation lines to align with the bullet text.
-    entry = entry.replace("\n", "\n  ")
+    # Indent all lines.
+    entry = entry.replace("\n", "\n\t  ")
     print(entry)
 
 for missed in POSSIBLE_MISSED_TICKETS:


### PR DESCRIPTION
Reverts cfengine/core#6087 on 3.24.x.

The ChangeLog file on 3.24.x is still in the legacy tab-indented format (`3.24.3:` headers, tab-prefixed bullets). The markdown conversion was only applied on master and 3.27.x. So the generator on 3.24.x needs to keep emitting tab-prefixed bullets to match the file it's writing into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)