### PR TITLE
ENT-14090: Stopped using system_owned in copy_from acceptance tests (3.24.x)

### DIFF
--- a/tests/acceptance/28_inform_testing/01_files/copy_from01.cf
+++ b/tests/acceptance/28_inform_testing/01_files/copy_from01.cf
@@ -17,9 +17,16 @@ bundle agent setup
   files:
     "$(G.testroot)/TEST.source"
       depth_search => recurse("inf"),
-      perms => system_owned("0644"),
+      perms => agent_owned("0644"),
       copy_from => example("$(this.promise_dirname)/test_files");
 
+}
+
+body perms agent_owned(mode)
+{
+      mode   => "$(mode)";
+      owners => { "$(sys.user_data[username])" };
+      groups => { "$(sys.user_data[gid])" };
 }
 
 bundle agent main

--- a/tests/acceptance/28_inform_testing/01_files/copy_from03.cf
+++ b/tests/acceptance/28_inform_testing/01_files/copy_from03.cf
@@ -17,9 +17,16 @@ bundle agent setup
   files:
     "$(G.testroot)/TEST.source"
       depth_search => recurse("inf"),
-      perms => system_owned("0644"),
+      perms => agent_owned("0644"),
       copy_from => example("$(this.promise_dirname)/test_files");
 
+}
+
+body perms agent_owned(mode)
+{
+      mode   => "$(mode)";
+      owners => { "$(sys.user_data[username])" };
+      groups => { "$(sys.user_data[gid])" };
 }
 
 bundle agent main


### PR DESCRIPTION
After `plucked.sub.cf` was regenerated from masterfiles (commit a8a4aa284 on 3.24.x), the `system_owned` body sets group to `sys` (gid 3) on Solaris specifically. The destination file created by `copy_from` with `preserve => "true"` is opened with the agent's effective gid (0), so `VerifyCopiedFileAttributes` detects the mismatch against the source's gid and emits an extra `Group of ... was 0, set to 3` log line that isn't in the `.expected` output. This caused `28_inform_testing/01_files/copy_from01.cf` and `copy_from03.cf` to start failing on Solaris 11.

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&style=plastic)](https://ci.cfengine.com/job/pr-pipeline/13807/)