### PR TITLE
fix off-by-one in ProtocolGet and ProtocolOpenDir recv buffers

### DIFF
--- a/libcfnet/protocol.c
+++ b/libcfnet/protocol.c
@@ -38,7 +38,7 @@ Seq *ProtocolOpenDir(AgentConnection *conn, const char *path)
     assert(conn != NULL);
     assert(path != NULL);
 
-    char buf[CF_MSGSIZE] = {0};
+    char buf[CF_BUFSIZE] = {0};
     int tosend = snprintf(buf, CF_MSGSIZE, "OPENDIR %s", path);
     if (tosend < 0 || tosend >= CF_MSGSIZE)
     {
@@ -110,7 +110,7 @@ bool ProtocolGet(AgentConnection *conn, const char *remote_path,
         return false;
     }
 
-    char buf[CF_MSGSIZE] = {0};
+    char buf[CF_BUFSIZE] = {0};
     int to_send = snprintf(buf, CF_MSGSIZE, "GET %d %s",
                            CF_MSGSIZE, remote_path);
 


### PR DESCRIPTION
Tracing the file-receive path in `libcfnet/protocol.c`.

`TLSRecv()` NUL-terminates what it reads:

    tls_generic.c:  buffer[received] = '\0';   // received can equal toget

So the buffer must hold `toget + 1` bytes. `net.c` does exactly that already
with `char proto[CF_INBAND_OFFSET + 1]` for a `CF_INBAND_OFFSET` read.

`ProtocolGet()` and `ProtocolOpenDir()` declare `buf[CF_MSGSIZE]` yet receive
up to `CF_MSGSIZE` bytes. GET goes straight through `TLSRecv(ssl, buf,
CF_MSGSIZE)`. OPENDIR goes through `ReceiveTransaction()`, whose length cap is
`CF_BUFSIZE - CF_INBAND_OFFSET`, i.e. `CF_MSGSIZE`. A peer that fills the
record makes `received` reach `CF_MSGSIZE`, so the terminating NUL is written
to `buf[CF_MSGSIZE]`, one byte past the array. The byte count is server
controlled, so the reach crosses the trust boundary.

Confirmed by modelling the terminating write with a guard byte placed right
after the buffer: the guard is clobbered at `CF_MSGSIZE`, intact once the
buffer is `CF_BUFSIZE`.

`ProtocolStat()` in the same file already sizes its buffer `CF_BUFSIZE`. The
other two now match it.
