### PR TITLE
Added mpf_masterfiles_stage_build_always flag file to enable legacy behavior of masterfiles-stage to always run cfbs build (3.24)

### DIFF
--- a/contrib/masterfiles-stage/README.org
+++ b/contrib/masterfiles-stage/README.org
@@ -97,6 +97,16 @@ are pre-installed when using CFEngine Enterprise.
 
 Next, configure the default parameter set (=DEFAULT_PARAMS_FILE=).
 
+*** Legacy behavior
+
+Before CFEngine 3.24.0 release the cfbs variant of this script would run cfbs build every update policy run.
+
+This could be used to run scripts to dynamically create files in the policy set but also broke one important feature of cfbs build which is to make deterministic builds that result in the same outputs given the same inputs.
+
+The new default behavior as of 3.24.0 is to not run cfbs build if the repository has not changed.
+
+As of release 3.24.4, 3.27.1 and 3.28.0 you can restore this legacy behavior by touching the file /var/cfengine/state/mpf_masterfiles_stage_build_always.flag.
+
 *** Troubleshooting
 
 You may experience issues trying to use the old versions of various dependencies. Try these solutions to common issues.

--- a/contrib/masterfiles-stage/common.sh
+++ b/contrib/masterfiles-stage/common.sh
@@ -212,7 +212,9 @@ git_cfbs_deploy_refspec() {
     # We don't mkdir $1 directly, just its parent dir if that doesn't exist.
 
   if git_check_is_in_sync "${local_mirrored_repo}" "$1" "$2"; then
-    return 0
+    if [ ! -f /var/cfengine/state/mpf_masterfiles_stage_build_always.flag ]; then
+      return 0
+    fi
   fi
 
   ########################## 1. CREATE EMPTY TEMP DIR


### PR DESCRIPTION
This enables the previous unwanted behavior of running cfbs regardless of whether changes exist.
In some cases this behavior was used to run scripts which updated information dynamically on a periodic basis.
The goal of cfbs is to make reproducible builds so this strategy is not recommended and the behavior in masterfiles-stage is deprecated.

Ticket: ENT-13756
Changelog: title
(cherry picked from commit f22b0889bd2d5b01bd17f4a50a971933debff59a)
