### PR TITLE
ENT-13720: Suppress spurious validation error log on SIGTERM (3.24.x)

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -1470,7 +1470,15 @@ bool GenericAgentArePromisesValid(const GenericAgentConfig *config)
 
     if (!ShellCommandReturnsZero(cmd, true))
     {
-        Log(LOG_LEVEL_ERR, "Policy failed validation with command '%s'", cmd);
+        if (IsPendingTermination())
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Policy validation aborted due to termination signal");
+        }
+        else
+        {
+            Log(LOG_LEVEL_ERR, "Policy failed validation with command '%s'", cmd);
+        }
         return false;
     }
 


### PR DESCRIPTION
During shutdown, the polling loop in `ShellCommandReturnsZero` (added in ec2627ec983be8dc233cba3b7e38ee7cd0fefe77) aborts the cf-promises child and returns `false`. The caller `GenericAgentArePromisesValid` could not distinguish this from a real validation failure and logged `Policy failed validation with command '...'` at `LOG_LEVEL_ERR`.

The valgrind CI's `check_daemon_output` greps the daemon stdout for `error` and fails on this otherwise harmless shutdown message (see valgrind-checks job [#303](https://ci.cfengine.com/job/valgrind-checks/303/consoleFull)).

Now check `IsPendingTermination()` at the call site and downgrade to `LOG_LEVEL_VERBOSE` when we aborted because the daemon is shutting down. Real validation failures keep their original error log.

Backported from https://github.com/cfengine/core/pull/6133

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&style=plastic)](https://ci.cfengine.com/job/pr-pipeline/13806/)
