### PR TITLE
CFE-4718: Added process_darwin.c so macOS reports process state and start time

### DIFF
--- a/libpromises/Makefile.am
+++ b/libpromises/Makefile.am
@@ -206,13 +206,20 @@ libpromises_la_SOURCES += \
 	process_freebsd.c
 endif
 
+if MACOSX
+libpromises_la_SOURCES += \
+	process_darwin.c
+endif
+
 if !LINUX
 if !AIX
 if !HPUX
 if !SOLARIS
 if !FREEBSD
+if !MACOSX
 libpromises_la_SOURCES += \
 	process_unix_stub.c
+endif
 endif
 endif
 endif

--- a/libpromises/process_darwin.c
+++ b/libpromises/process_darwin.c
@@ -1,0 +1,118 @@
+/*
+  Copyright 2024 Northern.tech AS
+
+  This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by the
+  Free Software Foundation; version 3.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+  To the extent this program is licensed as part of the Enterprise
+  versions of CFEngine, the applicable Commercial Open Source License
+  (COSL) may apply to this file if you as a licensee so wish it. See
+  included file COSL.txt.
+*/
+
+#include <cf3.defs.h>
+#include <process_lib.h>
+#include <process_unix_priv.h>
+
+#include <sys/param.h>
+#include <sys/sysctl.h>
+
+typedef struct
+{
+    time_t starttime;
+    char state;
+} ProcessStat;
+
+static bool GetProcessStat(pid_t pid, ProcessStat *state)
+{
+    int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, pid };
+    struct kinfo_proc psinfo;
+    size_t len = sizeof(psinfo);
+
+    /* Zeroed because a lookup that finds nothing succeeds without writing
+     * anything to the buffer, see below. */
+    memset(&psinfo, 0, sizeof(psinfo));
+
+    if (sysctl(mib, sizeof(mib)/sizeof(mib[0]), &psinfo, &len, NULL, 0) != 0)
+    {
+        return false;
+    }
+
+    /* Unlike other BSDs, KERN_PROC_PID on Darwin reports a pid that does not
+     * exist by succeeding and setting the returned length to zero, rather than
+     * by failing with ESRCH. Without this check we would read a stale or
+     * uninitialised kinfo_proc and report a dead process as running. */
+    if (len == 0)
+    {
+        return false;
+    }
+
+    state->starttime = psinfo.kp_proc.p_starttime.tv_sec;
+
+    switch (psinfo.kp_proc.p_stat)
+    {
+        case SRUN:
+        case SIDL:
+            state->state = 'R';
+            break;
+        case SSTOP:
+            state->state = 'T';
+            break;
+        case SSLEEP:
+            state->state = 'S';
+            break;
+        case SZOMB:
+            state->state = 'Z';
+            break;
+        default:
+            state->state = 'X';
+    }
+
+    return true;
+}
+
+time_t GetProcessStartTime(pid_t pid)
+{
+    ProcessStat st;
+    if (GetProcessStat(pid, &st))
+    {
+        return st.starttime;
+    }
+    else
+    {
+        return PROCESS_START_TIME_UNKNOWN;
+    }
+}
+
+ProcessState GetProcessState(pid_t pid)
+{
+    ProcessStat st;
+    if (GetProcessStat(pid, &st))
+    {
+        switch (st.state)
+        {
+        case 'T':
+            return PROCESS_STATE_STOPPED;
+        case 'Z':
+            return PROCESS_STATE_ZOMBIE;
+        default:
+            return PROCESS_STATE_RUNNING;
+        }
+    }
+    else
+    {
+        return PROCESS_STATE_DOES_NOT_EXIST;
+    }
+}

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -183,7 +183,6 @@ TESTS = $(check_PROGRAMS) $(check_SCRIPTS)
 
 if MACOSX
 XFAIL_TESTS = set_domainname_test
-XFAIL_TESTS += process_test
 XFAIL_TESTS += mon_processes_test
 XFAIL_TESTS += rlist_test
 endif


### PR DESCRIPTION
Ticket: [CFE-4718](https://northerntech.atlassian.net/browse/CFE-4718)

macOS falls through to `process_unix_stub.c`, so `GetProcessStartTime()` always returns `PROCESS_START_TIME_UNKNOWN` and `GetProcessState()` can never report `STOPPED` or `ZOMBIE`. This adds `libpromises/process_darwin.c` using `sysctl KERN_PROC_PID`, modelled on `process_freebsd.c`.

**Three consequences on master today**

- Custom promise modules cannot run at all — `PromiseModule_Load()` fails the module when its start time is unknown (`mod_custom.c:504`), which on the stub is unconditional.
- `SafeKill()`'s PID-recycling guard never runs for callers that pass a stored start time, since `Kill()` falls back to a plain `kill(2)` (`process_unix.c:229`). Affects `locks.c:630` and `mod_custom.c`. (`timeout.c:45` passes `PROCESS_START_TIME_UNKNOWN` by design and is unaffected.)
- `kill(pid, 0)` succeeds on a zombie, so an exited child still reads as `RUNNING` and both `ProcessWaitUntilExited()` calls in `GracefulTerminate()` poll to their full `STOP_WAIT_TIMEOUT`. Timed against both platform files on an unreaped child: several seconds (7–12 s here, tracking how much a 10 ms `nanosleep()` overshoots under load) versus tens of milliseconds.

**One Darwin difference from the FreeBSD file, worth a look**

For a pid that does not exist, `KERN_PROC_PID` *succeeds* and returns a length of zero, leaving the buffer untouched — it does not fail with `ESRCH`. Copying FreeBSD's `if (sysctl(...) == 0)` test alone would parse an unwritten `kinfo_proc` and report dead processes as running, i.e. worse than the stub. The buffer is zeroed and the length checked.

`proc_pidinfo(PROC_PIDTBSDINFO)` was rejected: it fails with `EPERM` for other users' processes unless privileged, and reports `ESRCH` for an unreaped zombie, so it cannot express `PROCESS_STATE_ZOMBIE`.

**Testing**

`tests/unit/process_test` covers exactly these cases and was XFAIL'd wholesale on macOS. Rebuilding the library both ways (forced relink; a partial rebuild leaves the old platform object in the archive and fakes a pass):

- stub: 4 failures — `process_test.c:91,92` (start time), `:149` (STOPPED), `:216` (ZOMBIE)
- with this patch: 0 failures

So it has to leave `XFAIL_TESTS`, or the macOS job fails with XPASS. Full `make check` in `tests/unit`: 66 PASS, 3 XFAIL, 1 SKIP, 0 FAIL, 0 XPASS (baseline 65/4). 20 runs of `process_test`, 12 serial and 8 concurrent, no flake. Clean under `-Werror -Wall -Wextra`.

Verified on macOS 26.6.1 (Darwin 25.6.0), arm64; `sizeof(struct kinfo_proc)` is 648 on the 15.0, 15.4, 26.0 and 26.5 SDKs. No older macOS was booted, so cross-version layout stability is an expectation rather than a measurement — the macOS CI job here is a better test of that than anything I can run locally.

AI-assisted, reviewed and verified by me before submitting, per CONTRIBUTING.


[CFE-4718]: https://northerntech.atlassian.net/browse/CFE-4718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ