### PR TITLE
ENT-13720: Install smtp-sink in valgrind check container

### DIFF
--- a/tests/valgrind-check/Containerfile
+++ b/tests/valgrind-check/Containerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04 AS build
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --fix-missing && \
- DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev libxml2-dev libpam0g-dev liblmdb-dev libacl1-dev libpcre2-dev librsync-dev python3 git flex bison byacc automake make autoconf libtool valgrind curl
+ DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev libxml2-dev libpam0g-dev liblmdb-dev libacl1-dev libpcre2-dev librsync-dev python3 git flex bison byacc automake make autoconf libtool valgrind curl postfix
 COPY masterfiles masterfiles
 COPY core core
 WORKDIR core

--- a/tests/valgrind-check/valgrind.sh
+++ b/tests/valgrind-check/valgrind.sh
@@ -85,6 +85,13 @@ set -x
 auto_destruct_pid=$!
 trap "kill $auto_destruct_pid" EXIT
 
+# cf-execd's MailResult connects to localhost:25 whenever a cf-agent run
+# produces output. Run smtp-sink (from the postfix package) so the connect
+# succeeds and cf-execd's mail code path is exercised under valgrind without
+# leaving an "error: Mail report: couldn't connect" line in execd_output.txt.
+echo "Starting smtp-sink to absorb cf-execd mail reports"
+/usr/sbin/smtp-sink 127.0.0.1:25 1000 &
+
 # Assume we are in core directory
 if [ -f ./configure ] ; then
   ./configure -C --enable-debug


### PR DESCRIPTION
cf-execd's `MailResult` connects to `localhost:25` whenever a cf-agent run produces output. The valgrind check container had no SMTP listener, so cf-execd logged `error: Mail report: couldn't connect to host 'localhost'` and `check_daemon_output` caught it as a test failure. This was timing-dependent — it only surfaced when cf-agent completed a run within the test window.

Install postfix in the container for `smtp-sink`, and run it on `127.0.0.1:25` before the daemons start. cf-execd's mail code path now gets exercised under valgrind instead of silently failing on connect.

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&style=plastic&subject=valgind-checks&status=humming)](https://ci.cfengine.com/job/pr-pipeline/13808/)