### PR TITLE
CFE-4722: Warned about CMDB keys whose dots are taken as a scope separator

### DIFF
--- a/libpromises/cmdb.c
+++ b/libpromises/cmdb.c
@@ -93,6 +93,45 @@ static bool CheckObjectForUnexpandedVars(JsonElement *object, ARG_UNUSED void *d
     return true;
 }
 
+/**
+ * Report that the dots in a CMDB key were taken as a scope separator.
+ *
+ * VarRefParse() splits a key at its first dot, so the flat-looking key
+ * "com.dotted.key" does not become a variable of that name, it becomes the
+ * variable "dotted.key" in the scope "com". Naming a scope like this is a
+ * supported feature, so a key of the documented "[namespace:]bundle.variable"
+ * form is only reported at the verbose level; warning on every agent run
+ * about a working policy would just be noise.
+ *
+ * The remaining keys cannot be of that form: it has room for exactly one dot,
+ * and neither the bundle name nor the variable name can be empty. A variable
+ * name that still contains a dot is a particularly good hint, since a vars
+ * promise cannot create one (the same splitting happens there), so nothing
+ * but CMDB data can address it. Those keys are much more likely to be flat
+ * keys meant literally, and get a warning.
+ */
+static void LogCMDBVariableScope(const char *key, const VarRef *ref)
+{
+    assert(key != NULL);
+    assert(ref != NULL);
+
+    char *address = VarRefToString(ref, true);
+    if (!StringEqual(ref->scope, "") && !StringEqual(ref->lval, "") &&
+        (strchr(ref->lval, '.') == NULL))
+    {
+        Log(LOG_LEVEL_VERBOSE, "The CMDB key '%s' names the '%s' scope,"
+            " the variable is addressed as '%s'",
+            key, ref->scope, address);
+    }
+    else
+    {
+        Log(LOG_LEVEL_WARNING, "The '.' in the CMDB key '%s' was taken as a"
+            " scope separator: the variable is named '%s' in the '%s' scope,"
+            " addressed as '%s'", key, ref->lval, ref->scope, address);
+    }
+    free(address);
+}
+
 static VarRef *GetCMDBVariableRef(const char *key)
 {
     VarRef *ref = VarRefParse(key);
@@ -115,24 +154,32 @@ static VarRef *GetCMDBVariableRef(const char *key)
     {
         ref->scope = xstrdup("variables");
     }
+    else
+    {
+        /* The key contained a dot, so the variable did not land in the
+         * default scope. Tell the operator where it went instead. */
+        LogCMDBVariableScope(key, ref);
+    }
     return ref;
 }
 
-static bool AddCMDBVariable(EvalContext *ctx, const char *key, const VarRef *ref,
+static bool AddCMDBVariable(EvalContext *ctx, const VarRef *ref,
                             JsonElement *data, StringSet *tags, const char *comment)
 {
     assert(ctx != NULL);
-    assert(key != NULL);
     assert(ref != NULL);
     assert(data != NULL);
     assert(tags != NULL);
 
     bool ret;
+    /* Not '%s:%s.%s' of ref->ns, ref->scope and key: a key that names a scope
+     * already contains that scope, which would then be printed twice. */
+    char *address = VarRefToString(ref, true);
     if (JsonGetElementType(data) == JSON_ELEMENT_TYPE_PRIMITIVE)
     {
         char *value = JsonPrimitiveToString(data);
-        Log(LOG_LEVEL_VERBOSE, "Installing CMDB variable '%s:%s.%s=%s'",
-            ref->ns, ref->scope, key, value);
+        Log(LOG_LEVEL_VERBOSE, "Installing CMDB variable '%s=%s'",
+            address, value);
         ret = EvalContextVariablePutTagsSetWithComment(ctx, ref, value, CF_DATA_TYPE_STRING,
                                                        tags, comment);
         free(value);
@@ -141,8 +188,7 @@ static bool AddCMDBVariable(EvalContext *ctx, const char *key, const VarRef *ref
              JsonArrayContainsOnlyPrimitives(data))
     {
         // map to slist if the data only has primitives
-        Log(LOG_LEVEL_VERBOSE, "Installing CMDB slist variable '%s:%s.%s'",
-            ref->ns, ref->scope, key);
+        Log(LOG_LEVEL_VERBOSE, "Installing CMDB slist variable '%s'", address);
         Rlist *data_rlist = RlistFromContainer(data);
         ret = EvalContextVariablePutTagsSetWithComment(ctx, ref,
                                                        data_rlist, CF_DATA_TYPE_STRING_LIST,
@@ -152,12 +198,13 @@ static bool AddCMDBVariable(EvalContext *ctx, const char *key, const VarRef *ref
     else
     {
         // install as a data container
-        Log(LOG_LEVEL_VERBOSE, "Installing CMDB data container variable '%s:%s.%s'",
-            ref->ns, ref->scope, key);
+        Log(LOG_LEVEL_VERBOSE, "Installing CMDB data container variable '%s'",
+            address);
         ret = EvalContextVariablePutTagsSetWithComment(ctx, ref,
                                                        data, CF_DATA_TYPE_CONTAINER,
                                                        tags, comment);
     }
+    free(address);
     if (!ret)
     {
         /* On success, EvalContextVariablePutTagsSet() consumes the tags set,
@@ -197,7 +244,7 @@ static bool ReadCMDBVars(EvalContext *ctx, JsonElement *vars)
 
         StringSet *tags = StringSetNew();
         StringSetAdd(tags, xstrdup(CMDB_SOURCE_TAG));
-        bool ret = AddCMDBVariable(ctx, key, ref, data, tags, NULL);
+        bool ret = AddCMDBVariable(ctx, ref, data, tags, NULL);
         VarRefDestroy(ref);
         if (!ret)
         {
@@ -326,7 +373,7 @@ static bool ReadCMDBVariables(EvalContext *ctx, JsonElement *variables)
         assert(tags != NULL);
         assert(data != NULL);
 
-        bool ret = AddCMDBVariable(ctx, key, ref, data, tags, comment);
+        bool ret = AddCMDBVariable(ctx, ref, data, tags, comment);
         VarRefDestroy(ref);
         if (!ret)
         {

--- a/tests/acceptance/00_basics/06_host_specific_data/14-dotted-keys.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/14-dotted-keys.cf
@@ -1,0 +1,52 @@
+# test of the host_specific.json functionality: keys with more dots than the
+# "[namespace:]bundle.variable" form allows are warned about, plain scope
+# qualification is not
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent init
+{
+  files:
+    "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+      create => "true",
+      perms => mog(
+        "0700", "$(sys.user_data[username])", "$(sys.user_data[username])"
+      );
+
+  methods:
+    "prepare_host_specific_data"
+      usebundle => file_copy(
+        "$(this.promise_filename).json",
+        "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"
+      ),
+      handle => "prepare_host_specific_data";
+
+    "empty_promises_cf"
+      usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+bundle agent check
+{
+  vars:
+    "command"
+      string => "$(sys.cf_promises) --show-vars -f $(sys.inputdir)/promises.cf";
+
+  methods:
+    ""
+      usebundle => dcs_passif_output(
+        # both dotted keys are warned about, and both variables are still
+        # installed at the address the dots ask for
+        ".*warning: The '.' in the CMDB key 'com\.dotted\.key' was taken as a scope separator: the variable is named 'dotted\.key' in the 'com' scope, addressed as 'data:com\.dotted\.key'.*warning: The '.' in the CMDB key 'vcom\.vdotted\.vkey' was taken as a scope separator.*data:com\.dotted\.key\s+dotted_value\s.*data:myscope\.myvar\s+scoped_value\s.*data:vcom\.vdotted\.vkey\s+dotted_value2\s.*",
+        # a plain "bundle.variable" key is a supported way to pick a scope,
+        # it must not be warned about
+        ".*warning:[^\n]*'myscope\.myvar'.*",
+        $(command),
+        $(this.promise_filename)
+      );
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/14-dotted-keys.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/14-dotted-keys.cf.json
@@ -1,0 +1,11 @@
+{
+  "vars": {
+    "com.dotted.key": "dotted_value",
+    "myscope.myvar": "scoped_value"
+  },
+  "variables": {
+    "vcom.vdotted.vkey": {
+      "value": "dotted_value2"
+    }
+  }
+}


### PR DESCRIPTION
`GetCMDBVariableRef()` hands a CMDB key to `VarRefParse()`, which splits it at the first dot. A flat-looking key such as `com.dotted.key` therefore installs the variable `dotted.key` in the scope `com`, reachable as `$(data:com.dotted.key)` and not as a variable of the name that was written. Nothing said so.

**Behaviour is unchanged.** Picking a scope this way is a supported feature that policies rely on; the same variable is installed at the same address as before. Only the logging is new.

```
warning: The '.' in the CMDB key 'com.dotted.key' was taken as a scope
separator: the variable is named 'dotted.key' in the 'com' scope,
addressed as 'data:com.dotted.key'
```

### Where the line is drawn

A warning on every agent run about a working configuration would be worse than no warning at all, so this reports at two levels:

- **`LOG_LEVEL_VERBOSE`** for a key of the documented `[namespace:]bundle.variable` form. That is indistinguishable from a deliberate scope qualification, so it is not warned about.
- **`LOG_LEVEL_WARNING`** only for keys that *cannot* be of that form: it has room for exactly one dot and neither half may be empty. So an empty scope (`.key`), an empty variable name (`key.`), or a variable name that still contains a dot (`com.dotted.key`).

The dotted-variable-name case is the strongest signal: a `vars:` promise splits its promiser the same way, so no policy can create a variable whose name contains a dot. Such an address can only come from CMDB data.

Keys with indices are unaffected — `idx[a.b]` has lval `idx`, and dots inside `[]` are never scope separators.

### Also fixed

The three `Installing CMDB variable` verbose messages printed `'%s:%s.%s'` of `ns`, `scope` and the raw key, which repeated the scope for any scope-qualified key (`data:com.com.dotted.key`) — misreporting the very address the operator needs. They now print `VarRefToString()` of the ref actually installed.

### Sections

`vars` and `variables` (CFE-3633) share `GetCMDBVariableRef()` and are both covered. `classes` is *not* affected: class names are not scope-parsed — `EvalContextClassPutTagsSet()` canonifies them, so `com.dotted.class` becomes `data:com_dotted_class` rather than moving scope. That canonification is also silent, but it is universal CFEngine behaviour for classes from every source, so it belongs in `eval_context.c` rather than the CMDB loader and is not touched here.

### Testing

`14-dotted-keys.cf` asserts both warnings fire, that all three variables still land at their original dotted addresses, and — as a false-positive guard — that `myscope.myvar` is **not** warned about. Fails on unpatched code, passes with the fix.

Behaviour non-regression was verified by diffing `--show-vars` and `--show-classes` output filtered to `source=cmdb`, before and after, across dotted, scoped, namespace-qualified, indexed and edge-case (`.leading`, `trailing.`, `a..b`) fixtures: byte-identical.

### Note

Developed and tested on macOS (arm64); I have not been able to exercise this on the project's own CI.

Ticket: [CFE-4722](https://northerntech.atlassian.net/browse/CFE-4722)


[CFE-4722]: https://northerntech.atlassian.net/browse/CFE-4722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ