### PR TITLE
Added a workflow to keep the help output copyright year current

### DIFF
--- a/.github/workflows/copyright_year.yml
+++ b/.github/workflows/copyright_year.yml
@@ -1,0 +1,64 @@
+name: Copyright year
+
+# Keeps the copyright year in the help output (`--help`) current.
+#
+# The year is a plain literal in configure.ac, updated by a reviewed pull
+# request -- this workflow only opens that pull request, it never pushes to a
+# release branch. Scheduled runs act on the default branch; to refresh a
+# maintained branch, dispatch this workflow with that branch selected and the
+# pull request will target it.
+#
+# The edit itself lives in ci/update-copyright-year.sh so it can be linted and
+# run by hand.
+
+on:
+  schedule:
+    # 03:00 UTC on January 2nd, by which point the year has rolled over
+    # in every timezone.
+    - cron: '0 3 2 1 *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump_copyright_year:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update the copyright year
+        id: bump
+        run: |
+          year=$(ci/update-copyright-year.sh)
+          echo "year=$year" >> "$GITHUB_OUTPUT"
+          echo "branch=copyright-year-${GITHUB_REF_NAME//\//-}-$year" >> "$GITHUB_OUTPUT"
+
+      # sign-commits creates the commit through the GitHub API so it is signed
+      # by GitHub and shows as verified; it also ignores the committer and
+      # author inputs, so there is no bot identity to configure here.
+      #
+      # If the year was already current there is nothing to commit and the
+      # action exits without opening anything.
+      - name: Open a pull request
+        uses: cfengine/create-pull-request@v7
+        with:
+          base: ${{ github.ref_name }}
+          branch: ${{ steps.bump.outputs.branch }}
+          delete-branch: true
+          sign-commits: true
+          add-paths: configure.ac
+          commit-message: |
+            Updated help menu copyright year to ${{ steps.bump.outputs.year }}
+
+            Opened automatically by .github/workflows/copyright_year.yml.
+
+            Changelog: none
+          title: Updated help menu copyright year to ${{ steps.bump.outputs.year }}
+          body: |
+            The copyright year shown by `--help` is a literal in `configure.ac`; this updates it to ${{ steps.bump.outputs.year }}.
+
+            Opened automatically by [.github/workflows/copyright_year.yml](.github/workflows/copyright_year.yml).
+
+            Pull requests opened with `GITHUB_TOKEN` do not trigger other workflows, so CI has not started on its own -- comment `@cf-bottom jenkins, please` to run it.

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -20,3 +20,5 @@ jobs:
     - name: Run shellcheck
 # todo: add more places to run shellcheck besides misc/cf-support
       run: make -C misc check
+    - name: Run shellcheck on ci scripts
+      run: shellcheck ci/update-copyright-year.sh

--- a/ci/update-copyright-year.sh
+++ b/ci/update-copyright-year.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Set the copyright year shown in the help output (`--help`).
+#
+# The year is a plain literal in configure.ac. This script rewrites that literal
+# and nothing else -- committing it and opening a pull request is left to the
+# caller, see .github/workflows/copyright_year.yml.
+#
+# The year it settled on is printed on stdout, everything else goes to stderr:
+#
+#   year=$(ci/update-copyright-year.sh)       # the current year
+#   year=$(ci/update-copyright-year.sh 2027)  # a specific year
+
+set -eu
+
+year=${1:-$(date -u +%Y)}
+
+case "$year" in
+    [0-9][0-9][0-9][0-9]) ;;
+    *)
+        echo "$0: '$year' is not a four digit year" >&2
+        exit 1
+        ;;
+esac
+
+cd "$(dirname "$0")/.."
+
+current=$(sed -nE 's/^AC_DEFINE\(CF_COPYRIGHT, "([0-9]{4}) Northern\.tech AS".*/\1/p' configure.ac)
+
+# Fail loudly rather than silently doing nothing if the define is ever renamed
+# or reformatted -- a silent no-op here is exactly how the year went three
+# releases without being updated.
+if [ -z "$current" ]; then
+    echo "$0: no CF_COPYRIGHT define in the expected form in configure.ac, update this script" >&2
+    exit 1
+fi
+
+if [ "$current" = "$year" ]; then
+    echo "configure.ac: copyright year is already $year" >&2
+else
+    sed -i -E \
+        "s/^(AC_DEFINE\(CF_COPYRIGHT, \")[0-9]{4}( Northern\.tech AS\")/\1$year\2/" \
+        configure.ac
+    echo "configure.ac: copyright year $current -> $year" >&2
+fi
+
+echo "$year"


### PR DESCRIPTION
This adds a scheduled workflow that does the remembering: on January 2nd it
bumps the `CF_COPYRIGHT` and opens the pull request.