### PR TITLE
CFE-4737: Fixed JSON reals truncated to two decimals and large JSON integers terminating the agent

### DIFF
--- a/libenv/unix_iface.c
+++ b/libenv/unix_iface.c
@@ -1435,11 +1435,19 @@ void GetNetworkingInfo(EvalContext *ctx)
                 JsonElement *metric = JsonObjectGet(route, "metric");
                 if (metric != NULL &&
                     JsonGetElementType(metric) == JSON_ELEMENT_TYPE_PRIMITIVE &&
-                    JsonGetPrimitiveType(metric) == JSON_PRIMITIVE_TYPE_INTEGER &&
-                    (default_route == NULL ||
-                     JsonPrimitiveGetAsInteger(metric) < lowest_metric))
+                    JsonGetPrimitiveType(metric) == JSON_PRIMITIVE_TYPE_INTEGER)
                 {
-                    default_route = route;
+                    /* Not JsonPrimitiveGetAsInteger(): it reaches
+                     * StringToLongExitOnError(), which would terminate the
+                     * agent over a metric too large for a long. A metric we
+                     * cannot read simply does not win. */
+                    long metric_value;
+                    if (StringToLong(JsonPrimitiveGetAsString(metric),
+                                     &metric_value) == 0 &&
+                        (default_route == NULL || metric_value < lowest_metric))
+                    {
+                        default_route = route;
+                    }
                 }
             }
         }

--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -2048,7 +2048,17 @@ time_t ReadTimestampFromPolicyValidatedFile(const GenericAgentConfig *config, co
             JsonElement *timestamp = JsonObjectGet(validated_doc, "timestamp");
             if (timestamp)
             {
-                validated_at = JsonPrimitiveGetAsInteger(timestamp);
+                /* Not JsonPrimitiveGetAsInteger(): it reaches
+                 * StringToLongExitOnError(), which would terminate the agent
+                 * over a corrupt or crafted timestamp in this file. A
+                 * timestamp we cannot read leaves validated_at at 0, meaning
+                 * "not validated", which is the safe direction. */
+                long parsed;
+                if (StringToLong(JsonPrimitiveGetAsString(timestamp), &parsed)
+                    == 0)
+                {
+                    validated_at = parsed;
+                }
             }
             JsonDestroy(validated_doc);
         }

--- a/libpromises/iteration.c
+++ b/libpromises/iteration.c
@@ -697,17 +697,12 @@ static void SeqAppendContainerPrimitive(Seq *seq, const JsonElement *primitive)
                         xstrdup("true") : xstrdup("false")));
         break;
     case JSON_PRIMITIVE_TYPE_INTEGER:
-    {
-        char *str = StringFromLong(JsonPrimitiveGetAsInteger(primitive));
-        SeqAppend(seq, str);
-        break;
-    }
     case JSON_PRIMITIVE_TYPE_REAL:
-    {
-        char *str = StringFromDouble(JsonPrimitiveGetAsReal(primitive));
-        SeqAppend(seq, str);
+        /* Use the number as it was parsed -- see RlistAppendJson(). Going
+         * through long or double is lossy for reals and fatal for integers
+         * too large for this platform. */
+        SeqAppend(seq, xstrdup(JsonPrimitiveGetAsString(primitive)));
         break;
-    }
     case JSON_PRIMITIVE_TYPE_STRING:
         SeqAppend(seq, xstrdup(JsonPrimitiveGetAsString(primitive)));
         break;

--- a/libpromises/rlist.c
+++ b/libpromises/rlist.c
@@ -1725,18 +1725,13 @@ static void RlistAppendContainerPrimitive(Rlist **list, const JsonElement *primi
         RlistAppendScalar(list, JsonPrimitiveGetAsBool(primitive) ? "true" : "false");
         break;
     case JSON_PRIMITIVE_TYPE_INTEGER:
-        {
-            char *str = StringFromLong(JsonPrimitiveGetAsInteger(primitive));
-            RlistAppendScalar(list, str);
-            free(str);
-        }
-        break;
     case JSON_PRIMITIVE_TYPE_REAL:
-        {
-            char *str = StringFromDouble(JsonPrimitiveGetAsReal(primitive));
-            RlistAppendScalar(list, str);
-            free(str);
-        }
+        /* Use the number as it was parsed. Converting through long or double
+         * first is lossy for reals ("%.2f" turns 0.00049 into 0.00) and fatal
+         * for integers JSON permits but this platform cannot represent --
+         * JsonPrimitiveGetAsInteger() reaches StringToLongExitOnError(),
+         * which calls DoCleanupAndExit(). */
+        RlistAppendScalar(list, JsonPrimitiveGetAsString(primitive));
         break;
     case JSON_PRIMITIVE_TYPE_STRING:
         RlistAppendScalar(list, JsonPrimitiveGetAsString(primitive));

--- a/tests/unit/rlist_test.c
+++ b/tests/unit/rlist_test.c
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 
 #include <rlist.h>
+#include <json.h>
+#include <buffer.h>
 #include <string_lib.h>
 
 #include <assoc.h>
@@ -797,6 +799,62 @@ static void test_key_in_ignore_case()
     assert_true(RlistKeyIn_IgnoreCase(NULL, "term") == NULL);
 }
 
+static void test_from_container_numbers(void)
+{
+    /* Every element of this array is a number RFC 8259 allows and JsonParse()
+     * accepts. Before the fix, building an Rlist from it converted each one
+     * through long or double first, which lost information for the reals and
+     * called DoCleanupAndExit() for the integers too large for a long -- so
+     * a data container holding one of these terminated the agent rather than
+     * producing a list. Each element must come back exactly as written. */
+    static const char *const expected[] = {
+        "42",
+        "-42",
+        "9223372036854775807",              /* LONG_MAX */
+        "9223372036854775808",              /* one past it: was fatal */
+        "1000000000000000000000000000000",  /* 10^30: was fatal */
+        "2000000000000",                    /* fits long, not int */
+        "0.00049",                          /* was truncated to 0.00 */
+        "3.14159265",                       /* was truncated to 3.14 */
+        "1e-8",                             /* was fatal on stock libntech */
+        "1.5e3",
+    };
+    const size_t n = sizeof(expected) / sizeof(expected[0]);
+
+    Buffer *doc = BufferNew();
+    BufferAppendChar(doc, '[');
+    for (size_t i = 0; i < n; i++)
+    {
+        if (i > 0)
+        {
+            BufferAppendChar(doc, ',');
+        }
+        BufferAppendString(doc, expected[i]);
+    }
+    BufferAppendChar(doc, ']');
+
+    const char *data = BufferData(doc);
+    JsonElement *json = NULL;
+    assert_int_equal(JSON_PARSE_OK, JsonParse(&data, &json));
+    assert_true(json != NULL);
+    assert_int_equal(n, JsonLength(json));
+
+    Rlist *list = RlistFromContainer(json);
+    assert_true(list != NULL);
+    assert_int_equal(n, RlistLen(list));
+
+    const Rlist *rp = list;
+    for (size_t i = 0; i < n; i++, rp = rp->next)
+    {
+        assert_true(rp != NULL);
+        assert_string_equal(expected[i], RlistScalarValue(rp));
+    }
+
+    RlistDestroy(list);
+    JsonDestroy(json);
+    BufferDestroy(doc);
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -806,6 +864,7 @@ int main()
         unit_test(test_length),
         unit_test(test_equality),
         unit_test(test_copy),
+        unit_test(test_from_container_numbers),
         unit_test(test_rval_to_scalar),
         unit_test(test_rval_to_scalar2),
         unit_test(test_rval_to_list),


### PR DESCRIPTION
Ticket: [CFE-4737](https://northerntech.atlassian.net/browse/CFE-4737)

Two call sites take a JSON number, convert it to a C numeric type, and format it back. Both conversions are wrong in the same two ways.

**Reals lose precision silently.** `RlistAppendJson()` and the iteration equivalent ran reals through `StringFromDouble()`, which formats with `"%.2f"`. Any real with more than two decimals came back as a *different* value, not a rounded one: `0.00049` becomes `0.00`. That is how a rate or threshold in JSON data silently becomes zero once it reaches a CFEngine variable.

**Large integers terminate the agent.** The same paths used `JsonPrimitiveGetAsInteger()`, which reaches `StringToLongExitOnError()` and so `DoCleanupAndExit()`. JSON places no limit on a number's magnitude, so a valid document may hold one no `long` can represent — and merely *rendering* it killed the process rather than reporting anything.

Two further callers have the same exit-on-overflow shape and take their input from JSON rather than from our own code: `ReadTimestampFromPolicyValidatedFile()` and the interface-data path in `libenv/unix_iface.c`.

For the list and iteration cases the repair is to stop converting and use the number as parsed, via `JsonPrimitiveGetAsString()`. For the two that genuinely want an integer, it is to stop using a converter that exits — a timestamp that cannot be read now leaves `validated_at` at 0, which already means "not validated" and is the safe direction.

**Independence from CFE-4724.** This branch was originally developed against an unmerged libntech commit, and I had assumed it was blocked on that. It is not, and I verified rather than assumed: `JsonPrimitiveGetAsString()` already exists on libntech master (`libutils/json.h:246`), which already creates primitives from the parsed text buffer (`json.c:2377`). This branch is rebased onto current master with the `libntech` submodule pointer **identical to master's** (`0c0620d`) — the diff is 5 source files, no submodule change — and it builds clean and passes its test against libntech master. CFE-4724 fixes complementary defects on the libntech side; neither blocks the other.

**Testing.** New `test_from_container_numbers` goes through the public `RlistFromContainer()` with ten numbers — `LONG_MAX` and one past it, 10^30, a value that fits a `long` but not an `int`, reals with more than two decimals, and exponent forms — requiring each back exactly as written. Discrimination verified both directions: with `libpromises/rlist.c` reverted the test does not merely fail, it takes the process with it —

```
error: Conversion error (34 - Overflow) on '9223372036854775808' (StringToLongExitOnError)
```

— which is the defect itself. With the fix, all ten round-trip.

*Note for macOS reviewers:* `rlist_test` aborts later in `test_rval_to_scalar2` at `rlist.c:135`. Pre-existing and unrelated — it reproduces identically on unpatched master, and is why `rlist_test` is on the macOS `XFAIL_TESTS` list.

AI-assisted and multi-model vetted before submitting, reviewed by me, per CONTRIBUTING.


[CFE-4737]: https://northerntech.atlassian.net/browse/CFE-4737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ