### PR TITLE
CFE-4714: Added the parameters of the remaining variadic functions to the syntax description

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -10598,6 +10598,7 @@ static const FnCallArg ACCUM_ARGS[] =
 
 static const FnCallArg AND_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Class expression"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -10690,11 +10691,14 @@ static const FnCallArg CLASSIFY_ARGS[] =
 
 static const FnCallArg CLASSMATCH_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Regular expression"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Tag regular expression"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
 static const FnCallArg CONCAT_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "String to concatenate"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -10754,6 +10758,7 @@ static const FnCallArg FILESEXIST_ARGS[] =
 
 static const FnCallArg FINDFILES_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Glob pattern to match files"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -10919,6 +10924,8 @@ static const FnCallArg HOSTSWITHGROUP_ARGS[] =
 
 static const FnCallArg IFELSE_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Class expression"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Value if the preceding class expression is true"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -11069,6 +11076,8 @@ static const FnCallArg MAPDATA_ARGS[] =
 
 static const FnCallArg MERGEDATA_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "CFEngine variable identifier or inline JSON"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "CFEngine variable identifier or inline JSON"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -11085,6 +11094,7 @@ static const FnCallArg NOW_ARGS[] =
 
 static const FnCallArg OR_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Class expression"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 


### PR DESCRIPTION
and(), or(), concat(), ifelse(), findfiles(), mergedata() and the classmatch() family reported no parameters at all. Only the leading arguments are described, as bundlesmatching() and format() already do, and CF_ANYSTRING keeps the argument type check they activate as permissive as it was.

Ticket: CFE-4714
