### PR TITLE
CFE-4721: Made policy function eval() return whole numbers without a fractional part

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -194,6 +194,27 @@ static FnCallResult FnReturnF(const char *fmt, ...)
     return FnReturnNoCopy(buffer);
 }
 
+/*
+ * Return a double, rendered as an integer when it has no fractional part
+ * and fits in a long, and with "%lf" otherwise.
+ */
+static FnCallResult FnReturnRealOrInt(double result)
+{
+    /* The bounds are deliberately asymmetric. LONG_MIN is a power of two and
+     * converts to double exactly, but (double) LONG_MAX rounds up to
+     * LONG_MAX + 1 where long is 64 bits, so testing "result <= (double)
+     * LONG_MAX" would admit a value the cast cannot represent -- which is
+     * undefined behaviour, not a wrapped result. */
+    if (isfinite(result) && (result == floor(result)) &&
+        (result >= (double) LONG_MIN) &&
+        (result < (double) LONG_MAX + 1.0))
+    {
+        return FnReturnF("%ld", (long) result);
+    }
+
+    return FnReturnF("%lf", result);
+}
+
 static FnCallResult FnReturnContext(bool result)
 {
     return FnReturn(result ? "any" : "!any");
@@ -7640,7 +7661,7 @@ static FnCallResult FnCallEval(EvalContext *ctx, ARG_UNUSED const Policy *policy
         return FnReturn(""); /* TODO: why not FnFailure() ? */
     }
 
-    return FnReturnF("%lf", result);
+    return FnReturnRealOrInt(result);
 }
 
 /*********************************************************************/

--- a/tests/acceptance/01_vars/02_functions/eval.cf
+++ b/tests/acceptance/01_vars/02_functions/eval.cf
@@ -60,6 +60,11 @@ bundle agent init
 
     "values[43]" -> { "CFE-2762" }
       string => "1 * .75";
+
+    # An integral result is rendered without a fractional part. Negative zero
+    # is integral, so it renders as a plain zero rather than "-0.000000".
+    "values[44]" -> { "CFE-4721" }
+      string => "-1 * 0";
 }
 
 #######################################################
@@ -81,14 +86,14 @@ bundle agent check
     # note this test will be MUCH more accurate when we have sprintf and rounding
     "verify[0]" string => '';
     "verify[1]" string => '';
-    "verify[2]" string => '300.000000';
-    "verify[3]" string => '100.000000';
+    "verify[2]" string => '300';
+    "verify[3]" string => '100';
     "verify[4]" string => '';
-    "verify[5]" string => '0.000000';
-    "verify[6]" string => '0.000000';
+    "verify[5]" string => '0';
+    "verify[6]" string => '0';
     "verify[7]" string => 'inf';
-    "verify[8]" string => '27.000000';
-    "verify[9]" string => '1.000000';
+    "verify[8]" string => '27';
+    "verify[9]" string => '1';
     "verify[10]" string => '0.912945';
     "verify[11]" string => '0.408082';
     "verify[12]" string => '0.201358';
@@ -98,33 +103,36 @@ bundle agent check
     "verify[16]" string => '-1.609438';
     "verify[17]" string => '0.693147';
     "verify[18]" string => '2.302585';
-    "verify[19]" string => '2.000000';
+    "verify[19]" string => '2';
     "verify[20]" string => '0.447214';
-    "verify[21]" string => '4.000000';
-    "verify[22]" string => '3.000000';
+    "verify[21]" string => '4';
+    "verify[22]" string => '3';
     "verify[23]" string => '3.400000';
     "verify[24]" string => '-6.800000';
     "verify[25]" string => '-6.800001';
     "verify[26]" string => '3.141593';
     "verify[27]" string => '2.718282';
-    "verify[28]" string => '1.000000';
-    "verify[29]" string => '0.000000';
-    "verify[30]" string => '1.000000';
-    "verify[31]" string => '1.000000';
-    "verify[32]" string => '0.000000';
-    "verify[33]" string => '100000.000000';
+    "verify[28]" string => '1';
+    "verify[29]" string => '0';
+    "verify[30]" string => '1';
+    "verify[31]" string => '1';
+    "verify[32]" string => '0';
+    "verify[33]" string => '100000';
     "verify[34]" string => '0.000050';
-    "verify[35]" string => '0.000000';
-    "verify[36]" string => '0.000000';
-    "verify[37]" string => '1.000000';
-    "verify[38]" string => '0.000000';
-    "verify[39]" string => '0.000000';
-    "verify[40]" string => '1.000000';
-    "verify[41]" string => '1.000000';
-    "verify[42]" string => '1.000000';
+    "verify[35]" string => '0';
+    "verify[36]" string => '0';
+    "verify[37]" string => '1';
+    "verify[38]" string => '0';
+    "verify[39]" string => '0';
+    "verify[40]" string => '1';
+    "verify[41]" string => '1';
+    "verify[42]" string => '1';
 
     "verify[43]" -> { "CFE-2762" }
       string => '0.750000';
+
+    "verify[44]" -> { "CFE-4721" }
+      string => '0';
 
     "indices" slist => getindices("verify");
 
@@ -178,6 +186,7 @@ bundle agent check
         ok_41,
         ok_42,
         ok_43,
+        ok_44,
       };
 
   reports:

--- a/tests/unit/evalfunction_test.c
+++ b/tests/unit/evalfunction_test.c
@@ -133,6 +133,86 @@ static void test_basename(void)
     basename_single_testcase("//a//b///c.csv////", ".csv", "c");
 }
 
+/* Evaluate 'input' the way eval() does by default, i.e. as infix math, and
+ * hand the caller the string the function would return. */
+static char *eval_math(const char *input)
+{
+    EvalContext *ctx = EvalContextNew();
+    Rlist *args = NULL;
+
+    RlistAppendScalar(&args, input);
+    FnCall *call = FnCallNew("eval", args);
+
+    FnCallResult res = FnCallEval(ctx, NULL, call, args);
+    assert_int_equal(FNCALL_SUCCESS, res.status);
+    char *result = xstrdup(res.rval.item);
+
+    RvalDestroy(res.rval);
+    FnCallDestroy(call);
+    EvalContextDestroy(ctx);
+
+    return result;
+}
+
+static void eval_single_testcase(const char *input, const char *expected)
+{
+    char *result = eval_math(input);
+    assert_string_equal(expected, result);
+    free(result);
+}
+
+/* Assert only that the result was not rendered as an integer. Used for
+ * infinities and NaN, whose "%lf" spelling ("inf", "Inf", "nan", "-nan",
+ * ...) is platform dependent. */
+static void eval_not_integer_testcase(const char *input)
+{
+    char *result = eval_math(input);
+    assert_int_not_equal(strspn(result, "-0123456789"), strlen(result));
+    free(result);
+}
+
+static void test_eval_integral_result(void)
+{
+    /* An integral result is rendered without a fractional part, so that it
+     * can be handed straight to a function taking a count, for example
+     * sublist(list, "tail", eval("$(n) - 1", "math", "infix")). */
+    eval_single_testcase("4 - 1", "3");
+    eval_single_testcase("2 + 2", "4");
+    eval_single_testcase("2 - (3 - 1)", "0");
+    eval_single_testcase("3^3", "27");
+    eval_single_testcase("100k", "100000");
+    eval_single_testcase("10 == 10", "1");
+    eval_single_testcase("0 - 7", "-7");
+
+    /* Negative zero is integral and renders as a plain zero, not
+     * "-0.000000". */
+    eval_single_testcase("-1 * 0", "0");
+
+    /* Non-integral results keep the historical "%lf" rendering. */
+    eval_single_testcase("10 / 4", "2.500000");
+    eval_single_testcase("1 * .75", "0.750000");
+    eval_single_testcase("pi", "3.141593");
+    eval_single_testcase("0 - 3.4", "-3.400000");
+
+    /* Infinities and NaN have no integer representation. */
+    eval_not_integer_testcase("3 / 0");
+    eval_not_integer_testcase("-3 / 0");
+    eval_not_integer_testcase("sqrt(-1)");
+
+#if LONG_MAX == 9223372036854775807L
+    /* 2^62 fits in a long. */
+    eval_single_testcase("2^62", "4611686018427387904");
+
+    /* LONG_MIN is -2^63 and is exactly representable as a double. */
+    eval_single_testcase("0 - 2^63", "-9223372036854775808");
+
+    /* 2^63 is one past LONG_MAX, so the cast would be undefined behaviour
+     * rather than a wrapped value. Such results stay real. */
+    eval_single_testcase("2^63", "9223372036854775808.000000");
+    eval_single_testcase("0 - 2^64", "-18446744073709551616.000000");
+#endif
+}
+
 static void test_module_protocol_percent_no_delimiter(void)
 {
     EvalContext *ctx = EvalContextNew();
@@ -187,6 +267,7 @@ int main()
         unit_test(test_hostinnetgroup_found),
         unit_test(test_hostinnetgroup_not_found),
         unit_test(test_basename),
+        unit_test(test_eval_integral_result),
         unit_test(test_module_protocol_percent_no_delimiter),
     };
 


### PR DESCRIPTION
`eval()` always formats its result with `"%lf"`, so an integral result comes back with six decimal places:

```
R: eval(4-1)=[3.000000]  eval(2+2)=[4.000000]  eval(10/4)=[2.500000]
```

The consequence is that arithmetic cannot feed any function taking a count:

```
sublist(list, "tail", eval("$(n) - 1", "math", "infix"))
  -> Anomalous ending '.0' while parsing integer number: 4.000000
```

The working form today is `format("%d", eval(...))`. Notably, every other `eval()` call in the bundled acceptance suite already wraps the result in `int()` or `format()` — the six-decimal form was being worked around rather than relied on.

A new `FnReturnRealOrInt()` renders `"%ld"` when the result is integral and in range, and is otherwise unchanged.

### Range check

```c
isfinite(result) && result == floor(result) &&
result >= (double) LONG_MIN && result < (double) LONG_MAX + 1.0
```

The bounds are asymmetric deliberately. `LONG_MIN` is a power of two and converts to `double` exactly, so `>=` is correct. `(double) LONG_MAX` rounds *up* to `LONG_MAX + 1` on 64-bit `long`, so `result <= (double) LONG_MAX` would admit 2^63 and make the cast undefined.

| expression | before | after |
|---|---|---|
| `4-1` | `3.000000` | `3` |
| `10/4` | `2.500000` | `2.500000` |
| `-1*0` | `-0.000000` | `0` |
| `3/0` | `inf` | `inf` |
| `sqrt(-1)` | `nan` | `nan` |
| `2^62` | `4611686018427387904.000000` | `4611686018427387904` |
| `2^63` | `9223372036854775808.000000` | `9223372036854775808.000000` |
| `0-2^63` (`LONG_MIN`) | `-9223372036854775808.000000` | `-9223372036854775808` |

### Scope

`sum`, `product`, `mean` and `variance` keep `"%lf"` and are deliberately untouched. All four are declared `CF_DATA_TYPE_REAL` in the function table and policy assigns them to `real =>` variables, so a real number is their documented contract. `eval` is declared `CF_DATA_TYPE_STRING`, so changing its rendering stays within its contract. `"class"` mode is untouched.

### Compatibility

This is a visible change and worth calling out: any policy that string-compares or regex-matches `eval()` output will see the new form, and boolean-ish results shift too (`10 == 10` gives `1`, not `1.000000`). The bundled `eval.cf` was itself asserting `300.000000`, `100.000000` and similar, and its expectations are updated here. This probably belongs in a minor release rather than a patch release. I have not surveyed masterfiles or any Enterprise policy for `eval()` consumers.

### Testing

`test_eval_integral_result` in `tests/unit/evalfunction_test.c` drives the real `FnCallEval` rather than a reimplementation; it fails on unpatched code (`"3" != "3.000000"`) and passes with the fix, verified with the shared library forcibly relinked rather than only the test binary. Long-boundary cases are guarded for 32-bit `long`. Full unit suite passes.

### Note

Developed and tested on macOS (arm64); I have not been able to exercise this on the project's own CI.

Ticket: [CFE-4721](https://northerntech.atlassian.net/browse/CFE-4721)


[CFE-4721]: https://northerntech.atlassian.net/browse/CFE-4721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ