### PR TITLE
ENT-14108: cf-execd.service: drain cf-agent on stop (3.27.x)

### DIFF
--- a/misc/systemd/cf-execd.service.in
+++ b/misc/systemd/cf-execd.service.in
@@ -12,5 +12,14 @@ Restart=always
 RestartSec=10
 KillMode=process
 
+# Drain in-flight cf-agent, so it does not pull dependencies back in after the
+# stop is reported successful (as seen in ENT-14108).
+ExecStopPost=/bin/sh -c 't=60; \
+    while [ $$t -gt 0 ] && pgrep -x cf-agent >/dev/null 2>&1; do \
+        sleep 1; \
+        t=$$((t - 1)); \
+    done; \
+    pkill -KILL -x cf-agent >/dev/null 2>&1 || true'
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
`KillMode=process` only signals cf-execd. Any cf-agent spawned by cf-execd keeps running after systemctl stop returns. A mid-run agent can then re-trigger cf-php-fpm (`Wants=cf-postgres`), causing dependencies to be pulled back in after the stop was reported successful.

This fix adds `ExecStopPost=` that waits up to 60s for cf-agent to drain, then `SIGKILL`s any survivor. It runs after cf-execd has exited, so no new agents are spawned during the drain.

Ticket: ENT-14108

Backported from https://github.com/cfengine/core/pull/6146
