### PR TITLE
Fixed dubious argument order in RecordPkgOperationInChroot

### DIFF
--- a/libpromises/changes_chroot.c
+++ b/libpromises/changes_chroot.c
@@ -265,7 +265,7 @@ bool RecordFileEvaluatedInChroot(const char *path)
     return ret;
 }
 
-bool RecordPkgOperationInChroot(const char *op, const char *name, const char *arch, const char *version)
+bool RecordPkgOperationInChroot(const char *op, const char *name, const char *version, const char *arch)
 {
     assert(op != NULL);
     assert(name != NULL);

--- a/libpromises/changes_chroot.h
+++ b/libpromises/changes_chroot.h
@@ -34,6 +34,6 @@ void PrepareChangesChroot(const char *path);
 bool RecordFileChangedInChroot(const char *path);
 bool RecordFileRenamedInChroot(const char *old_name, const char *new_name);
 bool RecordFileEvaluatedInChroot(const char *path);
-bool RecordPkgOperationInChroot(const char *op, const char *name, const char *arch, const char *version);
+bool RecordPkgOperationInChroot(const char *op, const char *name, const char *version, const char *arch);
 
 #endif /* CFENGINE_CHANGES_CHROOT_H */


### PR DESCRIPTION
Each call to `RecordPkgOperationInChroot` passed version followed by architecture in the arguments. However, the function signature had this the other way around. To avoid any change in behavior, I changed the parameter names to match the arguments of the call sites.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
