### PR TITLE
Added Termux for sys.os_name_human when running in Termux Linux Environment (Android)

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -3815,6 +3815,12 @@ static void SysOSNameHuman(EvalContext *ctx)
                                       "Alpine", CF_DATA_TYPE_STRING,
                                       "source=agent,derived-from=alpine");
     }
+    else if (EvalContextClassGet(ctx, NULL, "termux") != NULL)
+    {
+        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,
+                                      "Termux", CF_DATA_TYPE_STRING,
+                                      "source=agent,derived-from=termux");
+    }
     else if (EvalContextClassGet(ctx, NULL, "gentoo") != NULL)
     {
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,

--- a/tests/acceptance/31_tickets/CFE-2663/test.cf
+++ b/tests/acceptance/31_tickets/CFE-2663/test.cf
@@ -12,70 +12,69 @@ bundle agent __main__
 bundle agent init
 {
   vars:
-      # No trailing newline in the strings, so the "[section2]" header is
-      # genuinely the last line of the "actual" file. The region selected for
-      # section2 is therefore empty and sits at the end of the file.
-      "actual" string => "[section]
+    # No trailing newline in the strings, so the "[section2]" header is
+    # genuinely the last line of the "actual" file. The region selected for
+    # section2 is therefore empty and sits at the end of the file.
+    "actual" string => "[section]
 keyone=valueone
 [section2]";
-
-      "expected" string => "[section]
+    "expected" string => "[section]
 keyone=valueone
 [section2]
 keytwo=valuetwo";
-
-      "files" slist => { "actual", "expected" };
+    "files" slist => { "actual", "expected" };
 
   files:
-      "$(G.testfile).$(files)"
-        create => "true",
-        edit_line => init_insert("$(init.$(files))"),
-        edit_defaults => init_empty;
+    "$(G.testfile).$(files)"
+      create => "true",
+      edit_line => init_insert("$(init.$(files))"),
+      edit_defaults => init_empty;
 }
 
 bundle edit_line init_insert(str)
 {
   insert_lines:
-      "$(str)";
+    "$(str)";
 }
 
 body edit_defaults init_empty
 {
-      empty_file_before_editing => "true";
+  empty_file_before_editing => "true";
 }
 
 bundle agent test
 {
   meta:
-      "description"
-        string => "Insertion into an empty trailing region (the select_start delimiter is the last line of the file) must succeed when select_end_match_eof is true",
-        meta => { "CFE-2663" };
+    "description"
+      string => "Insertion into an empty trailing region (the select_start delimiter is the last line of the file) must succeed when select_end_match_eof is true",
+      meta => { "CFE-2663" };
 
   files:
-      "$(G.testfile).actual"
-        edit_line => insert_into_trailing_section;
+    "$(G.testfile).actual" edit_line => insert_into_trailing_section;
 }
 
 bundle edit_line insert_into_trailing_section
 {
   insert_lines:
-      "keytwo=valuetwo"
-        select_region => ini_section("section2");
+    "keytwo=valuetwo" select_region => ini_section("section2");
 }
 
 body select_region ini_section(x)
 # @brief Restrict the edit to the lines in section [x], matching to EOF when
 # [x] is the final section in the file.
 {
-      select_start => "\[$(x)\]\s*";
-      select_end => "\[.*\]\s*";
-      select_end_match_eof => "true";
+  select_start => "\[$(x)\]\s*";
+  select_end => "\[.*\]\s*";
+  select_end_match_eof => "true";
 }
 
 bundle agent check
 {
   methods:
-      "any" usebundle => dcs_check_diff("$(G.testfile).actual",
-                                        "$(G.testfile).expected",
-                                        "$(this.promise_filename)");
+    "any"
+      usebundle => dcs_check_diff(
+        "$(G.testfile).actual",
+        "$(G.testfile).expected",
+        "$(this.promise_filename)"
+      );
 }


### PR DESCRIPTION
We already supported and included the termux class.
This change removes noise when running components like cf-agent.

Ticket: CFE-4427
Changelog: title

