### PR TITLE
ENT-3868: Improved persistent class logging and plugged memory leak (3.27)

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -753,6 +753,18 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
                     free(new_info);
                     return;
                 }
+                else if (policy == CONTEXT_STATE_POLICY_RESET)
+                {
+                    Log(LOG_LEVEL_VERBOSE,
+                        "Resetting persistent class '%s' timer to %u minutes (was %jd minutes remaining)",
+                        key, ttl_minutes, (intmax_t)((existing_info->expires - now) / 60));
+                }
+                else
+                {
+                    Log(LOG_LEVEL_VERBOSE,
+                        "Updating persistent class '%s' (%u minutes, policy preserve)",
+                        key, ttl_minutes);
+                }
             }
             else
             {
@@ -765,9 +777,14 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
             }
             free(existing_info);
         }
+        else
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Creating persistent class '%s' (%u minutes, policy %s)",
+                key, ttl_minutes,
+                policy == CONTEXT_STATE_POLICY_PRESERVE ? "preserve" : "reset");
+        }
     }
-
-    Log(LOG_LEVEL_VERBOSE, "Updating persistent class '%s'", key);
 
     WriteDB(dbp, key, new_info, new_info_size);
 

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -748,6 +748,7 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
                     Log(LOG_LEVEL_VERBOSE, "Persistent class '%s' is already in a preserved state --  %jd minutes to go",
                         key, (intmax_t)((existing_info->expires - now) / 60));
                     CloseDB(dbp);
+                    free(existing_info);
                     free(key);
                     free(new_info);
                     return;
@@ -757,10 +758,12 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
             {
                 Log(LOG_LEVEL_ERR, "While persisting class '%s', error reading existing value", key);
                 CloseDB(dbp);
+                free(existing_info);
                 free(key);
                 free(new_info);
                 return;
             }
+            free(existing_info);
         }
     }
 


### PR DESCRIPTION
This change makes it easier to see when a persistent class timer is being reset. It highlighted a gap in classes promises, they are not able to specify the timer_policy, the ability to specify timer_policy is currently only available in classes bodies. Thus, currently, classes promises always cause a timer reset.

Ticket: ENT-3868