### PR TITLE
CFE-4534: Added the parameters of string_mustache() to the syntax description (3.24)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -10237,6 +10237,8 @@ static const FnCallArg DATA_EXPAND_ARGS[] =
 
 static const FnCallArg STRING_MUSTACHE_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Mustache template string"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "CFEngine variable identifier or inline JSON, can be blank"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 


### PR DESCRIPTION
cf-promises --syntax-description reported no parameters for string_mustache(),
leaving documentation and editor completion with nothing to show. It takes a
template and an optional data container, described the same way url_get()
describes its equivalent argument.

Ticket: CFE-4534
