### PR TITLE
ENT-14018: Added missing RHEL9 SELinux rules (3.24.x)

### DIFF
--- a/misc/selinux/cfengine-enterprise.te.all
+++ b/misc/selinux/cfengine-enterprise.te.all
@@ -738,6 +738,7 @@ allow cfengine_reactor_t postfix_spool_t:dir { add_name remove_name search write
 allow cfengine_reactor_t postfix_spool_t:file { create getattr open read rename setattr write };
 allow cfengine_reactor_t sendmail_exec_t:file map;
 allow cfengine_reactor_t sendmail_exec_t:file { execute execute_no_trans open read };
+allow cfengine_reactor_t smtp_port_t:tcp_socket name_connect;
 
 
 #============= cfengine_action_script_t ==============


### PR DESCRIPTION
Added:
 - cfengine_reactor_t cfsmtp_port_t:tcp_socket name_connect, to be able to send scheduled emails