### PR TITLE
Proper identification of Arch Linux ARM

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -3797,6 +3797,12 @@ static void SysOSNameHuman(EvalContext *ctx)
                                       "Arch", CF_DATA_TYPE_STRING,
                                       "source=agent,derived-from=arch");
     }
+    else if (EvalContextClassGet(ctx, NULL, "archarm") != NULL)
+    {
+        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,
+                                      "Arch", CF_DATA_TYPE_STRING,
+                                      "source=agent,derived-from=archarm");
+    }
     else if (EvalContextClassGet(ctx, NULL, "postmarketos") != NULL)
     {
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,


### PR DESCRIPTION
This is a small addition to libenv/sysinfo.c to properly identify Arch Linux ARM as Arch Linux (Set SysOSNameHuman to "Arch").