### PR TITLE
CFE-4228: Added the promisee to verbose output for reports promises

### DIFF
--- a/libpromises/verify_reports.c
+++ b/libpromises/verify_reports.c
@@ -129,7 +129,9 @@ PromiseResult VerifyReportPromise(EvalContext *ctx, const Promise *pp)
 
     YieldCurrentLock(thislock);
 
-    ClassAuditLog(ctx, pp, &a, result);
+    /* cfPS calls ClassAuditLog itself and also logs the promise context,
+     * which is where the promisee comes from */
+    cfPS(ctx, LOG_LEVEL_VERBOSE, result, pp, &a, "Reports promise '%s' processed", pp->promiser);
     return result;
 }
 

--- a/tests/acceptance/14_reports/reports_promisee_emitted_in_verbose.cf
+++ b/tests/acceptance/14_reports/reports_promisee_emitted_in_verbose.cf
@@ -1,0 +1,26 @@
+body common control
+{
+  inputs => { "../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description" -> { "CFE-4228" }
+      string => "Test that promisees on reports are emitted in verbose output.";
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    ""
+      usebundle => dcs_passif_output(
+        ".*promisee 'the_promisee_of_a_report'.*",
+        "",
+        "$(sys.cf_agent) -Kvf $(this.promise_filename).sub",
+        $(this.promise_filename)
+      );
+}

--- a/tests/acceptance/14_reports/reports_promisee_emitted_in_verbose.cf.sub
+++ b/tests/acceptance/14_reports/reports_promisee_emitted_in_verbose.cf.sub
@@ -1,0 +1,5 @@
+bundle agent main
+{
+  reports:
+    "This is an example report" -> "the_promisee_of_a_report";
+}


### PR DESCRIPTION
Goes through cfPS() like other promise types, which logs the promise context where the promisee is printed.

Ticket: CFE-4228
