### PR TITLE
CFE-3988: Fixed insert_lines ignoring include_end_delimiter when locating the region (3.27)

### DIFF
--- a/cf-agent/files_editline.c
+++ b/cf-agent/files_editline.c
@@ -765,6 +765,13 @@ static PromiseResult VerifyLineInsertions(EvalContext *ctx, const Promise *pp, E
         return result;
     }
 
+    /* The region is half open, [begin_ptr, end_ptr), so including the end
+     * delimiter means moving the bound past it -- after the NULL check above. */
+    if (a.region.include_end != 0 && end_ptr != NULL)
+    {
+        end_ptr = end_ptr->next;
+    }
+
     if (allow_multi_lines)
     {
         // promise to insert duplicates on first pass only

--- a/tests/acceptance/31_tickets/CFE-3988/2/before_test.xml.txt
+++ b/tests/acceptance/31_tickets/CFE-3988/2/before_test.xml.txt
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+      <web-app xmlns="http://java.sun.com/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+      version="3.0"
+      metadata-complete="true">
+      <!-- General -->
+      <display-name>Atlassian JIRA Web Application</display-name>
+      <description>The Atlassian JIRA web application - see http://www.atlassian.com/software/jira for more information
+      </description>
+
+      <absolute-ordering />
+
+      <!-- Filters -->
+
+      <!-- Special filters that must come at the beginning of the chain because they prevent
+      all other filters from running.  This is to prevent those later filters from doing
+      lookups in Pico, which could alter the order in which it instantiates components
+      and thereby trigger a deadlock. -->
+
+      <filter>
+      <filter-name>JiraImportProgressFilter</filter-name>
+      <filter-class>com.atlassian.jira.web.filters.JiraImportProgressFilter</filter-class>
+      </filter>
+
+      <!-- ========================================================
+           THIS MUST BE THE FIRST FILTER IN THE NORMAL FILTER CHAIN
+           ======================================================== -->
+
+      <filter>
+      <filter-name>JiraFirstFilter</filter-name>
+      <filter-class>com.atlassian.jira.web.filters.JiraFirstFilter</filter-class>
+      </filter>
+
+      <!-- =====================================================
+           THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN
+           ===================================================== -->
+
+      <filter>
+      <filter-name>JiraLastFilter</filter-name>
+      <filter-class>com.atlassian.jira.web.filters.JiraLastFilter</filter-class>
+      </filter>
+
+      <!-- =====================================================
+           FILTER MAPPINGS FOLLOW :
+           ===================================================== -->
+
+</web-app>

--- a/tests/acceptance/31_tickets/CFE-3988/2/test.cf
+++ b/tests/acceptance/31_tickets/CFE-3988/2/test.cf
@@ -22,7 +22,7 @@ bundle agent test
 {
   meta:
     "description"
-      string => "edit_line should insert after the last matched line when selecting a region where the end delimiter is included",
+      string => "edit_line should insert before the end delimiter when the end delimiter is not included in the region",
       meta => { "CFE-3988" };
 
   vars:
@@ -30,30 +30,33 @@ bundle agent test
     "test_file" string => "$(G.testfile)";
 
   files:
-    "$(test_file)" edit_line => CFE_3988;
+    "$(test_file)" edit_line => CFE_3988_excluded_end;
 }
 
 bundle agent check
+# @brief Companion to case 1. With include_end_delimiter left at its default of
+# false the end delimiter is not part of the region, so the last matching line
+# is the one before it and the insertion must land above the delimiter.
 {
   methods:
     # We expect to find lines that look something like this:
     #      THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN
-    #      ===================================================== -->
     #INSERT ME
+    #      ===================================================== -->
     "Pass/FAIL"
       usebundle => dcs_check_regcmp(
-        ".*\s+THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN\R\s+=+\s+-->\RINSERT\sME.*",
+        ".*\s+THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN\RINSERT\sME\R\s+=+\s+-->.*",
         readfile("$(test.test_file)"),
         $(this.promise_filename),
         "no"
       );
 }
 
-bundle edit_line CFE_3988
+bundle edit_line CFE_3988_excluded_end
 {
   insert_lines:
     "INSERT ME"
-      select_region => my_comment_last_filter,
+      select_region => my_comment_last_filter_excluded_end,
       location => my_location_after_comment_last_filter;
 }
 
@@ -65,11 +68,11 @@ body location my_location_after_comment_last_filter
   select_line_matching => ".*";
 }
 
-body select_region my_comment_last_filter
+body select_region my_comment_last_filter_excluded_end
 {
   select_start => "\s+THIS MUST BE THE LAST FILTER IN THE DEFINED CHAIN";
   select_end => "\s+=+\s+-->";
   include_start_delimiter => "true";
-  include_end_delimiter => "true";
+  include_end_delimiter => "false";
   select_end_match_eof => "false";
 }


### PR DESCRIPTION
Inserting after the last line of a region built with `include_end_delimiter => "true"` landed above the delimiter instead of below it, because the insertion path treats the region as the half-open range `[begin_ptr, end_ptr)`.

Backport of #6265.

Ticket: CFE-3988