### PR TITLE
ENT-14083: Fix inet_ntop/inet_pton declaration check for MinGW cross-compilation (3.24.x)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1182,7 +1182,16 @@ AC_CHECK_DECLS(getaddrinfo, [], [], [[
 #endif
 ]])
 
-AC_CHECK_DECLS([[inet_ntop], [inet_pton]], [], [], [[#include <arpa/inet.h>]])
+AC_CHECK_DECLS([[inet_ntop], [inet_pton]], [], [], [[
+#if HAVE_WINSOCK2_H
+    #include <winsock2.h>
+#endif
+#if HAVE_WS2TCPIP_H
+    #include <ws2tcpip.h>
+#else
+    #include <arpa/inet.h>
+#endif
+]])
 
 AC_CHECK_FUNCS(getifaddrs)
 


### PR DESCRIPTION
The AC_CHECK_DECLS for inet_ntop and inet_pton only checked
<arpa/inet.h>, which does not exist on MinGW. On MinGW, these
functions are declared in <ws2tcpip.h>. This caused the check to
fail, leaving HAVE_DECL_INET_NTOP=0, which made platform.h
re-declare inet_ntop with socklen_t. With mingw-w64 >= v11 (Ubuntu
24.04), ws2tcpip.h declares inet_ntop with size_t, causing a
conflicting types error.

Include the correct Winsock headers in the check, matching the
pattern already used by the getaddrinfo check above.

Ticket: ENT-13766
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 294f0f6cdee3dc9cdb896c4d14c0af6a9e955e3c)

Backported from https://github.com/cfengine/core/pull/6051