### PR TITLE
CFE-3987: Fixed insert_lines prepending to the file instead of to the selected region (3.27)

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -1065,10 +1065,10 @@ static bool InsertMultipleLinesToRegion(EvalContext *ctx, Item **start, Item *be
 
     if (a->location.before_after == EDIT_ORDER_BEFORE)
     {
-        /* As region was already selected by SelectRegion() and we know
-         * what are the region boundaries (begin_ptr and end_ptr) there
-         * is no reason to iterate over whole file. */
-        for (ip = begin_ptr; ip != NULL; ip = ip->next)
+        /* Start at the top of the file so prev ends up as the line before
+         * the region. From begin_ptr prev stays NULL, and a NULL prev means
+         * prepend to the file. */
+        for (ip = *start; ip != NULL; ip = ip->next)
         {
             if (ip == begin_ptr)
             {

--- a/tests/acceptance/31_tickets/CFE-3987/1/test.cf
+++ b/tests/acceptance/31_tickets/CFE-3987/1/test.cf
@@ -25,10 +25,6 @@ bundle agent test
       string => "edit_line doesn't insert text immediately before a selected region if a location body only explicitly sets before_after => 'before'",
       meta => { "CFE-3987" };
 
-    "test_soft_fail"
-      string => "any",
-      meta => { "CFE-3987" };
-
   vars:
     "seed_file" string => "$(this.promise_dirname)/before_test.xml.txt";
     "test_file" string => "$(G.testfile)";
@@ -38,11 +34,14 @@ bundle agent test
 }
 
 bundle agent check
+# @brief The selected region begins at the first line matching select_start,
+# which is '<!-- General -->', so the line must be inserted immediately before
+# it and not at the start of the file.
 {
   methods:
     "Pass/FAIL"
       usebundle => dcs_check_regcmp(
-        ".*INSERT\sME\R\s+<!--\s=+\R\s+THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN.*",
+        ".*\R\s+metadata-complete=\S+\RINSERT\sME\R\s+<!--\sGeneral\s-->.*",
         readfile("$(test.test_file)"),
         $(this.promise_filename),
         "no"


### PR DESCRIPTION
Prior to this fix, promising content before a selected region would
instead insert at the top of the file. While technically still before
the region, that was not the intended behavior.

Ticket: CFE-3987