### PR TITLE
Added support on SuSE for user promises without lib PAM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1025,9 +1025,19 @@ AS_IF([test x$with_pam != xno],
               [users_promises_ok=yes],
               [users_promises_ok=no])
      ])
-], [
-  users_promises_ok=no
+],
+[
+   user_promises_ok=no
 ])
+AS_CASE(["$target_os"],
+   [sles|*suse*|*alpine*],
+   [
+      AS_IF([test "x$have_userprogs" = "xyes"],
+            [users_promises_ok=yes],
+            [users_promises_ok=no])
+      users_promises_ok=no
+   ])
+
 AM_CONDITIONAL(HAVE_USERS_PROMISE_DEPS, [test "x$users_promises_ok" = "xyes"])
 
 AC_CHECK_DECLS(getnetgrent, [], [], [[#include <netdb.h>]])


### PR DESCRIPTION
On older SuSE distributions the PAM modules are linked to an older version of openssl/libcrypt than we vendor and so when cf-agent tries to use PAM the modules fail to load and operations fail.

Ticket: ENT-14406
Changelog: title
