### PR TITLE
CFE-4681: default timer_policy => reset for classes: promises (3.28.0)

### DIFF
--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -1134,21 +1134,18 @@ ContextConstraint GetContextConstraints(const EvalContext *ctx, const Promise *p
 
     {
         const char *tp = PromiseGetConstraintAsRval(pp, "timer_policy", RVAL_TYPE_SCALAR);
-        if (StringEqual(tp, "reset"))
+        if (StringEqual(tp, "absolute"))
         {
-            a.timer = CONTEXT_STATE_POLICY_RESET;
+            a.timer = CONTEXT_STATE_POLICY_PRESERVE;
         }
         else
         {
-            /* Default to PRESERVE (absolute) for backward compatibility:
-             * classes: promises historically skip re-evaluation when the
-             * class is already defined, so the timer was never reset.
-             *
-             * NOTE: this default is planned to change to RESET in 3.28.0
-             * (CFE-4681) to align with classes bodies, whose timer_policy
-             * already defaults to reset.  The absolute default is retained on
-             * the 3.24 and 3.27 LTS backports. */
-            a.timer = CONTEXT_STATE_POLICY_PRESERVE;
+            /* Default to RESET: a persistent class that keeps being
+             * rediscovered should keep persisting.  This aligns classes:
+             * promises with classes bodies, whose timer_policy has always
+             * defaulted to reset.  Set timer_policy => "absolute" to keep
+             * the original expiry instead. */
+            a.timer = CONTEXT_STATE_POLICY_RESET;
         }
     }
 

--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -226,7 +226,7 @@ const ConstraintSyntax CF_CLASSBODY[] =
     ConstraintSyntaxNewContext("not", "Evaluate the negation of string expression in normal form", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewContextList("select_class", "Select one of the named list of classes to define based on host identity. Default value: random_selection", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewContextList("xor", "Combine class sources with XOR", SYNTAX_STATUS_NORMAL),
-    ConstraintSyntaxNewOption("timer_policy", "absolute,reset", "Whether a persistent class restarts its counter when rediscovered. Default value: absolute", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewOption("timer_policy", "absolute,reset", "Whether a persistent class restarts its counter when rediscovered. Default value: reset", SYNTAX_STATUS_NORMAL),
     ConstraintSyntaxNewNull()
 };
 

--- a/libpromises/promises.c
+++ b/libpromises/promises.c
@@ -705,8 +705,10 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
     pcopy->org_pp = pp->org_pp;
 
     // if this is a class promise, check if it is already set, if so, skip
-    // Exception: persistent classes with timer_policy => "reset" must not
+    // Exception: persistent classes with the reset timer policy must not
     // be skipped — the promise needs to fire so the timer gets reset.
+    // reset is the default, so only an explicit timer_policy => "absolute"
+    // restores the skip.
     if (strcmp("classes", PromiseGetPromiseType(pp)) == 0)
     {
         if (IsDefinedClass(ctx, CanonifyName(pcopy->promiser)))
@@ -714,7 +716,7 @@ Promise *ExpandDeRefPromise(EvalContext *ctx, const Promise *pp, bool *excluded)
             const char *tp = PromiseGetConstraintAsRval(pp, "timer_policy", RVAL_TYPE_SCALAR);
             int persistence = PromiseGetConstraintAsInt(ctx, "persistence", pp);
 
-            if (StringEqual(tp, "reset") && persistence > 0)
+            if (!StringEqual(tp, "absolute") && persistence > 0)
             {
                 Log(LOG_LEVEL_DEBUG,
                     "Class '%s' is already set but timer_policy is reset"

--- a/tests/acceptance/02_classes/01_basic/persistent_timer_policy_default.cf
+++ b/tests/acceptance/02_classes/01_basic/persistent_timer_policy_default.cf
@@ -1,0 +1,89 @@
+#######################################################
+#
+# CFE-4681: classes: promises default timer_policy is "reset"
+#
+# Verify that a classes: promise with NO timer_policy attribute
+# resets the persistence timer on subsequent agent runs (the
+# default is "reset"), even though the class is already defined
+# (loaded from the persistent DB).
+#
+# This is the counterpart to persistent_timer_policy.cf, which sets
+# timer_policy => "absolute" explicitly and expects the promise to
+# be skipped.  Here we omit the attribute entirely and expect the
+# reset behaviour from the default.
+#
+# First run:  expect "Creating persistent class"
+# Second run: expect "Resetting persistent class" (not skipped)
+#
+# Both sub-agent runs happen in the test bundle so that the check
+# bundle only evaluates assertions -- this avoids a spurious FAIL
+# report during the agent's convergence passes.
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.sub.cf" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  # Remove the persistent class DB to ensure a clean state.
+  files:
+      "$(sys.workdir)/state/cf_state.lmdb"
+        delete => tidy;
+      "$(sys.workdir)/state/cf_state.lmdb-lock"
+        delete => tidy;
+      "$(sys.workdir)/state/cf_state.lmdb.lock"
+        delete => tidy;
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-4681" }
+        string => "classes: promises default to timer_policy => reset, resetting the persistence timer on subsequent runs";
+
+  commands:
+    # First run: define the persistent class (no timer_policy).
+    !first_done::
+      "$(sys.cf_agent) -Kv -f $(this.promise_filename).sub > $(G.testdir)/timer_default_run1.log 2>&1"
+        contain => in_shell,
+        classes => always("first_done");
+
+    # Second run: the class already exists in the DB; the default
+    # timer_policy (reset) must cause the promise to be evaluated and
+    # the timer to be reset.
+    first_done.!second_done::
+      "$(sys.cf_agent) -Kv -f $(this.promise_filename).sub > $(G.testdir)/timer_default_run2.log 2>&1"
+        contain => in_shell,
+        classes => always("second_done");
+}
+
+bundle agent check
+{
+  classes:
+      "first_ok" expression => regline(".*Creating persistent class.*timer_default_test_class.*",
+                                       "$(G.testdir)/timer_default_run1.log");
+      # Match the EvalContextHeapPersistentSave message specifically (it
+      # reports "... timer to N minutes (was M remaining)").  This only
+      # appears when the existing DB record is actually found, so it would
+      # NOT match the "C: + Resetting persistent class timer: ..." progress
+      # line that VerifyClassPromise logs regardless.  This distinction is
+      # what makes the test catch a broken existing-record lookup.
+      "second_ok" expression => regline(".*Resetting persistent class 'timer_default_test_class' timer to.*",
+                                        "$(G.testdir)/timer_default_run2.log");
+      "ok" expression => "first_ok.second_ok";
+
+  reports:
+    DEBUG.!first_ok::
+      "FAIL: first run did not log 'Creating persistent class'";
+    DEBUG.!second_ok::
+      "FAIL: second run did not log 'Resetting persistent class' (default reset not applied)";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/02_classes/01_basic/persistent_timer_policy_default.cf.sub
+++ b/tests/acceptance/02_classes/01_basic/persistent_timer_policy_default.cf.sub
@@ -1,0 +1,16 @@
+body common control
+{
+      bundlesequence => { run };
+}
+
+bundle agent run
+{
+  classes:
+      # Define a persistent class with NO timer_policy attribute.
+      # The default is "reset", so on the second run the timer should
+      # be reset even though the class is already defined from the
+      # persistent DB.
+      "timer_default_test_class"
+        expression  => "any",
+        persistence => "120";
+}

--- a/tests/acceptance/02_classes/01_basic/persistent_timer_policy_default_lmdb.cf
+++ b/tests/acceptance/02_classes/01_basic/persistent_timer_policy_default_lmdb.cf
@@ -1,0 +1,117 @@
+#######################################################
+#
+# CFE-4681: classes: promises default timer_policy is "reset"
+#           -- verified at the source (the cf_state LMDB)
+#
+# Companion to persistent_timer_policy_default.cf, which asserts the
+# default-reset behaviour by matching the agent's verbose log lines
+# ("Creating ..." / "Resetting persistent class ... timer to ...").
+# A log message is a brittle thing to hinge a test on, so this test
+# instead inspects the persistence database itself -- "the truth at
+# the source" -- with `cf-check dump`.
+#
+# A classes: promise with NO timer_policy attribute defaults to
+# "reset", which is observable in the cf_state LMDB two ways:
+#
+#   1. the persistent class record is stored with policy RESET
+#      (an explicit timer_policy => "absolute" would store PRESERVE);
+#   2. the record's expiry (now + persistence*60) is refreshed on each
+#      run -- so across two runs separated by a sleep, the second
+#      expiry is strictly greater (PRESERVE would keep it identical).
+#
+# If the default ever regressed to "absolute", check #1 would see
+# PRESERVE and check #2 would see an unchanged expiry; either fails
+# the test.
+#
+# The relevant code is EvalContextHeapPersistentSave()
+# (libpromises/eval_context.c): new_info->expires = now + ttl*60 and
+# new_info->policy = policy. cf-check renders these as the "expires"
+# and "policy" fields (cf-check/dump.c, print_struct_persistent_class).
+#
+#######################################################
+
+body common control
+{
+      inputs => { "../../default.sub.cf" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+bundle agent init
+{
+  # Remove the persistent class DB to ensure a clean state.
+  files:
+      "$(sys.workdir)/state/cf_state.lmdb"
+        delete => tidy;
+      "$(sys.workdir)/state/cf_state.lmdb-lock"
+        delete => tidy;
+      "$(sys.workdir)/state/cf_state.lmdb.lock"
+        delete => tidy;
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-4681" }
+        string => "classes: promises default to timer_policy => reset, observable in the cf_state LMDB (stored policy RESET; persistence-timer expiry advances on re-evaluation)";
+
+  vars:
+      "state" string => "$(sys.workdir)/state/cf_state.lmdb";
+      "sub"   string => "$(this.promise_filename).sub";
+
+  commands:
+    # One shell invocation runs the whole sequence so it converges in a
+    # single pass (no cross-pass class juggling):
+    #   run 1 -> snapshot the stored policy + expiry from the LMDB
+    #   sleep -> let wall-clock 'now' advance (expiry is now + ttl*60)
+    #   run 2 -> snapshot the expiry again
+    # Each snapshot reads straight from the state DB with 'cf-check dump'
+    # rather than parsing agent log text. The 'grep <class>' isolates our
+    # record; 'tr -dc' keeps only the digits / capital letters we extracted.
+    !done::
+      "$(sys.cf_agent) -Kf $(sub) > /dev/null 2>&1 ;
+       $(sys.cf_check) dump -n $(state) | grep timer_default_lmdb_class | grep -oE 'expires.:[0-9]+' | tr -dc '0-9' > $(G.testdir)/lmdb_expires1 ;
+       $(sys.cf_check) dump -n $(state) | grep timer_default_lmdb_class | grep -oE 'policy.:.[A-Z]+' | tr -dc 'A-Z' > $(G.testdir)/lmdb_policy ;
+       sleep 2 ;
+       $(sys.cf_agent) -Kf $(sub) > /dev/null 2>&1 ;
+       $(sys.cf_check) dump -n $(state) | grep timer_default_lmdb_class | grep -oE 'expires.:[0-9]+' | tr -dc '0-9' > $(G.testdir)/lmdb_expires2"
+        contain => in_shell,
+        classes => always("done");
+}
+
+bundle agent check
+{
+  vars:
+      "policy" string => readfile("$(G.testdir)/lmdb_policy", 4096);
+      "e1"     string => readfile("$(G.testdir)/lmdb_expires1", 4096);
+      "e2"     string => readfile("$(G.testdir)/lmdb_expires2", 4096);
+
+  classes:
+      # #1 The default classes: promise stored its persistent class with
+      #    policy RESET (an explicit "absolute" would store PRESERVE).
+      "policy_is_reset" expression => strcmp("$(policy)", "RESET");
+
+      # Guard the numeric compare: both snapshots must be non-empty integers.
+      "have_expiries" expression => and(regcmp("[0-9]+", "$(e1)"),
+                                        regcmp("[0-9]+", "$(e2)"));
+
+      # #2 The stored expiry advanced between the two runs -> the persistence
+      #    timer was actually reset (PRESERVE would leave it identical).
+      "timer_advanced" expression => eval("$(e2) > $(e1)", "class", "infix"),
+        if => "have_expiries";
+
+      "ok" expression => "policy_is_reset.timer_advanced";
+
+  reports:
+    DEBUG::
+      "stored policy = '$(policy)' (expect RESET)";
+      "expiry run1 = '$(e1)', run2 = '$(e2)' (expect run2 > run1)";
+    DEBUG.!policy_is_reset::
+      "FAIL: persistent class not stored with policy RESET (default reset not applied)";
+    DEBUG.!timer_advanced::
+      "FAIL: persistence-timer expiry did not advance (timer not reset)";
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/02_classes/01_basic/persistent_timer_policy_default_lmdb.cf.sub
+++ b/tests/acceptance/02_classes/01_basic/persistent_timer_policy_default_lmdb.cf.sub
@@ -1,0 +1,15 @@
+body common control
+{
+      bundlesequence => { run };
+}
+
+bundle agent run
+{
+  classes:
+      # Define a persistent class with NO timer_policy attribute. The default
+      # is "reset" (CFE-4681), so the class is stored in the cf_state LMDB with
+      # policy RESET and its expiry is refreshed on every re-evaluation.
+      "timer_default_lmdb_class"
+        expression  => "any",
+        persistence => "120";
+}


### PR DESCRIPTION
With https://github.com/cfengine/core/pull/6174


## Summary

Flips the default `timer_policy` for `classes:` promises from `absolute` to **`reset`** for 3.28.0.

[#6167](https://github.com/cfengine/core/pull/6167) introduced the `timer_policy` attribute on `classes:` promises with a default of `absolute` (preserve) for backward compatibility. This PR changes that default to `reset` so that:

- `classes:` promises align with `classes` bodies, whose `timer_policy` has always defaulted to `reset`.
- A persistent class that keeps being rediscovered keeps persisting, rather than lapsing once its original timer expires — matching what most users expect.

Setting `timer_policy => "absolute"` explicitly restores the previous skip-and-preserve behavior.

## ⚠️ Stacked on #6167 — merge that first

This branch is based on `CFE-4681/timer-policy-classes-promises` (the #6167 head), so until #6167 merges to `master` this PR's diff shows both. The change unique to this PR is the final commit, `07657cce4`.

## ⚠️ Master-only — do NOT backport

The `timer_policy` attribute is being backported to the LTS streams (**3.27.2**, **3.24.5**) with the long-standing `absolute` default preserved, so behavior on those releases is unchanged and `reset` stays opt-in there. This default flip is intentional for **3.28.0 only**.

## Changes

- `GetContextConstraints()` (`attributes.c`): resolve the timer policy to `RESET` by default; only an explicit `timer_policy => "absolute"` selects `PRESERVE`.
- `ExpandDeRefPromise()` (`promises.c`): an already-defined persistent class is no longer skipped unless `timer_policy => "absolute"` is set, so the default `reset` can refresh the timer.
- `mod_common.c`: syntax doc default for the `classes:` promise `timer_policy` updated to `reset`.
- Acceptance test `persistent_timer_policy_default.cf`: a `classes:` promise with no `timer_policy` resets the timer on a subsequent run.

## Test plan

- [x] `libpromises` compiles clean (full-binary link blocked locally by an unrelated ASan toolchain issue; relying on CI for the binary build + acceptance run)
- [ ] CI acceptance tests pass, including the existing `persistent_timer_policy.cf` (explicit `absolute` → still skipped) and the new `persistent_timer_policy_default.cf` (default → reset)

Ticket: [CFE-4681](https://northerntech.atlassian.net/browse/CFE-4681)

[CFE-4681]: https://northerntech.atlassian.net/browse/CFE-4681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ