### PR TITLE
ENT-14192: Update parser with event driven cfengine syntax

### DIFF
--- a/libpromises/Makefile.am
+++ b/libpromises/Makefile.am
@@ -134,6 +134,7 @@ libpromises_la_SOURCES = \
 	mod_storage.c mod_storage.h \
 	mod_knowledge.c mod_knowledge.h \
 	mod_users.c mod_users.h \
+	mod_watch.c mod_watch.h \
 	modes.c \
 	monitoring_read.c monitoring_read.h \
 	ornaments.c ornaments.h \

--- a/libpromises/mod_common.c
+++ b/libpromises/mod_common.c
@@ -42,6 +42,7 @@
 #include <mod_measurement.h>
 #include <mod_knowledge.h>
 #include <mod_users.h>
+#include <mod_watch.h>
 
 #include <conversion.h>
 #include <policy.h>
@@ -549,6 +550,7 @@ const PromiseTypeSyntax *const CF_ALL_PROMISE_TYPES[] =
     CF_MEASUREMENT_PROMISE_TYPES,    /* mod_measurement.c */
     CF_KNOWLEDGE_PROMISE_TYPES,      /* mod_knowledge.c */
     CF_USERS_PROMISE_TYPES,          /* mod_users.c */
+    CF_WATCH_PROMISE_TYPES,          /* mod_watch.c */
 };
 
 const int CF3_MODULES = (sizeof(CF_ALL_PROMISE_TYPES) / sizeof(CF_ALL_PROMISE_TYPES[0]));

--- a/libpromises/mod_watch.c
+++ b/libpromises/mod_watch.c
@@ -1,0 +1,51 @@
+/*
+  Copyright 2026 Northern.tech AS
+
+  This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by the
+  Free Software Foundation; version 3.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <mod_watch.h>
+
+#include <syntax.h>
+
+static const ConstraintSyntax when_constraints[] =
+{
+    CONSTRAINT_SYNTAX_GLOBAL,
+
+    /* Row models */
+    ConstraintSyntaxNewStringList("files_deleted", CF_ANYSTRING, "List of files to watch for deletion", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewNull()
+};
+
+static const BodySyntax when_body = BodySyntaxNew("when", when_constraints, NULL, SYNTAX_STATUS_NORMAL);
+
+static const ConstraintSyntax CF_EVENT_BODIES[] =
+{
+    ConstraintSyntaxNewBody("when", &when_body, "Event to watch", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewBundle("then", "Bundle to run on event", SYNTAX_STATUS_NORMAL),
+    ConstraintSyntaxNewNull()
+};
+
+const PromiseTypeSyntax CF_WATCH_PROMISE_TYPES[] =
+{
+    PromiseTypeSyntaxNew("watch", "events", CF_EVENT_BODIES, NULL, SYNTAX_STATUS_NORMAL),
+    PromiseTypeSyntaxNewNull()
+};

--- a/libpromises/mod_watch.h
+++ b/libpromises/mod_watch.h
@@ -1,0 +1,32 @@
+/*
+  Copyright 2026 Northern.tech AS
+
+  This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by the
+  Free Software Foundation; version 3.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#ifndef CFENGINE_MOD_WATCH_H
+#define CFENGINE_MOD_WATCH_H
+
+#include <cf3.defs.h>
+
+extern const PromiseTypeSyntax CF_WATCH_PROMISE_TYPES[];
+
+#endif

--- a/tests/acceptance/32_cf-watchd/syntax.cf
+++ b/tests/acceptance/32_cf-watchd/syntax.cf
@@ -1,0 +1,28 @@
+bundle agent main
+{
+  reports:
+    "$(this.promise_filename) Pass";
+}
+
+body when file_deleted(filename)
+{
+  files_deleted => { "$(filename)" };
+}
+
+bundle agent create_file(filename)
+{
+  files:
+    "$(filename)" create => "true";
+}
+
+bundle watch event_handler
+{
+  events:
+    "Create /tmp/a"
+      when => file_deleted("/tmp/a"),
+      then => create_file("/tmp/a");
+
+    "Create /tmp/b"
+      when => file_deleted("/tmp/b"),
+      then => create_file("/tmp/b");
+}


### PR DESCRIPTION
Depends on: https://github.com/cfengine/core/pull/6186 (Edit: merged now).

This PR simply allows the new event promise type to be parsed, but is ignored by cf-agent. Test policy:

```

bundle agent main {
  reports:
    "Hello world";
}

body when file_deleted(filename)
{
  files_deleted => { "$(filename)" };
}

bundle agent create_file(filename)
{
  files:
    "$(filename)" create => "true";
}


bundle reactor event_handler {

  events:
    "Create /tmp/a"
      when => file_deleted("/tmp/a"),
      then => create_file("/tmp/a");

    "Create /tmp/b"
      when => file_deleted("/tmp/b"),
      then => create_file("/tmp/b");
}
```

The syntax here differs from the one defined in the ticket: event promises only take one single when body and one single then bundle. There is a ticket for this in the future.