### PR TITLE
Made GetExecOutput() return an empty string on empty command output

### DIFF
--- a/libpromises/exec_tools.c
+++ b/libpromises/exec_tools.c
@@ -37,6 +37,14 @@
 bool GetExecOutput(const char *command, char **buffer, size_t *buffer_size, ShellType shell, OutputSelect output_select, int *ret_out)
 /* Buffer initially contains whole exec string */
 {
+    assert(buffer != NULL && *buffer != NULL);
+    assert(buffer_size != NULL && *buffer_size > 0);
+
+    /* Terminate up front: if the command produces no output the read loop
+     * below never writes to the buffer, and a caller that allocated it with
+     * malloc() would otherwise see stale heap data as command output. */
+    (*buffer)[0] = '\0';
+
     FILE *pp;
 
     if (shell == SHELL_TYPE_USE)


### PR DESCRIPTION
The read loop never touched the output buffer when the command produced no output: it hit EOF on the first iteration and returned success, leaving the buffer exactly as the caller allocated it. A caller using malloc() then saw stale heap data as command output — this made cf-agent's container inventory intermittently treat a freed 'docker image inspect' JSON buffer as the 'docker volume ls --quiet' result on Windows.

NUL-terminate the buffer up front so callers always get a valid, possibly empty, string.