### PR TITLE
ENT-13720: Fixed daemon hang on SIGTERM during child process wait (3.24.x)

### DIFF
--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -25,6 +25,7 @@
 #include <unix.h>
 #include <exec_tools.h>
 #include <file_lib.h>
+#include <signals.h>    /* IsPendingTermination() */
 #include <string_lib.h> /* StringToInt64() */
 
 #ifdef HAVE_SYS_UIO_H
@@ -231,6 +232,23 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
         {
             if (errno != EINTR)
             {
+                return false;
+            }
+            /* A daemon received a terminating signal while we are blocked on
+             * waitpid(). Stop the child so we can return control to the main
+             * loop, otherwise the daemon would stay unresponsive to SIGTERM
+             * for as long as the child runs (e.g. a stuck cf-promises during
+             * policy validation). */
+            if (IsPendingTermination())
+            {
+                Log(LOG_LEVEL_VERBOSE,
+                    "Termination pending; aborting child '%s' (pid %jd)",
+                    command, (intmax_t) pid);
+                ProcessSignalTerminate(pid);
+                while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
+                {
+                    /* Child has been signalled; just reap it. */
+                }
                 return false;
             }
         }

--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -228,17 +228,31 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
     {
         ALARM_PID = pid;
 
-        while (waitpid(pid, &status, 0) < 0)
+        /* Poll for the child instead of blocking in waitpid(). signal() on
+         * Linux/glibc installs handlers with SA_RESTART, so SIGTERM does not
+         * interrupt a blocking waitpid() and PENDING_TERMINATION is never
+         * observed until the child exits on its own. With WNOHANG we get
+         * control back between iterations and can react to a pending
+         * termination (e.g. a stuck cf-promises during policy validation
+         * keeping the daemon unresponsive to SIGTERM). nanosleep() is
+         * interruptible regardless of SA_RESTART, so SIGTERM wakes us up
+         * promptly. */
+        while (true)
         {
-            if (errno != EINTR)
+            pid_t wait_result = waitpid(pid, &status, WNOHANG);
+            if (wait_result == pid)
             {
+                break; /* child exited and was reaped */
+            }
+            if (wait_result < 0)
+            {
+                if (errno == EINTR)
+                {
+                    continue;
+                }
                 return false;
             }
-            /* A daemon received a terminating signal while we are blocked on
-             * waitpid(). Stop the child so we can return control to the main
-             * loop, otherwise the daemon would stay unresponsive to SIGTERM
-             * for as long as the child runs (e.g. a stuck cf-promises during
-             * policy validation). */
+            /* wait_result == 0: child is still running */
             if (IsPendingTermination())
             {
                 Log(LOG_LEVEL_VERBOSE,
@@ -251,6 +265,11 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
                 }
                 return false;
             }
+            struct timespec poll_interval = {
+                .tv_sec = 0,
+                .tv_nsec = 100000000 /* 100 ms */
+            };
+            nanosleep(&poll_interval, NULL);
         }
 
         return (WEXITSTATUS(status) == 0);


### PR DESCRIPTION
`ShellCommandReturnsZero` retried `waitpid()` unconditionally on `EINTR`, so daemons blocked waiting for a child — e.g. `cf-promises` during policy validation — stayed unresponsive to `SIGTERM` until the child finished. `HandleSignalsForDaemon` sets `PENDING_TERMINATION`, but the main loop never got control back to check it.

On interrupted `waitpid`, we now check `IsPendingTermination()` and, if set, stop the child via `ProcessSignalTerminate` and reap it, so the daemon can exit.

Observed in the `valgrind-checks` CI job, where `pkill -f cf-serverd` failed to kill the bootstrap daemon and the valgrind-wrapped replacement could not bind to the listening port.

Backported from https://github.com/cfengine/core/pull/6129

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline)](https://ci.cfengine.com/job/pr-pipeline/13801/)