### PR TITLE
CFE-4682: Fix memory leak in EvalContextHeapPersistentSave

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -748,6 +748,7 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
                     Log(LOG_LEVEL_VERBOSE, "Persistent class '%s' is already in a preserved state --  %jd minutes to go",
                         key, (intmax_t)((existing_info->expires - now) / 60));
                     CloseDB(dbp);
+                    free(existing_info);
                     free(key);
                     free(new_info);
                     return;
@@ -757,10 +758,12 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
             {
                 Log(LOG_LEVEL_ERR, "While persisting class '%s', error reading existing value", key);
                 CloseDB(dbp);
+                free(existing_info);
                 free(key);
                 free(new_info);
                 return;
             }
+            free(existing_info);
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix memory leak of `existing_info` in `EvalContextHeapPersistentSave()` (`eval_context.c`)
- `existing_info` was allocated via `xcalloc` but never freed on three paths:
  1. The PRESERVE early-return (class already preserved and not expired)
  2. The `ReadDB` error early-return
  3. The normal fall-through after the RESET/update log branches

## Test plan

- The existing unit test `test_persistent_class_timer_policy` exercises the PRESERVE early-return path that leaks
- Valgrind CI would catch this regression
- [x] Code review: all `xcalloc` allocations now have matching `free` on every return path

Ticket: [CFE-4682](https://northerntech.atlassian.net/browse/CFE-4682)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CFE-4682]: https://northerntech.atlassian.net/browse/CFE-4682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ