### PR TITLE
Fixed crash on JSON null values in def.json augments data

### DIFF
--- a/libpromises/generic_agent.c
+++ b/libpromises/generic_agent.c
@@ -385,6 +385,22 @@ static inline const char *GetAugmentsComment(const char *item_type, const char *
     return JsonPrimitiveGetAsString(json_comment);
 }
 
+/** Does the given JSON array have a JSON null among its direct children? */
+static bool JsonArrayContainsNull(const JsonElement *array)
+{
+    assert(JsonGetType(array) == JSON_TYPE_ARRAY);
+
+    const size_t length = JsonLength(array);
+    for (size_t i = 0; i < length; i++)
+    {
+        if (JsonGetType(JsonArrayGet(array, i)) == JSON_TYPE_NULL)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonElement* augment)
 {
     bool loaded = false;
@@ -451,6 +467,15 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
                 JsonElement *data = JsonObjectGet(vars, vkey);
                 if (JsonGetElementType(data) == JSON_ELEMENT_TYPE_PRIMITIVE)
                 {
+                    if (JsonGetPrimitiveType(data) == JSON_PRIMITIVE_TYPE_NULL)
+                    {
+                        /* JsonPrimitiveToString() returns NULL for JSON null and
+                         * there is no scalar to install in its place. */
+                        Log(LOG_LEVEL_ERR, "Invalid value for augments variable '%s' in '%s'"
+                            " (null is not a supported value)", vkey, filename);
+                        VarRefDestroy(ref);
+                        continue;
+                    }
                     char *value = JsonPrimitiveToString(data);
                     if ((ref->ns == NULL) && (ref->scope == NULL))
                     {
@@ -476,6 +501,16 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
                          JsonGetContainerType(data) == JSON_CONTAINER_TYPE_ARRAY &&
                          JsonArrayContainsOnlyPrimitives(data))
                 {
+                    if (JsonArrayContainsNull(data))
+                    {
+                        /* RlistFromContainer() skips JSON nulls, so the resulting
+                         * slist would silently be shorter than the data it came
+                         * from. */
+                        Log(LOG_LEVEL_ERR, "Invalid value for augments variable '%s' in '%s'"
+                            " (a list must not contain null)", vkey, filename);
+                        VarRefDestroy(ref);
+                        continue;
+                    }
                     // map to slist if the data only has primitives
                     Rlist *data_as_rlist = RlistFromContainer(data);
                     if ((ref->ns == NULL) && (ref->scope == NULL))
@@ -603,6 +638,18 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
                 bool installed = false;
                 if (JsonGetElementType(data) == JSON_ELEMENT_TYPE_PRIMITIVE)
                 {
+                    if (JsonGetPrimitiveType(data) == JSON_PRIMITIVE_TYPE_NULL)
+                    {
+                        /* JsonPrimitiveToString() returns NULL for JSON null and
+                         * there is no scalar to install in its place. This is the
+                         * bare-value form ("key": null); {"value": null} is
+                         * already rejected above by the NULL_JSON(data) check. */
+                        Log(LOG_LEVEL_ERR, "Invalid value for augments variable '%s' in '%s'"
+                            " (null is not a supported value)", vkey, filename);
+                        VarRefDestroy(ref);
+                        StringSetDestroy(tags);
+                        continue;
+                    }
                     char *value = JsonPrimitiveToString(data);
                     if ((ref->ns == NULL) && (ref->scope == NULL))
                     {
@@ -630,6 +677,17 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
                          JsonGetContainerType(data) == JSON_CONTAINER_TYPE_ARRAY &&
                          JsonArrayContainsOnlyPrimitives((JsonElement *) data))
                 {
+                    if (JsonArrayContainsNull(data))
+                    {
+                        /* RlistFromContainer() skips JSON nulls, so the resulting
+                         * slist would silently be shorter than the data it came
+                         * from. */
+                        Log(LOG_LEVEL_ERR, "Invalid value for augments variable '%s' in '%s'"
+                            " (a list must not contain null)", vkey, filename);
+                        VarRefDestroy(ref);
+                        StringSetDestroy(tags);
+                        continue;
+                    }
                     // map to slist if the data only has primitives
                     Rlist *data_as_rlist = RlistFromContainer(data);
                     if ((ref->ns == NULL) && (ref->scope == NULL))
@@ -720,6 +778,14 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
                 JsonElement *data = JsonObjectGet(classes, ckey);
                 if (JsonGetElementType(data) == JSON_ELEMENT_TYPE_PRIMITIVE)
                 {
+                    if (JsonGetPrimitiveType(data) == JSON_PRIMITIVE_TYPE_NULL)
+                    {
+                        /* JsonPrimitiveToString() returns NULL for JSON null and
+                         * there is no class expression to check in its place. */
+                        Log(LOG_LEVEL_ERR, "Invalid augments class expression for class '%s' in '%s'"
+                            " (null is not a supported value)", ckey, filename);
+                        continue;
+                    }
                     char *check = JsonPrimitiveToString(data);
                     // check if class is true
                     if (CheckContextClassmatch(ctx, check))
@@ -836,7 +902,8 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
 
             if (JsonGetElementType(inputs) == JSON_ELEMENT_TYPE_CONTAINER &&
                 JsonGetContainerType(inputs) == JSON_CONTAINER_TYPE_ARRAY &&
-                JsonArrayContainsOnlyPrimitives(inputs))
+                JsonArrayContainsOnlyPrimitives(inputs) &&
+                !JsonArrayContainsNull(inputs))
             {
                 Log(LOG_LEVEL_VERBOSE, "Installing augments def.augments_inputs from file '%s'",
                     filename);
@@ -849,6 +916,9 @@ static bool LoadAugmentsData(EvalContext *ctx, const char *filename, const JsonE
             }
             else
             {
+                /* Also reached when the array contains a null: RlistFromContainer()
+                 * skips JSON nulls, so the installed list would silently be shorter
+                 * than the data it came from. */
                 Log(LOG_LEVEL_ERR, "Trying to augment inputs in '%s' but the value was not a list of strings",
                     filename);
             }

--- a/tests/acceptance/00_basics/def.json/null_values.cf
+++ b/tests/acceptance/00_basics/def.json/null_values.cf
@@ -1,0 +1,70 @@
+# test of the def.json facility: JSON null values are rejected per entry
+# (used to crash cf-promises/cf-agent -- CFE-4739), the rest of the
+# augments data is still installed
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent test
+{
+  methods:
+    "" usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+
+    ""
+      usebundle => file_copy(
+        "$(this.promise_filename).json", "$(sys.inputdir)/def.json"
+      );
+}
+
+#######################################################
+bundle agent check
+{
+  vars:
+    "vars_command"
+      string => "$(sys.cf_promises) --show-vars -f $(sys.inputdir)/promises.cf | $(G.grep) -E 'error:|value_from_'";
+
+    # Errors are logged once per cf-promises invocation regardless of which
+    # section they came from, so both commands below see all five. The
+    # offending entries are reported in the order they appear in the
+    # augments data (vars, then variables, then classes); the remaining
+    # entries are still installed and shown by --show-vars/--show-classes.
+    "all_errors"
+      string => concat(
+        "\s*error: Invalid value for augments variable 'null_scalar'.*null is not a supported value.*",
+        "\s+error: Invalid value for augments variable 'null_list'.*a list must not contain null.*",
+        "\s+error: Invalid value for augments variable 'null_bare'.*null is not a supported value.*",
+        "\s+error: Invalid value for augments variable 'null_value_list'.*a list must not contain null.*",
+        "\s+error: Invalid augments class expression for class 'null_class'.*null is not a supported value.*",
+        "\s+error: Trying to augment inputs in.*but the value was not a list of strings.*"
+      );
+
+    "vars_expected"
+      string => "$(all_errors)\s+default:def\.good_variables\s+value_from_variables\s+source=augments_file\s+default:def\.good_vars\s+value_from_vars\s+source=augments_file\s*";
+
+    "classes_command"
+      string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf | $(G.grep) -E 'error:|test_class'";
+
+    "classes_expected"
+      string => "$(all_errors)\s+test_class_29665402e2b4331f10b8d767b512cd916eeb5db9\s+source=augments_file\s*";
+
+  methods:
+    "vars"
+      usebundle => dcs_passif_output(
+        $(vars_expected),
+        "",
+        $(vars_command),
+        $(this.promise_filename)
+      );
+
+    "classes"
+      usebundle => dcs_passif_output(
+        $(classes_expected),
+        "",
+        $(classes_command),
+        $(this.promise_filename)
+      );
+}

--- a/tests/acceptance/00_basics/def.json/null_values.cf.json
+++ b/tests/acceptance/00_basics/def.json/null_values.cf.json
@@ -1,0 +1,17 @@
+{
+  "vars": {
+    "null_scalar": null,
+    "null_list": ["a", null],
+    "good_vars": "value_from_vars"
+  },
+  "variables": {
+    "null_bare": null,
+    "null_value_list": ["a", null],
+    "good_variables": "value_from_variables"
+  },
+  "classes": {
+    "null_class": null,
+    "test_class_29665402e2b4331f10b8d767b512cd916eeb5db9": "any"
+  },
+  "inputs": ["a", null]
+}


### PR DESCRIPTION
## Summary

The augments (`def.json`) loader has the same null-crash root cause as `host_specific.json` CMDB data ([CFE-4738](https://northerntech.atlassian.net/browse/CFE-4738), #6316): `JsonPrimitiveToString()` returns `NULL` for a JSON `null`, and that `NULL` was passed straight into `xstrdup()` (via `EvalContextVariablePut*`) or `CheckContextClassmatch()` without a check. Each of these crashed `cf-promises`/`cf-agent` with SIGSEGV:

```json
{"vars": {"k": null}}
{"variables": {"k": null}}
{"classes": {"k": null}}
```

- Reject a null value per entry and continue the loop -- the same skip-with-error idiom `LoadAugmentsData()` already uses for every other per-entry problem (invalid variable spec, missing `"value"` field). Whole-section rejection stays reserved for structural problems.
- An array of primitives containing a null is rejected the same way in `"vars"`, `"variables"`, and `"inputs"`: not a crash, but `RlistFromContainer()` silently drops nulls, so the installed list would otherwise be silently shorter than the source data -- the same defect class [CFE-4738](https://northerntech.atlassian.net/browse/CFE-4738) fixed in `cmdb.c`.
- The `"classes"` array path and the `class_expressions`/`regular_expressions`/further-`"augments"`-files array paths were already null-safe (`JsonIteratorNextValueByType(..., skip_null=true)`).
- `{"value": null}` under `"variables"` was already rejected safely before this change, via a `NULL_JSON()` check `cmdb.c` lacked.

Ticket: [CFE-4739](https://northerntech.atlassian.net/browse/CFE-4739)

## Test plan

- [x] Built unpatched, confirmed a real SIGSEGV (rc=139) loading the exact `def.json` from the new test
- [x] Rebuilt patched (forced full `libpromises` relink, not just recompile), confirmed the new acceptance test passes
- [x] Ran all 22 tests in `tests/acceptance/00_basics/def.json/`, zero regressions
- [x] Independent review (grok, on a disposable copy of the tree): SHIP -- no leaks on the new early-return paths, no missed null-crash site in the function

[CFE-4738]: https://northerntech.atlassian.net/browse/CFE-4738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFE-4738]: https://northerntech.atlassian.net/browse/CFE-4738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ