### PR TITLE
CFE-3275: Removed the repository destination from LogFileChange()

### DIFF
--- a/cf-agent/cf-agent-enterprise-stubs.c
+++ b/cf-agent/cf-agent-enterprise-stubs.c
@@ -25,14 +25,13 @@
 #include <cf-agent-enterprise-stubs.h>
 #include <eval_context.h>
 
-ENTERPRISE_FUNC_8ARG_DEFINE_STUB(PromiseResult, LogFileChange,
+ENTERPRISE_FUNC_7ARG_DEFINE_STUB(PromiseResult, LogFileChange,
                                  ARG_UNUSED EvalContext *, ctx,
                                  ARG_UNUSED const char *, file,
                                  ARG_UNUSED int, change,
                                  ARG_UNUSED const Attributes *, attr,
                                  ARG_UNUSED const Promise *, pp,
                                  ARG_UNUSED CopyRegularFileFunction, CopyRegularFilePtr,
-                                 ARG_UNUSED const char *, destination,
                                  ARG_UNUSED DeleteCompressedArrayFunction, DeleteCompressedArrayPtr)
 {
     RecordNoChange(ctx, pp, attr, "Logging file differences requires version Nova or above");

--- a/cf-agent/cf-agent-enterprise-stubs.h
+++ b/cf-agent/cf-agent-enterprise-stubs.h
@@ -45,14 +45,14 @@ typedef bool (*CopyRegularFileFunction)(EvalContext *ctx,
                                        AgentConnection *conn,
                                        PromiseResult *result);
 typedef void (*DeleteCompressedArrayFunction)(CompressedArray *start);
-ENTERPRISE_FUNC_8ARG_DECLARE(PromiseResult, LogFileChange,
+ENTERPRISE_FUNC_7ARG_DECLARE(PromiseResult, LogFileChange,
                              EvalContext *, ctx,
                              const char *, file,
                              int, change,
                              const Attributes *, attr,
                              const Promise *, pp,
                              CopyRegularFileFunction, CopyRegularFilePtr,
-                             const char *, destination, DeleteCompressedArrayFunction, DeleteCompressedArrayPtr);
+                             DeleteCompressedArrayFunction, DeleteCompressedArrayPtr);
 
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, ReportPatches, PackageManager *, list);
 ENTERPRISE_VOID_FUNC_1ARG_DECLARE(void, Nova_TrackExecution, const char *, input_file);

--- a/cf-agent/verify_files_utils.c
+++ b/cf-agent/verify_files_utils.c
@@ -3738,12 +3738,7 @@ static PromiseResult VerifyFileIntegrity(EvalContext *ctx, const char *file, con
 
     if (attr->change.report_diffs && MakingInternalChanges(ctx, pp, attr, &result, "report diffs in '%s'", file))
     {
-        char destination[CF_BUFSIZE];
-        if (!GetRepositoryPath(file, attr, destination))
-        {
-            destination[0] = '\0';
-        }
-        LogFileChange(ctx, file, changed, attr, pp, &CopyRegularFile, destination, &DeleteCompressedArray);
+        LogFileChange(ctx, file, changed, attr, pp, &CopyRegularFile, &DeleteCompressedArray);
     }
 
     return result;


### PR DESCRIPTION
`LogFileChange()` no longer takes a repository destination, because change details for `report_diffs` are now always stored under the state directory.

Must merge together with cfengine/enterprise#1000 — either alone breaks the enterprise build. Test in cfengine/system-testing#720.