### PR TITLE
CFE-4526: testall egrep & fgrep warnings

### DIFF
--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -285,9 +285,9 @@ workdir() {
 }
 
 # Example:    fgrepvar 'word'  VARNAME
-# Silent fgrep for variables: search for "word" in $VARNAME
+# Silent grep -F for variables: search for "word" in $VARNAME
 fgrepvar() {
-    eval echo \$$2  |  fgrep "$1"  >  /dev/null
+    eval echo \$$2  |  grep -F "$1"  >  /dev/null
 }
 
 # Same but instead of word search for a regex
@@ -524,22 +524,22 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
         echo "Return code is $RETVAL." >> "$WORKDIR/$LOG"
 
         # Try to collect test metadata if any
-        if egrep "R: test description: " $OUTFILE > /dev/null
+        if grep -E "R: test description: " $OUTFILE > /dev/null
         then
-            TEST_DESCRIPTION="$(egrep "R: test description" $OUTFILE | sed -e "s,.*test description: \([A-Za-z0-9_]*\),\1,")"
+            TEST_DESCRIPTION="$(grep -E "R: test description" $OUTFILE | sed -e "s,.*test description: \([A-Za-z0-9_]*\),\1,")"
         fi
-        if egrep -e "R: test story_id: " $OUTFILE > /dev/null
+        if grep -E -e "R: test story_id: " $OUTFILE > /dev/null
         then
-            TEST_STORY="$(egrep "R: test story_id" $OUTFILE | sed -e "s,.*test story_id: \([0-9][0-9]*\),\1,")"
+            TEST_STORY="$(grep -E "R: test story_id" $OUTFILE | sed -e "s,.*test story_id: \([0-9][0-9]*\),\1,")"
         fi
-        if egrep -e "R: test covers: " $OUTFILE > /dev/null
+        if grep -E -e "R: test covers: " $OUTFILE > /dev/null
         then
-            TEST_COVERS="$(egrep "R: test covers" $OUTFILE | sed -e "s,.*test covers: \([A-Za-z0-9_]*\),\1,")"
+            TEST_COVERS="$(grep -E "R: test covers" $OUTFILE | sed -e "s,.*test covers: \([A-Za-z0-9_]*\),\1,")"
         fi
 
         if [ $TEST_TYPE = errorexit ]
         then
-            if [ $RETVAL -gt 0 ] && [ $RETVAL -lt 128 ] && egrep "error:|aborted on defined class" $OUTFILE > /dev/null
+            if [ $RETVAL -gt 0 ] && [ $RETVAL -lt 128 ] && grep -E "error:|aborted on defined class" $OUTFILE > /dev/null
             then
                 RESULT=Pass
                 RESULT_MSG="${COLOR_SUCCESS}Pass${COLOR_NORMAL}"
@@ -557,7 +557,7 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
             then
                 RESULT=FAIL
                 RESULT_MSG="${COLOR_FAILURE}FAIL (NON-ZERO EXIT CODE!)${COLOR_NORMAL}"
-            elif fgrep 'error: ' "$OUTFILE" > /dev/null
+            elif grep -F 'error: ' "$OUTFILE" > /dev/null
             then
                 RESULT=Pass
                 RESULT_MSG="${COLOR_SUCCESS}Pass${COLOR_NORMAL}"
@@ -575,21 +575,21 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
             # Some states are output by dcs.sub.cf, therefore check for both TEST
             # prefix and dcs.sub.cf prefix.
             ESCAPED_TEST="$(echo "($TEST|dcs.sub.cf)" | sed -e 's/\./\\./g')"
-            if egrep "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE > /dev/null && ! egrep "R: .*$ESCAPED_TEST Wait/" $OUTFILE > /dev/null
+            if grep -E "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE > /dev/null && ! grep -E "R: .*$ESCAPED_TEST Wait/" $OUTFILE > /dev/null
             then
                 # Check for passed outcome, which should not happen.
-                if egrep "R: .*$ESCAPED_TEST " $OUTFILE | egrep "R: .*$ESCAPED_TEST Pass" > /dev/null
+                if grep -E "R: .*$ESCAPED_TEST " $OUTFILE | grep -E "R: .*$ESCAPED_TEST Pass" > /dev/null
                 then
                     RESULT=FAIL
                     RESULT_MSG="${COLOR_FAILURE}FAIL (The test Passed, but failure was expected)${COLOR_NORMAL}"
-                elif egrep "R: .*$ESCAPED_TEST " $OUTFILE | egrep -v "R: .*$ESCAPED_TEST [XS]?FAIL" > /dev/null
+                elif grep -E "R: .*$ESCAPED_TEST " $OUTFILE | grep -E -v "R: .*$ESCAPED_TEST [XS]?FAIL" > /dev/null
                 then
                     # Other test case outcomes than fail. Should not happen.
                     RESULT=FAIL
                     RESULT_MSG="${COLOR_FAILURE}FAIL (Failure was expected, but the test had an unexpected test outcome, check test output, Pass/FAIL need to match exactly)${COLOR_NORMAL}"
                 else
-                    TICKET="$(egrep "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE | sed -e "s,.*[XS]FAIL/\(.*\),\1,")"
-                    RESULT="$(egrep "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE | sed -e "s,.*\([XS]FAIL\).*,\1,")"
+                    TICKET="$(grep -E "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE | sed -e "s,.*[XS]FAIL/\(.*\),\1,")"
+                    RESULT="$(grep -E "R: .*$ESCAPED_TEST [XS]FAIL" $OUTFILE | sed -e "s,.*\([XS]FAIL\).*,\1,")"
                     if [ "$RESULT" = "XFAIL" ]
                     then
                         RESULT_MSG="${COLOR_WARNING}FAIL (Suppressed, $TICKET)${COLOR_NORMAL}"
@@ -600,38 +600,38 @@ export CFENGINE_TEST_OVERRIDE_WORKDIR TEMP CFENGINE_TEST_OVERRIDE_EXTENSION_LIBR
             elif [ $RETVAL -ne 0 ]
             then
                 RESULT=FAIL
-            elif egrep "R: .*$ESCAPED_TEST FAIL/no_ticket_number" $OUTFILE > /dev/null
+            elif grep -E "R: .*$ESCAPED_TEST FAIL/no_ticket_number" $OUTFILE > /dev/null
             then
                 RESULT=FAIL
                 RESULT_MSG="${COLOR_FAILURE}FAIL (Tried to suppress failure, but no issue number is provided)${COLOR_NORMAL}"
-            elif egrep "R: .*$ESCAPED_TEST Wait/[0-9]+" $OUTFILE > /dev/null
+            elif grep -E "R: .*$ESCAPED_TEST Wait/[0-9]+" $OUTFILE > /dev/null
             then
                 if [ -z "$NEXT_TIMEOUT_VAR" ]
                 then
                     RESULT=FAIL
                     RESULT_MSG="${COLOR_FAILURE}FAIL (Test tried to wait but is not in \"timed\" directory)${COLOR_NORMAL}"
                 else
-                    WAIT_TIME=$(egrep "R: .*$ESCAPED_TEST Wait/[0-9]+" $OUTFILE | sed -e 's,.*Wait/\([0-9][0-9]*\).*,\1,')
+                    WAIT_TIME=$(grep -E "R: .*$ESCAPED_TEST Wait/[0-9]+" $OUTFILE | sed -e 's,.*Wait/\([0-9][0-9]*\).*,\1,')
                     eval $NEXT_TIMEOUT_VAR=$(($TEST_END_TIME+$WAIT_TIME))
                     RESULT=Wait
                     RESULT_MSG="Awaiting ($WAIT_TIME seconds)..."
                 fi
-            elif egrep "R: .*$ESCAPED_TEST Pass" $OUTFILE > /dev/null
+            elif grep -E "R: .*$ESCAPED_TEST Pass" $OUTFILE > /dev/null
             then
                 RESULT=Pass
                 RESULT_MSG="${COLOR_SUCCESS}Pass${COLOR_NORMAL}"
-            elif egrep "R: .*$ESCAPED_TEST Skip/unsupported" $OUTFILE > /dev/null
+            elif grep -E "R: .*$ESCAPED_TEST Skip/unsupported" $OUTFILE > /dev/null
             then
                 RESULT=Skip
                 RESULT_MSG="${COLOR_WARNING}Skipped (No platform support)${COLOR_NORMAL}"
-            elif egrep "R: .*$ESCAPED_TEST Skip/needs_work" $OUTFILE > /dev/null
+            elif grep -E "R: .*$ESCAPED_TEST Skip/needs_work" $OUTFILE > /dev/null
             then
                 RESULT=Skip
                 RESULT_MSG="${COLOR_WARNING}Skipped (Test needs work)${COLOR_NORMAL}"
-            elif egrep "R: .*$ESCAPED_TEST FLAKEY" $OUTFILE > /dev/null
+            elif grep -E "R: .*$ESCAPED_TEST FLAKEY" $OUTFILE > /dev/null
             then
                 RESULT=FLAKEY
-                TICKET="$(egrep "R: .*$ESCAPED_TEST FLAKEY" $OUTFILE | sed -e "s,.*FLAKEY/\(.*\),\1,")"
+                TICKET="$(grep -E "R: .*$ESCAPED_TEST FLAKEY" $OUTFILE | sed -e "s,.*FLAKEY/\(.*\),\1,")"
                 RESULT_MSG="${COLOR_WARNING}Flakey fail ($TICKET)${COLOR_NORMAL}"
 
             else
@@ -1075,7 +1075,7 @@ fi
 
 for addtest in $ALL_TESTS
 do
-    if echo "$addtest" | fgrep "/timed/" > /dev/null
+    if echo "$addtest" | grep -F "/timed/" > /dev/null
     then
         if [ "$TIMED_TESTS" = 1 ]
         then
@@ -1133,12 +1133,12 @@ print_header() {
 
 print_footer() {
     # Recalculate results since sub invocations may not have been recorded.
-    PASSED_TESTS=`egrep '^Pass ' $SUMMARY | wc -l | tr -d ' '`
-    FAILED_TESTS=`egrep '^(FAIL|XFAIL) ' $SUMMARY | wc -l | tr -d ' '`
-    SUPPRESSED_FAILURES=`egrep '^XFAIL ' $SUMMARY | wc -l | tr -d ' '`
-    SOFT_FAILURES=`egrep '^SFAIL ' $SUMMARY | wc -l | tr -d ' '`
-    FLAKEY_FAILURES=`egrep '^FLAKEY ' $SUMMARY | wc -l | tr -d ' '`
-    SKIPPED_TESTS=`egrep '^Skip ' $SUMMARY | wc -l | tr -d ' '`
+    PASSED_TESTS=`grep -E '^Pass ' $SUMMARY | wc -l | tr -d ' '`
+    FAILED_TESTS=`grep -E '^(FAIL|XFAIL) ' $SUMMARY | wc -l | tr -d ' '`
+    SUPPRESSED_FAILURES=`grep -E '^XFAIL ' $SUMMARY | wc -l | tr -d ' '`
+    SOFT_FAILURES=`grep -E '^SFAIL ' $SUMMARY | wc -l | tr -d ' '`
+    FLAKEY_FAILURES=`grep -E '^FLAKEY ' $SUMMARY | wc -l | tr -d ' '`
+    SKIPPED_TESTS=`grep -E '^Skip ' $SUMMARY | wc -l | tr -d ' '`
 
     ( echo
       echo ======================================================================


### PR DESCRIPTION
Ticket: CFE-4526

**Running tests before change**:

```
Passed tests:    1760
Failed tests:    1
Skipped tests:   237
Soft failures:   45
Flakey failures: 0
Total tests:     2043
```

**Running tests after change**:

```
Passed tests:    1760
Failed tests:    1
Skipped tests:   237
Soft failures:   45
Flakey failures: 0
Total tests:     2043
```

I wasn't sure if support of older systems is needed, so I didn't implement a check of whether the -E/-F option is present, but I can change this if necessary. 