### PR TITLE
ENT-3868: Improve persistent class logging

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -753,6 +753,18 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
                     free(new_info);
                     return;
                 }
+                else if (policy == CONTEXT_STATE_POLICY_RESET)
+                {
+                    Log(LOG_LEVEL_VERBOSE,
+                        "Resetting persistent class '%s' timer to %u minutes (was %jd minutes remaining)",
+                        key, ttl_minutes, (intmax_t)((existing_info->expires - now) / 60));
+                }
+                else
+                {
+                    Log(LOG_LEVEL_VERBOSE,
+                        "Updating persistent class '%s' (%u minutes, policy preserve)",
+                        key, ttl_minutes);
+                }
             }
             else
             {
@@ -765,9 +777,14 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
             }
             free(existing_info);
         }
+        else
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Creating persistent class '%s' (%u minutes, policy %s)",
+                key, ttl_minutes,
+                policy == CONTEXT_STATE_POLICY_PRESERVE ? "preserve" : "reset");
+        }
     }
-
-    Log(LOG_LEVEL_VERBOSE, "Updating persistent class '%s'", key);
 
     WriteDB(dbp, key, new_info, new_info_size);
 

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -748,6 +748,7 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
                     Log(LOG_LEVEL_VERBOSE, "Persistent class '%s' is already in a preserved state --  %jd minutes to go",
                         key, (intmax_t)((existing_info->expires - now) / 60));
                     CloseDB(dbp);
+                    free(existing_info);
                     free(key);
                     free(new_info);
                     return;
@@ -757,10 +758,12 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
             {
                 Log(LOG_LEVEL_ERR, "While persisting class '%s', error reading existing value", key);
                 CloseDB(dbp);
+                free(existing_info);
                 free(key);
                 free(new_info);
                 return;
             }
+            free(existing_info);
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix pre-existing memory leak of `existing_info` in `EvalContextHeapPersistentSave` (missing `free()` on the fall-through and early-return paths)
- Replace the generic `"Updating persistent class '%s'"` log message with context-aware messages that distinguish between:
  - **Creating** a new persistent class (no prior record in the DB)
  - **Resetting** a timer (existing record with RESET policy)
  - **Updating** an existing record (expired PRESERVE or changed tags)

This helps diagnose timer_policy behavior from verbose logs, which was the remaining gap identified in ENT-3868.

### Before

```
Updating persistent class 'my_class'
```

### After

```
Creating persistent class 'my_class' (10 minutes, policy reset)
Resetting persistent class 'my_class' timer to 10 minutes (was 7 minutes remaining)
Persistent class 'my_class' is already in a preserved state -- 7 minutes to go
Updating persistent class 'my_class' (10 minutes, policy preserve)
```

## Changelog

### Commit 1: Fix memory leak
`existing_info` was allocated via `xcalloc` but never freed on the fall-through path (after the PRESERVE early-return check) or on the error early-return path. Added `free(existing_info)` in all code paths.

### Commit 2: Improve logging
Moved logging into the branches where the existing/new state is already known, replacing the single generic message with descriptive alternatives.

## Test plan

- [ ] Verify build succeeds
- [ ] Write a policy with `persistence => "10"` on a classes promise, run `cf-agent -Kv` twice — first run should log "Creating", second should log "Resetting"
- [ ] Write a policy using `timer_policy => "absolute"` in a classes body on a files promise, run twice — should log "Creating" then "already in a preserved state"

## Ticket

[ENT-3868](https://northerntech.atlassian.net/browse/ENT-3868)

[ENT-3868]: https://northerntech.atlassian.net/browse/ENT-3868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ