### PR TITLE
ENT-14193: Fixed cf-watchd build by using CF3_CFLAGS

### DIFF
--- a/cf-watchd/Makefile.am
+++ b/cf-watchd/Makefile.am
@@ -30,7 +30,8 @@ AM_CPPFLAGS = -I$(srcdir)/../libpromises -I$(srcdir)/../libntech/libutils \
 	$(PCRE2_CPPFLAGS) \
 	$(ENTERPRISE_CPPFLAGS)
 
-AM_CFLAGS = @CFLAGS@ \
+AM_CFLAGS = $(CF3_CFLAGS) \
+	$(DEBUG_CFLAGS) \
 	$(OPENSSL_CFLAGS) \
 	$(ENTERPRISE_CFLAGS)
 

--- a/cf-watchd/cf-watchd.c
+++ b/cf-watchd/cf-watchd.c
@@ -84,12 +84,14 @@ int main(int argc, char **argv)
   EvalContext *ctx = EvalContextNew();
   GenericAgentConfigApply(ctx, config);
 
+#ifndef __MINGW32__
   pid_t existing_pid = ReadPID("cf-watchd.pid");
   if ((existing_pid != -1) && (kill(existing_pid, 0) == 0))
   {
       Log(LOG_LEVEL_ERR, "Another instance of cf-watchd is already running, terminating");
       return 1;
   }
+#endif
 
 #ifdef __MINGW32__
 


### PR DESCRIPTION
`@CFLAGS@` omitted `-std=gnu99`, causing C99 for-loop errors.
