### PR TITLE
ENT-14405: Widened cf-support SELinux collection

### DIFF
--- a/misc/cf-support
+++ b/misc/cf-support
@@ -395,6 +395,19 @@ if command -v ausearch >/dev/null; then
   ausearch -m avc -se cfengine > "$tmpdir"/ausearch-cfengine-avcs.log || true
 fi
 
+# SELinux state, to interpret the denials above
+log_cmd "sestatus"
+log_cmd "semodule -l | grep cfengine"
+log_cmd "semanage fcontext -C -l"
+
+# Federated Reporting transport: metadata only, the transport private key is here
+if [ -d /opt/cfengine/federation ]; then
+  log_cmd "getent passwd cftransport"
+  log_cmd "ls -ldZ /opt /opt/cfengine /opt/cfengine/federation /opt/cfengine/federation/cftransport /opt/cfengine/federation/cftransport/.ssh"
+  log_cmd "ls -laZ /opt/cfengine/federation/cftransport/.ssh"
+  log_cmd "ssh -V"
+fi
+
 gzip_add $WORKDIR/outputs/previous
 gzip_add $WORKDIR/outputs/dc-scripts.log # masterfiles-stage log
 # Collect up to the two most recent standalone_self_upgrade logs (separate cf-agent process)

--- a/misc/cf-support
+++ b/misc/cf-support
@@ -390,9 +390,9 @@ else
 fi
 echo "Captured output of $syslog_cmd filtered for cf-|CFEngine"
 
-# cf- component related SELinux denials
+# cf- component related SELinux denials, as either subject or object
 if command -v ausearch >/dev/null; then
-  ausearch -m avc -su cfengine > "$tmpdir"/ausearch-cfengine-avcs.log
+  ausearch -m avc -se cfengine > "$tmpdir"/ausearch-cfengine-avcs.log || true
 fi
 
 gzip_add $WORKDIR/outputs/previous


### PR DESCRIPTION
cf-support searched AVCs by subject only, so a denial raised against a CFEngine file by some other domain was never captured. Also collects SELinux state and the Federated Reporting transport tree labels.