### PR TITLE
CFE-4734: Fixed exec_timeout arming its alarm before the child existed

### DIFF
--- a/cf-agent/nfs.c
+++ b/cf-agent/nfs.c
@@ -578,8 +578,7 @@ bool LoadMountInfo(Seq *list)
     }
 
     free(vbuff);
-    alarm(0);
-    signal(SIGALRM, SIG_DFL);
+    ClearTimeOut();
     cf_pclose(pp);
     return true;
 }
@@ -1175,8 +1174,7 @@ void MountAll()
     }
 
     free(line);
-    alarm(0);
-    signal(SIGALRM, SIG_DFL);
+    ClearTimeOut();
     cf_pclose(pp);
 }
 

--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -288,6 +288,9 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
 
     CommandPrefix(cmdline, comm);
 
+    /* Set once the command has been reaped, if its exec_timeout fired. */
+    bool timed_out = false;
+
     bool do_work_here = true;
 
 #ifndef __MINGW32__
@@ -448,7 +451,31 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
         {
             int ret = cf_pclose(pfp);
 
-            if (ret == -1)
+            /* Sample only now, and never earlier. The read loop above ends as
+             * soon as the command closes its output, which it can do long
+             * before it exits -- so the alarm may not fire until cf_pclose()
+             * is already waiting for the child. Reading the flag before that
+             * wait misses exactly the case this is here to catch. It is still
+             * read before the alarm is disarmed further down. */
+            timed_out = (a->contain.timeout != CF_NOINT) && TimeOutHasFired();
+
+            if (timed_out)
+            {
+                /* The command exceeded exec_timeout and was signalled, so its
+                 * exit status cannot be trusted to say so. A command killed
+                 * after it has written its last output, or one that exits
+                 * normally while only its children are killed, is reaped with a
+                 * status VerifyCommandRetcode() reads as success -- and the
+                 * promise is then reported kept or repaired even though the
+                 * command never completed. Classify on the timeout instead. */
+                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_TIMEOUT, pp, a,
+                     TimeOutSignalledProcess()
+                         ? "Command '%s' exceeded exec_timeout of %d seconds and was terminated"
+                         : "Command '%s' exceeded exec_timeout of %d seconds; it was NOT terminated and ran to completion",
+                     pp->promiser, a->contain.timeout);
+                *result = PromiseResultUpdate(*result, PROMISE_RESULT_TIMEOUT);
+            }
+            else if (ret == -1)
             {
                 cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a, "Finished script '%s' - failed (abnormal termination)", pp->promiser);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
@@ -492,7 +519,7 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
     }
 #endif /* !__MINGW32__ */
 
-    return ACTION_RESULT_OK;
+    return timed_out ? ACTION_RESULT_TIMEOUT : ACTION_RESULT_OK;
 }
 
 /*************************************************************/

--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -472,8 +472,7 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
 
     if (a->contain.timeout != CF_NOINT)
     {
-        alarm(0);
-        signal(SIGALRM, SIG_DFL);
+        ClearTimeOut();
     }
 
     Log(info_or_verbose, "Completed execution of '%s'", cmdline);

--- a/cf-monitord/history.c
+++ b/cf-monitord/history.c
@@ -374,8 +374,7 @@ static Item *NovaReSample(EvalContext *ctx, int slot, const Attributes *attr, co
 
     if (a.contain.timeout != 0)
     {
-        alarm(0);
-        signal(SIGALRM, SIG_DFL);
+        ClearTimeOut();
     }
 
     Log(LOG_LEVEL_INFO, "Collected sample of %s", pp->promiser);

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -236,6 +236,13 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
         sigset_t sigmask;
         sigemptyset(&sigmask);
         sigprocmask(SIG_SETMASK, &sigmask, NULL);
+
+        /* Lead a new process group, so that anything the command spawns can be
+         * signalled as a unit. Without this only the direct child is reachable,
+         * and a grandchild outlives exec_timeout still holding the pipe open,
+         * which leaves the parent blocked reading it. setpgid() is
+         * async-signal-safe, so it is legal here. */
+        setpgid(0, 0);
     }
 
     ALARM_PID = (pid != 0 ? pid : -1);

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -255,7 +255,17 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
          * must stay in ours. */
         if (TimeOutIsArmed())
         {
-            setpgid(0, 0);
+            if (setpgid(0, 0) != 0)
+            {
+                /* The command stays in our group, so TimeOut()'s check of its
+                 * group will skip the group kill; only its descendants are
+                 * then out of the timeout's reach. Log() is not
+                 * async-signal-safe, so it is confined to this failure branch,
+                 * where the alternative is losing the descendants silently. */
+                Log(LOG_LEVEL_WARNING,
+                    "Could not give the timed command its own process group (setpgid: %s), its descendants will survive a timeout",
+                    GetErrorStr());
+            }
         }
     }
 

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -271,6 +271,15 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
 
     ALARM_PID = (pid != 0 ? pid : -1);
 
+    if (pid > 0)
+    {
+        /* Only now is there a process for TimeOut() to terminate. Starting the
+         * clock any earlier -- as SetTimeOut() used to -- lets the alarm fire
+         * in the window before this assignment, where it finds nothing
+         * registered and the command then runs unbounded. */
+        StartTimeOutClock();
+    }
+
     return pid;
 }
 

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -33,6 +33,7 @@
 #include <file_lib.h>
 #include <signals.h>
 #include <string_lib.h>
+#include <timeout.h>
 
 static bool CfSetuid(uid_t uid, gid_t gid);
 
@@ -237,12 +238,25 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
         sigemptyset(&sigmask);
         sigprocmask(SIG_SETMASK, &sigmask, NULL);
 
-        /* Lead a new process group, so that anything the command spawns can be
-         * signalled as a unit. Without this only the direct child is reachable,
-         * and a grandchild outlives exec_timeout still holding the pipe open,
-         * which leaves the parent blocked reading it. setpgid() is
-         * async-signal-safe, so it is legal here. */
-        setpgid(0, 0);
+        /* When a timeout is armed, lead a new process group, so that anything
+         * the command spawns can be signalled as a unit. Without this only the
+         * direct child is reachable, and a grandchild outlives exec_timeout
+         * still holding the pipe open, which leaves the parent blocked reading
+         * it. setpgid() is async-signal-safe, so it is legal here.
+         *
+         * Only when a timeout is armed. A child in a process group of its own
+         * is no longer in the terminal's foreground group, so on an interactive
+         * run it is stopped by SIGTTIN the moment it reads the terminal, and
+         * the agent then blocks forever on the pipe -- the very hang this is
+         * meant to bound, reintroduced on a path with no timeout to end it. It
+         * also leaves the child out of reach of a terminal SIGINT and of
+         * cf-execd's agent_expireafter, both of which kill by process group.
+         * Children with no timeout have nothing to bound their wait, so they
+         * must stay in ours. */
+        if (TimeOutIsArmed())
+        {
+            setpgid(0, 0);
+        }
     }
 
     ALARM_PID = (pid != 0 ? pid : -1);

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -26,11 +26,34 @@
 #include <timeout.h>
 #include <process_lib.h>
 
+/* Set by TimeOut() when the alarm fires, so that the caller can tell "the
+ * command timed out" from "the command finished". Written from a signal
+ * handler, hence volatile sig_atomic_t. */
+static volatile sig_atomic_t TIMEOUT_FIRED = 0; /* GLOBAL_X */
+
+/* Set only when TimeOut() actually had a process to signal. The alarm can fire
+ * with ALARM_PID already cleared -- cf_pclose() clears it before waiting -- in
+ * which case the command timed out but was never terminated, and saying
+ * otherwise would be a false statement in an error message. */
+static volatile sig_atomic_t TIMEOUT_SIGNALLED = 0; /* GLOBAL_X */
+
 void SetTimeOut(int timeout)
 {
     ALARM_PID = -1;
+    TIMEOUT_FIRED = 0;
+    TIMEOUT_SIGNALLED = 0;
     signal(SIGALRM, (void *) TimeOut);
     alarm(timeout);
+}
+
+bool TimeOutHasFired(void)
+{
+    return TIMEOUT_FIRED != 0;
+}
+
+bool TimeOutSignalledProcess(void)
+{
+    return TIMEOUT_SIGNALLED != 0;
 }
 
 /*************************************************************************/
@@ -38,9 +61,11 @@ void SetTimeOut(int timeout)
 void TimeOut()
 {
     alarm(0);
+    TIMEOUT_FIRED = 1;
 
     if (ALARM_PID != -1)
     {
+        TIMEOUT_SIGNALLED = 1;
         Log(LOG_LEVEL_VERBOSE, "Time out of process %jd", (intmax_t)ALARM_PID);
         GracefulTerminate(ALARM_PID, PROCESS_START_TIME_UNKNOWN);
     }

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -43,6 +43,11 @@ static volatile sig_atomic_t TIMEOUT_SIGNALLED = 0; /* GLOBAL_X */
  * well as from ClearTimeOut(), hence volatile sig_atomic_t. */
 static volatile sig_atomic_t TIMEOUT_ARMED = 0; /* GLOBAL_X */
 
+/* Seconds requested by SetTimeOut(), held until StartTimeOutClock() arms the
+ * real timer once cf_popen() has a pid to kill. Not touched from the
+ * handler. */
+static int TIMEOUT_PENDING = 0; /* GLOBAL_X */
+
 void SetTimeOut(int timeout)
 {
     ALARM_PID = -1;
@@ -50,7 +55,30 @@ void SetTimeOut(int timeout)
     TIMEOUT_SIGNALLED = 0;
     TIMEOUT_ARMED = 1;
     signal(SIGALRM, (void *) TimeOut);
+#if defined(__MINGW32__) || defined(__CYGWIN__)
+    /* Keep starting the clock here on exactly the platforms that do not build
+     * pipes_unix.c -- Makefile NT, i.e. mingw and cygwin. Their pipe
+     * implementation is outside this tree, so nothing there would ever reach
+     * StartTimeOutClock() and a deferred clock would never start at all. */
     alarm(timeout);
+#else
+    /* Hold the clock until there is a process registered to terminate. Cancel
+     * any timer leaked by an earlier caller first, so it cannot fire as ours. */
+    alarm(0);
+    TIMEOUT_PENDING = timeout;
+#endif
+}
+
+void StartTimeOutClock(void)
+{
+    /* One-shot: a second fork under the same timeout runs on the time already
+     * ticking, rather than restarting the command's budget. */
+    if ((TIMEOUT_ARMED != 0) && (TIMEOUT_PENDING > 0))
+    {
+        int seconds = TIMEOUT_PENDING;
+        TIMEOUT_PENDING = 0;
+        alarm(seconds);
+    }
 }
 
 void ClearTimeOut(void)
@@ -61,6 +89,7 @@ void ClearTimeOut(void)
     alarm(0);
     signal(SIGALRM, SIG_DFL);
     TIMEOUT_ARMED = 0;
+    TIMEOUT_PENDING = 0;
 }
 
 bool TimeOutIsArmed(void)

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -94,6 +94,12 @@ void TimeOut()
          * once GracefulTerminate() has killed it, getpgid() fails with ESRCH and
          * we would have no safe way to tell whether it led a group of its own. */
         const pid_t pgid = getpgid(ALARM_PID);
+        if (pgid == -1)
+        {
+            Log(LOG_LEVEL_WARNING,
+                "Could not read the process group of timed-out process %jd (getpgid: %s), not signalling its process group",
+                (intmax_t)ALARM_PID, GetErrorStr());
+        }
 
         GracefulTerminate(ALARM_PID, PROCESS_START_TIME_UNKNOWN);
 

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -39,15 +39,16 @@ static volatile sig_atomic_t TIMEOUT_SIGNALLED = 0; /* GLOBAL_X */
 
 /* Set while a timeout alarm is pending. cf_popen()'s child consults it to
  * decide whether to lead a process group of its own; only a child that may
- * have to be killed as a tree needs one. */
-static bool TIMEOUT_ARMED = false; /* GLOBAL_X */
+ * have to be killed as a tree needs one. Cleared from the signal handler as
+ * well as from ClearTimeOut(), hence volatile sig_atomic_t. */
+static volatile sig_atomic_t TIMEOUT_ARMED = 0; /* GLOBAL_X */
 
 void SetTimeOut(int timeout)
 {
     ALARM_PID = -1;
     TIMEOUT_FIRED = 0;
     TIMEOUT_SIGNALLED = 0;
-    TIMEOUT_ARMED = true;
+    TIMEOUT_ARMED = 1;
     signal(SIGALRM, (void *) TimeOut);
     alarm(timeout);
 }
@@ -59,12 +60,12 @@ void ClearTimeOut(void)
      * after the disarm. Only the next SetTimeOut() resets them. */
     alarm(0);
     signal(SIGALRM, SIG_DFL);
-    TIMEOUT_ARMED = false;
+    TIMEOUT_ARMED = 0;
 }
 
 bool TimeOutIsArmed(void)
 {
-    return TIMEOUT_ARMED;
+    return TIMEOUT_ARMED != 0;
 }
 
 bool TimeOutHasFired(void)
@@ -83,13 +84,14 @@ void TimeOut()
 {
     alarm(0);
     TIMEOUT_FIRED = 1;
-    TIMEOUT_ARMED = false;
+    TIMEOUT_ARMED = 0;
 
     if (ALARM_PID != -1)
     {
         TIMEOUT_SIGNALLED = 1;
         Log(LOG_LEVEL_VERBOSE, "Time out of process %jd", (intmax_t)ALARM_PID);
 
+#ifndef __MINGW32__
         /* Read the process group while the process is still alive to be read:
          * once GracefulTerminate() has killed it, getpgid() fails with ESRCH and
          * we would have no safe way to tell whether it led a group of its own. */
@@ -100,9 +102,11 @@ void TimeOut()
                 "Could not read the process group of timed-out process %jd (getpgid: %s), not signalling its process group",
                 (intmax_t)ALARM_PID, GetErrorStr());
         }
+#endif
 
         GracefulTerminate(ALARM_PID, PROCESS_START_TIME_UNKNOWN);
 
+#ifndef __MINGW32__
         /* GracefulTerminate() only reaches the process we started. Anything that
          * process spawned survives it, and keeps the pipe open, so the caller
          * stays blocked reading a command it has already given up on.
@@ -111,11 +115,16 @@ void TimeOut()
          * cf_popen()'s child arranges with setpgid(). If that did not take
          * effect the process is still in our group, its pgid is not its pid, and
          * a negative kill() here would signal an unrelated group -- possibly our
-         * own. */
+         * own.
+         *
+         * Windows has no POSIX process groups and no setpgid() in the child
+         * (cf_popen() lives in pipes_unix.c), so there is nothing to widen the
+         * signal to there. */
         if (pgid == ALARM_PID)
         {
             kill(-ALARM_PID, SIGKILL);
         }
+#endif
     }
     else
     {

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -42,7 +42,27 @@ void TimeOut()
     if (ALARM_PID != -1)
     {
         Log(LOG_LEVEL_VERBOSE, "Time out of process %jd", (intmax_t)ALARM_PID);
+
+        /* Read the process group while the process is still alive to be read:
+         * once GracefulTerminate() has killed it, getpgid() fails with ESRCH and
+         * we would have no safe way to tell whether it led a group of its own. */
+        const pid_t pgid = getpgid(ALARM_PID);
+
         GracefulTerminate(ALARM_PID, PROCESS_START_TIME_UNKNOWN);
+
+        /* GracefulTerminate() only reaches the process we started. Anything that
+         * process spawned survives it, and keeps the pipe open, so the caller
+         * stays blocked reading a command it has already given up on.
+         *
+         * Guarded on the timed-out process leading its own group, which
+         * cf_popen()'s child arranges with setpgid(). If that did not take
+         * effect the process is still in our group, its pgid is not its pid, and
+         * a negative kill() here would signal an unrelated group -- possibly our
+         * own. */
+        if (pgid == ALARM_PID)
+        {
+            kill(-ALARM_PID, SIGKILL);
+        }
     }
     else
     {

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -26,11 +26,29 @@
 #include <timeout.h>
 #include <process_lib.h>
 
+/* Set while a timeout alarm is pending. cf_popen()'s child consults it to
+ * decide whether to lead a process group of its own; only a child that may
+ * have to be killed as a tree needs one. */
+static bool TIMEOUT_ARMED = false; /* GLOBAL_X */
+
 void SetTimeOut(int timeout)
 {
     ALARM_PID = -1;
+    TIMEOUT_ARMED = true;
     signal(SIGALRM, (void *) TimeOut);
     alarm(timeout);
+}
+
+void ClearTimeOut(void)
+{
+    alarm(0);
+    signal(SIGALRM, SIG_DFL);
+    TIMEOUT_ARMED = false;
+}
+
+bool TimeOutIsArmed(void)
+{
+    return TIMEOUT_ARMED;
 }
 
 /*************************************************************************/
@@ -38,6 +56,7 @@ void SetTimeOut(int timeout)
 void TimeOut()
 {
     alarm(0);
+    TIMEOUT_ARMED = false;
 
     if (ALARM_PID != -1)
     {

--- a/libpromises/timeout.h
+++ b/libpromises/timeout.h
@@ -25,7 +25,16 @@
 #ifndef CFENGINE_TIMEOUT_H
 #define CFENGINE_TIMEOUT_H
 
+/* Arm a timeout, but leave its clock stopped: wherever cf_popen() lives in this
+ * tree, the alarm is started by StartTimeOutClock() once there is a child to
+ * terminate. Platforms whose pipes are implemented elsewhere start it here. */
 void SetTimeOut(int timeout);
+
+/* Start the clock armed by SetTimeOut(). Called by cf_popen() right after the
+ * child's pid reaches ALARM_PID, so an alarm can never be pending with nothing
+ * registered to kill. No-op when no timeout is armed, or when the clock is
+ * already running. */
+void StartTimeOutClock(void);
 
 /* Cancel a pending alarm and restore the default handler. Callers used to
  * open-code this; it also has to clear the armed flag, so that a command which
@@ -34,9 +43,11 @@ void SetTimeOut(int timeout);
  * that record stays readable after the disarm, until the next SetTimeOut(). */
 void ClearTimeOut(void);
 
-/* True between SetTimeOut() arming the alarm and the alarm being disarmed.
- * Consulted by code that forks a child which the timeout may have to
- * terminate, to decide whether that child needs a process group of its own. */
+/* True between SetTimeOut() arming the timeout and it being disarmed, whether
+ * or not its clock has started. Consulted by code that forks a child which the
+ * timeout may have to terminate, to decide whether that child needs a process
+ * group of its own -- a question that has the same answer either side of the
+ * fork that starts the clock. */
 bool TimeOutIsArmed(void);
 
 /* True if the alarm armed by the last SetTimeOut() actually fired. Lets a

--- a/libpromises/timeout.h
+++ b/libpromises/timeout.h
@@ -26,6 +26,16 @@
 #define CFENGINE_TIMEOUT_H
 
 void SetTimeOut(int timeout);
+
+/* True between SetTimeOut() arming the alarm and the alarm being disarmed.
+ * Consulted by code that forks a child which the timeout may have to
+ * terminate, to decide whether that child needs a process group of its own. */
+bool TimeOutIsArmed(void);
+
+/* Cancel a pending alarm and restore the default handler. Callers used to
+ * open-code this; it also has to clear the armed flag, so that a command which
+ * completes in time does not leave it set for the next, unrelated, child. */
+void ClearTimeOut(void);
 void TimeOut(void);
 time_t SetReferenceTime(void);
 

--- a/libpromises/timeout.h
+++ b/libpromises/timeout.h
@@ -26,6 +26,16 @@
 #define CFENGINE_TIMEOUT_H
 
 void SetTimeOut(int timeout);
+
+/* True if the alarm armed by the last SetTimeOut() actually fired. Lets a
+ * caller report that a command was timed out even when the command's own exit
+ * status would otherwise read as success. Cleared by SetTimeOut(). */
+bool TimeOutHasFired(void);
+
+/* True if that alarm also had a process to signal. False means the command
+ * exceeded its timeout but was never terminated, which callers must not
+ * describe as a termination. */
+bool TimeOutSignalledProcess(void);
 void TimeOut(void);
 time_t SetReferenceTime(void);
 

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_after_output_closed.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_after_output_closed.cf
@@ -1,0 +1,61 @@
+#######################################################
+#
+# Test that exec_timeout is detected even when the command
+# closes its output long before it exits. The agent's read
+# loop ends at EOF, so it is already waiting for the child
+# when the alarm fires; a timeout sampled while output was
+# still open misses exactly this shape. The command then runs
+# to completion and exits 0, and must still be reported as
+# timed out.
+#
+# Deliberately slow: with its output already closed there is
+# no process left registered for the alarm to signal, so the
+# child's full 10 second sleep runs out before it is reaped.
+# Expect around 12 seconds of wall clock.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "exec_timeout is detected when the command closes its output before it exits";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with a POSIX shell payload";
+
+  commands:
+    "/bin/sh"
+      arglist => { "-c", "exec 1>&- 2>&-; sleep 10; exit 0" },
+      contain => exec_timeout_2,
+      classes => dcs_all_classes("output_closed");
+}
+
+body contain exec_timeout_2
+{
+  exec_timeout => "2";
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "output_closed_repair_timeout",
+        "output_closed_promise_kept,output_closed_promise_repaired",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_does_not_leak_to_next_promise.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_does_not_leak_to_next_promise.cf
@@ -1,0 +1,66 @@
+#######################################################
+#
+# Test that a fired exec_timeout is charged to the promise
+# whose command timed out, and only that promise: a
+# subsequent commands: promise that finishes inside its own
+# timeout must come out repaired, not timed out.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "A fired exec_timeout does not leak into the next commands promise";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with POSIX shell payloads";
+
+  commands:
+    "/bin/sh"
+      arglist => { "-c", "sleep 2.4; exit 0" },
+      contain => exec_timeout_2,
+      classes => dcs_all_classes("leak_first");
+
+    # Runs after the first command has already timed out, armed with
+    # its own timeout so that a stale flag surviving from the first
+    # promise would be sampled here if it leaked.
+    "/bin/sh"
+      arglist => { "-c", "exit 0" },
+      contain => exec_timeout_10,
+      classes => dcs_all_classes("leak_second");
+}
+
+body contain exec_timeout_2
+{
+  exec_timeout => "2";
+}
+
+body contain exec_timeout_10
+{
+  exec_timeout => "10";
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "leak_first_repair_timeout,leak_second_promise_repaired",
+        "leak_first_promise_kept,leak_first_promise_repaired,leak_second_repair_timeout",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_kills_descendants.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_kills_descendants.cf
@@ -1,0 +1,98 @@
+#######################################################
+#
+# Test that a fired exec_timeout also ends the command's
+# descendants. The termination ladder only reaches the direct
+# child; the sleep the shell spawned inherits the write end of
+# the output pipe, and if it survives the timeout it holds that
+# pipe open for its full 30 seconds while the agent sits in its
+# read loop -- exec_timeout then does not bound the promise's
+# wall clock at all. Killing the command's process group ends
+# the sleep at the timeout, so the promise completes in well
+# under 20 seconds.
+#
+# The elapsed time is measured between two marker files touched
+# immediately before and after the timed promise; commands in a
+# bundle run in order of declaration.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent init
+{
+  files:
+    # The markers must come from this run: a stale pair could carry a
+    # bounded-looking mtime difference from an earlier one.
+    "$(G.testdir)/desc_start" delete => tidy;
+    "$(G.testdir)/desc_end" delete => tidy;
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "A fired exec_timeout terminates the command's descendants";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with POSIX shell payloads";
+
+  commands:
+    "/bin/sh"
+      arglist => { "-c", "touch $(G.testdir)/desc_start" };
+
+    # The shell waits for its sleep, so at the 2 second timeout the
+    # sleep is alive holding the pipe. Only ending it too releases
+    # the pipe before its natural end at 30 seconds.
+    "/bin/sh"
+      arglist => { "-c", "sleep 30; exit 0" },
+      contain => exec_timeout_2,
+      classes => dcs_all_classes("desc_timed");
+
+    "/bin/sh"
+      arglist => { "-c", "touch $(G.testdir)/desc_end" };
+}
+
+body contain exec_timeout_2
+{
+  exec_timeout => "2";
+}
+
+#######################################################
+bundle agent check
+{
+  vars:
+    "start" string => filestat("$(G.testdir)/desc_start", "mtime");
+    "end" string => filestat("$(G.testdir)/desc_end", "mtime");
+    "elapsed" string => eval("$(end) - $(start)", "math", "infix");
+
+  classes:
+    # 20 is well past the ~10 seconds the timeout plus termination
+    # ladder takes, and well short of the sleep's 30. The fileexists()
+    # guards keep a missing marker from passing as boundedness.
+    "bounded"
+      and => {
+        fileexists("$(G.testdir)/desc_start"),
+        fileexists("$(G.testdir)/desc_end"),
+        islessthan("$(elapsed)", "20")
+      },
+      scope => "namespace";
+
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "desc_timed_repair_timeout,bounded",
+        "desc_timed_promise_kept,desc_timed_promise_repaired",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_overrides_exit_zero.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_overrides_exit_zero.cf
@@ -1,0 +1,58 @@
+#######################################################
+#
+# Test that a commands: promise whose exec_timeout fires is
+# reported as timed out even though the command exits 0. The
+# exit status of a command that was signalled does not say
+# whether it ran to completion, so a fired timeout must take
+# precedence over a successful exit status.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "A fired exec_timeout takes precedence over a successful exit status";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with a POSIX shell payload";
+
+  commands:
+    # The sleep outlives the 2 second timeout by less than the
+    # termination ladder's grace period, so the signalled shell
+    # still reaps its child and exits 0 -- the shape in which the
+    # exit status used to win over the fired timeout.
+    "/bin/sh"
+      arglist => { "-c", "sleep 2.4; exit 0" },
+      contain => exec_timeout_2,
+      classes => dcs_all_classes("timeout_exit0");
+}
+
+body contain exec_timeout_2
+{
+  exec_timeout => "2";
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "timeout_exit0_repair_timeout",
+        "timeout_exit0_promise_kept,timeout_exit0_promise_repaired",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_overrides_kept_returncodes.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_overrides_kept_returncodes.cf
@@ -1,0 +1,66 @@
+#######################################################
+#
+# Test that kept_returncodes does not resurrect "kept" when
+# exec_timeout fired: the timed-out command exits 0, and 0 is
+# listed in kept_returncodes, but the promise must still be
+# reported as timed out, not kept.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "kept_returncodes does not resurrect kept when exec_timeout fired";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with a POSIX shell payload";
+
+  commands:
+    "/bin/sh"
+      arglist => { "-c", "sleep 2.4; exit 0" },
+      contain => exec_timeout_2,
+      classes => all_classes_kept_0("timeout_kept0");
+}
+
+body contain exec_timeout_2
+{
+  exec_timeout => "2";
+}
+
+# dcs_all_classes (dcs.sub.cf) carries no returncode attributes and
+# classes bodies do not compose, so this is dcs_all_classes plus
+# kept_returncodes.
+body classes all_classes_kept_0(prefix)
+{
+  promise_kept => { "$(prefix)_promise_kept" };
+  promise_repaired => { "$(prefix)_promise_repaired" };
+  repair_failed => { "$(prefix)_repair_failed" };
+  repair_denied => { "$(prefix)_repair_denied" };
+  repair_timeout => { "$(prefix)_repair_timeout" };
+  kept_returncodes => { "0" };
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "timeout_kept0_repair_timeout",
+        "timeout_kept0_promise_kept,timeout_kept0_promise_repaired",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/04_exec_timeout/within_timeout_normal_outcomes.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/within_timeout_normal_outcomes.cf
@@ -1,0 +1,59 @@
+#######################################################
+#
+# Test that an armed exec_timeout that does not fire leaves
+# the outcome of a commands: promise to the exit status: 0
+# repairs the promise and non-zero fails it, exactly as if no
+# timeout were set. Guards the normal path against
+# regressions from the timed-out path.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "An exec_timeout that does not fire leaves the outcome to the exit status";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with POSIX shell payloads";
+
+  commands:
+    "/bin/sh"
+      arglist => { "-c", "sleep 1; exit 0" },
+      contain => exec_timeout_10,
+      classes => dcs_all_classes("within_exit0");
+
+    "/bin/sh"
+      arglist => { "-c", "sleep 1; exit 3" },
+      contain => exec_timeout_10,
+      classes => dcs_all_classes("within_exit3");
+}
+
+body contain exec_timeout_10
+{
+  exec_timeout => "10";
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "within_exit0_promise_repaired,within_exit3_repair_failed",
+        "within_exit0_repair_timeout,within_exit0_repair_failed,within_exit3_repair_timeout,within_exit3_promise_repaired",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -170,6 +170,13 @@ noinst_PROGRAMS = redirection_test_stub
 redirection_test_stub_SOURCES = redirection_test_stub.c
 endif
 
+# Waits for a real SIGALRM. platform.h declares alarm() for Windows but no
+# implementation of it ships in this tree, so the test would have nothing to
+# wait for there.
+if !NT
+check_PROGRAMS += timeout_test
+endif
+
 check_SCRIPTS = dynamic_dependency_test.sh \
 	tar_portability_test.sh
 

--- a/tests/unit/timeout_test.c
+++ b/tests/unit/timeout_test.c
@@ -1,0 +1,124 @@
+#include <test.h>
+
+#include <cf3.defs.h>
+#include <cf3.extern.h>
+#include <timeout.h>
+
+/* The alarm handler interrupts the sleep, so this normally returns as soon as
+ * it fires. Loop anyway: the alarm may already have fired before we get here,
+ * and a sleep interrupted by anything else must not end the wait early. */
+static void WaitForAlarm(void)
+{
+    for (int i = 0; (i < 30) && !TimeOutHasFired(); i++)
+    {
+        struct timespec ts = { .tv_sec = 0, .tv_nsec = 100 * 1000 * 1000 };
+        nanosleep(&ts, NULL);
+    }
+}
+
+static void test_set_arms_and_resets_the_record(void)
+{
+    SetTimeOut(3600);
+    assert_true(TimeOutIsArmed());
+    assert_false(TimeOutHasFired());
+    assert_false(TimeOutSignalledProcess());
+    ClearTimeOut();
+}
+
+/* A command that finished in time must not leave the flag set for the next,
+ * unrelated, child: it is what decides whether cf_popen()'s child puts itself
+ * in a process group of its own. */
+static void test_clear_disarms(void)
+{
+    SetTimeOut(3600);
+    ClearTimeOut();
+    assert_false(TimeOutIsArmed());
+}
+
+static void test_fired_alarm_without_a_process(void)
+{
+    SetTimeOut(1);
+    WaitForAlarm();
+
+    assert_true(TimeOutHasFired());
+    /* Nothing else disarms on this path -- the handler does it itself. */
+    assert_false(TimeOutIsArmed());
+    /* SetTimeOut() cleared ALARM_PID, so there was no process to signal and
+     * the caller must not describe the command as terminated. */
+    assert_false(TimeOutSignalledProcess());
+}
+
+/* ClearTimeOut() runs after the command is reaped, before the caller reports
+ * on it. Clearing the record there would make a timed-out command whose exit
+ * status reads as success indistinguishable from one that finished. */
+static void test_clear_preserves_the_record(void)
+{
+    SetTimeOut(1);
+    WaitForAlarm();
+    assert_true(TimeOutHasFired());
+
+    ClearTimeOut();
+    assert_false(TimeOutIsArmed());
+    assert_true(TimeOutHasFired());
+    assert_false(TimeOutSignalledProcess());
+}
+
+/* The other tests never give TimeOut() a process to signal, so they cannot
+ * tell a ClearTimeOut() that wipes a TRUE TimeOutSignalledProcess() from one
+ * that leaves it alone -- both look identical when the flag started false.
+ * Fork a real child and let the alarm reach it. */
+static void test_clear_preserves_a_true_signalled_flag(void)
+{
+    pid_t child = fork();
+    if (child == 0)
+    {
+        /* Long enough to still be alive when TimeOut() runs GracefulTerminate()
+         * on it; short enough that a leaked child does not linger. */
+        sleep(5);
+        _exit(0);
+    }
+    assert_true(child > 0);
+
+    SetTimeOut(1);
+    ALARM_PID = child;
+    WaitForAlarm();
+
+    assert_true(TimeOutHasFired());
+    assert_true(TimeOutSignalledProcess());
+
+    ClearTimeOut();
+    assert_false(TimeOutIsArmed());
+    assert_true(TimeOutSignalledProcess());
+
+    int status;
+    waitpid(child, &status, 0);
+}
+
+static void test_next_set_resets_the_record(void)
+{
+    SetTimeOut(1);
+    WaitForAlarm();
+    assert_true(TimeOutHasFired());
+
+    SetTimeOut(3600);
+    assert_true(TimeOutIsArmed());
+    assert_false(TimeOutHasFired());
+    assert_false(TimeOutSignalledProcess());
+    ClearTimeOut();
+}
+
+int main()
+{
+    const UnitTest tests[] =
+    {
+        unit_test(test_set_arms_and_resets_the_record),
+        unit_test(test_clear_disarms),
+        unit_test(test_fired_alarm_without_a_process),
+        unit_test(test_clear_preserves_the_record),
+        unit_test(test_clear_preserves_a_true_signalled_flag),
+        unit_test(test_next_set_resets_the_record)
+    };
+
+    PRINT_TEST_BANNER();
+    return run_tests(tests);
+}

--- a/tests/unit/timeout_test.c
+++ b/tests/unit/timeout_test.c
@@ -2,6 +2,7 @@
 
 #include <cf3.defs.h>
 #include <cf3.extern.h>
+#include <pipes.h>
 #include <timeout.h>
 
 /* The alarm handler interrupts the sleep, so this normally returns as soon as
@@ -38,6 +39,9 @@ static void test_clear_disarms(void)
 static void test_fired_alarm_without_a_process(void)
 {
     SetTimeOut(1);
+    /* Production starts the clock only once a pid is registered; start it by
+     * hand to reach the handler's no-process branch. */
+    StartTimeOutClock();
     WaitForAlarm();
 
     assert_true(TimeOutHasFired());
@@ -54,6 +58,7 @@ static void test_fired_alarm_without_a_process(void)
 static void test_clear_preserves_the_record(void)
 {
     SetTimeOut(1);
+    StartTimeOutClock();
     WaitForAlarm();
     assert_true(TimeOutHasFired());
 
@@ -81,6 +86,8 @@ static void test_clear_preserves_a_true_signalled_flag(void)
 
     SetTimeOut(1);
     ALARM_PID = child;
+    /* Same order as cf_popen(): publish the pid, then start the clock. */
+    StartTimeOutClock();
     WaitForAlarm();
 
     assert_true(TimeOutHasFired());
@@ -97,6 +104,7 @@ static void test_clear_preserves_a_true_signalled_flag(void)
 static void test_next_set_resets_the_record(void)
 {
     SetTimeOut(1);
+    StartTimeOutClock();
     WaitForAlarm();
     assert_true(TimeOutHasFired());
 
@@ -105,6 +113,86 @@ static void test_next_set_resets_the_record(void)
     assert_false(TimeOutHasFired());
     assert_false(TimeOutSignalledProcess());
     ClearTimeOut();
+}
+
+/* The arming-order half of the timeout guarantee: the clock must not run
+ * before cf_popen() has a pid to kill. Arming immediately, as SetTimeOut()
+ * used to, lets the alarm fire during the caller's own setup -- umask(),
+ * logging, cf_popen dispatch -- and burn the whole timeout on nothing, after
+ * which the command runs unbounded.
+ *
+ * Deliberately not a fixed-wait liveness check: it waits twice the timeout
+ * before forking at all, so the old behaviour fires with certainty rather than
+ * by timing luck, and the command it then runs outlives its timeout by 4s. */
+static void test_clock_does_not_run_before_the_fork(void)
+{
+    SetTimeOut(1);
+
+    for (int i = 0; (i < 20) && !TimeOutHasFired(); i++)
+    {
+        struct timespec ts = { .tv_sec = 0, .tv_nsec = 100 * 1000 * 1000 };
+        nanosleep(&ts, NULL);
+    }
+    /* Two seconds into a one-second timeout, with no child yet. */
+    assert_false(TimeOutHasFired());
+
+    FILE *pp = cf_popen("/bin/sleep 5", "r", true);
+    assert_true(pp != NULL);
+
+    /* Ends at EOF, which arrives when the alarm terminates the child. */
+    char buf[64];
+    while (fread(buf, 1, sizeof(buf), pp) > 0)
+    {
+    }
+    cf_pclose(pp);
+
+    assert_true(TimeOutHasFired());
+    assert_true(TimeOutSignalledProcess());
+    ClearTimeOut();
+}
+
+static void test_set_leaves_the_clock_stopped(void)
+{
+    SetTimeOut(3600);
+    assert_true(TimeOutIsArmed());
+    /* alarm(0) returns the seconds left on a running clock, and 0 if none is
+     * running. Armed, but not yet ticking. */
+    assert_int_equal(alarm(0), 0);
+    ClearTimeOut();
+}
+
+/* One-shot: a second fork under the same timeout runs on the time already
+ * ticking, so the second start must not restart the command's budget. The
+ * second StartTimeOutClock() is deliberately issued against a *running* clock
+ * -- reading it with alarm(0) first would cancel it, and a starter that resets
+ * a live timer would then look identical to one that leaves it alone. */
+static void test_start_runs_the_clock_once(void)
+{
+    SetTimeOut(5);
+    StartTimeOutClock();
+
+    struct timespec ts = { .tv_sec = 1, .tv_nsec = 0 };
+    nanosleep(&ts, NULL);
+
+    StartTimeOutClock();
+
+    const int left = alarm(0);
+    assert_true(left > 0);
+    /* The remainder of the original 5s, not a fresh 5s. */
+    assert_true(left <= 4);
+    ClearTimeOut();
+}
+
+/* A timeout armed but never followed by a fork -- cf_popen() failing, or a
+ * caller returning early -- must be fully retired, not left able to start. */
+static void test_clear_retires_an_unstarted_clock(void)
+{
+    SetTimeOut(3600);
+    ClearTimeOut();
+
+    StartTimeOutClock();
+    assert_int_equal(alarm(0), 0);
+    assert_false(TimeOutIsArmed());
 }
 
 int main()
@@ -116,7 +204,11 @@ int main()
         unit_test(test_fired_alarm_without_a_process),
         unit_test(test_clear_preserves_the_record),
         unit_test(test_clear_preserves_a_true_signalled_flag),
-        unit_test(test_next_set_resets_the_record)
+        unit_test(test_next_set_resets_the_record),
+        unit_test(test_clock_does_not_run_before_the_fork),
+        unit_test(test_set_leaves_the_clock_stopped),
+        unit_test(test_start_runs_the_clock_once),
+        unit_test(test_clear_retires_an_unstarted_clock)
     };
 
     PRINT_TEST_BANNER();


### PR DESCRIPTION
Ticket: [CFE-4734](https://northerntech.atlassian.net/browse/CFE-4734)

> **Stacked on #6305.** Cut as a sibling from that PR's series, not stacked on #6310 or #6312. **The only new commit here is `ab98a5df4`.** If #6305 merges first this becomes a single-commit PR.

`SetTimeOut()` called `alarm()` immediately, but `cf_popen()` only registers the child in `ALARM_PID` after `fork()`. A `SIGALRM` delivered in that window — which spans `umask()`, logging and the `cf_popen` dispatch — found no process, burned the timeout on nothing, and the command then ran to completion unbounded by `exec_timeout`. Observed as a unit-test flake under parallel `make check` load.

`SetTimeOut()` now stashes the timeout and leaves the clock stopped; `cf_popen()` starts it via `StartTimeOutClock()` immediately after publishing the pid, so no alarm can be pending without a process to kill. One-shot per `SetTimeOut()`: a second fork under the same timeout runs on the remaining time, as before. `TIMEOUT_ARMED` is still set before the fork, so the child's process-group decision is unchanged, and the agent's own setup work is no longer charged against the command's budget.

mingw and cygwin keep arming in `SetTimeOut()` — they are exactly the platforms that do not build `pipes_unix.c`, so nothing there would reach the starter. (Guarding on `__MINGW32__` alone would have left Cygwin on the deferred path with no starter at all, since `AM_CONDITIONAL([NT])` is `mingw|cygwin`; `timeout_test` is `!NT` too, so no CI job would have caught it.)

This does not make the existing `SetTimeOut()` leaks safe and does not try to. A timeout armed but never followed by a successful `cf_popen` now leaves `TIMEOUT_PENDING` set with no timer running, and the next `GenericCreatePipeAndFork()` starts that *full* budget against whatever it forks — where before, the leaked alarm was already ticking and could only spend its remainder. Those leak sites are pre-existing and handled separately (CFE-4732, #6308).

**Testing** — unit 6/6 → 10/10; acceptance `08_commands/04_exec_timeout` 6/6 both sides (62 s → 74 s). Discrimination proved rather than asserted: rebuilding with the pre-fix arming order emulated fails exactly 2 of 10 (`test_clock_does_not_run_before_the_fork`, `test_set_leaves_the_clock_stopped`), both passing again on revert.

AI-assisted, reviewed and verified by me before submitting, per CONTRIBUTING.


[CFE-4734]: https://northerntech.atlassian.net/browse/CFE-4734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ