### PR TITLE
CFE-4714: Added the parameters of the remaining variadic functions to the syntax description (3.24.x)

### DIFF
--- a/libpromises/evalfunction.c
+++ b/libpromises/evalfunction.c
@@ -9319,6 +9319,7 @@ static const FnCallArg ACCUM_ARGS[] =
 
 static const FnCallArg AND_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Class expression"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -9404,11 +9405,14 @@ static const FnCallArg CLASSIFY_ARGS[] =
 
 static const FnCallArg CLASSMATCH_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Regular expression"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Tag regular expression"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
 static const FnCallArg CONCAT_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "String to concatenate"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -9468,6 +9472,7 @@ static const FnCallArg FILESEXIST_ARGS[] =
 
 static const FnCallArg FINDFILES_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Glob pattern to match files"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -9605,6 +9610,8 @@ static const FnCallArg HOSTSWITHCLASS_ARGS[] =
 
 static const FnCallArg IFELSE_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Class expression"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Value if the preceding class expression is true"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -9740,6 +9747,8 @@ static const FnCallArg MAPDATA_ARGS[] =
 
 static const FnCallArg MERGEDATA_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "CFEngine variable identifier or inline JSON"},
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "CFEngine variable identifier or inline JSON"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 
@@ -9756,6 +9765,7 @@ static const FnCallArg NOW_ARGS[] =
 
 static const FnCallArg OR_ARGS[] =
 {
+    {CF_ANYSTRING, CF_DATA_TYPE_STRING, "Class expression"},
     {NULL, CF_DATA_TYPE_NONE, NULL}
 };
 


### PR DESCRIPTION
Backport of #6289 to 3.24.x. Adds the parameter descriptions for the remaining variadic functions so `cf-promises --syntax-description` reports them.

Ticket: CFE-4714