### PR TITLE
CFE-4720: Fixed one bad CMDB entry discarding every entry in its section

### DIFF
--- a/libpromises/cmdb.c
+++ b/libpromises/cmdb.c
@@ -116,73 +116,66 @@ static bool CheckObjectForUnexpandedVars(JsonElement *object, void *data)
 }
 
 /**
- * Reject CMDB data containing unresolved variable references, naming the entry
- * that was rejected.
+ * Reject a single CMDB entry containing unresolved variable references,
+ * naming the entry that was rejected.
  *
- * Each top-level entry is walked separately so that the entry can be named,
- * which is what an operator needs to find the offending line. A single walk of
- * the whole section could only report the immediate property name, and in the
- * 'variables' format (CFE-3633) that is the metadata key 'value' rather than
- * the name of the variable holding it.
+ * Checked per entry, rather than once for the whole section, so that one
+ * offending entry does not take every other entry in the section down with
+ * it -- matching the skip-and-continue idiom the rest of this file already
+ * uses for other per-entry problems (an invalid variable specification, a
+ * missing "value" field).
  *
- * @param data      the CMDB section to check, which must be a JSON object
+ * @param entry     the entry's value, as found under key in its section
+ * @param key       the entry's key, as it appears in the CMDB file
  * @param section   the section's key, as it appears in the CMDB file
  * @param file_path the CMDB file the data came from
- * @return          whether the data is free of variable references
+ * @return          whether the entry is free of variable references
  */
-static bool CheckCMDBDataForUnexpandedVars(JsonElement *data,
-                                           const char *section,
-                                           const char *file_path)
+static bool CheckCMDBEntryForUnexpandedVars(JsonElement *entry,
+                                            const char *key,
+                                            const char *section,
+                                            const char *file_path)
 {
-    assert(data != NULL);
-    assert(JsonGetType(data) == JSON_TYPE_OBJECT);
+    assert(entry != NULL);
+    assert(key != NULL);
     assert(section != NULL);
     assert(file_path != NULL);
 
-    JsonIterator iter = JsonIteratorInit(data);
-    while (JsonIteratorHasMore(&iter))
+    if (StringContainsUnresolved(key))
     {
-        JsonElement *child = JsonIteratorNextValue(&iter);
-        const char *entry = JsonGetPropertyAsString(child);
-
-        if (StringContainsUnresolved(entry))
-        {
-            Log(LOG_LEVEL_ERR,
-                "Invalid '%s' CMDB data in '%s', cannot contain variable"
-                " references (offending key: '%s')",
-                section, file_path, entry);
-            return false;
-        }
-
-        CMDBUnexpandedVar offender = {NULL, NULL};
-        if (JsonWalk(child, CheckObjectForUnexpandedVars,
-                     NULL, CheckPrimitiveForUnexpandedVars, &offender))
-        {
-            continue;
-        }
-
-        /* The walk stops only when one of the two visitors above stops it,
-         * and each records what it found before doing so. */
-        assert((offender.value != NULL) || (offender.key != NULL));
-
-        if (offender.value != NULL)
-        {
-            Log(LOG_LEVEL_ERR,
-                "Invalid '%s' CMDB data in '%s', cannot contain variable"
-                " references (offending value in entry '%s': '%s')",
-                section, file_path, entry, offender.value);
-        }
-        else
-        {
-            Log(LOG_LEVEL_ERR,
-                "Invalid '%s' CMDB data in '%s', cannot contain variable"
-                " references (offending key in entry '%s': '%s')",
-                section, file_path, entry, offender.key);
-        }
+        Log(LOG_LEVEL_ERR,
+            "Invalid '%s' CMDB data in '%s', cannot contain variable"
+            " references (offending key: '%s')",
+            section, file_path, key);
         return false;
     }
 
-    return true;
+    CMDBUnexpandedVar offender = {NULL, NULL};
+    if (JsonWalk(entry, CheckObjectForUnexpandedVars,
+                 NULL, CheckPrimitiveForUnexpandedVars, &offender))
+    {
+        return true;
+    }
+
+    /* The walk stops only when one of the two visitors above stops it, and
+     * each records what it found before doing so. */
+    assert((offender.value != NULL) || (offender.key != NULL));
+
+    if (offender.value != NULL)
+    {
+        Log(LOG_LEVEL_ERR,
+            "Invalid '%s' CMDB data in '%s', cannot contain variable"
+            " references (offending value in entry '%s': '%s')",
+            section, file_path, key, offender.value);
+    }
+    else
+    {
+        Log(LOG_LEVEL_ERR,
+            "Invalid '%s' CMDB data in '%s', cannot contain variable"
+            " references (offending key in entry '%s': '%s')",
+            section, file_path, key, offender.key);
+    }
+    return false;
 }
 
 static VarRef *GetCMDBVariableRef(const char *key)
@@ -272,16 +265,16 @@ static bool ReadCMDBVars(EvalContext *ctx, JsonElement *vars,
         return false;
     }
 
-    if (!CheckCMDBDataForUnexpandedVars(vars, "vars", file_path))
-    {
-        return false;
-    }
-
     JsonIterator iter = JsonIteratorInit(vars);
     while (JsonIteratorHasMore(&iter))
     {
         const char *key = JsonIteratorNextKey(&iter);
         JsonElement *data = JsonObjectGet(vars, key);
+
+        if (!CheckCMDBEntryForUnexpandedVars(data, key, "vars", file_path))
+        {
+            continue;
+        }
 
         VarRef *ref = GetCMDBVariableRef(key);
         if (ref == NULL)
@@ -375,23 +368,22 @@ static bool ReadCMDBVariables(EvalContext *ctx, JsonElement *variables,
         return false;
     }
 
-    if (!CheckCMDBDataForUnexpandedVars(variables, "variables", file_path))
-    {
-        return false;
-    }
-
     JsonIterator iter = JsonIteratorInit(variables);
     while (JsonIteratorHasMore(&iter))
     {
         const char *key = JsonIteratorNextKey(&iter);
+        JsonElement *const var_info = JsonObjectGet(variables, key);
+
+        if (!CheckCMDBEntryForUnexpandedVars(var_info, key, "variables", file_path))
+        {
+            continue;
+        }
 
         VarRef *ref = GetCMDBVariableRef(key);
         if (ref == NULL)
         {
             continue;
         }
-
-        JsonElement *const var_info = JsonObjectGet(variables, key);
 
         JsonElement *data;
         StringSet *tags;
@@ -480,16 +472,17 @@ static bool ReadCMDBClasses(EvalContext *ctx, JsonElement *classes,
         return false;
     }
 
-    if (!CheckCMDBDataForUnexpandedVars(classes, "classes", file_path))
-    {
-        return false;
-    }
-
     JsonIterator iter = JsonIteratorInit(classes);
     while (JsonIteratorHasMore(&iter))
     {
         const char *key = JsonIteratorNextKey(&iter);
         JsonElement *data = JsonObjectGet(classes, key);
+
+        if (!CheckCMDBEntryForUnexpandedVars(data, key, "classes", file_path))
+        {
+            continue;
+        }
+
         if (JsonGetElementType(data) == JSON_ELEMENT_TYPE_PRIMITIVE)
         {
             const char *expr = JsonPrimitiveGetAsString(data);

--- a/libpromises/cmdb.c
+++ b/libpromises/cmdb.c
@@ -67,17 +67,38 @@ JsonElement *ReadJsonFile(const char *filename, LogLevel log_level, size_t size_
     return doc;
 }
 
-static bool CheckPrimitiveForUnexpandedVars(JsonElement *primitive, ARG_UNUSED void *data)
+/* What made the unexpanded-variable walk below stop: exactly one of these is
+ * set, depending on which visitor stopped it. Both point into the JSON
+ * document being walked and must not be freed. */
+typedef struct
+{
+    const char *key;            /* set if a key held the reference */
+    const char *value;          /* set if a value held the reference */
+} CMDBUnexpandedVar;
+
+static bool CheckPrimitiveForUnexpandedVars(JsonElement *primitive, void *data)
 {
     assert(JsonGetElementType(primitive) == JSON_ELEMENT_TYPE_PRIMITIVE);
+    assert(data != NULL);
 
-    /* Stop the iteration if a variable expression is found. */
-    return (!StringContainsUnresolved(JsonPrimitiveGetAsString(primitive)));
+    const char *const value = JsonPrimitiveGetAsString(primitive);
+    if (!StringContainsUnresolved(value))
+    {
+        return true;
+    }
+
+    /* Stop the iteration and report what stopped it. The primitive's own
+     * property name is not recorded: it is the metadata key 'value' in the
+     * 'variables' format, and nothing at all for an array element, whereas
+     * the caller knows the top-level entry and reports that instead. */
+    ((CMDBUnexpandedVar *) data)->value = value;
+    return false;
 }
 
-static bool CheckObjectForUnexpandedVars(JsonElement *object, ARG_UNUSED void *data)
+static bool CheckObjectForUnexpandedVars(JsonElement *object, void *data)
 {
     assert(JsonGetType(object) == JSON_TYPE_OBJECT);
+    assert(data != NULL);
 
     /* Stop the iteration if a variable expression is found among children
      * keys. (elements inside the object are checked separately) */
@@ -87,9 +108,80 @@ static bool CheckObjectForUnexpandedVars(JsonElement *object, ARG_UNUSED void *d
         const char *key = JsonIteratorNextKey(&iter);
         if (StringContainsUnresolved(key))
         {
+            ((CMDBUnexpandedVar *) data)->key = key;
             return false;
         }
     }
+    return true;
+}
+
+/**
+ * Reject CMDB data containing unresolved variable references, naming the entry
+ * that was rejected.
+ *
+ * Each top-level entry is walked separately so that the entry can be named,
+ * which is what an operator needs to find the offending line. A single walk of
+ * the whole section could only report the immediate property name, and in the
+ * 'variables' format (CFE-3633) that is the metadata key 'value' rather than
+ * the name of the variable holding it.
+ *
+ * @param data      the CMDB section to check, which must be a JSON object
+ * @param section   the section's key, as it appears in the CMDB file
+ * @param file_path the CMDB file the data came from
+ * @return          whether the data is free of variable references
+ */
+static bool CheckCMDBDataForUnexpandedVars(JsonElement *data,
+                                           const char *section,
+                                           const char *file_path)
+{
+    assert(data != NULL);
+    assert(JsonGetType(data) == JSON_TYPE_OBJECT);
+    assert(section != NULL);
+    assert(file_path != NULL);
+
+    JsonIterator iter = JsonIteratorInit(data);
+    while (JsonIteratorHasMore(&iter))
+    {
+        JsonElement *child = JsonIteratorNextValue(&iter);
+        const char *entry = JsonGetPropertyAsString(child);
+
+        if (StringContainsUnresolved(entry))
+        {
+            Log(LOG_LEVEL_ERR,
+                "Invalid '%s' CMDB data in '%s', cannot contain variable"
+                " references (offending key: '%s')",
+                section, file_path, entry);
+            return false;
+        }
+
+        CMDBUnexpandedVar offender = {NULL, NULL};
+        if (JsonWalk(child, CheckObjectForUnexpandedVars,
+                     NULL, CheckPrimitiveForUnexpandedVars, &offender))
+        {
+            continue;
+        }
+
+        /* The walk stops only when one of the two visitors above stops it,
+         * and each records what it found before doing so. */
+        assert((offender.value != NULL) || (offender.key != NULL));
+
+        if (offender.value != NULL)
+        {
+            Log(LOG_LEVEL_ERR,
+                "Invalid '%s' CMDB data in '%s', cannot contain variable"
+                " references (offending value in entry '%s': '%s')",
+                section, file_path, entry, offender.value);
+        }
+        else
+        {
+            Log(LOG_LEVEL_ERR,
+                "Invalid '%s' CMDB data in '%s', cannot contain variable"
+                " references (offending key in entry '%s': '%s')",
+                section, file_path, entry, offender.key);
+        }
+        return false;
+    }
+
     return true;
 }
 
@@ -167,19 +259,21 @@ static bool AddCMDBVariable(EvalContext *ctx, const char *key, const VarRef *ref
     return ret;
 }
 
-static bool ReadCMDBVars(EvalContext *ctx, JsonElement *vars)
+static bool ReadCMDBVars(EvalContext *ctx, JsonElement *vars,
+                         const char *file_path)
 {
     assert(vars != NULL);
 
     if (JsonGetType(vars) != JSON_TYPE_OBJECT)
     {
-        Log(LOG_LEVEL_ERR, "Invalid 'vars' CMDB data, must be a JSON object");
+        Log(LOG_LEVEL_ERR,
+            "Invalid 'vars' CMDB data in '%s', must be a JSON object",
+            file_path);
         return false;
     }
 
-    if (!JsonWalk(vars, CheckObjectForUnexpandedVars, NULL, CheckPrimitiveForUnexpandedVars, NULL))
+    if (!CheckCMDBDataForUnexpandedVars(vars, "vars", file_path))
     {
-        Log(LOG_LEVEL_ERR, "Invalid 'vars' CMDB data, cannot contain variable references");
         return false;
     }
 
@@ -268,19 +362,21 @@ static inline const char *GetCMDBComment(const char *item_type, const char *iden
 }
 
 /** Uses the new format allowing metadata (CFE-3633) */
-static bool ReadCMDBVariables(EvalContext *ctx, JsonElement *variables)
+static bool ReadCMDBVariables(EvalContext *ctx, JsonElement *variables,
+                              const char *file_path)
 {
     assert(variables != NULL);
 
     if (JsonGetType(variables) != JSON_TYPE_OBJECT)
     {
-        Log(LOG_LEVEL_ERR, "Invalid 'variables' CMDB data, must be a JSON object");
+        Log(LOG_LEVEL_ERR,
+            "Invalid 'variables' CMDB data in '%s', must be a JSON object",
+            file_path);
         return false;
     }
 
-    if (!JsonWalk(variables, CheckObjectForUnexpandedVars, NULL, CheckPrimitiveForUnexpandedVars, NULL))
+    if (!CheckCMDBDataForUnexpandedVars(variables, "variables", file_path))
     {
-        Log(LOG_LEVEL_ERR, "Invalid 'variables' CMDB data, cannot contain variable references");
         return false;
     }
 
@@ -371,19 +467,21 @@ static bool AddCMDBClass(EvalContext *ctx, const char *key, StringSet *tags, con
     return ret;
 }
 
-static bool ReadCMDBClasses(EvalContext *ctx, JsonElement *classes)
+static bool ReadCMDBClasses(EvalContext *ctx, JsonElement *classes,
+                            const char *file_path)
 {
     assert(classes != NULL);
 
     if (JsonGetType(classes) != JSON_TYPE_OBJECT)
     {
-        Log(LOG_LEVEL_ERR, "Invalid 'classes' CMDB data, must be a JSON object");
+        Log(LOG_LEVEL_ERR,
+            "Invalid 'classes' CMDB data in '%s', must be a JSON object",
+            file_path);
         return false;
     }
 
-    if (!JsonWalk(classes, CheckObjectForUnexpandedVars, NULL, CheckPrimitiveForUnexpandedVars, NULL))
+    if (!CheckCMDBDataForUnexpandedVars(classes, "classes", file_path))
     {
-        Log(LOG_LEVEL_ERR, "Invalid 'classes' CMDB data, cannot contain variable references");
         return false;
     }
 
@@ -548,18 +646,19 @@ bool LoadCMDBData(EvalContext *ctx)
 
     bool success = true;
     JsonElement *vars = JsonObjectGet(data, "vars");
-    if (JSON_NOT_NULL(vars) && !ReadCMDBVars(ctx, vars))
+    if (JSON_NOT_NULL(vars) && !ReadCMDBVars(ctx, vars, file_path))
     {
         success = false;
     }
     /* Uses the new format allowing metadata (CFE-3633) */
     JsonElement *variables = JsonObjectGet(data, "variables");
-    if (JSON_NOT_NULL(variables) && !ReadCMDBVariables(ctx, variables))
+    if (JSON_NOT_NULL(variables) &&
+        !ReadCMDBVariables(ctx, variables, file_path))
     {
         success = false;
     }
     JsonElement *classes = JsonObjectGet(data, "classes");
-    if (JSON_NOT_NULL(classes) && !ReadCMDBClasses(ctx, classes))
+    if (JSON_NOT_NULL(classes) && !ReadCMDBClasses(ctx, classes, file_path))
     {
         success = false;
     }

--- a/tests/acceptance/00_basics/06_host_specific_data/12-variable-references-name-offender.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/12-variable-references-name-offender.cf
@@ -1,0 +1,48 @@
+# test that a rejected host_specific.json names the offending entry and the file
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent init
+{
+  files:
+    "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+      create => "true",
+      perms => mog(
+        "0700", "$(sys.user_data[username])", "$(sys.user_data[username])"
+      );
+
+  methods:
+    "prepare_host_specific_data"
+      usebundle => file_copy(
+        "$(this.promise_filename).json",
+        "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"
+      ),
+      handle => "prepare_host_specific_data";
+
+    "empty_promises_cf"
+      usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+bundle agent check
+{
+  vars:
+    "command"
+      string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf";
+
+  methods:
+    # The error must name the file it came from and the key whose value holds
+    # the unresolved reference, not just the section that was rejected.
+    ""
+      usebundle => dcs_passif_output(
+        ".*error: Invalid 'vars' CMDB data in '.*host_specific\.json', cannot contain variable references \(offending value in entry 'key_with_unresolved_value': .*",
+        "",
+        $(command),
+        $(this.promise_filename)
+      );
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/12-variable-references-name-offender.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/12-variable-references-name-offender.cf.json
@@ -1,0 +1,6 @@
+{
+  "vars": {
+    "good_key": "a literal value",
+    "key_with_unresolved_value": "$(sys.workdir)"
+  }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/15-variable-references-metadata-format.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/15-variable-references-metadata-format.cf
@@ -1,0 +1,49 @@
+# test that the offending entry is named by its CMDB key, not by the 'value'
+# metadata key that physically holds the unresolved reference (CFE-3633 format)
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent init
+{
+  files:
+    "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+      create => "true",
+      perms => mog(
+        "0700", "$(sys.user_data[username])", "$(sys.user_data[username])"
+      );
+
+  methods:
+    "prepare_host_specific_data"
+      usebundle => file_copy(
+        "$(this.promise_filename).json",
+        "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"
+      ),
+      handle => "prepare_host_specific_data";
+
+    "empty_promises_cf"
+      usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+bundle agent check
+{
+  vars:
+    "command"
+      string => "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf";
+
+  methods:
+    # The error must name the file it came from and the key whose value holds
+    # the unresolved reference, not just the section that was rejected.
+    ""
+      usebundle => dcs_passif_output(
+        ".*error: Invalid 'variables' CMDB data in '.*host_specific\.json', cannot contain variable references \(offending value in entry 'key_with_unresolved_value': .*",
+        "",
+        $(command),
+        $(this.promise_filename)
+      );
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/15-variable-references-metadata-format.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/15-variable-references-metadata-format.cf.json
@@ -1,0 +1,12 @@
+{
+  "variables": {
+    "good_key": {
+      "value": "a literal value"
+    },
+    "key_with_unresolved_value": {
+      "value": "$(sys.workdir)",
+      "comment": "the offending entry must be named by this key, not by 'value'",
+      "tags": ["test_tag"]
+    }
+  }
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/16-variable-references-good-entry-survives.cf
+++ b/tests/acceptance/00_basics/06_host_specific_data/16-variable-references-good-entry-survives.cf
@@ -1,0 +1,78 @@
+# test that one entry with an unresolved variable reference does not drop
+# every other entry in the same section
+body common control
+{
+  inputs => { "../../default.sub.cf" };
+  bundlesequence => { default("$(this.promise_filename)") };
+  version => "1.0";
+}
+
+#######################################################
+bundle agent init
+{
+  files:
+    "$(sys.workdir)$(const.dirsep)data$(const.dirsep)."
+      create => "true",
+      perms => mog(
+        "0700", "$(sys.user_data[username])", "$(sys.user_data[username])"
+      );
+
+  methods:
+    "prepare_host_specific_data"
+      usebundle => file_copy(
+        "$(this.promise_filename).json",
+        "$(sys.workdir)$(const.dirsep)data$(const.dirsep)host_specific.json"
+      ),
+      handle => "prepare_host_specific_data";
+
+    "empty_promises_cf"
+      usebundle => file_make("$(sys.inputdir)/promises.cf", '');
+}
+
+#######################################################
+bundle agent check
+{
+  vars:
+    "error_output"
+      string => execresult(
+        "$(sys.cf_promises) --show-classes -f $(sys.inputdir)/promises.cf",
+        "useshell"
+      ),
+      depends_on => { "prepare_host_specific_data" };
+
+    "vars_output"
+      string => execresult(
+        "$(sys.cf_promises) --show-vars -f $(sys.inputdir)/promises.cf | $(G.grep) good_key",
+        "useshell"
+      ),
+      depends_on => { "prepare_host_specific_data" };
+
+  classes:
+    # The offending entry is still rejected and named.
+    "offender_named"
+      expression => regcmp(
+        ".*error: Invalid 'vars' CMDB data in '.*host_specific\.json', cannot contain variable references \(offending value in entry 'key_with_unresolved_value': .*",
+        "$(error_output)"
+      );
+
+    # Its sibling entry in the same section is installed anyway -- a single
+    # bad entry must not take the rest of the section down with it.
+    "good_entry_survived"
+      expression => regcmp(
+        "data:variables\.good_key\s+a literal value\s+source=cmdb",
+        "$(vars_output)"
+      );
+
+    "ok" and => { "offender_named", "good_entry_survived" };
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+
+    !ok::
+      "$(this.promise_filename) FAIL";
+
+    !ok.DEBUG::
+      "error_output was: '$(error_output)'";
+      "vars_output was: '$(vars_output)'";
+}

--- a/tests/acceptance/00_basics/06_host_specific_data/16-variable-references-good-entry-survives.cf.json
+++ b/tests/acceptance/00_basics/06_host_specific_data/16-variable-references-good-entry-survives.cf.json
@@ -1,0 +1,6 @@
+{
+  "vars": {
+    "good_key": "a literal value",
+    "key_with_unresolved_value": "$(sys.workdir)"
+  }
+}


### PR DESCRIPTION
Ticket: [CFE-4720](https://northerntech.atlassian.net/browse/CFE-4720)

Stacked on #6315 (CFE-4719) — this branch is #6315's commit plus one more. Diff will shrink to just the new commit once #6315 merges.

`CheckCMDBDataForUnexpandedVars()` rejected a whole `vars`/`variables`/`classes` section on the first entry containing an unresolved variable reference, discarding every other entry in that section along with it — a single bad `host_specific.json` key could silently drop all CMDB-sourced variables on a host. Checked per entry instead, inside each section's own install loop, matching this file's existing skip-and-continue idiom for other per-entry problems (an invalid variable specification, a missing `value` field).

New acceptance test: one good and one bad entry in the same `vars` section, asserting the bad entry is still rejected and named, and the good entry installs anyway. Discrimination proved: fails on the unpatched function, passes with the fix; full `00_basics/06_host_specific_data` suite still 14/14.

AI-assisted, reviewed and verified by me before submitting.

[CFE-4720]: https://northerntech.atlassian.net/browse/CFE-4720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ