### PR TITLE
CFE-4738: Fixed a JSON null in host_specific.json crashing the agent

### DIFF
--- a/libpromises/cmdb.c
+++ b/libpromises/cmdb.c
@@ -118,6 +118,22 @@ static VarRef *GetCMDBVariableRef(const char *key)
     return ref;
 }
 
+/** Does the given JSON array have a JSON null among its direct children? */
+static bool JsonArrayContainsNull(const JsonElement *array)
+{
+    assert(JsonGetType(array) == JSON_TYPE_ARRAY);
+
+    const size_t length = JsonLength(array);
+    for (size_t i = 0; i < length; i++)
+    {
+        if (JsonGetType(JsonArrayGet(array, i)) == JSON_TYPE_NULL)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 static bool AddCMDBVariable(EvalContext *ctx, const char *key, const VarRef *ref,
                             JsonElement *data, StringSet *tags, const char *comment)
 {
@@ -130,24 +146,46 @@ static bool AddCMDBVariable(EvalContext *ctx, const char *key, const VarRef *ref
     bool ret;
     if (JsonGetElementType(data) == JSON_ELEMENT_TYPE_PRIMITIVE)
     {
-        char *value = JsonPrimitiveToString(data);
-        Log(LOG_LEVEL_VERBOSE, "Installing CMDB variable '%s:%s.%s=%s'",
-            ref->ns, ref->scope, key, value);
-        ret = EvalContextVariablePutTagsSetWithComment(ctx, ref, value, CF_DATA_TYPE_STRING,
-                                                       tags, comment);
-        free(value);
+        if (JsonGetPrimitiveType(data) == JSON_PRIMITIVE_TYPE_NULL)
+        {
+            /* JsonPrimitiveToString() returns NULL for JSON null and there is
+             * no scalar to install in its place. */
+            Log(LOG_LEVEL_ERR, "Invalid value in '%s' variable specification in CMDB data"
+                " (null is not a supported value)", key);
+            ret = false;
+        }
+        else
+        {
+            char *value = JsonPrimitiveToString(data);
+            Log(LOG_LEVEL_VERBOSE, "Installing CMDB variable '%s:%s.%s=%s'",
+                ref->ns, ref->scope, key, value);
+            ret = EvalContextVariablePutTagsSetWithComment(ctx, ref, value, CF_DATA_TYPE_STRING,
+                                                           tags, comment);
+            free(value);
+        }
     }
     else if ((JsonGetType(data) == JSON_TYPE_ARRAY) &&
              JsonArrayContainsOnlyPrimitives(data))
     {
-        // map to slist if the data only has primitives
-        Log(LOG_LEVEL_VERBOSE, "Installing CMDB slist variable '%s:%s.%s'",
-            ref->ns, ref->scope, key);
-        Rlist *data_rlist = RlistFromContainer(data);
-        ret = EvalContextVariablePutTagsSetWithComment(ctx, ref,
-                                                       data_rlist, CF_DATA_TYPE_STRING_LIST,
-                                                       tags, comment);
-        RlistDestroy(data_rlist);
+        if (JsonArrayContainsNull(data))
+        {
+            /* RlistFromContainer() skips JSON nulls, so the resulting slist
+             * would silently be shorter than the data it came from. */
+            Log(LOG_LEVEL_ERR, "Invalid value in '%s' variable specification in CMDB data"
+                " (a list must not contain null)", key);
+            ret = false;
+        }
+        else
+        {
+            // map to slist if the data only has primitives
+            Log(LOG_LEVEL_VERBOSE, "Installing CMDB slist variable '%s:%s.%s'",
+                ref->ns, ref->scope, key);
+            Rlist *data_rlist = RlistFromContainer(data);
+            ret = EvalContextVariablePutTagsSetWithComment(ctx, ref,
+                                                           data_rlist, CF_DATA_TYPE_STRING_LIST,
+                                                           tags, comment);
+            RlistDestroy(data_rlist);
+        }
     }
     else
     {

--- a/tests/acceptance/00_basics/06_host_specific_data/13-null-values.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/13-null-values.cf
@@ -1,0 +1,60 @@
+# test of the host_specific.json functionality: JSON null values are rejected
+# per entry, the rest of the CMDB data is still installed (used to crash)
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent init
+{
+  files:
+    "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+      create => "true",
+      perms => mog(
+        "0700", "$(sys.user_data[username])", "$(sys.user_data[username])"
+      );
+
+  methods:
+    "prepare_host_specific_data"
+      usebundle => file_copy(
+        "$(this.promise_filename).json",
+        "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"
+      ),
+      handle => "prepare_host_specific_data";
+
+    "empty_promises_cf"
+      usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+bundle agent check
+{
+  vars:
+    "command"
+      string => "$(sys.cf_promises) --show-vars -f $(sys.inputdir)/promises.cf | $(G.grep) -E 'CMDB data|value_from_'";
+
+    # The offending entries are reported in the order they appear in the CMDB
+    # data, the remaining variables are installed and shown by --show-vars.
+    "expected"
+      string => concat(
+        "\s*error: Invalid value in 'null_scalar'.*null is not a supported value.*",
+        "\s+error: Invalid value in 'null_list'.*a list must not contain null.*",
+        "\s+error: Invalid value in 'null_value'.*null is not a supported value.*",
+        "\s+error: Invalid value in 'null_bare'.*null is not a supported value.*",
+        "\s+error: Invalid value in 'null_value_list'.*a list must not contain null.*",
+        "\s+data:variables\.good_variables\s+value_from_variables\s+source=cmdb",
+        "\s+data:variables\.good_vars\s+value_from_vars\s+source=cmdb\s*"
+      );
+
+  methods:
+    ""
+      usebundle => dcs_passif_output(
+        $(expected),
+        "",
+        $(command),
+        $(this.promise_filename)
+      );
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/13-null-values.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/13-null-values.cf.json
@@ -1,0 +1,19 @@
+{
+  "vars": {
+    "null_scalar": null,
+    "null_list": ["a", null],
+    "good_vars": "value_from_vars"
+  },
+  "variables": {
+    "null_value": {
+      "value": null
+    },
+    "null_bare": null,
+    "null_value_list": {
+      "value": ["a", null]
+    },
+    "good_variables": {
+      "value": "value_from_variables"
+    }
+  }
+}


### PR DESCRIPTION
A `host_specific.json` containing a JSON `null` value segfaults `cf-promises` and `cf-agent`. The document is valid JSON and passes CFEngine's own unresolved-variable check.

```
$ cat $(sys.workdir)/data/host_specific.json
{"vars": {"k": null}}
$ cf-promises --show-classes -f promises.cf
Segmentation fault: 11
```

`cf-agent` dies inside `GenericAgentDiscoverContext()` — before any promise is evaluated — so an affected host stops converging and falls back to failsafe.

### Mechanism

```
AddCMDBVariable                          libpromises/cmdb.c:136
EvalContextVariablePutTagsSetWithComment libpromises/eval_context.c:2492
VariableTablePut                         libpromises/variable.c:255
RvalNewRewriter                          libntech/libutils/rlist.c:474
xstrdup                                  libntech/libutils/alloc.c:57
strdup -> strlen        <-- EXC_BAD_ACCESS at 0x0
```

`JsonPrimitiveToString()` returns NULL for `JSON_PRIMITIVE_TYPE_NULL`, and `AddCMDBVariable()` passes it straight in as the variable's value with no NULL check.

### Crashing inputs fixed

| input | before |
|---|---|
| `{"vars": {"k": null}}` | SIGSEGV |
| `{"variables": {"k": {"value": null}}}` | SIGSEGV |
| `{"variables": {"k": null}}` | SIGSEGV |
| `{"vars": {"ns:bundle.k": null}}` | SIGSEGV |
| `{"vars": {"k": [1, null]}}` | silently installed `{"1"}` |
| `{"vars": {"k": [null]}}` | silently installed an empty slist |

### Behaviour chosen

Skip the offending entry with an error and continue, rather than rejecting the section. This follows the file's own idiom — `cmdb.c` already `continue`s for every per-entry problem (bad var ref, missing `value` field, all five invalid-class cases) and reserves `return false` for section-level structural faults. A single bad entry in a generated CMDB file should not discard the rest of the host's data.

Nulls nested inside data containers are deliberately left alone — they are stored and rendered correctly today.

### Testing

`13-null-values.cf` asserts the full ordered diagnostic sequence *and* that the neighbouring good entries are still installed, so it pins the skip-and-continue semantics rather than merely the absence of a crash. It fails on unpatched code (which segfaults) and passes with the fix; the whole `00_basics/06_host_specific_data` directory passes.

### Related, not fixed here

The augments loader (`def.json`) has the same root cause at three sites in `libpromises/generic_agent.c` — `:454`, `:606` and `:723` all reach `JsonPrimitiveToString()` unchecked and segfault on the equivalent input. Different file and different feature, so it is left for a separate change rather than widening this one.

### Note

Developed and tested on macOS (arm64); I have not been able to exercise this on the project's own CI.

Ticket: [CFE-4738](https://northerntech.atlassian.net/browse/CFE-4738)


[CFE-4738]: https://northerntech.atlassian.net/browse/CFE-4738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ