### PR TITLE
Removed soft fail on redhat_10 in 16_cf-serverd/serial/copy_from_ciphers_success.cf

### DIFF
--- a/tests/acceptance/16_cf-serverd/serial/copy_from_ciphers_success.cf
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_ciphers_success.cf
@@ -8,8 +8,8 @@ body common control
 bundle agent test
 {
   meta:
-      "test_soft_fail" string => "windows|redhat_10",
-        meta => { "ENT-10401", "ENT-13494" };
+      "test_soft_fail" string => "windows",
+        meta => { "ENT-10401" };
 
   methods:
       # source file


### PR DESCRIPTION
We are now building our own openssl 4.0.0 which includes needed ciphers.

This change is only valid for master where we are vendoring openssl with redhat distributions again.

Ticket: ENT-13494
Changelog: none
