### PR TITLE
ENT-14018: Added missing RHEL9 SELinux rules

### DIFF
--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -15,6 +15,7 @@ require {
 	attribute exec_type;
 	attribute non_security_file_type;
 	attribute non_auth_file_type;
+	type autofs_t;
 	type bin_t;
 	type cert_t;
 	type devlog_t;
@@ -393,6 +394,9 @@ allow cfengine_hub_t sssd_var_lib_t:sock_file write;
 allow cfengine_hub_t sysctl_net_t:dir search;
 allow cfengine_hub_t sysfs_t:dir read;
 allow cfengine_hub_t sysfs_t:file { getattr open read };
+allow cfengine_hub_t sysfs_t:lnk_file read;
+allow cfengine_hub_t autofs_t:dir getattr;
+allow cfengine_hub_t cfengine_httpd_exec_t:file getattr;
 allow cfengine_hub_t syslogd_var_run_t:dir search;
 allow cfengine_hub_t systemd_systemctl_exec_t:file getattr;
 allow cfengine_hub_t tmp_t:sock_file write;
@@ -575,7 +579,7 @@ allow cfengine_httpd_t smtp_port_t:tcp_socket name_connect;
 allow cfengine_httpd_t ldap_port_t:tcp_socket name_connect;
 
 # allow PHP-FPM to use hugepages for opcache
-allow cfengine_httpd_t hugetlbfs_t:file map;
+allow cfengine_httpd_t hugetlbfs_t:file { map read write };
 
 # allow PHP-FPM to lock opcache files in tmpfs
 allow cfengine_httpd_t tmpfs_t:file lock;
@@ -744,6 +748,7 @@ allow cfengine_reactor_t postfix_spool_t:dir { add_name remove_name search write
 allow cfengine_reactor_t postfix_spool_t:file { create getattr open read rename setattr write };
 allow cfengine_reactor_t sendmail_exec_t:file map;
 allow cfengine_reactor_t sendmail_exec_t:file { execute execute_no_trans open read };
+allow cfengine_reactor_t smtp_port_t:tcp_socket name_connect;
 
 
 #============= cfengine_action_script_t ==============

--- a/misc/selinux/cfengine-enterprise.te.el10
+++ b/misc/selinux/cfengine-enterprise.te.el10
@@ -19,16 +19,11 @@ allow cfengine_apachectl_t user_devpts_t:chr_file getattr;
 allow cfengine_execd_t http_port_t:tcp_socket name_connect;
 
 #============= cfengine_httpd_t ==============
-allow cfengine_httpd_t hugetlbfs_t:file { read write };
 allow cfengine_httpd_t systemd_userdbd_runtime_t:dir { open read getattr search };
 allow cfengine_httpd_t systemd_userdbd_runtime_t:lnk_file read;
 allow cfengine_httpd_t systemd_userdbd_runtime_t:sock_file write;
 allow cfengine_httpd_t systemd_userdbd_t:unix_stream_socket connectto;
 allow cfengine_httpd_t kernel_t:unix_stream_socket connectto;
-
-#============= cfengine_hub_t ==============
-allow cfengine_hub_t cfengine_httpd_exec_t:file getattr;
-allow cfengine_hub_t sysfs_t:lnk_file read;
 
 #============= cfengine_postgres_t ==============
 allow cfengine_postgres_t systemd_userdbd_runtime_t:dir { open read getattr search };


### PR DESCRIPTION
Moved the common rules from the RHEL 10 policy into cfengine-enterprise.te.all so they apply to all platforms.

Added:
 - cfengine_reactor_t cfsmtp_port_t:tcp_socket name_connect, to be able to send scheduled emails
 - cfengine_hub_t autofs_t:dir getattr (cf-hub calls stat() on /efi automount during inventory)

Ticket: ENT-14018