### PR TITLE
Fixed m4/cf3_gcc_flags.m4 to actually test compiler flags

### DIFF
--- a/m4/cf3_gcc_flags.m4
+++ b/m4/cf3_gcc_flags.m4
@@ -48,38 +48,53 @@ if test x"$GCC" = "xyes" && test x"$HP_UX_AC" != x"yes"; then
     CF3_CFLAGS="$CF3_CFLAGS -std=gnu99 -g -Wall"
     AC_MSG_RESULT(yes)
 
+    dnl Save CFLAGS to restore after using it to test for compiler flag support
+    save_CFLAGS="$CFLAGS"
     AC_MSG_CHECKING(for -Wno-pointer-sign)
+    CFLAGS="-Wno-pointer-sign"
     AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main() {}])],
      [AC_MSG_RESULT(yes)
      CF3_CFLAGS="$CF3_CFLAGS -Wno-pointer-sign"],
      [AC_MSG_RESULT(no)])
 
     AC_MSG_CHECKING(for -Werror=implicit-function-declaration)
+    CFLAGS="-Werror=implicit-function-declaration"
     AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main() {}])],
      [AC_MSG_RESULT(yes)
      CF3_CFLAGS="$CF3_CFLAGS -Werror=implicit-function-declaration"],
      [AC_MSG_RESULT(no)])
 
     AC_MSG_CHECKING(for -Wunused-parameter)
+    CFLAGS="-Wunused-parameter"
     AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main() {}])],
      [AC_MSG_RESULT(yes)
      CF3_CFLAGS="$CF3_CFLAGS -Wunused-parameter"],
      [AC_MSG_RESULT(no)])
 
     AC_MSG_CHECKING(for -Wno-incompatible-pointer-types)
+    CFLAGS="-Wno-incompatible-pointer-types"
     AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main() {}])],
      [AC_MSG_RESULT(yes)
      CF3_CFLAGS="$CF3_CFLAGS -Wno-incompatible-pointer-types"],
      [AC_MSG_RESULT(no)])
 
+    dnl Clang does not like 'const const' construct arising from
+    dnl expansion of TYPED_SET_DECLARE macro
+    dnl
+    dnl This check is relying on explicit compilator detection due to
+    dnl GCC irregularities checking for -Wno-* command-line options
+    dnl (command line is not fully checked until actual warning occurs)
     AC_MSG_CHECKING(for -Wno-duplicate-decl-specifier)
+    CFLAGS="-Wno-duplicate-decl-specifier"
     AC_COMPILE_IFELSE([AC_LANG_SOURCE([#ifndef __clang__
-# GET_DIR_ERROR Not a clang
+# error Not a clang
 #endif
 int main() {}])],
      [AC_MSG_RESULT(yes)
      CF3_CFLAGS="$CF3_CFLAGS -Wno-duplicate-decl-specifier"],
      [AC_MSG_RESULT(no)])
+    dnl restore CFLAGS
+    CFLAGS="$save_CFLAGS"
 else
     AC_MSG_RESULT(no)
 fi

--- a/m4/cf3_gcc_flags.m4
+++ b/m4/cf3_gcc_flags.m4
@@ -1,5 +1,5 @@
 #
-#  Copyright 2021 Northern.tech AS
+#  Copyright 2026 Northern.tech AS
 #
 #  This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 #


### PR DESCRIPTION
This was broken in CFE-3629 in commit fc40dd612d32139bee32e657b10fea82159999eb

Ticket: ENT-14382
Changelog: none

together
https://github.com/cfengine/core/pull/6252
https://github.com/cfengine/enterprise/pull/988
https://github.com/cfengine/nova/pull/2670