### PR TITLE
Changed copy_from_ciphers_success.cf acceptance test from soft fail on redhat_10 to expected pass (3.24)

### DIFF
--- a/tests/acceptance/16_cf-serverd/serial/copy_from_ciphers_success.cf
+++ b/tests/acceptance/16_cf-serverd/serial/copy_from_ciphers_success.cf
@@ -8,7 +8,7 @@ body common control
 bundle agent test
 {
   meta:
-      "test_soft_fail" string => "windows|redhat_10",
+      "test_soft_fail" string => "windows",
         meta => { "ENT-10401", "ENT-13494" };
 
   methods:


### PR DESCRIPTION
Ticket: none
Changelog: none
(cherry picked from commit dbccb532cdbfde5d84dea6c68a9b45d379d6dbd0)
