### PR TITLE
Bump libntech and adjust configure.ac to increase portability of use of alloca() function (3.24)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -911,6 +911,7 @@ AC_CHECK_LIB([sec], [fgetspent], [
 
 AC_CHECK_DECLS(getloadavg)
 AC_FUNC_GETLOADAVG
+AC_FUNC_ALLOCA
 
 AC_C_BIGENDIAN
 AC_CHECK_HEADERS([endian.h])


### PR DESCRIPTION
This function is not available except as a builtin on Solaris for example.

Ticket: ENT-14344
Changelog: none
