### PR TITLE
ENT-3868: Improved persistent class logging and plugged memory leak (3.24)

### DIFF
--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -723,6 +723,7 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
                     Log(LOG_LEVEL_VERBOSE, "Persistent class '%s' is already in a preserved state --  %jd minutes to go",
                         key, (intmax_t)((existing_info->expires - now) / 60));
                     CloseDB(dbp);
+                    free(existing_info);
                     free(key);
                     free(new_info);
                     return;
@@ -732,10 +733,12 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
             {
                 Log(LOG_LEVEL_ERR, "While persisting class '%s', error reading existing value", key);
                 CloseDB(dbp);
+                free(existing_info);
                 free(key);
                 free(new_info);
                 return;
             }
+            free(existing_info);
         }
     }
 

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -728,6 +728,18 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
                     free(new_info);
                     return;
                 }
+                else if (policy == CONTEXT_STATE_POLICY_RESET)
+                {
+                    Log(LOG_LEVEL_VERBOSE,
+                        "Resetting persistent class '%s' timer to %u minutes (was %jd minutes remaining)",
+                        key, ttl_minutes, (intmax_t)((existing_info->expires - now) / 60));
+                }
+                else
+                {
+                    Log(LOG_LEVEL_VERBOSE,
+                        "Updating persistent class '%s' (%u minutes, policy preserve)",
+                        key, ttl_minutes);
+                }
             }
             else
             {
@@ -740,9 +752,14 @@ void EvalContextHeapPersistentSave(EvalContext *ctx, const char *name, unsigned 
             }
             free(existing_info);
         }
+        else
+        {
+            Log(LOG_LEVEL_VERBOSE,
+                "Creating persistent class '%s' (%u minutes, policy %s)",
+                key, ttl_minutes,
+                policy == CONTEXT_STATE_POLICY_PRESERVE ? "preserve" : "reset");
+        }
     }
-
-    Log(LOG_LEVEL_VERBOSE, "Updating persistent class '%s'", key);
 
     WriteDB(dbp, key, new_info, new_info_size);
 


### PR DESCRIPTION
This change makes it easier to see when a persistent class timer is being reset. It highlighted a gap in classes promises, they are not able to specify the timer_policy, the ability to specify timer_policy is currently only available in classes bodies. Thus, currently, classes promises always cause a timer reset.

Ticket: [ENT-3868](https://northerntech.atlassian.net/browse/ENT-3868)

[ENT-3868]: https://northerntech.atlassian.net/browse/ENT-3868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ