### PR TITLE
CFE-4735: Fixed ALARM_PID staying armed against a reaped pid on fdopen() failure

### DIFF
--- a/cf-agent/nfs.c
+++ b/cf-agent/nfs.c
@@ -578,8 +578,7 @@ bool LoadMountInfo(Seq *list)
     }
 
     free(vbuff);
-    alarm(0);
-    signal(SIGALRM, SIG_DFL);
+    ClearTimeOut();
     cf_pclose(pp);
     return true;
 }
@@ -1175,8 +1174,7 @@ void MountAll()
     }
 
     free(line);
-    alarm(0);
-    signal(SIGALRM, SIG_DFL);
+    ClearTimeOut();
     cf_pclose(pp);
 }
 

--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -288,6 +288,9 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
 
     CommandPrefix(cmdline, comm);
 
+    /* Set once the command has been reaped, if its exec_timeout fired. */
+    bool timed_out = false;
+
     bool do_work_here = true;
 
 #ifndef __MINGW32__
@@ -448,7 +451,31 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
         {
             int ret = cf_pclose(pfp);
 
-            if (ret == -1)
+            /* Sample only now, and never earlier. The read loop above ends as
+             * soon as the command closes its output, which it can do long
+             * before it exits -- so the alarm may not fire until cf_pclose()
+             * is already waiting for the child. Reading the flag before that
+             * wait misses exactly the case this is here to catch. It is still
+             * read before the alarm is disarmed further down. */
+            timed_out = (a->contain.timeout != CF_NOINT) && TimeOutHasFired();
+
+            if (timed_out)
+            {
+                /* The command exceeded exec_timeout and was signalled, so its
+                 * exit status cannot be trusted to say so. A command killed
+                 * after it has written its last output, or one that exits
+                 * normally while only its children are killed, is reaped with a
+                 * status VerifyCommandRetcode() reads as success -- and the
+                 * promise is then reported kept or repaired even though the
+                 * command never completed. Classify on the timeout instead. */
+                cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_TIMEOUT, pp, a,
+                     TimeOutSignalledProcess()
+                         ? "Command '%s' exceeded exec_timeout of %d seconds and was terminated"
+                         : "Command '%s' exceeded exec_timeout of %d seconds; it was NOT terminated and ran to completion",
+                     pp->promiser, a->contain.timeout);
+                *result = PromiseResultUpdate(*result, PROMISE_RESULT_TIMEOUT);
+            }
+            else if (ret == -1)
             {
                 cfPS(ctx, LOG_LEVEL_ERR, PROMISE_RESULT_FAIL, pp, a, "Finished script '%s' - failed (abnormal termination)", pp->promiser);
                 *result = PromiseResultUpdate(*result, PROMISE_RESULT_FAIL);
@@ -492,7 +519,7 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
     }
 #endif /* !__MINGW32__ */
 
-    return ACTION_RESULT_OK;
+    return timed_out ? ACTION_RESULT_TIMEOUT : ACTION_RESULT_OK;
 }
 
 /*************************************************************/

--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -371,6 +371,10 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
         if (pfp == NULL)
         {
             Log(LOG_LEVEL_ERR, "Couldn't open pipe to command '%s'. (cf_popen: %s)", cmdline, GetErrorStr());
+            if (a->contain.timeout != CF_NOINT)
+            {
+                ClearTimeOut();
+            }
             return ACTION_RESULT_FAILED;
         }
 

--- a/cf-agent/verify_exec.c
+++ b/cf-agent/verify_exec.c
@@ -472,8 +472,7 @@ static ActionResult RepairExec(EvalContext *ctx, const Attributes *a,
 
     if (a->contain.timeout != CF_NOINT)
     {
-        alarm(0);
-        signal(SIGALRM, SIG_DFL);
+        ClearTimeOut();
     }
 
     Log(info_or_verbose, "Completed execution of '%s'", cmdline);

--- a/cf-monitord/history.c
+++ b/cf-monitord/history.c
@@ -374,8 +374,7 @@ static Item *NovaReSample(EvalContext *ctx, int slot, const Attributes *attr, co
 
     if (a.contain.timeout != 0)
     {
-        alarm(0);
-        signal(SIGALRM, SIG_DFL);
+        ClearTimeOut();
     }
 
     Log(LOG_LEVEL_INFO, "Collected sample of %s", pp->promiser);

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -38,6 +38,7 @@
 static bool CfSetuid(uid_t uid, gid_t gid);
 
 static int cf_pwait(pid_t pid);
+static void ClearAlarmedPid(pid_t pid);
 
 static pid_t *CHILDREN = NULL; /* GLOBAL_X */
 static int MAX_FD = 2048; /* GLOBAL_X */ /* Max number of simultaneous pipes */
@@ -458,6 +459,7 @@ FILE *cf_popen_select(const char *command, const char *type, OutputSelect output
             if ((pp = fdopen(pd[0], type)) == NULL)
             {
                 cf_pwait(pid);
+                ClearAlarmedPid(pid);
                 ArgFree(argv);
                 return NULL;
             }
@@ -470,6 +472,7 @@ FILE *cf_popen_select(const char *command, const char *type, OutputSelect output
             if ((pp = fdopen(pd[1], type)) == NULL)
             {
                 cf_pwait(pid);
+                ClearAlarmedPid(pid);
                 ArgFree(argv);
                 return NULL;
             }
@@ -588,6 +591,7 @@ FILE *cf_popensetuid(const char *command, const Seq *arglist,
             if ((pp = fdopen(pd[0], type)) == NULL)
             {
                 cf_pwait(pid);
+                ClearAlarmedPid(pid);
                 ArgFree(argv);
                 return NULL;
             }
@@ -600,6 +604,7 @@ FILE *cf_popensetuid(const char *command, const Seq *arglist,
             if ((pp = fdopen(pd[1], type)) == NULL)
             {
                 cf_pwait(pid);
+                ClearAlarmedPid(pid);
                 ArgFree(argv);
                 return NULL;
             }
@@ -670,6 +675,7 @@ FILE *cf_popen_sh_select(const char *command, const char *type, OutputSelect out
             if ((pp = fdopen(pd[0], type)) == NULL)
             {
                 cf_pwait(pid);
+                ClearAlarmedPid(pid);
                 return NULL;
             }
             break;
@@ -681,6 +687,7 @@ FILE *cf_popen_sh_select(const char *command, const char *type, OutputSelect out
             if ((pp = fdopen(pd[1], type)) == NULL)
             {
                 cf_pwait(pid);
+                ClearAlarmedPid(pid);
                 return NULL;
             }
         }
@@ -789,6 +796,7 @@ FILE *cf_popen_shsetuid(const char *command, const char *type,
             if ((pp = fdopen(pd[0], type)) == NULL)
             {
                 cf_pwait(pid);
+                ClearAlarmedPid(pid);
                 return NULL;
             }
             break;
@@ -800,6 +808,7 @@ FILE *cf_popen_shsetuid(const char *command, const char *type,
             if ((pp = fdopen(pd[1], type)) == NULL)
             {
                 cf_pwait(pid);
+                ClearAlarmedPid(pid);
                 return NULL;
             }
         }

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -846,6 +846,31 @@ static int cf_pwait(pid_t pid)
     return retcode;
 }
 
+/* The pid the timeout alarm would signal stays registered until the child is
+ * actually reaped: cf_pwait() blocks with no bound of its own, and a command
+ * that closed its output but kept running is terminated by TimeOut() during
+ * exactly that wait. Deregistered only afterwards, with SIGALRM blocked so
+ * the handler cannot read the pid of an already-reaped -- and from then on
+ * recyclable -- process halfway through the clear.
+ *
+ * pthread_sigmask(), not sigprocmask(): this closer is reached from
+ * cf-serverd/cf-execd worker threads (DoExec2(), LocalExecThread()), and
+ * POSIX leaves sigprocmask()'s effect in a multithreaded process
+ * unspecified -- house style elsewhere in this tree (signal_lib.h,
+ * client_code.c) already uses pthread_sigmask() for exactly this reason. */
+static void ClearAlarmedPid(pid_t pid)
+{
+    sigset_t sigalrm, oldmask;
+    sigemptyset(&sigalrm);
+    sigaddset(&sigalrm, SIGALRM);
+    pthread_sigmask(SIG_BLOCK, &sigalrm, &oldmask);
+    if (ALARM_PID == pid)
+    {
+        ALARM_PID = -1;
+    }
+    pthread_sigmask(SIG_SETMASK, &oldmask, NULL);
+}
+
 /*******************************************************************/
 
 /**
@@ -881,8 +906,6 @@ int cf_pclose(FILE *pp)
         return -1;
     }
 
-    ALARM_PID = -1;
-
     if (fd >= MAX_FD)
     {
         ThreadUnlock(cft_count);
@@ -904,7 +927,9 @@ int cf_pclose(FILE *pp)
             GetErrorStr());
     }
 
-    return cf_pwait(pid);
+    int ret = cf_pwait(pid);
+    ClearAlarmedPid(pid);
+    return ret;
 }
 
 int cf_pclose_full_duplex_side(int fd)
@@ -969,7 +994,6 @@ int cf_pclose_full_duplex(IOData *data)
         return -1;
     }
 
-    ALARM_PID = -1;
     pid_t pid = 0;
 
     /* Safe as pipes[1] is -1 if not initialized */
@@ -1035,7 +1059,9 @@ int cf_pclose_full_duplex(IOData *data)
         return -1;
     }
 
-    return cf_pwait(pid);
+    int ret = cf_pwait(pid);
+    ClearAlarmedPid(pid);
+    return ret;
 }
 
 bool PipeToPid(pid_t *pid, FILE *pp)

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -236,6 +236,13 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
         sigset_t sigmask;
         sigemptyset(&sigmask);
         sigprocmask(SIG_SETMASK, &sigmask, NULL);
+
+        /* Lead a new process group, so that anything the command spawns can be
+         * signalled as a unit. Without this only the direct child is reachable,
+         * and a grandchild outlives exec_timeout still holding the pipe open,
+         * which leaves the parent blocked reading it. setpgid() is
+         * async-signal-safe, so it is legal here. */
+        setpgid(0, 0);
     }
 
     ALARM_PID = (pid != 0 ? pid : -1);

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -255,7 +255,17 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
          * must stay in ours. */
         if (TimeOutIsArmed())
         {
-            setpgid(0, 0);
+            if (setpgid(0, 0) != 0)
+            {
+                /* The command stays in our group, so TimeOut()'s check of its
+                 * group will skip the group kill; only its descendants are
+                 * then out of the timeout's reach. Log() is not
+                 * async-signal-safe, so it is confined to this failure branch,
+                 * where the alternative is losing the descendants silently. */
+                Log(LOG_LEVEL_WARNING,
+                    "Could not give the timed command its own process group (setpgid: %s), its descendants will survive a timeout",
+                    GetErrorStr());
+            }
         }
     }
 

--- a/libpromises/pipes_unix.c
+++ b/libpromises/pipes_unix.c
@@ -33,6 +33,7 @@
 #include <file_lib.h>
 #include <signals.h>
 #include <string_lib.h>
+#include <timeout.h>
 
 static bool CfSetuid(uid_t uid, gid_t gid);
 
@@ -237,12 +238,25 @@ static pid_t GenericCreatePipeAndFork(IOPipe *pipes)
         sigemptyset(&sigmask);
         sigprocmask(SIG_SETMASK, &sigmask, NULL);
 
-        /* Lead a new process group, so that anything the command spawns can be
-         * signalled as a unit. Without this only the direct child is reachable,
-         * and a grandchild outlives exec_timeout still holding the pipe open,
-         * which leaves the parent blocked reading it. setpgid() is
-         * async-signal-safe, so it is legal here. */
-        setpgid(0, 0);
+        /* When a timeout is armed, lead a new process group, so that anything
+         * the command spawns can be signalled as a unit. Without this only the
+         * direct child is reachable, and a grandchild outlives exec_timeout
+         * still holding the pipe open, which leaves the parent blocked reading
+         * it. setpgid() is async-signal-safe, so it is legal here.
+         *
+         * Only when a timeout is armed. A child in a process group of its own
+         * is no longer in the terminal's foreground group, so on an interactive
+         * run it is stopped by SIGTTIN the moment it reads the terminal, and
+         * the agent then blocks forever on the pipe -- the very hang this is
+         * meant to bound, reintroduced on a path with no timeout to end it. It
+         * also leaves the child out of reach of a terminal SIGINT and of
+         * cf-execd's agent_expireafter, both of which kill by process group.
+         * Children with no timeout have nothing to bound their wait, so they
+         * must stay in ours. */
+        if (TimeOutIsArmed())
+        {
+            setpgid(0, 0);
+        }
     }
 
     ALARM_PID = (pid != 0 ? pid : -1);

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -26,11 +26,34 @@
 #include <timeout.h>
 #include <process_lib.h>
 
+/* Set by TimeOut() when the alarm fires, so that the caller can tell "the
+ * command timed out" from "the command finished". Written from a signal
+ * handler, hence volatile sig_atomic_t. */
+static volatile sig_atomic_t TIMEOUT_FIRED = 0; /* GLOBAL_X */
+
+/* Set only when TimeOut() actually had a process to signal. The alarm can fire
+ * with ALARM_PID already cleared -- cf_pclose() clears it before waiting -- in
+ * which case the command timed out but was never terminated, and saying
+ * otherwise would be a false statement in an error message. */
+static volatile sig_atomic_t TIMEOUT_SIGNALLED = 0; /* GLOBAL_X */
+
 void SetTimeOut(int timeout)
 {
     ALARM_PID = -1;
+    TIMEOUT_FIRED = 0;
+    TIMEOUT_SIGNALLED = 0;
     signal(SIGALRM, (void *) TimeOut);
     alarm(timeout);
+}
+
+bool TimeOutHasFired(void)
+{
+    return TIMEOUT_FIRED != 0;
+}
+
+bool TimeOutSignalledProcess(void)
+{
+    return TIMEOUT_SIGNALLED != 0;
 }
 
 /*************************************************************************/
@@ -38,9 +61,11 @@ void SetTimeOut(int timeout)
 void TimeOut()
 {
     alarm(0);
+    TIMEOUT_FIRED = 1;
 
     if (ALARM_PID != -1)
     {
+        TIMEOUT_SIGNALLED = 1;
         Log(LOG_LEVEL_VERBOSE, "Time out of process %jd", (intmax_t)ALARM_PID);
         GracefulTerminate(ALARM_PID, PROCESS_START_TIME_UNKNOWN);
     }

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -94,6 +94,12 @@ void TimeOut()
          * once GracefulTerminate() has killed it, getpgid() fails with ESRCH and
          * we would have no safe way to tell whether it led a group of its own. */
         const pid_t pgid = getpgid(ALARM_PID);
+        if (pgid == -1)
+        {
+            Log(LOG_LEVEL_WARNING,
+                "Could not read the process group of timed-out process %jd (getpgid: %s), not signalling its process group",
+                (intmax_t)ALARM_PID, GetErrorStr());
+        }
 
         GracefulTerminate(ALARM_PID, PROCESS_START_TIME_UNKNOWN);
 

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -31,10 +31,11 @@
  * handler, hence volatile sig_atomic_t. */
 static volatile sig_atomic_t TIMEOUT_FIRED = 0; /* GLOBAL_X */
 
-/* Set only when TimeOut() actually had a process to signal. The alarm can fire
- * with ALARM_PID already cleared -- cf_pclose() clears it before waiting -- in
- * which case the command timed out but was never terminated, and saying
- * otherwise would be a false statement in an error message. */
+/* Set only when TimeOut() actually had a process to signal. The alarm can
+ * still fire with no process registered -- before cf_popen() has forked, or
+ * after cf_pclose() has reaped a child that finished just under the wire --
+ * in which case nothing was terminated, and saying otherwise would be a false
+ * statement in an error message. */
 static volatile sig_atomic_t TIMEOUT_SIGNALLED = 0; /* GLOBAL_X */
 
 /* Set while a timeout alarm is pending. cf_popen()'s child consults it to

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -39,15 +39,16 @@ static volatile sig_atomic_t TIMEOUT_SIGNALLED = 0; /* GLOBAL_X */
 
 /* Set while a timeout alarm is pending. cf_popen()'s child consults it to
  * decide whether to lead a process group of its own; only a child that may
- * have to be killed as a tree needs one. */
-static bool TIMEOUT_ARMED = false; /* GLOBAL_X */
+ * have to be killed as a tree needs one. Cleared from the signal handler as
+ * well as from ClearTimeOut(), hence volatile sig_atomic_t. */
+static volatile sig_atomic_t TIMEOUT_ARMED = 0; /* GLOBAL_X */
 
 void SetTimeOut(int timeout)
 {
     ALARM_PID = -1;
     TIMEOUT_FIRED = 0;
     TIMEOUT_SIGNALLED = 0;
-    TIMEOUT_ARMED = true;
+    TIMEOUT_ARMED = 1;
     signal(SIGALRM, (void *) TimeOut);
     alarm(timeout);
 }
@@ -59,12 +60,12 @@ void ClearTimeOut(void)
      * after the disarm. Only the next SetTimeOut() resets them. */
     alarm(0);
     signal(SIGALRM, SIG_DFL);
-    TIMEOUT_ARMED = false;
+    TIMEOUT_ARMED = 0;
 }
 
 bool TimeOutIsArmed(void)
 {
-    return TIMEOUT_ARMED;
+    return TIMEOUT_ARMED != 0;
 }
 
 bool TimeOutHasFired(void)
@@ -83,13 +84,14 @@ void TimeOut()
 {
     alarm(0);
     TIMEOUT_FIRED = 1;
-    TIMEOUT_ARMED = false;
+    TIMEOUT_ARMED = 0;
 
     if (ALARM_PID != -1)
     {
         TIMEOUT_SIGNALLED = 1;
         Log(LOG_LEVEL_VERBOSE, "Time out of process %jd", (intmax_t)ALARM_PID);
 
+#ifndef __MINGW32__
         /* Read the process group while the process is still alive to be read:
          * once GracefulTerminate() has killed it, getpgid() fails with ESRCH and
          * we would have no safe way to tell whether it led a group of its own. */
@@ -100,9 +102,11 @@ void TimeOut()
                 "Could not read the process group of timed-out process %jd (getpgid: %s), not signalling its process group",
                 (intmax_t)ALARM_PID, GetErrorStr());
         }
+#endif
 
         GracefulTerminate(ALARM_PID, PROCESS_START_TIME_UNKNOWN);
 
+#ifndef __MINGW32__
         /* GracefulTerminate() only reaches the process we started. Anything that
          * process spawned survives it, and keeps the pipe open, so the caller
          * stays blocked reading a command it has already given up on.
@@ -111,11 +115,16 @@ void TimeOut()
          * cf_popen()'s child arranges with setpgid(). If that did not take
          * effect the process is still in our group, its pgid is not its pid, and
          * a negative kill() here would signal an unrelated group -- possibly our
-         * own. */
+         * own.
+         *
+         * Windows has no POSIX process groups and no setpgid() in the child
+         * (cf_popen() lives in pipes_unix.c), so there is nothing to widen the
+         * signal to there. */
         if (pgid == ALARM_PID)
         {
             kill(-ALARM_PID, SIGKILL);
         }
+#endif
     }
     else
     {

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -42,7 +42,27 @@ void TimeOut()
     if (ALARM_PID != -1)
     {
         Log(LOG_LEVEL_VERBOSE, "Time out of process %jd", (intmax_t)ALARM_PID);
+
+        /* Read the process group while the process is still alive to be read:
+         * once GracefulTerminate() has killed it, getpgid() fails with ESRCH and
+         * we would have no safe way to tell whether it led a group of its own. */
+        const pid_t pgid = getpgid(ALARM_PID);
+
         GracefulTerminate(ALARM_PID, PROCESS_START_TIME_UNKNOWN);
+
+        /* GracefulTerminate() only reaches the process we started. Anything that
+         * process spawned survives it, and keeps the pipe open, so the caller
+         * stays blocked reading a command it has already given up on.
+         *
+         * Guarded on the timed-out process leading its own group, which
+         * cf_popen()'s child arranges with setpgid(). If that did not take
+         * effect the process is still in our group, its pgid is not its pid, and
+         * a negative kill() here would signal an unrelated group -- possibly our
+         * own. */
+        if (pgid == ALARM_PID)
+        {
+            kill(-ALARM_PID, SIGKILL);
+        }
     }
     else
     {

--- a/libpromises/timeout.c
+++ b/libpromises/timeout.c
@@ -26,11 +26,29 @@
 #include <timeout.h>
 #include <process_lib.h>
 
+/* Set while a timeout alarm is pending. cf_popen()'s child consults it to
+ * decide whether to lead a process group of its own; only a child that may
+ * have to be killed as a tree needs one. */
+static bool TIMEOUT_ARMED = false; /* GLOBAL_X */
+
 void SetTimeOut(int timeout)
 {
     ALARM_PID = -1;
+    TIMEOUT_ARMED = true;
     signal(SIGALRM, (void *) TimeOut);
     alarm(timeout);
+}
+
+void ClearTimeOut(void)
+{
+    alarm(0);
+    signal(SIGALRM, SIG_DFL);
+    TIMEOUT_ARMED = false;
+}
+
+bool TimeOutIsArmed(void)
+{
+    return TIMEOUT_ARMED;
 }
 
 /*************************************************************************/
@@ -38,6 +56,7 @@ void SetTimeOut(int timeout)
 void TimeOut()
 {
     alarm(0);
+    TIMEOUT_ARMED = false;
 
     if (ALARM_PID != -1)
     {

--- a/libpromises/timeout.h
+++ b/libpromises/timeout.h
@@ -26,6 +26,16 @@
 #define CFENGINE_TIMEOUT_H
 
 void SetTimeOut(int timeout);
+
+/* True between SetTimeOut() arming the alarm and the alarm being disarmed.
+ * Consulted by code that forks a child which the timeout may have to
+ * terminate, to decide whether that child needs a process group of its own. */
+bool TimeOutIsArmed(void);
+
+/* Cancel a pending alarm and restore the default handler. Callers used to
+ * open-code this; it also has to clear the armed flag, so that a command which
+ * completes in time does not leave it set for the next, unrelated, child. */
+void ClearTimeOut(void);
 void TimeOut(void);
 time_t SetReferenceTime(void);
 

--- a/libpromises/timeout.h
+++ b/libpromises/timeout.h
@@ -26,6 +26,16 @@
 #define CFENGINE_TIMEOUT_H
 
 void SetTimeOut(int timeout);
+
+/* True if the alarm armed by the last SetTimeOut() actually fired. Lets a
+ * caller report that a command was timed out even when the command's own exit
+ * status would otherwise read as success. Cleared by SetTimeOut(). */
+bool TimeOutHasFired(void);
+
+/* True if that alarm also had a process to signal. False means the command
+ * exceeded its timeout but was never terminated, which callers must not
+ * describe as a termination. */
+bool TimeOutSignalledProcess(void);
 void TimeOut(void);
 time_t SetReferenceTime(void);
 

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_after_output_closed.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_after_output_closed.cf
@@ -1,0 +1,61 @@
+#######################################################
+#
+# Test that exec_timeout is detected even when the command
+# closes its output long before it exits. The agent's read
+# loop ends at EOF, so it is already waiting for the child
+# when the alarm fires; a timeout sampled while output was
+# still open misses exactly this shape. The command then runs
+# to completion and exits 0, and must still be reported as
+# timed out.
+#
+# Deliberately slow: with its output already closed there is
+# no process left registered for the alarm to signal, so the
+# child's full 10 second sleep runs out before it is reaped.
+# Expect around 12 seconds of wall clock.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "exec_timeout is detected when the command closes its output before it exits";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with a POSIX shell payload";
+
+  commands:
+    "/bin/sh"
+      arglist => { "-c", "exec 1>&- 2>&-; sleep 10; exit 0" },
+      contain => exec_timeout_2,
+      classes => dcs_all_classes("output_closed");
+}
+
+body contain exec_timeout_2
+{
+  exec_timeout => "2";
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "output_closed_repair_timeout",
+        "output_closed_promise_kept,output_closed_promise_repaired",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_after_output_closed.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_after_output_closed.cf
@@ -1,17 +1,27 @@
 #######################################################
 #
-# Test that exec_timeout is detected even when the command
-# closes its output long before it exits. The agent's read
-# loop ends at EOF, so it is already waiting for the child
+# Test that exec_timeout is detected AND enforced when the
+# command closes its output long before it exits. The agent's
+# read loop ends at EOF, so it is already waiting for the child
 # when the alarm fires; a timeout sampled while output was
-# still open misses exactly this shape. The command then runs
-# to completion and exits 0, and must still be reported as
-# timed out.
+# still open misses exactly this shape, and a pid registry
+# cleared before the wait leaves the alarm nothing to signal --
+# the child then runs its full sleep out. The command must be
+# reported as timed out and be terminated, never reaching the
+# completion marker after its sleep.
 #
-# Deliberately slow: with its output already closed there is
-# no process left registered for the alarm to signal, so the
-# child's full 10 second sleep runs out before it is reaped.
-# Expect around 12 seconds of wall clock.
+# The sleep is 30 seconds and the elapsed bound 25 because the
+# termination can take a while: each of the ladder's two waits
+# is nominally 1 second but iteration-counted, which overshoots
+# several-fold on Darwin (CFE-4728), and without process_darwin.c
+# the ladder cannot see the child die and burns its full waits
+# regardless (CFE-4718). Terminated is ~2+2 seconds where those
+# are fixed and up to ~20 here; only running to completion
+# reaches 30.
+#
+# The elapsed time is measured between two marker files touched
+# immediately before and after the timed promise; commands in a
+# bundle run in order of declaration.
 #
 #######################################################
 body common control
@@ -22,11 +32,23 @@ body common control
 }
 
 #######################################################
+bundle agent init
+{
+  files:
+    # The markers must come from this run: a stale pair could carry a
+    # bounded-looking mtime difference from an earlier one, and a stale
+    # completion marker would fail the run for the wrong reason.
+    "$(G.testdir)/oc_start" delete => tidy;
+    "$(G.testdir)/oc_end" delete => tidy;
+    "$(G.testdir)/oc_completed" delete => tidy;
+}
+
+#######################################################
 bundle agent test
 {
   meta:
     "description"
-      string => "exec_timeout is detected when the command closes its output before it exits";
+      string => "exec_timeout terminates a command that closed its output before it exits";
 
     "test_skip_unsupported"
       string => "windows",
@@ -34,9 +56,15 @@ bundle agent test
 
   commands:
     "/bin/sh"
-      arglist => { "-c", "exec 1>&- 2>&-; sleep 10; exit 0" },
+      arglist => { "-c", "touch $(G.testdir)/oc_start" };
+
+    "/bin/sh"
+      arglist => { "-c", "exec 1>&- 2>&-; sleep 30; touch $(G.testdir)/oc_completed; exit 0" },
       contain => exec_timeout_2,
       classes => dcs_all_classes("output_closed");
+
+    "/bin/sh"
+      arglist => { "-c", "touch $(G.testdir)/oc_end" };
 }
 
 body contain exec_timeout_2
@@ -47,10 +75,32 @@ body contain exec_timeout_2
 #######################################################
 bundle agent check
 {
+  vars:
+    "start" string => filestat("$(G.testdir)/oc_start", "mtime");
+    "end" string => filestat("$(G.testdir)/oc_end", "mtime");
+    "elapsed" string => eval("$(end) - $(start)", "math", "infix");
+
+  classes:
+    # The fileexists() guards keep a missing marker from passing as
+    # boundedness.
+    "bounded"
+      and => {
+        fileexists("$(G.testdir)/oc_start"),
+        fileexists("$(G.testdir)/oc_end"),
+        islessthan("$(elapsed)", "25")
+      },
+      scope => "namespace";
+
+    # The payload only touches this after its sleep; a terminated
+    # command never reaches it.
+    "terminated"
+      not => fileexists("$(G.testdir)/oc_completed"),
+      scope => "namespace";
+
   methods:
     "any"
       usebundle => dcs_passif_expected(
-        "output_closed_repair_timeout",
+        "output_closed_repair_timeout,bounded,terminated",
         "output_closed_promise_kept,output_closed_promise_repaired",
         $(this.promise_filename)
       ),

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_does_not_leak_to_next_promise.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_does_not_leak_to_next_promise.cf
@@ -1,0 +1,66 @@
+#######################################################
+#
+# Test that a fired exec_timeout is charged to the promise
+# whose command timed out, and only that promise: a
+# subsequent commands: promise that finishes inside its own
+# timeout must come out repaired, not timed out.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "A fired exec_timeout does not leak into the next commands promise";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with POSIX shell payloads";
+
+  commands:
+    "/bin/sh"
+      arglist => { "-c", "sleep 2.4; exit 0" },
+      contain => exec_timeout_2,
+      classes => dcs_all_classes("leak_first");
+
+    # Runs after the first command has already timed out, armed with
+    # its own timeout so that a stale flag surviving from the first
+    # promise would be sampled here if it leaked.
+    "/bin/sh"
+      arglist => { "-c", "exit 0" },
+      contain => exec_timeout_10,
+      classes => dcs_all_classes("leak_second");
+}
+
+body contain exec_timeout_2
+{
+  exec_timeout => "2";
+}
+
+body contain exec_timeout_10
+{
+  exec_timeout => "10";
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "leak_first_repair_timeout,leak_second_promise_repaired",
+        "leak_first_promise_kept,leak_first_promise_repaired,leak_second_repair_timeout",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_kills_descendants.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_kills_descendants.cf
@@ -1,0 +1,98 @@
+#######################################################
+#
+# Test that a fired exec_timeout also ends the command's
+# descendants. The termination ladder only reaches the direct
+# child; the sleep the shell spawned inherits the write end of
+# the output pipe, and if it survives the timeout it holds that
+# pipe open for its full 30 seconds while the agent sits in its
+# read loop -- exec_timeout then does not bound the promise's
+# wall clock at all. Killing the command's process group ends
+# the sleep at the timeout, so the promise completes in well
+# under 20 seconds.
+#
+# The elapsed time is measured between two marker files touched
+# immediately before and after the timed promise; commands in a
+# bundle run in order of declaration.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent init
+{
+  files:
+    # The markers must come from this run: a stale pair could carry a
+    # bounded-looking mtime difference from an earlier one.
+    "$(G.testdir)/desc_start" delete => tidy;
+    "$(G.testdir)/desc_end" delete => tidy;
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "A fired exec_timeout terminates the command's descendants";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with POSIX shell payloads";
+
+  commands:
+    "/bin/sh"
+      arglist => { "-c", "touch $(G.testdir)/desc_start" };
+
+    # The shell waits for its sleep, so at the 2 second timeout the
+    # sleep is alive holding the pipe. Only ending it too releases
+    # the pipe before its natural end at 30 seconds.
+    "/bin/sh"
+      arglist => { "-c", "sleep 30; exit 0" },
+      contain => exec_timeout_2,
+      classes => dcs_all_classes("desc_timed");
+
+    "/bin/sh"
+      arglist => { "-c", "touch $(G.testdir)/desc_end" };
+}
+
+body contain exec_timeout_2
+{
+  exec_timeout => "2";
+}
+
+#######################################################
+bundle agent check
+{
+  vars:
+    "start" string => filestat("$(G.testdir)/desc_start", "mtime");
+    "end" string => filestat("$(G.testdir)/desc_end", "mtime");
+    "elapsed" string => eval("$(end) - $(start)", "math", "infix");
+
+  classes:
+    # 20 is well past the ~10 seconds the timeout plus termination
+    # ladder takes, and well short of the sleep's 30. The fileexists()
+    # guards keep a missing marker from passing as boundedness.
+    "bounded"
+      and => {
+        fileexists("$(G.testdir)/desc_start"),
+        fileexists("$(G.testdir)/desc_end"),
+        islessthan("$(elapsed)", "20")
+      },
+      scope => "namespace";
+
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "desc_timed_repair_timeout,bounded",
+        "desc_timed_promise_kept,desc_timed_promise_repaired",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_overrides_exit_zero.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_overrides_exit_zero.cf
@@ -1,0 +1,58 @@
+#######################################################
+#
+# Test that a commands: promise whose exec_timeout fires is
+# reported as timed out even though the command exits 0. The
+# exit status of a command that was signalled does not say
+# whether it ran to completion, so a fired timeout must take
+# precedence over a successful exit status.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "A fired exec_timeout takes precedence over a successful exit status";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with a POSIX shell payload";
+
+  commands:
+    # The sleep outlives the 2 second timeout by less than the
+    # termination ladder's grace period, so the signalled shell
+    # still reaps its child and exits 0 -- the shape in which the
+    # exit status used to win over the fired timeout.
+    "/bin/sh"
+      arglist => { "-c", "sleep 2.4; exit 0" },
+      contain => exec_timeout_2,
+      classes => dcs_all_classes("timeout_exit0");
+}
+
+body contain exec_timeout_2
+{
+  exec_timeout => "2";
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "timeout_exit0_repair_timeout",
+        "timeout_exit0_promise_kept,timeout_exit0_promise_repaired",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/04_exec_timeout/timeout_overrides_kept_returncodes.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/timeout_overrides_kept_returncodes.cf
@@ -1,0 +1,66 @@
+#######################################################
+#
+# Test that kept_returncodes does not resurrect "kept" when
+# exec_timeout fired: the timed-out command exits 0, and 0 is
+# listed in kept_returncodes, but the promise must still be
+# reported as timed out, not kept.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "kept_returncodes does not resurrect kept when exec_timeout fired";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with a POSIX shell payload";
+
+  commands:
+    "/bin/sh"
+      arglist => { "-c", "sleep 2.4; exit 0" },
+      contain => exec_timeout_2,
+      classes => all_classes_kept_0("timeout_kept0");
+}
+
+body contain exec_timeout_2
+{
+  exec_timeout => "2";
+}
+
+# dcs_all_classes (dcs.sub.cf) carries no returncode attributes and
+# classes bodies do not compose, so this is dcs_all_classes plus
+# kept_returncodes.
+body classes all_classes_kept_0(prefix)
+{
+  promise_kept => { "$(prefix)_promise_kept" };
+  promise_repaired => { "$(prefix)_promise_repaired" };
+  repair_failed => { "$(prefix)_repair_failed" };
+  repair_denied => { "$(prefix)_repair_denied" };
+  repair_timeout => { "$(prefix)_repair_timeout" };
+  kept_returncodes => { "0" };
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "timeout_kept0_repair_timeout",
+        "timeout_kept0_promise_kept,timeout_kept0_promise_repaired",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/acceptance/08_commands/04_exec_timeout/within_timeout_normal_outcomes.cf
+++ b/tests/acceptance/08_commands/04_exec_timeout/within_timeout_normal_outcomes.cf
@@ -1,0 +1,59 @@
+#######################################################
+#
+# Test that an armed exec_timeout that does not fire leaves
+# the outcome of a commands: promise to the exit status: 0
+# repairs the promise and non-zero fails it, exactly as if no
+# timeout were set. Guards the normal path against
+# regressions from the timed-out path.
+#
+#######################################################
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  meta:
+    "description"
+      string => "An exec_timeout that does not fire leaves the outcome to the exit status";
+
+    "test_skip_unsupported"
+      string => "windows",
+      comment => "Drives /bin/sh with POSIX shell payloads";
+
+  commands:
+    "/bin/sh"
+      arglist => { "-c", "sleep 1; exit 0" },
+      contain => exec_timeout_10,
+      classes => dcs_all_classes("within_exit0");
+
+    "/bin/sh"
+      arglist => { "-c", "sleep 1; exit 3" },
+      contain => exec_timeout_10,
+      classes => dcs_all_classes("within_exit3");
+}
+
+body contain exec_timeout_10
+{
+  exec_timeout => "10";
+}
+
+#######################################################
+bundle agent check
+{
+  methods:
+    "any"
+      usebundle => dcs_passif_expected(
+        "within_exit0_promise_repaired,within_exit3_repair_failed",
+        "within_exit0_repair_timeout,within_exit0_repair_failed,within_exit3_repair_timeout,within_exit3_promise_repaired",
+        $(this.promise_filename)
+      ),
+      inherit => "true";
+}
+
+### PROJECT_ID: core
+### CATEGORY_ID: 26

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -170,6 +170,13 @@ noinst_PROGRAMS = redirection_test_stub
 redirection_test_stub_SOURCES = redirection_test_stub.c
 endif
 
+# Waits for a real SIGALRM. platform.h declares alarm() for Windows but no
+# implementation of it ships in this tree, so the test would have nothing to
+# wait for there.
+if !NT
+check_PROGRAMS += timeout_test
+endif
+
 check_SCRIPTS = dynamic_dependency_test.sh \
 	tar_portability_test.sh
 

--- a/tests/unit/timeout_test.c
+++ b/tests/unit/timeout_test.c
@@ -1,0 +1,124 @@
+#include <test.h>
+
+#include <cf3.defs.h>
+#include <cf3.extern.h>
+#include <timeout.h>
+
+/* The alarm handler interrupts the sleep, so this normally returns as soon as
+ * it fires. Loop anyway: the alarm may already have fired before we get here,
+ * and a sleep interrupted by anything else must not end the wait early. */
+static void WaitForAlarm(void)
+{
+    for (int i = 0; (i < 30) && !TimeOutHasFired(); i++)
+    {
+        struct timespec ts = { .tv_sec = 0, .tv_nsec = 100 * 1000 * 1000 };
+        nanosleep(&ts, NULL);
+    }
+}
+
+static void test_set_arms_and_resets_the_record(void)
+{
+    SetTimeOut(3600);
+    assert_true(TimeOutIsArmed());
+    assert_false(TimeOutHasFired());
+    assert_false(TimeOutSignalledProcess());
+    ClearTimeOut();
+}
+
+/* A command that finished in time must not leave the flag set for the next,
+ * unrelated, child: it is what decides whether cf_popen()'s child puts itself
+ * in a process group of its own. */
+static void test_clear_disarms(void)
+{
+    SetTimeOut(3600);
+    ClearTimeOut();
+    assert_false(TimeOutIsArmed());
+}
+
+static void test_fired_alarm_without_a_process(void)
+{
+    SetTimeOut(1);
+    WaitForAlarm();
+
+    assert_true(TimeOutHasFired());
+    /* Nothing else disarms on this path -- the handler does it itself. */
+    assert_false(TimeOutIsArmed());
+    /* SetTimeOut() cleared ALARM_PID, so there was no process to signal and
+     * the caller must not describe the command as terminated. */
+    assert_false(TimeOutSignalledProcess());
+}
+
+/* ClearTimeOut() runs after the command is reaped, before the caller reports
+ * on it. Clearing the record there would make a timed-out command whose exit
+ * status reads as success indistinguishable from one that finished. */
+static void test_clear_preserves_the_record(void)
+{
+    SetTimeOut(1);
+    WaitForAlarm();
+    assert_true(TimeOutHasFired());
+
+    ClearTimeOut();
+    assert_false(TimeOutIsArmed());
+    assert_true(TimeOutHasFired());
+    assert_false(TimeOutSignalledProcess());
+}
+
+/* The other tests never give TimeOut() a process to signal, so they cannot
+ * tell a ClearTimeOut() that wipes a TRUE TimeOutSignalledProcess() from one
+ * that leaves it alone -- both look identical when the flag started false.
+ * Fork a real child and let the alarm reach it. */
+static void test_clear_preserves_a_true_signalled_flag(void)
+{
+    pid_t child = fork();
+    if (child == 0)
+    {
+        /* Long enough to still be alive when TimeOut() runs GracefulTerminate()
+         * on it; short enough that a leaked child does not linger. */
+        sleep(5);
+        _exit(0);
+    }
+    assert_true(child > 0);
+
+    SetTimeOut(1);
+    ALARM_PID = child;
+    WaitForAlarm();
+
+    assert_true(TimeOutHasFired());
+    assert_true(TimeOutSignalledProcess());
+
+    ClearTimeOut();
+    assert_false(TimeOutIsArmed());
+    assert_true(TimeOutSignalledProcess());
+
+    int status;
+    waitpid(child, &status, 0);
+}
+
+static void test_next_set_resets_the_record(void)
+{
+    SetTimeOut(1);
+    WaitForAlarm();
+    assert_true(TimeOutHasFired());
+
+    SetTimeOut(3600);
+    assert_true(TimeOutIsArmed());
+    assert_false(TimeOutHasFired());
+    assert_false(TimeOutSignalledProcess());
+    ClearTimeOut();
+}
+
+int main()
+{
+    const UnitTest tests[] =
+    {
+        unit_test(test_set_arms_and_resets_the_record),
+        unit_test(test_clear_disarms),
+        unit_test(test_fired_alarm_without_a_process),
+        unit_test(test_clear_preserves_the_record),
+        unit_test(test_clear_preserves_a_true_signalled_flag),
+        unit_test(test_next_set_resets_the_record)
+    };
+
+    PRINT_TEST_BANNER();
+    return run_tests(tests);
+}

--- a/tests/unit/timeout_test.c
+++ b/tests/unit/timeout_test.c
@@ -4,6 +4,7 @@
 #include <cf3.extern.h>
 #include <timeout.h>
 #include <pipes.h>
+#include <sys/resource.h>
 
 /* The alarm handler interrupts the sleep, so this normally returns as soon as
  * it fires. Loop anyway: the alarm may already have fired before we get here,
@@ -150,6 +151,78 @@ static void test_pclose_leaves_the_alarm_its_process(void)
     assert_true(ALARM_PID == -1);
 }
 
+/* CFE-4735: RepairExec() armed a timeout, then a cf_popen*() call could fail
+ * (pipe()/fork() failure, or fdopen() failure on the successfully forked
+ * pipe) and return early without ever calling ClearTimeOut(). The alarm
+ * stayed armed and ticking. If the *next* command -- even one with no
+ * exec_timeout of its own -- happened to be running when that leftover
+ * alarm fired, TimeOut() would find ALARM_PID naming that unrelated child
+ * (GenericCreatePipeAndFork() publishes it unconditionally) and kill it.
+ * The fix is ClearTimeOut() on the early-return path; this pins that it
+ * actually prevents the kill, not just that the flags look right.
+ *
+ * RepairExec() itself lives in cf-agent and is not reachable from this
+ * libpromises-only unit test, so this drives the same primitives it calls:
+ * SetTimeOut() to arm, a real cf_popen_sh() failure to reach the early
+ * return, then ClearTimeOut() standing in for RepairExec()'s new call.
+ * Portable POSIX, no interposition: RLIMIT_NOFILE is dropped low enough
+ * that the pipe() inside cf_popen_sh() fails deterministically (a plain
+ * fdopen() failure cannot be forced this way -- fdopen() does not consume
+ * a new fd on this libc -- so this exercises the pipe()/fork()-failure
+ * shape of the same early-return family, not the eight fdopen()-failure
+ * sites; those are covered by inspection and object-code review instead).
+ *
+ * Asserting on TimeOutHasFired()/TimeOutSignalledProcess() rather than on
+ * whether the decoy is actually dead: a SIGKILLed child that nothing has
+ * waitpid()ed yet is a zombie, and kill(pid, 0) succeeds against a zombie
+ * exactly as it does against a live process -- that ambiguity, not a real
+ * pass, is what an earlier attempt at this test using a liveness poll was
+ * actually measuring. Whether TimeOut() ran and decided to act on
+ * ALARM_PID is unambiguous and doesn't need the termination ladder (whose
+ * own timing, CFE-4728/CFE-4718, is orthogonal to this defect) to finish.
+ *
+ * Discriminate by commenting out this test's own ClearTimeOut() call (not
+ * touching verify_exec.c, which this test cannot reach): the leftover
+ * alarm then fires against the decoy's freshly published ALARM_PID, and
+ * the assertions below fail. */
+static void test_leftover_alarm_does_not_kill_next_child(void)
+{
+    struct rlimit original;
+    assert_true(getrlimit(RLIMIT_NOFILE, &original) == 0);
+
+    SetTimeOut(2);
+
+    struct rlimit tiny = { .rlim_cur = 3, .rlim_max = original.rlim_max };
+    assert_true(setrlimit(RLIMIT_NOFILE, &tiny) == 0);
+
+    FILE *failed = cf_popen_sh("true", "r");
+    assert_true(failed == NULL);
+
+    assert_true(setrlimit(RLIMIT_NOFILE, &original) == 0);
+
+    /* Stand-in for RepairExec()'s new early-return call. */
+    ClearTimeOut();
+
+    FILE *decoy = cf_popen_sh("exec sleep 10", "r");
+    assert_true(decoy != NULL);
+    pid_t decoy_pid;
+    assert_true(PipeToPid(&decoy_pid, decoy));
+
+    /* Past when the leftover 2 second alarm would have fired, well short of
+     * the decoy's own 10 second sleep. */
+    struct timespec ts = { .tv_sec = 3, .tv_nsec = 0 };
+    nanosleep(&ts, NULL);
+
+    /* Fixed: ClearTimeOut() cancelled the alarm outright (alarm(0) plus
+     * SIG_DFL), so it never fires again and never touches the decoy's now-
+     * current ALARM_PID. */
+    assert_false(TimeOutHasFired());
+    assert_false(TimeOutSignalledProcess());
+
+    kill(decoy_pid, SIGKILL);
+    cf_pclose(decoy);
+}
+
 static void test_next_set_resets_the_record(void)
 {
     SetTimeOut(1);
@@ -173,6 +246,7 @@ int main()
         unit_test(test_clear_preserves_the_record),
         unit_test(test_clear_preserves_a_true_signalled_flag),
         unit_test(test_pclose_leaves_the_alarm_its_process),
+        unit_test(test_leftover_alarm_does_not_kill_next_child),
         unit_test(test_next_set_resets_the_record)
     };
 

--- a/tests/unit/timeout_test.c
+++ b/tests/unit/timeout_test.c
@@ -3,6 +3,7 @@
 #include <cf3.defs.h>
 #include <cf3.extern.h>
 #include <timeout.h>
+#include <pipes.h>
 
 /* The alarm handler interrupts the sleep, so this normally returns as soon as
  * it fires. Loop anyway: the alarm may already have fired before we get here,
@@ -94,6 +95,61 @@ static void test_clear_preserves_a_true_signalled_flag(void)
     waitpid(child, &status, 0);
 }
 
+/* CFE-4727: cf_pclose() used to clear ALARM_PID before waiting for the child,
+ * so a command that closed its output but kept running was unreachable by the
+ * time the alarm fired -- TimeOut() found no process to signal, and the full
+ * sleep ran out inside an unbounded waitpid(). The pid must stay registered
+ * until the reap, so an alarm firing during it still terminates the child.
+ *
+ * The sleep is 30 seconds and the elapsed bound 25 because the termination
+ * can take a while: each of the ladder's two waits is nominally 1 second but
+ * iteration-counted, which overshoots several-fold on Darwin (CFE-4728), and
+ * with no process_darwin.c the ladder cannot see the child die and burns its
+ * full waits regardless (CFE-4718). Terminated is ~2+2 seconds where those
+ * are fixed and up to ~20 here; only running to completion reaches 30.
+ *
+ * cf_popen_sh() runs before SetTimeOut(), not after: arming first (as
+ * verify_exec.c does) leaves a window between the alarm being armed and
+ * cf_popen()'s fork actually publishing the child's pid into ALARM_PID, and
+ * under load the 2 second alarm can fire inside that window -- observed
+ * directly under a parallel `make check`, not theoretical. That race is
+ * real but is not what this test pins; forking first and registering the
+ * already-known pid, the same way test_clear_preserves_a_true_signalled_flag
+ * does above, removes it from this test so a flake there cannot masquerade
+ * as a regression here. The payload chains through exec so the timed
+ * process is the pid cf_popen_sh() returned, with no intermediate shell
+ * left to hold the pipe open once it is killed. */
+static void test_pclose_leaves_the_alarm_its_process(void)
+{
+    FILE *pfp = cf_popen_sh("exec 1>&- 2>&-; exec sleep 30", "r");
+    assert_true(pfp != NULL);
+    pid_t child;
+    assert_true(PipeToPid(&child, pfp));
+
+    SetTimeOut(2);
+    ALARM_PID = child;
+    time_t start = time(NULL);
+
+    char buf[64];
+    while (fgets(buf, sizeof(buf), pfp) != NULL)
+    {
+    }
+
+    int ret = cf_pclose(pfp);
+    time_t elapsed = time(NULL) - start;
+    ClearTimeOut();
+
+    assert_true(TimeOutHasFired());
+    /* The blocking wait in cf_pclose() is where the alarm found the child. */
+    assert_true(TimeOutSignalledProcess());
+    /* A terminated child cannot have run its 30 second sleep out. */
+    assert_true(elapsed < 25);
+    /* And it did not run to completion's exit 0. */
+    assert_int_not_equal(0, ret);
+    /* The reap still deregisters the pid afterwards. */
+    assert_true(ALARM_PID == -1);
+}
+
 static void test_next_set_resets_the_record(void)
 {
     SetTimeOut(1);
@@ -116,6 +172,7 @@ int main()
         unit_test(test_fired_alarm_without_a_process),
         unit_test(test_clear_preserves_the_record),
         unit_test(test_clear_preserves_a_true_signalled_flag),
+        unit_test(test_pclose_leaves_the_alarm_its_process),
         unit_test(test_next_set_resets_the_record)
     };
 


### PR DESCRIPTION
Ticket: [CFE-4735](https://northerntech.atlassian.net/browse/CFE-4735)

> **Stacked on #6310, which is itself stacked on #6305.** This change uses `ClearAlarmedPid()`, introduced by #6310, so it genuinely depends on it. **The only new commit here is `453cc264d`.** Merging #6305 and #6310 first reduces this to a single-commit PR.

`cf_popen*()`'s eight `fdopen()`-failure paths reap the child but never clear `ALARM_PID` (`pipes_unix.c:458,470,588,600,670,681,789,800` — all `cf_pwait(pid); return NULL;`), and `RepairExec()`'s `pfp == NULL` branch returns `ACTION_RESULT_FAILED` without ever reaching the function's only `ClearTimeOut()` at `:502`.

An armed alarm can then stay pointed at a reaped, recyclable pid for up to the full `exec_timeout` — the same defect class as CFE-4727, but a window of seconds-to-minutes rather than instructions. Pre-existing and byte-identical to the pre-CFE-4727 parent; gated on rare `fdopen()` failures (ENOMEM/EMFILE).

Mechanical fix: `ClearAlarmedPid(pid)` after each of the eight `cf_pwait()` calls, plus `ClearTimeOut()` on `RepairExec()`'s `pfp == NULL` path under the same `a->contain.timeout != CF_NOINT` gate the normal-completion path already uses.

**Testing** — the original "untestable" claim was wrong. `tests/unit/timeout_test.c` gains `test_leftover_alarm_does_not_kill_next_child`, portable POSIX using `RLIMIT_NOFILE` to force a `pipe()` failure, no interposition needed. Discriminated by hand: it fails exactly at `TimeOutHasFired()` with the fix's `ClearTimeOut()` call removed.

Two further real-but-out-of-scope leaks were found while doing this and are deliberately not in this SHA: a raw fd leak on `fdopen()` failure, and two more `RepairExec()` early returns that skip `ClearTimeOut()`. Both belong to the CFE-4732 family (#6308).

AI-assisted, reviewed and verified by me before submitting, per CONTRIBUTING.


[CFE-4735]: https://northerntech.atlassian.net/browse/CFE-4735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ