### PR TITLE
CFE-4534: Added the parameters of string_mustache() to the syntax description

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -11541,6 +11541,8 @@ static const FnCallArg DATA_EXPAND_ARGS[] =
 
 static const FnCallArg STRING_MUSTACHE_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Mustache template string"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "CFEngine variable identifier or inline JSON, can be blank"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 


### PR DESCRIPTION
Describes the template and the optional data container the same way url_get() describes its equivalent argument.

Ticket: CFE-4534
