### PR TITLE
CFE-1982: Made an unrecognized action_policy fatal instead of defaulting to fix

### DIFF
--- a/libpromises/attributes.c
+++ b/libpromises/attributes.c
@@ -673,13 +673,22 @@ static TransactionContext GetTransactionConstraints(const EvalContext *ctx, cons
 
     value = PromiseGetConstraintAsRval(pp, "action_policy", RVAL_TYPE_SCALAR);
 
-    if (value && ((strcmp(value, "warn") == 0) || (strcmp(value, "nop") == 0)))
+    if ((value == NULL) || StringEqual(value, "fix"))
+    {
+        t.action = cfa_fix;     // default
+    }
+    else if (StringEqual(value, "warn") || StringEqual(value, "nop"))
     {
         t.action = cfa_warn;
     }
     else
     {
-        t.action = cfa_fix;     // default
+        /* The parser only checks the option list for literal values, so an
+         * expanded one gets here unchecked. Falling back to 'fix' would make
+         * changes on a host where the policy asked only to warn, so refuse to
+         * run instead. A literal typo is already fatal at policy check time. */
+        PromiseRef(LOG_LEVEL_ERR, pp);
+        FatalError(ctx, "Unrecognized 'action_policy' value '%s'", value);
     }
 
     t.background = PromiseGetConstraintAsBoolean(ctx, "background", pp);

--- a/tests/acceptance/00_basics/03_bodies/invalid_action_policy_errors.cf
+++ b/tests/acceptance/00_basics/03_bodies/invalid_action_policy_errors.cf
@@ -1,0 +1,27 @@
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description" -> { "CFE-1982" }
+      string => "Test that an unrecognized action_policy is a fatal error instead of being silently treated as fix";
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    ""
+      usebundle => dcs_passif_output(
+        ".*Fatal CFEngine error: Unrecognized 'action_policy' value 'waarn'.*",
+        # The agent should refuse to run, so the promise must not be actuated
+        ".*R: Report with a misspelled action_policy.*",
+        "$(sys.cf_agent) -Kf $(this.promise_filename).sub",
+        $(this.promise_filename)
+      );
+}

--- a/tests/acceptance/00_basics/03_bodies/invalid_action_policy_errors.cf.sub
+++ b/tests/acceptance/00_basics/03_bodies/invalid_action_policy_errors.cf.sub
@@ -1,0 +1,19 @@
+body common control
+{
+  bundlesequence => { "main" };
+}
+
+# The value has to arrive through a variable. A literal invalid option is
+# already rejected by the parser, which is why this defect is only reachable
+# via an expanded value.
+body action parameterized_action_policy(policy)
+{
+  action_policy => "$(policy)";
+}
+
+bundle agent main
+{
+  reports:
+    "Report with a misspelled action_policy"
+      action => parameterized_action_policy("waarn");
+}


### PR DESCRIPTION
An `action_policy` value that arrives through a variable skips the parser's
option-list check and was silently treated as `fix`, so a typo made changes on a
host where the policy asked only to warn. It is now a fatal error, which is what
a literal typo already does at policy check time.

Verified in both directions: with the fix the agent aborts and the promise is not
actuated, and with the fix reverted the report is emitted as before.
