### PR TITLE
ENT-14139: Fixed cf-agent SIGABRT on SIGTERM during early policy validation (3.27.x)

### DIFF
--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -1199,6 +1199,11 @@ static void PromiseModule_Terminate_untyped(void *data)
 
 void TerminateCustomPromises(void)
 {
+    if (custom_modules == NULL)
+    {
+        return;
+    }
+
     MapIterator iter = MapIteratorInit(custom_modules);
 
     for (const MapKeyValue *item = MapIteratorNext(&iter); item != NULL; item = MapIteratorNext(&iter))


### PR DESCRIPTION
When SIGTERM arrives before `ThisAgentInit()`, the signal handler calls `TerminateCustomPromises()` while `custom_modules` is still `NULL`, causing an assert to be triggered in `MapIteratorInit()`.

Ticket: ENT-14139

Backported from https://github.com/cfengine/core/pull/6140