### PR TITLE
CFE-4732: Fixed ReconcileMountOptions() leaving its remount timeout armed

### DIFF
--- a/cf-agent/nfs.c
+++ b/cf-agent/nfs.c
@@ -1468,6 +1468,10 @@ PromiseResult ReconcileMountOptions(EvalContext *ctx, char *name, const Attribut
             continue;
         }
 
+        /* Clear the mount reconciliation timeout before moving on to other things */
+        alarm(0);
+        signal(SIGALRM, SIG_DFL);
+
         /* Verify-after-act: confirm the live mount actually satisfies the promise. */
         if (LiveMountConverged(name, a))
         {


### PR DESCRIPTION
Ticket: [CFE-4732](https://northerntech.atlassian.net/browse/CFE-4732)

`ReconcileMountOptions()` arms a timeout at the remount and unmount_mount sites (`nfs.c:1436`, `:1461`) but never disarms it; the only reason it doesn't leak past the function is that `LiveMountConverged()` -> `LoadMountInfo()` incidentally re-arms and clears its own alarm as a side effect. Disarm locally after the dispatch, before `LiveMountConverged()`, matching the file's own idiom at `:581` and `:1178`.

No unit test: this function returns early under a dry run before reaching the fix, and its live path shells out to `mount`/`umount`, which CI can't run. Happy to extract a testable helper if you'd rather have the coverage.

AI-assisted, reviewed and verified by me before submitting.

[CFE-4732]: https://northerntech.atlassian.net/browse/CFE-4732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ