### PR TITLE
ENT-14405: Allowed sshd_session_t access to /opt/cfengine on EL10 (3.27.x)

### DIFF
--- a/misc/selinux/cfengine-enterprise.te.el10
+++ b/misc/selinux/cfengine-enterprise.te.el10
@@ -2,7 +2,14 @@ require {
     type devpts_t;
     type systemd_userdbd_runtime_t;
     type systemd_userdbd_t;
+    type sshd_session_t;
 }
+
+#============= special rules for Federated Reporting =============
+# EL10 serves connections in sshd_session_t, not sshd_t, and does not grant it
+# the generic file_type:dir search
+allow sshd_session_t cfengine_var_lib_t:dir { getattr open search };
+allow sshd_session_t cfengine_var_lib_t:file { getattr open read };
 
 #============= cfengine_apachectl_t ==============
 allow cfengine_apachectl_t devpts_t:dir { getattr search };


### PR DESCRIPTION
Backported from https://github.com/cfengine/core/pull/6278
