### PR TITLE
Added enterprise client report dumps to cf-support collection (3.24)

### DIFF
--- a/misc/cf-support
+++ b/misc/cf-support
@@ -404,6 +404,16 @@ for f in $su_logs; do
 done
 file_add $WORKDIR/policy_server.dat
 
+# Collect client-side report dumps from /var/cfengine/diagnostics
+if [ -d "$WORKDIR/diagnostics" ]; then
+  echo "Collecting diagnostics directory (includes report_dumps)..."
+  mkdir -p "$tmpdir/diagnostics"
+  cp -a "$WORKDIR/diagnostics/." "$tmpdir/diagnostics/"
+  echo "Added diagnostics directory (includes report_dumps)"
+else
+  echo "diagnostics directory not found, skipping"
+fi
+
 if [ -f $WORKDIR/share/cf-support-nova-hub.sh ]; then
   # shellcheck source=/dev/null
   . $WORKDIR/share/cf-support-nova-hub.sh


### PR DESCRIPTION
When `/var/cfengine/enable_report_dumps` is present cf-serverd will log
information provided to cf-hub in `/var/cfengine/diagnostics/report_dumps`. This
change makes sure those are collected by cf-support for review.

Ticket: ENT-5083
Changelog: None
(cherry picked from commit 82ba092deee86fc695c38e2e89963fbcc8d85493)