### PR TITLE
Fixed configure.ac to test for alloca() (3.27)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -953,6 +953,7 @@ AC_CHECK_LIB([sec], [fgetspent], [
 
 AC_CHECK_DECLS(getloadavg)
 AC_FUNC_GETLOADAVG
+AC_FUNC_ALLOCA
 
 AC_C_BIGENDIAN
 AC_CHECK_HEADERS([endian.h])


### PR DESCRIPTION
This was missed in the forward cherry-pick of bab324ea313ab4b43bd55f5c93c34273e2de8cce

Ticket: ENT-14344
Changelog: none
(cherry picked from commit 6b5d5adc748654cbe4ad688f47b1b627c3b7eb4e)
