### PR TITLE
Updated all help menus to say 2026 instead of 2023 for copyright year

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ AC_DEFINE(BUILD_YEAR, esyscmd([date +%Y | tr -d '\n']), "Software build year")
 
 AC_DEFINE(CF_WEBSITE, "https://cfengine.com", "Website. To be used in help screens")
 
-AC_DEFINE(CF_COPYRIGHT, "2023 Northern.tech AS", "Copyright. To be used in help screens")
+AC_DEFINE(CF_COPYRIGHT, "2026 Northern.tech AS", "Copyright. To be used in help screens")
 
 AC_DEFINE_UNQUOTED(ABS_TOP_SRCDIR,
 "`cd -- "$srcdir"; pwd`",


### PR DESCRIPTION
We stopped updating all the individual source files, but I still
think the help menu should be up to date.