### PR TITLE
Added Termux for sys.os_name_human when running in Termux Linux Environment (Android) (3.27)

### DIFF
--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -3809,6 +3809,12 @@ static void SysOSNameHuman(EvalContext *ctx)
                                       "Alpine", CF_DATA_TYPE_STRING,
                                       "source=agent,derived-from=alpine");
     }
+    else if (EvalContextClassGet(ctx, NULL, "termux") != NULL)
+    {
+        EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,
+                                      "Termux", CF_DATA_TYPE_STRING,
+                                      "source=agent,derived-from=termux");
+    }
     else if (EvalContextClassGet(ctx, NULL, "gentoo") != NULL)
     {
         EvalContextVariablePutSpecial(ctx, SPECIAL_SCOPE_SYS, lval,


### PR DESCRIPTION
We already supported and included the termux class.
This change removes noise when running components like cf-agent.

Ticket: CFE-4427
Changelog: title
(cherry picked from commit fe76460ec8ded399141a2524b68b5a4dd3afc871)
