### PR TITLE
GH Actions: Enabled stale action to get issues (PRs)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: read
 
     steps:
       - uses: actions/stale@v5


### PR DESCRIPTION
Not strictly necessary for public repos, but making change
everywhere for consistency.