### PR TITLE
Changed copy_from_ciphers_success.cf acceptance test from soft fail on redhat_10 to expected pass (3.27)

### DIFF
--- a/tests/acceptance/16_cf-serverd/serial/copy_from_ciphers_success.cf
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_ciphers_success.cf
@@ -9,8 +9,8 @@ bundle agent test
 {
   meta:
     "test_soft_fail"
-      string => "windows|redhat_10",
-      meta => { "ENT-10401" };
+      string => "windows",
+      meta => { "ENT-10401", "ENT-13494" };
 
   methods:
     # source file


### PR DESCRIPTION
Ticket: none
Changelog: none
