### PR TITLE
CFE-4733: Fixed ALARM_PID naming a reaped pid after ShellCommandReturnsZero()

### DIFF
--- a/libpromises/unix.c
+++ b/libpromises/unix.c
@@ -238,7 +238,8 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
             pid_t wait_result = waitpid(pid, &status, WNOHANG);
             if (wait_result == pid)
             {
-                break; /* child exited and was reaped */
+                ALARM_PID = -1; /* reaped: pid can be recycled, stop naming it */
+                break;
             }
             if (wait_result < 0)
             {
@@ -259,6 +260,7 @@ bool ShellCommandReturnsZero(const char *command, ShellType shell)
                 {
                     /* Child has been signalled; just reap it. */
                 }
+                ALARM_PID = -1; /* reaped: pid can be recycled, stop naming it */
                 return false;
             }
             struct timespec poll_interval = {

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -423,6 +423,10 @@ check_PROGRAMS += nfs_test
 nfs_test_SOURCES = nfs_test.c
 nfs_test_LDADD = ../../libpromises/libpromises.la libtest.la
 
+check_PROGRAMS += unix_test
+unix_test_SOURCES = unix_test.c
+unix_test_LDADD = ../../libpromises/libpromises.la libtest.la
+
 init_script_test_helper_SOURCES = init_script_test_helper.c
 init_script_test.sh: init_script_test_helper
 CLEANFILES += init_script_test_helper

--- a/tests/unit/unix_test.c
+++ b/tests/unit/unix_test.c
@@ -1,0 +1,42 @@
+#include <test.h>
+
+#include <exec_tools.h>
+
+/* ShellCommandReturnsZero() always reaps the child it forks (either via the
+ * WNOHANG poll loop, or via the blocking drain on the pending-termination
+ * path), so ALARM_PID must not still name that pid on return -- the pid is
+ * immediately recyclable and a later stray alarm firing against it would
+ * hit an unrelated process. */
+
+static void test_shell_command_resets_alarm_pid_on_success(void)
+{
+    ALARM_PID = -999; /* sentinel, distinct from both -1 and any real pid */
+
+    bool result = ShellCommandReturnsZero("true", SHELL_TYPE_USE);
+
+    assert_true(result);
+    assert_int_equal(ALARM_PID, -1);
+}
+
+static void test_shell_command_resets_alarm_pid_on_nonzero_exit(void)
+{
+    ALARM_PID = -999;
+
+    bool result = ShellCommandReturnsZero("false", SHELL_TYPE_USE);
+
+    assert_false(result);
+    assert_int_equal(ALARM_PID, -1);
+}
+
+int main()
+{
+    PRINT_TEST_BANNER();
+
+    const UnitTest tests[] =
+    {
+        unit_test(test_shell_command_resets_alarm_pid_on_success),
+        unit_test(test_shell_command_resets_alarm_pid_on_nonzero_exit),
+    };
+
+    return run_tests(tests);
+}


### PR DESCRIPTION
Ticket: [CFE-4733](https://northerntech.atlassian.net/browse/CFE-4733)

`ShellCommandReturnsZero()` (`libpromises/unix.c:166`) sets `ALARM_PID = pid` at `:225`, then reaps the child either through the `waitpid` `WNOHANG` poll loop's normal exit (`:238`) or the blocking drain on the pending-termination path (`:258`), and never resets `ALARM_PID`. The only `ALARM_PID = -1` in the function is at `:184`, in the child, before exec.

Once reaped, the pid is immediately recyclable. The usual reassurance for a stale `ALARM_PID` — "the process is still an unreaped zombie holding its slot" — does not hold here, because this call site is the one that reaps. A leaked alarm firing afterwards, before anything else rewrites `ALARM_PID`, would run `TimeOut()` against a pid that may now name an unrelated process, and `cf-agent` typically runs as root.

The chain is long (leak × no intervening rewrite × recycle × timing) so severity is low, but the one-line hygiene fix at each reap site removes the exception and makes the stale-`ALARM_PID` reasoning sound again.

The third return point (`:249`, `waitpid()` itself failed) is deliberately left alone — no reap happens there, so the zombie-holds-the-slot reasoning still applies and clearing would be wrong.

**Testing** — adds `tests/unit/unix_test.c`. Unlike the `nfs.c` family, this function is exported and has no `EvalContext`/`Promise` dependency, so it is directly testable: two cases assert `ALARM_PID == -1` after the reap. Discrimination confirmed by hand — both fail against the pre-fix code and pass with it. The `:258` blocking-drain path ships with the identical fix but no dedicated test, since forcing a real `SIGTERM` mid-poll was judged too CI-fragile.

AI-assisted, reviewed and verified by me before submitting, per CONTRIBUTING.


[CFE-4733]: https://northerntech.atlassian.net/browse/CFE-4733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ