### PR TITLE
CFE-3293: Added tracking of secret variables for later redaction

### DIFF
--- a/cf-agent/cf-agent.c
+++ b/cf-agent/cf-agent.c
@@ -1004,7 +1004,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
 
             VarRef *ref = VarRefParseFromScope(cp->lval, "control_agent");
             DataType value_type;
-            const void *value = EvalContextVariableGet(ctx, ref, &value_type);
+            const void *value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
             VarRefDestroy(ref);
 
             /* If var not found */
@@ -1831,7 +1831,7 @@ static PromiseResult DefaultVarPromise(EvalContext *ctx, const Promise *pp)
     const void *value = NULL;
     {
         VarRef *ref = VarRefParseFromScope(pp->promiser, "this");
-        value = EvalContextVariableGet(ctx, ref, &value_type);
+        value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
         VarRefDestroy(ref);
     }
 
@@ -1891,7 +1891,7 @@ static void LogVariableValue(const EvalContext *ctx, const Promise *pp)
     char *out = NULL;
 
     DataType type;
-    const void *var = EvalContextVariableGet(ctx, ref, &type);
+    const void *var = EvalContextVariableGetPlaintext(ctx, ref, &type);
     switch (type)
     {
         case CF_DATA_TYPE_INT:

--- a/cf-agent/verify_packages.c
+++ b/cf-agent/verify_packages.c
@@ -264,7 +264,7 @@ static PromiseResult HandleOldPackagePromiseType(EvalContext *ctx, const Promise
     {
         const char *reserved = reserved_vars[c];
         VarRef *var_ref = VarRefParseFromScope(reserved, "this");
-        if (EvalContextVariableGet(ctx, var_ref, NULL))
+        if (EvalContextVariableGetPlaintext(ctx, var_ref, NULL))
         {
             Log(LOG_LEVEL_WARNING, "$(%s) variable has a special meaning in packages promises. "
                 "Things may not work as expected if it is already defined.", reserved);

--- a/cf-execd/exec-config.c
+++ b/cf-execd/exec-config.c
@@ -175,7 +175,7 @@ ExecConfig *ExecConfigNew(bool scheduled_run, const EvalContext *ctx, const Poli
 
             VarRef *ref = VarRefParseFromScope(cp->lval, "control_executor");
             DataType t;
-            const void *value = EvalContextVariableGet(ctx, ref, &t);
+            const void *value = EvalContextVariableGetPlaintext(ctx, ref, &t);
             VarRefDestroy(ref);
 
             if (t == CF_DATA_TYPE_NONE)

--- a/cf-execd/execd-config.c
+++ b/cf-execd/execd-config.c
@@ -74,7 +74,7 @@ ExecdConfig *ExecdConfigNew(const EvalContext *ctx, const Policy *policy)
 
             VarRef *ref = VarRefParseFromScope(cp->lval, "control_executor");
             DataType t;
-            const void *value = EvalContextVariableGet(ctx, ref, &t);
+            const void *value = EvalContextVariableGetPlaintext(ctx, ref, &t);
             VarRefDestroy(ref);
 
             if (t == CF_DATA_TYPE_NONE)

--- a/cf-monitord/cf-monitord.c
+++ b/cf-monitord/cf-monitord.c
@@ -297,7 +297,7 @@ static void KeepPromises(EvalContext *ctx, const Policy *policy)
             }
 
             VarRef *ref = VarRefParseFromScope(cp->lval, "control_monitor");
-            const void *value = EvalContextVariableGet(ctx, ref, NULL);
+            const void *value = EvalContextVariableGetPlaintext(ctx, ref, NULL);
             VarRefDestroy(ref);
             if (!value)
             {

--- a/cf-runagent/cf-runagent.c
+++ b/cf-runagent/cf-runagent.c
@@ -650,7 +650,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy)
 
             VarRef *ref = VarRefParseFromScope(cp->lval, "control_runagent");
             DataType value_type;
-            const void *value = EvalContextVariableGet(ctx, ref, &value_type);
+            const void *value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
             VarRefDestroy(ref);
 
             /* If var not found, or if it's an empty list. */

--- a/cf-serverd/server_transform.c
+++ b/cf-serverd/server_transform.c
@@ -353,7 +353,7 @@ static void KeepControlPromises(EvalContext *ctx, const Policy *policy, GenericA
 
             VarRef *ref = VarRefParseFromScope(cp->lval, "control_server");
             DataType value_type;
-            const void *value = EvalContextVariableGet(ctx, ref, &value_type);
+            const void *value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
             VarRefDestroy(ref);
 
             if (unresolved_vars != NULL)

--- a/libenv/sysinfo.c
+++ b/libenv/sysinfo.c
@@ -3893,8 +3893,7 @@ static char *FindNextInteger(char *str, char **num)
 
 static void SysOsVersionMajor(EvalContext *ctx)
 {
-    const char *const_flavor = EvalContextVariableGetSpecialString(
-        ctx, SPECIAL_SCOPE_SYS, "flavor");
+    const char *const_flavor = EvalContextVariableGetSpecialString(ctx, SPECIAL_SCOPE_SYS, "flavor", true);
     char *flavor = SafeStringDuplicate(const_flavor);
 
     char *major;
@@ -3939,7 +3938,7 @@ static bool SetOsVersionMinorFromOSRelease(EvalContext *ctx)
 {
 
     DataType type_out;
-    const JsonElement *os_release = EvalContextVariableGetSpecial(ctx, SPECIAL_SCOPE_SYS, "os_release", &type_out);
+    const JsonElement *os_release = EvalContextVariableGetSpecialPlaintext(ctx, SPECIAL_SCOPE_SYS, "os_release", &type_out);
 
     if (os_release == NULL)
     {
@@ -4034,7 +4033,7 @@ void DetectEnvironment(EvalContext *ctx)
 static void SysPolicyReleaseId(EvalContext *ctx, Policy *policy)
 {
     DataType type;
-    const char *entry_dirname = EvalContextVariableGetSpecial(ctx, SPECIAL_SCOPE_SYS, "policy_entry_dirname", &type);
+    const char *entry_dirname = EvalContextVariableGetSpecialPlaintext(ctx, SPECIAL_SCOPE_SYS, "policy_entry_dirname", &type);
     if (entry_dirname == NULL || policy == NULL)
     {
         return;

--- a/libpromises/eval_context.c
+++ b/libpromises/eval_context.c
@@ -2237,11 +2237,26 @@ const void *EvalContextVariableGetSpecial(
     const EvalContext *const ctx,
     const SpecialScope scope,
     const char *const varname,
+    DataType *const type_out,
+    bool get_secret)
+{
+    VarRef *const ref = VarRefParseFromScope(
+        varname, SpecialScopeToString(scope));
+    const void *const result = EvalContextVariableGet(ctx, ref, type_out, get_secret);
+    VarRefDestroy(ref);
+
+    return result;
+}
+
+const void *EvalContextVariableGetSpecialPlaintext(
+    const EvalContext *const ctx,
+    const SpecialScope scope,
+    const char *const varname,
     DataType *const type_out)
 {
     VarRef *const ref = VarRefParseFromScope(
         varname, SpecialScopeToString(scope));
-    const void *const result = EvalContextVariableGet(ctx, ref, type_out);
+    const void *const result = EvalContextVariableGet(ctx, ref, type_out, true);
     VarRefDestroy(ref);
 
     return result;
@@ -2254,11 +2269,12 @@ const void *EvalContextVariableGetSpecial(
 const char *EvalContextVariableGetSpecialString(
     const EvalContext *const ctx,
     const SpecialScope scope,
-    const char *const varname)
+    const char *const varname,
+    bool get_secret)
 {
     DataType type_out;
     const void *const result = EvalContextVariableGetSpecial(
-        ctx, scope, varname, &type_out);
+        ctx, scope, varname, &type_out, get_secret);
     assert(type_out == CF_DATA_TYPE_STRING); // Programming error if not string
     return (type_out == CF_DATA_TYPE_STRING) ? result : NULL;
 }
@@ -2660,14 +2676,19 @@ static Variable *VariableResolve(const EvalContext *ctx, const VarRef *ref)
  *       list is empty. To check if the variable didn't resolve, check if
  *       #type_out was set to CF_DATA_TYPE_NONE.
  */
-const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *ref, DataType *type_out)
+const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *ref, DataType *type_out, bool get_secret)
 {
     Variable *var = VariableResolve(ctx, ref);
     if (var)
     {
         const VarRef *var_ref = VariableGetRef(var);
-        DataType var_type = VariableGetType(var);
-        Rval var_rval = VariableGetRval(var, true);
+
+        /* A redacted secret comes back as a scalar sentinel, so the declared
+         * type no longer describes it -- and reporting CONTAINER would hand that
+         * sentinel to RvalContainerValue() below, which aborts. */
+        const bool redacted = (!get_secret && VariableIsSecret(var));
+        DataType var_type = redacted ? CF_DATA_TYPE_STRING : VariableGetType(var);
+        Rval var_rval = VariableGetRval(var, get_secret);
 
         if (var_ref->num_indices == 0    &&
                  ref->num_indices > 0     &&
@@ -2699,6 +2720,11 @@ const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *ref, Da
         *type_out = CF_DATA_TYPE_NONE;
     }
     return NULL;
+}
+
+const void *EvalContextVariableGetPlaintext(const EvalContext *ctx, const VarRef *ref, DataType *type_out)
+{
+    return EvalContextVariableGet(ctx, ref, type_out, true);
 }
 
 const Promise *EvalContextVariablePromiseGet(const EvalContext *ctx, const VarRef *ref)
@@ -2755,7 +2781,7 @@ const void *EvalContextVariableControlCommonGet(const EvalContext *ctx, CommonCo
     assert(lval >= 0 && lval < COMMON_CONTROL_MAX);
 
     VarRef *ref = VarRefParseFromScope(CFG_CONTROLBODY[lval].lval, "control_common");
-    const void *ret = EvalContextVariableGet(ctx, ref, NULL);
+    const void *ret = EvalContextVariableGetPlaintext(ctx, ref, NULL);
     VarRefDestroy(ref);
     return ret;
 }

--- a/libpromises/eval_context.h
+++ b/libpromises/eval_context.h
@@ -223,9 +223,11 @@ bool EvalContextVariablePutSpecialTagsSetWithComment(EvalContext *ctx, SpecialSc
                                                      const char *lval, const void *value,
                                                      DataType type, StringSet *tags,
                                                      const char *comment);
-const void *EvalContextVariableGetSpecial(const EvalContext *ctx, const SpecialScope scope, const char *varname, DataType *type_out);
-const char *EvalContextVariableGetSpecialString(const EvalContext *ctx, const SpecialScope scope, const char *varname);
-const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *ref, DataType *type_out);
+const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *ref, DataType *type_out, bool get_secret);
+const void *EvalContextVariableGetPlaintext(const EvalContext *ctx, const VarRef *ref, DataType *type_out);
+const void *EvalContextVariableGetSpecial(const EvalContext *ctx, const SpecialScope scope, const char *varname, DataType *type_out, bool get_secret);
+const char *EvalContextVariableGetSpecialString(const EvalContext *ctx, const SpecialScope scope, const char *varname, bool get_secret);
+const void *EvalContextVariableGetSpecialPlaintext(const EvalContext *ctx, const SpecialScope scope, const char *varname, DataType *type_out);
 const Promise *EvalContextVariablePromiseGet(const EvalContext *ctx, const VarRef *ref);
 bool EvalContextVariableRemoveSpecial(const EvalContext *ctx, SpecialScope scope, const char *lval);
 bool EvalContextVariableRemove(const EvalContext *ctx, const VarRef *ref);

--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -249,7 +249,7 @@ static JsonElement* VarRefValueToJson(const EvalContext *ctx, const FnCall *fp, 
     assert(ref);
 
     DataType value_type = CF_DATA_TYPE_NONE;
-    const void *value = EvalContextVariableGet(ctx, ref, &value_type);
+    const void *value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
     bool want_type = true;
 
     // Convenience storage for the name of the function, since fp can be NULL
@@ -2327,7 +2327,7 @@ static FnCallResult FnCallBundlesMatching(EvalContext *ctx, const Policy *policy
             VarRef *ref = VarRefParseFromBundle("tags", bp);
             VarRefSetMeta(ref, true);
             DataType type;
-            const void *bundle_tags = EvalContextVariableGet(ctx, ref, &type);
+            const void *bundle_tags = EvalContextVariableGetPlaintext(ctx, ref, &type);
             VarRefDestroy(ref);
 
             bool found = false; // case where tag_args are given and the bundle has no tags
@@ -3695,7 +3695,7 @@ static FnCallResult FnCallGetIndices(EvalContext *ctx, ARG_UNUSED const Policy *
     {
         VarRef *ref = ResolveAndQualifyVarName(fp, name_str);
         DataType type;
-        EvalContextVariableGet(ctx, ref, &type);
+        EvalContextVariableGetPlaintext(ctx, ref, &type);
 
         /* A variable holding a data container. */
         if (DataTypeToRvalType(type) == RVAL_TYPE_CONTAINER || DataTypeToRvalType(type) == RVAL_TYPE_LIST)
@@ -4852,7 +4852,7 @@ static FnCallResult FnCallSelectServers(EvalContext *ctx,
 
     VarRef *ref = VarRefParse(naked);
     DataType value_type;
-    const Rlist *hostnameip = EvalContextVariableGet(ctx, ref, &value_type);
+    const Rlist *hostnameip = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
     if (value_type == CF_DATA_TYPE_NONE)
     {
         Log(LOG_LEVEL_VERBOSE,
@@ -5933,7 +5933,7 @@ static char *DataTypeStringFromVarName(EvalContext *ctx, const char *var_name, b
 
     VarRef *const var_ref = VarRefParse(var_name);
     DataType type;
-    const void *value = EvalContextVariableGet(ctx, var_ref, &type);
+    const void *value = EvalContextVariableGetPlaintext(ctx, var_ref, &type);
     VarRefDestroy(var_ref);
 
     const char *const type_str =
@@ -6229,7 +6229,7 @@ static bool CanFormatAsStringList(EvalContext *ctx, const Rlist *arg, const Rlis
     const char* const varname = RlistScalarValue(arg);
     VarRef *ref = VarRefParse(varname);
     DataType type;
-    *out = EvalContextVariableGet(ctx, ref, &type);
+    *out = EvalContextVariableGetPlaintext(ctx, ref, &type);
     VarRefDestroy(ref);
 
     return type == CF_DATA_TYPE_STRING_LIST;
@@ -6615,7 +6615,7 @@ static FnCallResult FnCallIsVariable(EvalContext *ctx, ARG_UNUSED const Policy *
     {
         VarRef *ref = VarRefParse(lval);
         DataType value_type;
-        EvalContextVariableGet(ctx, ref, &value_type);
+        EvalContextVariableGetPlaintext(ctx, ref, &value_type);
         if (value_type != CF_DATA_TYPE_NONE)
         {
             found = true;

--- a/libpromises/expand.c
+++ b/libpromises/expand.c
@@ -446,7 +446,7 @@ static Rval ExpandListEntry(const EvalContext *ctx,
                 VarRef *ref = VarRefParseFromScope(naked, scope);
 
                 DataType value_type;
-                const void *value = EvalContextVariableGet(ctx, ref, &value_type);
+                const void *value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
                 VarRefDestroy(ref);
 
                 if (value_type != CF_DATA_TYPE_NONE)     /* variable found? */
@@ -567,7 +567,7 @@ char *ExpandScalar(const EvalContext *ctx, const char *ns, const char *scope,
                 BufferData(current_item),
                 ns, scope, CF_NS, '.');
             DataType value_type;
-            const void *value = EvalContextVariableGet(ctx, ref, &value_type);
+            const void *value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
             VarRefDestroy(ref);
 
             switch (DataTypeToRvalType(value_type))
@@ -639,7 +639,7 @@ Rval EvaluateFinalRval(EvalContext *ctx, const Policy *policy,
         {
             VarRef *ref = VarRefParseFromScope(naked, scope);
             DataType value_type;
-            const void *value = EvalContextVariableGet(ctx, ref, &value_type);
+            const void *value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
             VarRefDestroy(ref);
 
             if (DataTypeToRvalType(value_type) == RVAL_TYPE_LIST)

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -370,7 +370,7 @@ static const void *IterVariableGet(const PromiseIterator *iterctx,
     VarRef *ref =
         VarRefParseFromNamespaceAndScope(varname, bundle->ns, bundle->name,
                                          CF_MANGLED_NS, CF_MANGLED_SCOPE);
-    value = EvalContextVariableGet(evalctx, ref, type);
+    value = EvalContextVariableGetPlaintext(evalctx, ref, type);
     VarRefDestroy(ref);
 
     if (*type == CF_DATA_TYPE_NONE)                             /* did not resolve */
@@ -383,7 +383,7 @@ static const void *IterVariableGet(const PromiseIterator *iterctx,
              * variable that is not an iterable, so it was not mangled in
              * ProcessVar(). */
             VarRef *ref2 = VarRefParse(varname);
-            value = EvalContextVariableGet(evalctx, ref2, type);
+            value = EvalContextVariableGetPlaintext(evalctx, ref2, type);
             VarRefDestroy(ref2);
         }
     }
@@ -445,7 +445,7 @@ static bool ShouldAddVariableAsIterationWheel(
     VarRef *ref = VarRefParseFromBundle(varname,
                                         PromiseGetBundle(iterctx->pp));
     DataType t;
-    ARG_UNUSED const void *value = EvalContextVariableGet(evalctx, ref, &t);
+    ARG_UNUSED const void *value = EvalContextVariableGetPlaintext(evalctx, ref, &t);
     VarRefDestroy(ref);
 
     size_t dollar_paren = FindDollarParen(varname, varname_len);

--- a/libpromises/mod_custom.c
+++ b/libpromises/mod_custom.c
@@ -28,7 +28,7 @@
 #include <string_lib.h>      // StringStartsWith()
 #include <string_sequence.h> // SeqStrginFromString()
 #include <policy.h>          // Promise
-#include <eval_context.h>    // cfPS(), EvalContextVariableGet()
+#include <eval_context.h>    // cfPS(), EvalContextVariableGetPlaintext()
 #include <attributes.h>      // GetClassContextAttributes(), IsClassesBodyConstraint()
 #include <expand.h>          // ExpandScalar()
 #include <var_expressions.h> // StringContainsUnresolved(), StringIsBareNonScalarRef()
@@ -685,7 +685,7 @@ static inline bool TryToGetContainerFromScalarRef(const EvalContext *ctx, const 
         VarRef *ref = VarRefParse(var_ref_str);
 
         DataType type = CF_DATA_TYPE_NONE;
-        const void *val = EvalContextVariableGet(ctx, ref, &type);
+        const void *val = EvalContextVariableGetPlaintext(ctx, ref, &type);
         free(var_ref_str);
         VarRefDestroy(ref);
 

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -1612,7 +1612,7 @@ void RlistFlatten(EvalContext *ctx, Rlist **list)
 
                 VarRef *ref = VarRefParse(naked);
                 DataType value_type;
-                const void *value = EvalContextVariableGet(ctx, ref, &value_type);
+                const void *value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
                 VarRefDestroy(ref);
 
                 if (value_type == CF_DATA_TYPE_NONE)

--- a/libpromises/scope.c
+++ b/libpromises/scope.c
@@ -156,13 +156,13 @@ void ScopeAugment(EvalContext *ctx, const Bundle *bp, const Promise *pp, const R
             if (pbp != NULL)
             {
                 VarRef *ref = VarRefParseFromBundle(naked, pbp);
-                value = EvalContextVariableGet(ctx, ref, &value_type);
+                value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
                 VarRefDestroy(ref);
             }
             else
             {
                 VarRef *ref = VarRefParseFromBundle(naked, bp);
-                value = EvalContextVariableGet(ctx, ref, &value_type);
+                value = EvalContextVariableGetPlaintext(ctx, ref, &value_type);
                 VarRefDestroy(ref);
             }
 

--- a/libpromises/syntax.c
+++ b/libpromises/syntax.c
@@ -488,7 +488,7 @@ vars:
             if (!IsExpandable(BufferData(inner_value)))
             {
                 VarRef *ref = VarRefParse(BufferData(inner_value));
-                EvalContextVariableGet(ctx, ref, &dtype);
+                EvalContextVariableGetPlaintext(ctx, ref, &dtype);
                 VarRefDestroy(ref);
 
                 if (DataTypeToRvalType(dtype) == RVAL_TYPE_LIST)

--- a/libpromises/verify_vars.c
+++ b/libpromises/verify_vars.c
@@ -177,7 +177,7 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
     }
     else
     {
-        existing_value = EvalContextVariableGet(ctx, ref, &existing_value_type);
+        existing_value = EvalContextVariableGetPlaintext(ctx, ref, &existing_value_type);
     }
 
     Rval rval = opts.cp_save->rval;
@@ -426,7 +426,7 @@ PromiseResult VerifyVarPromise(EvalContext *ctx, const Promise *pp,
             {
                 DataType existing_type;
                 VarRef *base_ref = VarRefCopyIndexless(ref);
-                if (EvalContextVariableGet(ctx, ref, &existing_type) && existing_type == CF_DATA_TYPE_CONTAINER)
+                if (EvalContextVariableGetPlaintext(ctx, ref, &existing_type) && existing_type == CF_DATA_TYPE_CONTAINER)
                 {
                     char *lval_str = VarRefToString(ref, true);
                     char *base_ref_str = VarRefToString(base_ref, true);

--- a/tests/unit/eval_context_test.c
+++ b/tests/unit/eval_context_test.c
@@ -197,6 +197,53 @@ static void test_persistent_class_timer_policy(void)
     EvalContextDestroy(ctx);
 }
 
+/* A secret-tagged container must redact for an INDEXED read too, not just for
+ * the whole variable. Before the type was derived from the redacted value, this
+ * took the container branch of EvalContextVariableGet() and handed the scalar
+ * sentinel to RvalContainerValue(), which is a ProgrammingError -> abort. */
+static void test_secret_container_redacts_indexed_read(void)
+{
+    EvalContext *ctx = EvalContextNew();
+
+    JsonElement *data = JsonObjectCreate(1);
+    JsonObjectAppendString(data, "key", "hunter2");
+
+    VarRef *ref = VarRefParse("default:secret_bundle.mydata");
+    assert_true(EvalContextVariablePut(ctx, ref, data, CF_DATA_TYPE_CONTAINER,
+                                       "secret"));
+    VarRef *indexed = VarRefParse("default:secret_bundle.mydata[key]");
+
+    /* Control: asking for plaintext still yields the real container and the
+     * real value behind the index, so redaction cannot be faked by breaking
+     * container reads. */
+    DataType type = CF_DATA_TYPE_NONE;
+    const void *value = EvalContextVariableGetPlaintext(ctx, ref, &type);
+    assert_int_equal(CF_DATA_TYPE_CONTAINER, type);
+    assert_true(value != NULL);
+
+    type = CF_DATA_TYPE_NONE;
+    value = EvalContextVariableGetPlaintext(ctx, indexed, &type);
+    assert_int_equal(CF_DATA_TYPE_CONTAINER, type);
+    assert_string_equal("hunter2", JsonPrimitiveGetAsString(value));
+
+    /* The whole variable, redacted. */
+    type = CF_DATA_TYPE_NONE;
+    value = EvalContextVariableGet(ctx, ref, &type, false);
+    assert_int_equal(CF_DATA_TYPE_STRING, type);
+    assert_string_equal("************", (const char *) value);
+
+    /* And one of its indices. */
+    type = CF_DATA_TYPE_NONE;
+    value = EvalContextVariableGet(ctx, indexed, &type, false);
+    assert_int_equal(CF_DATA_TYPE_STRING, type);
+    assert_string_equal("************", (const char *) value);
+
+    VarRefDestroy(ref);
+    VarRefDestroy(indexed);
+    JsonDestroy(data);          /* VariableTablePut() copies the Rval */
+    EvalContextDestroy(ctx);
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -208,6 +255,7 @@ int main()
         unit_test(test_persistent_class_timer_policy),
         unit_test(test_changes_chroot),
         unit_test(test_eval_with_token_from_list),
+        unit_test(test_secret_container_redacts_indexed_read),
     };
 
     int ret = run_tests(tests);

--- a/tests/unit/evalfunction_test.c
+++ b/tests/unit/evalfunction_test.c
@@ -146,7 +146,7 @@ static void test_module_protocol_percent_no_delimiter(void)
     ModuleProtocol(ctx, "/dev/null", ok, false, context, sizeof(context),
                    tags, &persistence);
     VarRef *good = VarRefParseFromScope("good", context);
-    assert_true(EvalContextVariableGet(ctx, good, NULL) != NULL);
+    assert_true(EvalContextVariableGetPlaintext(ctx, good, NULL) != NULL);
     VarRefDestroy(good);
     free(ok);
 
@@ -170,7 +170,7 @@ static void test_module_protocol_percent_no_delimiter(void)
     ModuleProtocol(ctx, "/dev/null", line, false, context, sizeof(context),
                    tags, &persistence);
     VarRef *ref = VarRefParseFromScope("bad", context);
-    assert_true(EvalContextVariableGet(ctx, ref, NULL) == NULL);
+    assert_true(EvalContextVariableGetPlaintext(ctx, ref, NULL) == NULL);
     VarRefDestroy(ref);
 
     assert_int_equal(munmap(region, pagesize * 2), 0);

--- a/tests/unit/rlist_test.c
+++ b/tests/unit/rlist_test.c
@@ -858,7 +858,7 @@ bool FullTextMatch(const char *regptr, const char *cmpptr)
     fail();
 }
 
-const void *EvalContextVariableGet(const EvalContext *ctx, const VarRef *lval, DataType *type_out)
+const void *EvalContextVariableGetPlaintext(const EvalContext *ctx, const VarRef *lval, DataType *type_out)
 {
     fail();
 }

--- a/tests/unit/set_domainname_test.c
+++ b/tests/unit/set_domainname_test.c
@@ -46,11 +46,11 @@ ExpectedVars expected_vars[] =
 static void TestSysVar(EvalContext *ctx, const char *lval, const char *expected)
 {
     VarRef *ref = VarRefParseFromScope(lval, "sys");
-    assert_string_equal(expected, EvalContextVariableGet(ctx, ref, NULL));
+    assert_string_equal(expected, EvalContextVariableGetPlaintext(ctx, ref, NULL));
     VarRefDestroy(ref);
 
-    assert_string_equal(expected, EvalContextVariableGetSpecial(ctx, SPECIAL_SCOPE_SYS, lval, NULL));
-    assert_string_equal(expected, EvalContextVariableGetSpecialString(ctx, SPECIAL_SCOPE_SYS, lval));
+    assert_string_equal(expected, EvalContextVariableGetSpecialPlaintext(ctx, SPECIAL_SCOPE_SYS, lval, NULL));
+    assert_string_equal(expected, EvalContextVariableGetSpecialString(ctx, SPECIAL_SCOPE_SYS, lval, true));
 }
 
 static void test_set_names(void)


### PR DESCRIPTION
`EvalContextVariableGet()` always returned the plaintext value, so a caller had no
way to ask for a secret-tagged variable to be redacted. This adds a `get_secret`
parameter, plus `EvalContextVariableGetPlaintext()` and friends, and moves the 20
existing call sites in core onto the plaintext form.

No behaviour change: every call site asks for plaintext, exactly as before. It is
the groundwork for the CFE-3294 leak fixes, which switch selected sites over.

It also fixes an indexed read of a secret-tagged container (`mydata[key]`) aborting
in `RvalContainerValue()`: the declared type was reported while the returned value
was the redacted scalar sentinel. Not reachable until a caller passes
`get_secret=false`, which the CFE-3294 work does.

Needs paired changes in the enterprise and nova repos, which call these accessors
and will not compile against the new signature — `enterprise/libcfserverd/server.c`
and four sites in `nova/cf-hub/cf-hub.c`. All three need to land together:

- https://github.com/cfengine/enterprise/pull/992
- https://github.com/cfengine/nova/pull/2691
